### PR TITLE
Add API method for getting tablet hosting goals

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/admin/HostingGoalForTablet.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/HostingGoalForTablet.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.client.admin;
+
+import java.util.Objects;
+
+import org.apache.accumulo.core.data.TabletId;
+
+/**
+ * This class contains information that defines the tablet hosting data for a table. The class
+ * contains the TabletId and associated goal for each tablet in a table or a subset of tablets if a
+ * range is provided.
+ */
+public class HostingGoalForTablet {
+  TabletId tabletId;
+  TabletHostingGoal hostingGoal;
+
+  public HostingGoalForTablet(TabletId tabletId, TabletHostingGoal hostingGoal) {
+    this.tabletId = tabletId;
+    this.hostingGoal = hostingGoal;
+  }
+
+  public TabletHostingGoal getHostingGoal() {
+    return hostingGoal;
+  }
+
+  public TabletId getTabletId() {
+    return tabletId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    HostingGoalForTablet that = (HostingGoalForTablet) o;
+    return Objects.equals(tabletId, that.tabletId) && hostingGoal == that.hostingGoal;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(tabletId, hostingGoal);
+  }
+}

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
@@ -29,6 +29,7 @@ import java.util.SortedSet;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
@@ -1005,4 +1006,17 @@ public interface TableOperations {
       throws AccumuloSecurityException, AccumuloException, TableNotFoundException {
     throw new UnsupportedOperationException();
   }
+
+  /**
+   * Retrieve the hosting goal for a range of tablets in the specified table.
+   *
+   * @param tableName table name
+   * @param range tablet range
+   * @since 4.0.0
+   */
+  default Stream<HostingGoalForTablet> getTabletHostingGoal(final String tableName,
+      final Range range) throws TableNotFoundException {
+    throw new UnsupportedOperationException();
+  }
+
 }

