### PR TITLE
fixes bulk import filename prefix

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/PrepBulkImport.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/PrepBulkImport.java
@@ -242,7 +242,7 @@ public class PrepBulkImport extends ManagerRepo {
 
     for (FileStatus file : files) {
       // since these are only valid files we know it has an extension
-      String newName = FilePrefix.BULK_IMPORT + namer.getNextName() + "."
+      String newName = FilePrefix.BULK_IMPORT.toPrefix() + namer.getNextName() + "."
           + FilenameUtils.getExtension(file.getPath().getName());
       oldToNewNameMap.put(file.getPath().getName(), new Path(bulkDir, newName).getName());
     }


### PR DESCRIPTION
Before this change bulk import files ended up with a name like BULK_IMPORT000008h.rf after this change the name would be I000008h.rf instead.