### PR TITLE
Don't use small-caps in monitor

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/css/screen.css
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/css/screen.css
@@ -73,7 +73,6 @@ body {
 
 h1 {
   font-size: 2.2em;
-  font-variant: small-caps;
   text-align: center;
 }
 
@@ -164,7 +163,6 @@ th {
   border-left: 1px #333333 dotted;
   border-right: 0;
   text-align: center;
-  font-variant: small-caps;
   padding-left: 0.5em;
   padding-right: 0.5em;
   padding-top: 0.2em;
@@ -235,7 +233,6 @@ pre.logevent {
 
 .table-caption {
   font-size: 2em;
-  font-variant: small-caps;
   text-align: center;
 }
 


### PR DESCRIPTION
Small caps might look nicer, but it's harder to read and can make some case-sensitive items to appear to be upper case when they are lower. This is especially important for table names.

This was identified as a potential problem in https://github.com/apache/accumulo/issues/3489#issuecomment-1590010243