### PR TITLE
TabletGroupWatcher update to handle servers being shutdown

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
@@ -149,16 +149,13 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
     private final List<TabletLocationState> suspendedToGoneServers = new ArrayList<>();
     private final Map<KeyExtent,UnassignedTablet> unassigned = new HashMap<>();
     private final Map<TServerInstance,List<Path>> logsForDeadServers = new TreeMap<>();
-    // read only lists of tablet servers
-    private final SortedMap<TServerInstance,TabletServerStatus> currentTServers;
-    private final SortedMap<TServerInstance,TabletServerStatus> destinations;
+    // read only list of tablet servers that are not shutting down
+    private final SortedMap<TServerInstance,TabletServerStatus> validAssignmentDestinations;
 
     public TabletLists(Manager m, SortedMap<TServerInstance,TabletServerStatus> curTServers) {
       var destinationsMod = new TreeMap<>(curTServers);
-      // Don't move tablets to servers that are shutting down
       destinationsMod.keySet().removeAll(m.serversToShutdown);
-      this.destinations = Collections.unmodifiableSortedMap(destinationsMod);
-      this.currentTServers = Collections.unmodifiableSortedMap(curTServers);
+      this.validAssignmentDestinations = Collections.unmodifiableSortedMap(destinationsMod);
     }
 
     public void reset() {
@@ -389,7 +386,7 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
     TServerInstance dest = manager.migrations.get(tablet);
     if (dest != null) {
       // if destination is still good, assign it
-      if (tLists.destinations.containsKey(dest)) {
+      if (tLists.validAssignmentDestinations.containsKey(dest)) {
         tLists.assignments.add(new Assignment(tablet, dest, unassignedTablet.getLastLocation()));
       } else {
         // get rid of this migration
@@ -407,7 +404,7 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
         < tableConf.getTimeInMillis(Property.TABLE_SUSPEND_DURATION)) {
       // Tablet is suspended. See if its tablet server is back.
       TServerInstance returnInstance = null;
-      Iterator<TServerInstance> find = tLists.destinations
+      Iterator<TServerInstance> find = tLists.validAssignmentDestinations
           .tailMap(new TServerInstance(tls.suspend.server, " ")).keySet().iterator();
       if (find.hasNext()) {
         TServerInstance found = find.next();
@@ -905,13 +902,13 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
 
   private void getAssignmentsFromBalancer(TabletLists tLists,
       Map<KeyExtent,UnassignedTablet> unassigned) {
-    if (!tLists.currentTServers.isEmpty()) {
+    if (!tLists.validAssignmentDestinations.isEmpty()) {
       Map<KeyExtent,TServerInstance> assignedOut = new HashMap<>();
-      manager.getAssignments(tLists.currentTServers, unassigned, assignedOut);
+      manager.getAssignments(tLists.validAssignmentDestinations, unassigned, assignedOut);
       for (Entry<KeyExtent,TServerInstance> assignment : assignedOut.entrySet()) {
         if (unassigned.containsKey(assignment.getKey())) {
           if (assignment.getValue() != null) {
-            if (!tLists.currentTServers.containsKey(assignment.getValue())) {
+            if (!tLists.validAssignmentDestinations.containsKey(assignment.getValue())) {
               Manager.log.warn(
                   "balancer assigned {} to a tablet server that is not current {} ignoring",
                   assignment.getKey(), assignment.getValue());
@@ -919,16 +916,6 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
             }
 
             final UnassignedTablet unassignedTablet = unassigned.get(assignment.getKey());
-            final TServerInstance serverInstance =
-                unassignedTablet != null ? unassignedTablet.getServerInstance() : null;
-            if (serverInstance != null
-                && !assignment.getValue().getHostPort().equals(serverInstance.getHostPort())) {
-              Manager.log.warn(
-                  "balancer assigned {} to {} which is not the suggested location of {}",
-                  assignment.getKey(), assignment.getValue().getHostPort(),
-                  serverInstance.getHostPort());
-            }
-
             tLists.assignments.add(new Assignment(assignment.getKey(), assignment.getValue(),
                 unassignedTablet != null ? unassignedTablet.getLastLocation() : null));
           }


### PR DESCRIPTION
The change updates TabletGroupWatcher to remove servers being shutdown from being sent as candidates for assignment. There was previous logic (e.g. v1.10) that filtered the servers being shutdown from being included in the candidate list. 

Verified that on t-server shutdown the tablets are unloaded and assigned to a different host (with HostRegexTableLoadBalancer).
```
# Configured system with sample tablets; and 5 t-servers:
# Shutdown one t-server:
$> bin/accumulo admin stop localhost:9997

# Manager logs report unload and t-server being shutdown is not in candidate list:
...
[manager.EventCoordinator] INFO : tablet 1;20230601_1728;20230601_1727 was unloaded from localhost:9997
...
[balancer.HostRegexTableLoadBalancer] DEBUG: Sending 40 tablets to balancer for table test_1 for assignment 
  within tservers [localhost:10000[10001cc843d0007], localhost:10003[10001cc843d000a],
  localhost:10004[10001cc843d000b], localhost:10005[10001cc843d000c]]
```

Closes #3368 