--- a/core/src/main/java/org/apache/accumulo/core/dataImpl/KeyExtent.java
+++ b/core/src/main/java/org/apache/accumulo/core/dataImpl/KeyExtent.java
@@ -380,8 +380,8 @@ public class KeyExtent implements Comparable<KeyExtent> {
    * <p>
    * For example, if this extent represented a range of data from <code>A</code> to <code>Z</code>
    * for a user table, <code>T</code>, this would compute the range to scan
-   * <code>accumulo.metadata</code> that would include all the the metadata for <code>T</code>'s
-   * tablets that contain data in the range <code>(A,Z]</code>.
+   * <code>accumulo.metadata</code> that would include all the metadata for <code>T</code>'s tablets
+   * that contain data in the range <code>(A,Z]</code>.
    */
   public Range toMetaRange() {
     Text metadataPrevRow =

--- a/shell/src/main/java/org/apache/accumulo/shell/Shell.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/Shell.java
@@ -111,6 +111,7 @@ import org.apache.accumulo.shell.commands.FormatterCommand;
 import org.apache.accumulo.shell.commands.GetAuthsCommand;
 import org.apache.accumulo.shell.commands.GetGroupsCommand;
 import org.apache.accumulo.shell.commands.GetSplitsCommand;
+import org.apache.accumulo.shell.commands.GetTabletHostingGoalCommand;
 import org.apache.accumulo.shell.commands.GrantCommand;
 import org.apache.accumulo.shell.commands.GrepCommand;
 import org.apache.accumulo.shell.commands.HelpCommand;
@@ -147,13 +148,13 @@ import org.apache.accumulo.shell.commands.SetAuthsCommand;
 import org.apache.accumulo.shell.commands.SetGroupsCommand;
 import org.apache.accumulo.shell.commands.SetIterCommand;
 import org.apache.accumulo.shell.commands.SetShellIterCommand;
+import org.apache.accumulo.shell.commands.SetTabletHostingGoalCommand;
 import org.apache.accumulo.shell.commands.SleepCommand;
 import org.apache.accumulo.shell.commands.SummariesCommand;
 import org.apache.accumulo.shell.commands.SystemPermissionsCommand;
 import org.apache.accumulo.shell.commands.TableCommand;
 import org.apache.accumulo.shell.commands.TablePermissionsCommand;
 import org.apache.accumulo.shell.commands.TablesCommand;
-import org.apache.accumulo.shell.commands.TabletHostingGoalCommand;
 import org.apache.accumulo.shell.commands.TraceCommand;
 import org.apache.accumulo.shell.commands.UserCommand;
 import org.apache.accumulo.shell.commands.UserPermissionsCommand;
@@ -399,9 +400,10 @@ public class Shell extends ShellOptions implements KeywordExecutable {
     Command[] tableCommands = {new CloneTableCommand(), new ConfigCommand(),
         new CreateTableCommand(), new DeleteTableCommand(), new DropTableCommand(), new DUCommand(),
         new ExportTableCommand(), new ImportTableCommand(), new OfflineCommand(),
-        new TabletHostingGoalCommand(), new OnlineCommand(), new RenameTableCommand(),
-        new TablesCommand(), new NamespacesCommand(), new CreateNamespaceCommand(),
-        new DeleteNamespaceCommand(), new RenameNamespaceCommand(), new SummariesCommand()};
+        new SetTabletHostingGoalCommand(), new GetTabletHostingGoalCommand(), new OnlineCommand(),
+        new RenameTableCommand(), new TablesCommand(), new NamespacesCommand(),
+        new CreateNamespaceCommand(), new DeleteNamespaceCommand(), new RenameNamespaceCommand(),
+        new SummariesCommand()};
     Command[] tableControlCommands = {new AddSplitsCommand(), new CompactCommand(),
         new ConstraintCommand(), new FlushCommand(), new GetGroupsCommand(), new GetSplitsCommand(),
         new MergeCommand(), new SetGroupsCommand()};

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/SetTabletHostingGoalCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/SetTabletHostingGoalCommand.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.shell.commands;
+
+import java.io.IOException;
+
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.admin.TabletHostingGoal;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.shell.Shell;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.hadoop.io.Text;
+
+public class SetTabletHostingGoalCommand extends TableOperation {
+
+  private Option optRow;
+  private Option optStartRowExclusive;
+  private Option optEndRowExclusive;
+  private Option goalOpt;
+
+  private Range range;
+  private TabletHostingGoal goal;
+
+  @Override
+  public String getName() {
+    return "setgoal";
+  }
+
+  @Override
+  public String description() {
+    return "Sets the hosting goal (ALWAYS, ONDEMAND, NEVER) for a range of tablets";
+  }
+
+  @Override
+  protected void doTableOp(final Shell shellState, final String tableName)
+      throws AccumuloException, AccumuloSecurityException, TableNotFoundException, IOException {
+    shellState.getAccumuloClient().tableOperations().setTabletHostingGoal(tableName, range, goal);
+    Shell.log.debug("Set goal state: {} on table: {}, range: {}", goal, tableName, range);
+  }
+
+  @Override
+  public int execute(final String fullCommand, final CommandLine cl, final Shell shellState)
+      throws Exception {
+
+    if ((cl.hasOption(OptUtil.START_ROW_OPT) || cl.hasOption(OptUtil.END_ROW_OPT))
+        && cl.hasOption(optRow.getOpt())) {
+      // did not see a way to make commons cli do this check... it has mutually exclusive options
+      // but does not support the or
+      throw new IllegalArgumentException("Options -" + optRow.getOpt() + " AND (-"
+          + OptUtil.START_ROW_OPT + " OR -" + OptUtil.END_ROW_OPT + ") are mutually exclusive ");
+    }
+
+    if (cl.hasOption(optRow.getOpt())) {
+      this.range = new Range(new Text(cl.getOptionValue(optRow.getOpt()).getBytes(Shell.CHARSET)));
+    } else {
+      Text startRow = OptUtil.getStartRow(cl);
+      Text endRow = OptUtil.getEndRow(cl);
+      final boolean startInclusive = !cl.hasOption(optStartRowExclusive.getOpt());
+      final boolean endInclusive = !cl.hasOption(optEndRowExclusive.getOpt());
+      this.range = new Range(startRow, startInclusive, endRow, endInclusive);
+    }
+
+    this.goal = TabletHostingGoal.valueOf(cl.getOptionValue(goalOpt).toUpperCase());
+    return super.execute(fullCommand, cl, shellState);
+  }
+
+  @Override
+  public Options getOptions() {
+    Option optStartRowInclusive =
+        new Option(OptUtil.START_ROW_OPT, "begin-row", true, "begin row (inclusive)");
+    optStartRowInclusive.setArgName("begin-row");
+    optStartRowExclusive = new Option("be", "begin-exclusive", false,
+        "make start row exclusive (by default it's inclusive)");
+    optStartRowExclusive.setArgName("begin-exclusive");
+    optEndRowExclusive = new Option("ee", "end-exclusive", false,
+        "make end row exclusive (by default it's inclusive)");
+    optEndRowExclusive.setArgName("end-exclusive");
+    optRow = new Option("r", "row", true, "tablet row to modify");
+    optRow.setArgName("row");
+    goalOpt = new Option("g", "goal", true, "tablet hosting goal");
+    goalOpt.setArgName("goal");
+    goalOpt.setArgs(1);
+    goalOpt.setRequired(true);
+
+    final Options opts = super.getOptions();
+    opts.addOption(optStartRowInclusive);
+    opts.addOption(optStartRowExclusive);
+    opts.addOption(OptUtil.endRowOpt());
+    opts.addOption(optEndRowExclusive);
+    opts.addOption(optRow);
+    opts.addOption(goalOpt);
+
+    return opts;
+  }
+}

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
@@ -32,10 +32,13 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -44,6 +47,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.SortedSet;
 import java.util.regex.Pattern;
 
 import org.apache.accumulo.core.Constants;
@@ -53,6 +57,7 @@ import org.apache.accumulo.core.client.BatchScanner;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.IteratorSetting.Column;
 import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.admin.TabletHostingGoal;
 import org.apache.accumulo.core.client.sample.RowColumnSampler;
 import org.apache.accumulo.core.client.sample.RowSampler;
@@ -100,6 +105,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -1225,14 +1231,14 @@ public class ShellServerIT extends SharedMiniClusterBase {
   }
 
   @Test
-  public void goal() throws Exception {
+  public void testSetGoalCommand() throws Exception {
     final String table = getUniqueNames(1)[0];
     ts.exec("createtable " + table);
     ts.exec("addsplits -t " + table + " a c e g");
-    String result = ts.exec("goal -?");
+    String result = ts.exec("setgoal -?");
     assertTrue(result.contains("Sets the hosting goal"));
-    ts.exec("goal -t " + table + " -b a -e a -g never");
-    ts.exec("goal -t " + table + " -b c -e e -ee -g always");
+    ts.exec("setgoal -t " + table + " -b a -e a -g never");
+    ts.exec("setgoal -t " + table + " -b c -e e -ee -g always");
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build();
         Scanner s = client.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
       String tableId = client.tableOperations().tableIdMap().get(table);
@@ -1242,11 +1248,13 @@ public class ShellServerIT extends SharedMiniClusterBase {
       for (Entry<Key,Value> e : s) {
         switch (e.getKey().getRow().toString()) {
           case "1;c":
-            assertEquals(TabletHostingGoal.NEVER.name(), e.getValue().toString());
-            break;
           case "1;e":
             assertEquals(TabletHostingGoal.ALWAYS.name(), e.getValue().toString());
             break;
+          case "1;a":
+            assertEquals(TabletHostingGoal.NEVER.name(), e.getValue().toString());
+            break;
+          case "1;g":
           case "1<":
             // this tablet was loaded ondemand when we executed
             // the addsplits command
@@ -1257,6 +1265,105 @@ public class ShellServerIT extends SharedMiniClusterBase {
         }
       }
     }
+  }
+
+  @Test
+  public void testGetGoalCommand() throws IOException, TableNotFoundException {
+
+    SortedSet<Text> splits =
+        Sets.newTreeSet(Arrays.asList(new Text("d"), new Text("m"), new Text("s")));
+
+    final String tableName = getUniqueNames(1)[0];
+    java.nio.file.Path splitsFilePath = null;
+
+    try {
+      splitsFilePath = createSplitsFile("splitsFile", splits);
+
+      ts.exec("createtable " + tableName + " -sf " + splitsFilePath.toAbsolutePath(), true);
+      String result = ts.exec("getgoal -?");
+      assertTrue(result.contains("usage: getgoal"));
+
+      result = ts.exec("getgoal");
+      assertTrue(result.contains("TABLE: " + tableName));
+      assertTrue(result.contains("TABLET ID    HOSTING GOAL"));
+      assertTrue(result.contains("1;d<         ONDEMAND"));
+      assertTrue(result.contains("1;m;d        ONDEMAND"));
+      assertTrue(result.contains("1;s;m        ONDEMAND"));
+      assertTrue(result.contains("1<;s         ONDEMAND"));
+
+      ts.exec("setgoal -g ALWAYS -r p");
+      result = ts.exec("getgoal -r p");
+      assertFalse(result.contains("1;d<         ONDEMAND"));
+      assertFalse(result.contains("1;m;d        ONDEMAND"));
+      assertTrue(result.contains("1;s;m        ALWAYS"));
+      assertFalse(result.contains("1<;s         ONDEMAND"));
+
+      result = ts.exec("getgoal");
+      assertTrue(result.contains("1;d<         ONDEMAND"));
+      assertTrue(result.contains("1;m;d        ONDEMAND"));
+      assertTrue(result.contains("1;s;m        ALWAYS"));
+      assertTrue(result.contains("1<;s         ONDEMAND"));
+
+      result = ts.exec("getgoal -b f -e p");
+      assertFalse(result.contains("1;d<         ONDEMAND"));
+      assertTrue(result.contains("1;m;d        ONDEMAND"));
+      assertTrue(result.contains("1;s;m        ALWAYS"));
+      assertFalse(result.contains("1<;s         ONDEMAND"));
+
+    } finally {
+      if (splitsFilePath != null) {
+        Files.delete(splitsFilePath);
+      }
+    }
+  }
+
+  // Verify that when splits are added after table creation, hosting goals are set properly
+  @Test
+  public void testGetGoalCommand_DelayedSplits() throws IOException {
+
+    final String[] tableName = getUniqueNames(2);
+
+    ts.exec("createtable " + tableName[0], true);
+    String result = ts.exec("getgoal");
+    assertTrue(result.contains("TABLE: " + tableName[0]));
+    assertTrue(result.contains("TABLET ID    HOSTING GOAL"));
+    assertTrue(result.contains("1<<          ONDEMAND"));
+
+    // add the splits and check goals again
+    ts.exec("addsplits d m s", true);
+    result = ts.exec("getgoal");
+    assertTrue(result.contains("1;d<         ONDEMAND"));
+    assertTrue(result.contains("1;m;d        ONDEMAND"));
+    assertTrue(result.contains("1;s;m        ONDEMAND"));
+    assertTrue(result.contains("1<;s         ONDEMAND"));
+
+    // scan metadata table to be sure the hosting goals were properly set
+    result = ts.exec("scan -t accumulo.metadata -c hosting:goal", true);
+    assertTrue(result.contains("1;d hosting:goal []\tONDEMAND"));
+    assertTrue(result.contains("1;m hosting:goal []\tONDEMAND"));
+    assertTrue(result.contains("1;s hosting:goal []\tONDEMAND"));
+    assertTrue(result.contains("1< hosting:goal []\tONDEMAND"));
+
+    ts.exec("createtable " + tableName[1] + " -g always", true);
+    result = ts.exec("getgoal");
+    assertTrue(result.contains("TABLE: " + tableName[1]));
+    assertTrue(result.contains("TABLET ID    HOSTING GOAL"));
+    assertTrue(result.contains("2<<          ALWAYS"));
+
+    ts.exec("addsplits d m s", true);
+    result = ts.exec("getgoal");
+    assertTrue(result.contains("2;d<         ALWAYS"));
+    assertTrue(result.contains("2;m;d        ALWAYS"));
+    assertTrue(result.contains("2;s;m        ALWAYS"));
+    assertTrue(result.contains("2<;s         ALWAYS"));
+
+    // scan metadata table to be sure the hosting goals were properly set
+    result = ts.exec("scan -t accumulo.metadata -c hosting:goal -b 2", true);
+    assertTrue(result.contains("2;d hosting:goal []\tALWAYS"));
+    assertTrue(result.contains("2;m hosting:goal []\tALWAYS"));
+    assertTrue(result.contains("2;s hosting:goal []\tALWAYS"));
+    assertTrue(result.contains("2< hosting:goal []\tALWAYS"));
+
   }
 
   @Test
@@ -2206,4 +2313,15 @@ public class ShellServerIT extends SharedMiniClusterBase {
     }
   }
 
+  private java.nio.file.Path createSplitsFile(final String splitsFile, final SortedSet<Text> splits)
+      throws IOException {
+    String fullSplitsFile = System.getProperty("user.dir") + "/target/" + splitsFile;
+    java.nio.file.Path path = Paths.get(fullSplitsFile);
+    try (BufferedWriter writer = Files.newBufferedWriter(path, UTF_8)) {
+      for (Text text : splits) {
+        writer.write(text.toString() + '\n');
+      }
+    }
+    return path;
+  }
 }


### PR DESCRIPTION
Add an API method for obtaining hosting goals for a tablet. This PR creates the new API method and also the corresponding shell command.

In order to simplify setting and retrieving hosting goals the previously created shell command, 'goal', which sets hosting goals was renamed to 'setgoal'. The shell command to retrieve hosting goals is named 'getgoal'.

Change summary:

* A class, HostingGoalForTablet, was created to hold the hosting goal informtion from a tablet query.
* TableOperations class was updated to contain the 'getTabletHostingGoal' API method.
* TabletOperationsImpl class was updated to contain the API implementation details.
* A simple typo was corrected in the KeyExtent class.
* Shell class modifications include updating the TableCommands section with the new GetTabletHostingGoalsCommand and renaming the TabletHostingGoalCommand to SetTabletHostingGoalCommand.
* Corrected a minor issue in the renamed SetTabletHostingGoalCommand usage statement. The statement was incorrectly using 'range' rather than 'row' in its output.
* Created a new class, GetTabletHostingGoalCommand.
* Wrote integration tests for both the API and Shell commands.

Closes #3302 
