### PR TITLE
fail when unknown config seen in cluster.yaml

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/cluster/ClusterConfigParser.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/cluster/ClusterConfigParser.java
@@ -97,19 +97,11 @@ public class ClusterConfigParser {
 
   public static void outputShellVariables(Map<String,String> config, PrintStream out) {
 
-    config.keySet().forEach(section -> {
-      if (VALID_CONFIG_KEYS.contains(section)) {
-        return;
-      }
-
-      for (String validPrefix : VALID_CONFIG_PREFIXES) {
-        if (section.startsWith(validPrefix)) {
-          return;
-        }
-      }
-
-      throw new IllegalArgumentException("Unknown configuration section : " + section);
-    });
+    // find invalid config sections and point the user to the first one
+    config.keySet().stream().filter(VALID_CONFIG_SECTIONS.negate()).findFirst()
+        .ifPresent(section -> {
+          throw new IllegalArgumentException("Unknown configuration section : " + section);
+        });
 
     for (String section : SECTIONS) {
       if (config.containsKey(section)) {

--- a/core/src/main/java/org/apache/accumulo/core/conf/cluster/ClusterConfigParser.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/cluster/ClusterConfigParser.java
@@ -43,8 +43,12 @@ public class ClusterConfigParser {
   private static final Set<String> VALID_CONFIG_KEYS = Set.of("manager", "monitor", "gc", "tserver",
       "tservers_per_host", "sservers_per_host", "compaction.coordinator");
 
-  private static final String[] VALID_CONFIG_PREFIXES =
-      new String[] {"compaction.compactor.", "sserver."};
+  private static final Set<String> VALID_CONFIG_PREFIXES =
+      Set.of("compaction.compactor.", "sserver.");
+
+  private static final Predicate<String> VALID_CONFIG_SECTIONS =
+      section -> VALID_CONFIG_KEYS.contains(section)
+          || VALID_CONFIG_PREFIXES.stream().anyMatch(section::startsWith);
 
   @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
   public static Map<String,String> parseConfiguration(String configFile) throws IOException {

--- a/core/src/main/java/org/apache/accumulo/core/conf/cluster/ClusterConfigParser.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/cluster/ClusterConfigParser.java
@@ -40,6 +40,12 @@ public class ClusterConfigParser {
   private static final String PROPERTY_FORMAT = "%s=\"%s\"%n";
   private static final String[] SECTIONS = new String[] {"manager", "monitor", "gc", "tserver"};
 
+  private static final Set<String> VALID_CONFIG_KEYS = Set.of("manager", "monitor", "gc", "tserver",
+      "tservers_per_host", "sservers_per_host", "compaction.coordinator");
+
+  private static final String[] VALID_CONFIG_PREFIXES =
+      new String[] {"compaction.compactor.", "sserver."};
+
   @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
   public static Map<String,String> parseConfiguration(String configFile) throws IOException {
     Map<String,String> results = new HashMap<>();
@@ -86,6 +92,20 @@ public class ClusterConfigParser {
   }
 
   public static void outputShellVariables(Map<String,String> config, PrintStream out) {
+
+    config.keySet().forEach(section -> {
+      if (VALID_CONFIG_KEYS.contains(section)) {
+        return;
+      }
+
+      for (String validPrefix : VALID_CONFIG_PREFIXES) {
+        if (section.startsWith(validPrefix)) {
+          return;
+        }
+      }
+
+      throw new IllegalArgumentException("Unknown configuration section : " + section);
+    });
 
     for (String section : SECTIONS) {
       if (config.containsKey(section)) {

--- a/core/src/main/java/org/apache/accumulo/core/conf/cluster/ClusterConfigParser.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/cluster/ClusterConfigParser.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.yaml.snakeyaml.Yaml;

--- a/core/src/test/java/org/apache/accumulo/core/conf/cluster/ClusterConfigParserTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/cluster/ClusterConfigParserTest.java
@@ -253,14 +253,10 @@ public class ClusterConfigParserTest {
     Map<String,String> contents =
         ClusterConfigParser.parseConfiguration(new File(configFile.toURI()).getAbsolutePath());
 
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    PrintStream ps = new PrintStream(baos);
-
-    var exception = assertThrows(IllegalArgumentException.class,
-        () -> ClusterConfigParser.outputShellVariables(contents, System.out));
-
-    assertTrue(exception.getMessage().contains("vserver"));
-
-    ps.close();
+    try (var baos = new ByteArrayOutputStream(); var ps = new PrintStream(baos)) {
+      var exception = assertThrows(IllegalArgumentException.class,
+          () -> ClusterConfigParser.outputShellVariables(contents, System.out));
+      assertTrue(exception.getMessage().contains("vserver"));
+    }
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/conf/cluster/ClusterConfigParserTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/cluster/ClusterConfigParserTest.java
@@ -21,10 +21,12 @@ package org.apache.accumulo.core.conf.cluster;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -242,4 +244,23 @@ public class ClusterConfigParserTest {
     assertEquals(expected, actual);
   }
 
+  @Test
+  public void testFileWithUnknownSections() throws Exception {
+    URL configFile = ClusterConfigParserTest.class
+        .getResource("/org/apache/accumulo/core/conf/cluster/bad-cluster.yaml");
+    assertNotNull(configFile);
+
+    Map<String,String> contents =
+        ClusterConfigParser.parseConfiguration(new File(configFile.toURI()).getAbsolutePath());
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    PrintStream ps = new PrintStream(baos);
+
+    var exception = assertThrows(IllegalArgumentException.class,
+        () -> ClusterConfigParser.outputShellVariables(contents, System.out));
+
+    assertTrue(exception.getMessage().contains("vserver"));
+
+    ps.close();
+  }
 }

--- a/core/src/test/java/org/apache/accumulo/core/conf/cluster/ClusterConfigParserTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/cluster/ClusterConfigParserTest.java
@@ -255,7 +255,7 @@ public class ClusterConfigParserTest {
 
     try (var baos = new ByteArrayOutputStream(); var ps = new PrintStream(baos)) {
       var exception = assertThrows(IllegalArgumentException.class,
-          () -> ClusterConfigParser.outputShellVariables(contents, System.out));
+          () -> ClusterConfigParser.outputShellVariables(contents, ps));
       assertTrue(exception.getMessage().contains("vserver"));
     }
   }

--- a/core/src/test/resources/org/apache/accumulo/core/conf/cluster/bad-cluster.yaml
+++ b/core/src/test/resources/org/apache/accumulo/core/conf/cluster/bad-cluster.yaml
@@ -1,0 +1,53 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+manager:
+  - localhost1
+  - localhost2
+
+monitor:
+  - localhost1
+  - localhost2
+
+gc:
+  - localhost
+
+tserver:
+  - localhost1
+  - localhost2
+  - localhost3
+  - localhost4
+
+vserver:
+  - localhost5
+  - localhost6
+  - localhost7
+  - localhost8
+
+#compaction:
+#  coordinator:
+#    - localhost1
+#    - localhost2
+#  compactor:
+#    - q1:
+#        - localhost1
+#        - localhost2
+#    - q2:
+#        - localhost1
+#        - localhost2

--- a/core/src/test/resources/org/apache/accumulo/core/conf/cluster/bad-cluster.yaml
+++ b/core/src/test/resources/org/apache/accumulo/core/conf/cluster/bad-cluster.yaml
@@ -34,6 +34,7 @@ tserver:
   - localhost3
   - localhost4
 
+# The following section name is not valid and should cause an error.
 vserver:
   - localhost5
   - localhost6


### PR DESCRIPTION
Parsing of the cluster.yaml file would ignore unrecognized config keys before this changes.  After this change it should throw an exception.