### PR TITLE
StoredTabletFile should lazy load ReferencedTabletFile

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/AbstractTabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/AbstractTabletFile.java
@@ -37,7 +37,6 @@ public abstract class AbstractTabletFile<T extends AbstractTabletFile<T>>
   protected AbstractTabletFile(Path path) {
     this.path = Objects.requireNonNull(path);
     this.fileName = path.getName();
-    ValidationUtil.validateFileName(fileName);
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/metadata/ReferencedTabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/ReferencedTabletFile.java
@@ -56,6 +56,9 @@ public class ReferencedTabletFile extends AbstractTabletFile<ReferencedTabletFil
     String errorMsg = "Missing or invalid part of tablet file metadata entry: " + metaPath;
     log.trace("Parsing TabletFile from {}", metaPath);
 
+    // Validate characters in file name
+    ValidationUtil.validateFileName(path.getName());
+
     // use Path object to step backwards from the filename through all the parts
     Path tabletDirPath = Objects.requireNonNull(metaPath.getParent(), errorMsg);
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/StoredTabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/StoredTabletFile.java
@@ -19,10 +19,13 @@
 package org.apache.accumulo.core.metadata;
 
 import java.util.Objects;
+import java.util.function.Supplier;
 
 import org.apache.accumulo.core.data.TableId;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
+
+import com.google.common.base.Suppliers;
 
 /**
  * Object representing a tablet file entry stored in the metadata table. Keeps a string of the exact
@@ -37,7 +40,7 @@ import org.apache.hadoop.io.Text;
  */
 public class StoredTabletFile extends AbstractTabletFile<StoredTabletFile> {
   private final String metadataEntry;
-  private final ReferencedTabletFile referencedTabletFile;
+  private final Supplier<ReferencedTabletFile> referencedTabletFile;
 
   /**
    * Construct a tablet file using the string read from the metadata. Preserve the exact string so
@@ -46,7 +49,7 @@ public class StoredTabletFile extends AbstractTabletFile<StoredTabletFile> {
   public StoredTabletFile(String metadataEntry) {
     super(new Path(metadataEntry));
     this.metadataEntry = metadataEntry;
-    this.referencedTabletFile = ReferencedTabletFile.of(getPath());
+    this.referencedTabletFile = Suppliers.memoize(() -> ReferencedTabletFile.of(getPath()));
   }
 
   /**
@@ -66,15 +69,15 @@ public class StoredTabletFile extends AbstractTabletFile<StoredTabletFile> {
   }
 
   public ReferencedTabletFile getTabletFile() {
-    return referencedTabletFile;
+    return referencedTabletFile.get();
   }
 
   public TableId getTableId() {
-    return referencedTabletFile.getTableId();
+    return referencedTabletFile.get().getTableId();
   }
 
   public String getNormalizedPathStr() {
-    return referencedTabletFile.getNormalizedPathStr();
+    return referencedTabletFile.get().getNormalizedPathStr();
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/metadata/UnreferencedTabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/UnreferencedTabletFile.java
@@ -42,6 +42,7 @@ public class UnreferencedTabletFile extends AbstractTabletFile<UnreferencedTable
 
   public UnreferencedTabletFile(FileSystem fs, Path path) {
     super(Objects.requireNonNull(fs).makeQualified(Objects.requireNonNull(path)));
+    ValidationUtil.validateFileName(path.getName());
   }
 
   @Override


### PR DESCRIPTION
This improves performance during GC cycles by about 3x because creating a `ReferencedTabletFile` does a lot of validation which can be slow due to the calls to Path.getParent() if there are several files created. Filename validation was also removed from the constructor as well to further improve performance. This PR is a follow on to #3501 for #3500 in main.

Removing/delaying the validation checks should be safe because a `StoredTabletFile` references an existing Tablet file that was already stored in Metadata so the Path has already been validated before. Also, the `ReferencedTabletFile` is not needed often so it makes sense to delay the creation/validation until it's actually needed.

It turns out that the refactoring I just did in #3417 made this super easy because the bottleneck is primarily the validation and calling Path.getParent() (not the actual creation of the Path object) which is now only done when accessing a ReferencedTabletFile. This would be harder to fix in 2.1.x due to the inheritance.

#### Benchmark _before_ this change running against main:

```
Warmup Iteration   1: 0.017 ms/op
Iteration   1: 0.012 ms/op
Iteration   2: 0.012 ms/op
Iteration   3: 0.011 ms/op

0.012 ±(99.9%) 0.008 ms/op [Average]
(min, avg, max) = (0.011, 0.012, 0.012), stdev = 0.001
CI (99.9%): [0.003, 0.020] (assumes normal distribution)
```

#### Benchmark _after_ this change running against main:

```
Warmup Iteration   1: 0.007 ms/op
Iteration   1: 0.004 ms/op
Iteration   2: 0.004 ms/op
Iteration   3: 0.004 ms/op

0.004 ±(99.9%) 0.002 ms/op [Average]
(min, avg, max) = (0.004, 0.004, 0.004), stdev = 0.001
CI (99.9%): [0.002, 0.007] (assumes normal distribution)
```

