### PR TITLE
fix low memory detector and test updates

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/mem/LowMemoryDetector.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/mem/LowMemoryDetector.java
@@ -139,16 +139,16 @@ public class LowMemoryDetector {
       final long allocatedMemory = rt.totalMemory();
       final long allocatedFreeMemory = rt.freeMemory();
       final long freeMemory = maxConfiguredMemory - (allocatedMemory - allocatedFreeMemory);
-      final double lowMemoryThreshold = maxConfiguredMemory * freeMemoryPercentage;
+      final long lowMemoryThreshold = (long) (maxConfiguredMemory * freeMemoryPercentage);
       LOG.trace("Memory info: max={}, allocated={}, free={}, free threshold={}",
-          maxConfiguredMemory, allocatedMemory, freeMemory, (long) lowMemoryThreshold);
+          maxConfiguredMemory, allocatedMemory, freeMemory, lowMemoryThreshold);
 
-      if (freeMemory < (long) lowMemoryThreshold) {
+      if (freeMemory < lowMemoryThreshold) {
         lowMemCount++;
         if (lowMemCount > 3 && !runningLowOnMemory) {
           runningLowOnMemory = true;
           LOG.warn("Running low on memory: max={}, allocated={}, free={}, free threshold={}",
-              maxConfiguredMemory, allocatedMemory, freeMemory, (long) lowMemoryThreshold);
+              maxConfiguredMemory, allocatedMemory, freeMemory, lowMemoryThreshold);
         }
       } else {
         // If we were running low on memory, but are not any longer, than log at warn
@@ -166,12 +166,7 @@ public class LowMemoryDetector {
         sawChange = true;
       }
 
-      String sign = "+";
-      if (freeMemory - lastMemorySize <= 0) {
-        sign = "";
-      }
-
-      sb.append(String.format(" freemem=%,d(%s%,d) totalmem=%,d", freeMemory, sign,
+      sb.append(String.format(" freemem=%,d(%+,d) totalmem=%,d", freeMemory,
           (freeMemory - lastMemorySize), rt.totalMemory()));
 
       if (sawChange) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/MemoryFreeingIterator.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MemoryFreeingIterator.java
@@ -20,13 +20,6 @@ package org.apache.accumulo.test.functional;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-import java.io.IOException;
-import java.util.Map;
-
-import org.apache.accumulo.core.data.Key;
-import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.iterators.IteratorEnvironment;
-import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iterators.WrappingIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,29 +31,14 @@ public class MemoryFreeingIterator extends WrappingIterator {
   private static final Logger LOG = LoggerFactory.getLogger(MemoryFreeingIterator.class);
 
   @SuppressFBWarnings(value = "DM_GC", justification = "gc is okay for test")
-  public MemoryFreeingIterator() {
-    super();
-    LOG.info("Freeing consumed memory");
+  public MemoryFreeingIterator() throws InterruptedException {
+    LOG.info("Try to free consumed memory - will block until isRunningLowOnMemory returns false.");
     MemoryConsumingIterator.freeBuffers();
     while (this.isRunningLowOnMemory()) {
       System.gc();
       // wait for LowMemoryDetector to recognize the memory is free.
-      try {
-        Thread.sleep(SECONDS.toMillis(1));
-      } catch (InterruptedException ex) {
-        Thread.currentThread().interrupt();
-        throw new RuntimeException("wait for low memory detector interrupted", ex);
-      }
+      Thread.sleep(SECONDS.toMillis(1));
     }
-    LOG.info("Consumed memory freed");
+    LOG.info("isRunningLowOnMemory returned false - memory available");
   }
-
-  @Override
-  @SuppressFBWarnings(value = "DM_GC", justification = "gc is okay for test")
-  public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options,
-      IteratorEnvironment env) throws IOException {
-    super.init(source, options, env);
-    LOG.info("init call - should free consumed memory");
-  }
-
 }

--- a/test/src/main/java/org/apache/accumulo/test/functional/MemoryFreeingIterator.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MemoryFreeingIterator.java
@@ -60,19 +60,7 @@ public class MemoryFreeingIterator extends WrappingIterator {
   public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options,
       IteratorEnvironment env) throws IOException {
     super.init(source, options, env);
-    // LOG.info("Freeing consumed memory");
-    // MemoryConsumingIterator.freeBuffers();
-    // while (this.isRunningLowOnMemory()) {
-    // System.gc();
-    // // wait for LowMemoryDetector to recognize the memory is free.
-    // try {
-    // Thread.sleep(SECONDS.toMillis(1));
-    // } catch (InterruptedException ex) {
-    // Thread.currentThread().interrupt();
-    // throw new IOException("wait for low memory detector interrupted", ex);
-    // }
-    // }
-    // LOG.info("Consumed memory freed");
+    LOG.info("init call - should free consumed memory");
   }
 
 }

--- a/test/src/main/java/org/apache/accumulo/test/functional/MemoryStarvedMajCIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MemoryStarvedMajCIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.test.functional;
 
+import static org.apache.accumulo.test.util.Wait.assertTrueWithRetry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -148,12 +149,9 @@ public class MemoryStarvedMajCIT extends SharedMiniClusterBase {
         ReadWriteIT.ingest(client, 100, 100, 100, 0, table);
         compactionThread.start();
 
-        while (paused <= 0) {
-          Thread.sleep(1000);
-          paused = MAJC_PAUSED.intValue();
-        }
+        assertTrueWithRetry(() -> MAJC_PAUSED.intValue() > 0);
 
-        MemoryStarvedScanIT.freeServerMemory(client, table);
+        MemoryStarvedScanIT.freeServerMemory(client);
         compactionThread.interrupt();
         compactionThread.join();
         assertNull(error.get());

--- a/test/src/main/java/org/apache/accumulo/test/functional/MemoryStarvedMajCIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MemoryStarvedMajCIT.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static org.apache.accumulo.test.util.Wait.assertTrueWithRetry;
+import static org.apache.accumulo.test.util.Wait.waitFor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -149,7 +149,7 @@ public class MemoryStarvedMajCIT extends SharedMiniClusterBase {
         ReadWriteIT.ingest(client, 100, 100, 100, 0, table);
         compactionThread.start();
 
-        assertTrueWithRetry(() -> MAJC_PAUSED.intValue() > 0);
+        assertTrue(waitFor(() -> MAJC_PAUSED.intValue() > 0));
 
         MemoryStarvedScanIT.freeServerMemory(client);
         compactionThread.interrupt();

--- a/test/src/main/java/org/apache/accumulo/test/functional/MemoryStarvedMinCIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MemoryStarvedMinCIT.java
@@ -153,7 +153,7 @@ public class MemoryStarvedMinCIT extends SharedMiniClusterBase {
           paused = MINC_PAUSED.intValue();
         }
 
-        MemoryStarvedScanIT.freeServerMemory(client, table);
+        MemoryStarvedScanIT.freeServerMemory(client);
         ingestThread.interrupt();
         ingestThread.join();
         assertNull(error.get());

--- a/test/src/main/java/org/apache/accumulo/test/functional/MemoryStarvedScanIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MemoryStarvedScanIT.java
@@ -492,10 +492,10 @@ public class MemoryStarvedScanIT extends SharedMiniClusterBase {
 
         // check across multiple low memory checks and metric updates that low memory detected
         // remains set
-        int checkCount = 6;
-        while (checkCount-- > 0) {
+        int checkCount = 0;
+        while (checkCount++ < 5) {
           Thread.sleep(5_000);
-          LOG.debug("Check low memory still set. Low Memeory Flag: {}, Check count: {}",
+          LOG.debug("Check low memory still set. Low Memory Flag: {}, Check count: {}",
               LOW_MEM_DETECTED.get(), checkCount);
           assertEquals(1, LOW_MEM_DETECTED.get());
         }

--- a/test/src/main/java/org/apache/accumulo/test/functional/MemoryStarvedScanIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MemoryStarvedScanIT.java
@@ -19,6 +19,8 @@
 package org.apache.accumulo.test.functional;
 
 import static org.apache.accumulo.core.metrics.MetricsProducer.METRICS_LOW_MEMORY;
+import static org.apache.accumulo.test.util.Wait.assertTrueWithRetry;
+import static org.apache.accumulo.test.util.Wait.waitFor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -40,6 +42,7 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.WrappingIterator;
 import org.apache.accumulo.core.metrics.MetricsProducer;
 import org.apache.accumulo.harness.MiniClusterConfigurationCallback;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
@@ -54,6 +57,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MemoryStarvedScanIT extends SharedMiniClusterBase {
 
@@ -83,6 +88,7 @@ public class MemoryStarvedScanIT extends SharedMiniClusterBase {
 
   public static final double FREE_MEMORY_THRESHOLD = 0.20D;
 
+  private static final Logger LOG = LoggerFactory.getLogger(MemoryStarvedScanIT.class);
   private static final DoubleAdder SCAN_START_DELAYED = new DoubleAdder();
   private static final DoubleAdder SCAN_RETURNED_EARLY = new DoubleAdder();
   private static final AtomicInteger LOW_MEM_DETECTED = new AtomicInteger(0);
@@ -132,11 +138,16 @@ public class MemoryStarvedScanIT extends SharedMiniClusterBase {
   }
 
   @BeforeEach
-  public void beforeEach() {
+  public void beforeEach() throws Exception {
+    // Free the server side memory
+    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
+      freeServerMemory(client);
+    }
+    // allow metric collection to cycle and metric value to reset to zero
+    waitFor(() -> 0 == LOW_MEM_DETECTED.get());
     // Reset the client side counters
     SCAN_START_DELAYED.reset();
     SCAN_START_DELAYED.reset();
-    LOW_MEM_DETECTED.set(0);
   }
 
   static void consumeServerMemory(Scanner scanner) {
@@ -162,13 +173,11 @@ public class MemoryStarvedScanIT extends SharedMiniClusterBase {
     assertTrue(iter.hasNext());
   }
 
-  static void freeServerMemory(AccumuloClient client, String table) throws Exception {
-    try (Scanner scanner = client.createScanner(table)) {
-      scanner.addScanIterator(new IteratorSetting(11, MemoryFreeingIterator.class, Map.of()));
-      @SuppressWarnings("unused")
-      Iterator<Entry<Key,Value>> iter = scanner.iterator(); // init'ing the iterator should be
-                                                            // enough to free the memory
-    }
+  static void freeServerMemory(AccumuloClient client) throws Exception {
+    // Instantiating this class on the TabletServer will free the memory as it
+    // frees the buffers created by the MemoryConsumingIterator in its constructor.
+    client.instanceOperations().testClassLoad(MemoryFreeingIterator.class.getName(),
+        WrappingIterator.class.getCanonicalName());
   }
 
   @Test
@@ -183,19 +192,16 @@ public class MemoryStarvedScanIT extends SharedMiniClusterBase {
       ReadWriteIT.ingest(client, 10, 10, 10, 0, table);
 
       try (Scanner scanner = client.createScanner(table)) {
-        double returned = SCAN_RETURNED_EARLY.doubleValue();
-        double paused = SCAN_START_DELAYED.doubleValue();
+        final double returned = SCAN_RETURNED_EARLY.doubleValue();
+        final double paused = SCAN_START_DELAYED.doubleValue();
 
         consumeServerMemory(scanner);
 
-        // Wait for longer than the memory check interval
-        Thread.sleep(6_000);
+        // Wait for The metric that indicates a scan was returned early due to low memory
+        waitFor(() -> SCAN_RETURNED_EARLY.doubleValue() > returned
+            && SCAN_START_DELAYED.doubleValue() >= paused);
 
-        // The metric that indicates a scan was returned early due to low memory should
-        // have been incremented.
-        assertTrue(SCAN_RETURNED_EARLY.doubleValue() > returned);
-        assertTrue(SCAN_START_DELAYED.doubleValue() >= paused);
-        freeServerMemory(client, table);
+        freeServerMemory(client);
       } finally {
         to.delete(table);
       }
@@ -236,6 +242,7 @@ public class MemoryStarvedScanIT extends SharedMiniClusterBase {
         memoryConsumingScanner.setReadaheadThreshold(Long.MAX_VALUE);
 
         t.start();
+        LOG.info("Waiting for memory to be consumed");
 
         // Wait until the dataConsumingScanner has started fetching data
         int currentCount = fetched.get();
@@ -252,30 +259,32 @@ public class MemoryStarvedScanIT extends SharedMiniClusterBase {
         // Confirm that some data was fetched by the memoryConsumingScanner
         currentCount = fetched.get();
         assertTrue(currentCount > 0 && currentCount < 100);
+        LOG.info("Memory consumed");
 
         // Grab the current metric counts, wait
-        double returned = SCAN_RETURNED_EARLY.doubleValue();
-        double paused = SCAN_START_DELAYED.doubleValue();
+        final double returned = SCAN_RETURNED_EARLY.doubleValue();
+        final double paused = SCAN_START_DELAYED.doubleValue();
         Thread.sleep(1500);
         // One of two conditions could exist here:
         // The number of fetched rows equals the current count before the wait above
         // and the SCAN_START_DELAYED has been incremented OR the number of fetched
         // rows is one more than the current count and the SCAN_RETURNED_EARLY has
         // been incremented.
-        assertTrue((currentCount == fetched.get() && SCAN_START_DELAYED.doubleValue() > paused)
-            || (currentCount + 1 == fetched.get() && SCAN_RETURNED_EARLY.doubleValue() > returned));
+        final int currentCountCopy = currentCount;
+        waitFor(
+            () -> (currentCountCopy == fetched.get() && SCAN_START_DELAYED.doubleValue() > paused)
+                || (currentCountCopy + 1 == fetched.get()
+                    && SCAN_RETURNED_EARLY.doubleValue() > returned));
         currentCount = fetched.get();
 
         // Perform the check again
-        paused = SCAN_START_DELAYED.doubleValue();
-        returned = SCAN_RETURNED_EARLY.doubleValue();
-        Thread.sleep(1500);
+        assertTrueWithRetry(() -> 1 == LOW_MEM_DETECTED.get());
         assertEquals(currentCount, fetched.get());
 
-        assertEquals(1, LOW_MEM_DETECTED.get());
-
         // Free the memory which will allow the pausing scanner to continue
-        freeServerMemory(client, table);
+        LOG.info("Freeing memory");
+        freeServerMemory(client);
+        LOG.info("Memory freed");
 
         t.join();
         assertEquals(30, fetched.get());
@@ -301,20 +310,18 @@ public class MemoryStarvedScanIT extends SharedMiniClusterBase {
 
       try (BatchScanner scanner = client.createBatchScanner(table,
           client.securityOperations().getUserAuthorizations(client.whoami()), 1)) {
-        double returned = SCAN_RETURNED_EARLY.doubleValue();
-        double paused = SCAN_START_DELAYED.doubleValue();
+
+        final double returned = SCAN_RETURNED_EARLY.doubleValue();
+        final double paused = SCAN_START_DELAYED.doubleValue();
 
         consumeServerMemory(scanner);
 
-        // Wait for longer than the memory check interval
-        Thread.sleep(6000);
+        // Wait for metric that indicates a scan was returned early due to low memory
+        assertTrueWithRetry(() -> SCAN_RETURNED_EARLY.doubleValue() > returned
+            && SCAN_START_DELAYED.doubleValue() >= paused);
+        assertTrueWithRetry(() -> 1 == LOW_MEM_DETECTED.get());
 
-        // The metric that indicates a scan was returned early due to low memory should
-        // have been incremented.
-        assertTrue(SCAN_RETURNED_EARLY.doubleValue() > returned);
-        assertTrue(SCAN_START_DELAYED.doubleValue() >= paused);
-        assertEquals(1, LOW_MEM_DETECTED.get());
-        freeServerMemory(client, table);
+        freeServerMemory(client);
       } finally {
         to.delete(table);
       }
@@ -377,13 +384,103 @@ public class MemoryStarvedScanIT extends SharedMiniClusterBase {
         // Grab the current paused count, wait two seconds and then confirm that
         // the number of rows fetched by the memoryConsumingScanner has not increased
         // and that the scan delay counter has increased.
+        final double returned = SCAN_RETURNED_EARLY.doubleValue();
+        final double paused = SCAN_START_DELAYED.doubleValue();
+
+        final int currentCountCopy = currentCount;
+        waitFor(
+            () -> (currentCountCopy == fetched.get() && SCAN_START_DELAYED.doubleValue() > paused)
+                || (currentCountCopy + 1 == fetched.get()
+                    && SCAN_RETURNED_EARLY.doubleValue() > returned));
+        waitFor(() -> 1 == LOW_MEM_DETECTED.get());
+
+        // Perform the check again
+        final double paused2 = SCAN_START_DELAYED.doubleValue();
+        final double returned2 = SCAN_RETURNED_EARLY.doubleValue();
+        Thread.sleep(1500);
+        assertEquals(currentCount, fetched.get());
+        assertTrue(SCAN_START_DELAYED.doubleValue() >= paused2);
+        assertEquals(returned2, SCAN_RETURNED_EARLY.doubleValue());
+        waitFor(() -> 1 == LOW_MEM_DETECTED.get());
+
+        // Free the memory which will allow the pausing scanner to continue
+        freeServerMemory(client);
+
+        t.join();
+        assertEquals(30, fetched.get());
+
+      } finally {
+        to.delete(table);
+      }
+    }
+  }
+
+  /**
+   * Check that the low memory condition is set and remains set until free memory is available.
+   */
+  @Test
+  public void testLowMemoryFlapping() throws Exception {
+
+    String table = getUniqueNames(1)[0];
+    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
+
+      TableOperations to = client.tableOperations();
+      to.create(table);
+
+      // check memory okay before starting
+      assertEquals(0, LOW_MEM_DETECTED.get());
+
+      ReadWriteIT.ingest(client, 10, 3, 10, 0, table);
+
+      try (BatchScanner dataConsumingScanner = client.createBatchScanner(table);
+          Scanner memoryConsumingScanner = client.createScanner(table)) {
+
+        dataConsumingScanner.addScanIterator(
+            new IteratorSetting(11, SlowIterator.class, Map.of("sleepTime", "500")));
+        dataConsumingScanner.setRanges(Collections.singletonList(new Range()));
+        Iterator<Entry<Key,Value>> iter = dataConsumingScanner.iterator();
+        AtomicInteger fetched = new AtomicInteger(0);
+        Thread t = new Thread(() -> {
+          int i = 0;
+          while (iter.hasNext()) {
+            iter.next();
+            fetched.set(++i);
+          }
+        });
+
+        memoryConsumingScanner
+            .addScanIterator(new IteratorSetting(11, MemoryConsumingIterator.class, Map.of()));
+        memoryConsumingScanner.setBatchSize(1);
+        memoryConsumingScanner.setReadaheadThreshold(Long.MAX_VALUE);
+
+        t.start();
+
+        // Wait until the dataConsumingScanner has started fetching data
+        int currentCount = fetched.get();
+        while (currentCount == 0) {
+          Thread.sleep(500);
+          currentCount = fetched.get();
+        }
+
+        // This should block until the GarbageCollectionLogger runs and notices that the
+        // VM is low on memory.
+        Iterator<Entry<Key,Value>> consumingIter = memoryConsumingScanner.iterator();
+        assertTrue(consumingIter.hasNext());
+
+        // Confirm that some data was fetched by the dataConsumingScanner
+        currentCount = fetched.get();
+        assertTrue(currentCount > 0 && currentCount < 100);
+
+        // Grab the current paused count, wait two seconds and then confirm that
+        // the number of rows fetched by the memoryConsumingScanner has not increased
+        // and that the scan delay counter has increased.
         double returned = SCAN_RETURNED_EARLY.doubleValue();
         double paused = SCAN_START_DELAYED.doubleValue();
         Thread.sleep(1500);
         assertEquals(currentCount, fetched.get());
         assertTrue(SCAN_START_DELAYED.doubleValue() >= paused);
         assertTrue(SCAN_RETURNED_EARLY.doubleValue() >= returned);
-        assertEquals(1, LOW_MEM_DETECTED.get());
+        assertTrueWithRetry(() -> LOW_MEM_DETECTED.get() == 1);
 
         // Perform the check again
         paused = SCAN_START_DELAYED.doubleValue();
@@ -392,21 +489,28 @@ public class MemoryStarvedScanIT extends SharedMiniClusterBase {
         assertEquals(currentCount, fetched.get());
         assertTrue(SCAN_START_DELAYED.doubleValue() >= paused);
         assertEquals(returned, SCAN_RETURNED_EARLY.doubleValue());
-        assertEquals(1, LOW_MEM_DETECTED.get());
 
+        // check across multiple low memory checks and metric updates that low memory detected
+        // remains set
+        int checkCount = 6;
+        while (checkCount-- > 0) {
+          Thread.sleep(5_000);
+          LOG.debug("Check low memory still set. Low Memeory Flag: {}, Check count: {}",
+              LOW_MEM_DETECTED.get(), checkCount);
+          assertEquals(1, LOW_MEM_DETECTED.get());
+        }
         // Free the memory which will allow the pausing scanner to continue
-        freeServerMemory(client, table);
+        freeServerMemory(client);
 
         t.join();
         assertEquals(30, fetched.get());
         // allow metic collection to cycle.
         Thread.sleep(6_000);
-        assertEquals(0, LOW_MEM_DETECTED.get());
+        assertTrueWithRetry(() -> LOW_MEM_DETECTED.get() == 0);
 
       } finally {
         to.delete(table);
       }
     }
   }
-
 }

--- a/test/src/main/java/org/apache/accumulo/test/util/Wait.java
+++ b/test/src/main/java/org/apache/accumulo/test/util/Wait.java
@@ -18,8 +18,6 @@
  */
 package org.apache.accumulo.test.util;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.util.concurrent.TimeUnit;
 
 public class Wait {
@@ -49,14 +47,5 @@ public class Wait {
       conditionSatisfied = condition.isSatisfied();
     }
     return conditionSatisfied;
-  }
-
-  /**
-   * A retry for use in junit tests when testing asynchronous conditions that are expected to
-   * eventually meet the condition or fail the test. Using this method should be used instead of an
-   * arbitrary sleep and hoping to catch the condition in the expected state.
-   */
-  public static void assertTrueWithRetry(final Wait.Condition condition) throws Exception {
-    assertTrue(waitFor(condition));
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/util/Wait.java
+++ b/test/src/main/java/org/apache/accumulo/test/util/Wait.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.test.util;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.concurrent.TimeUnit;
 
 public class Wait {
@@ -47,5 +49,14 @@ public class Wait {
       conditionSatisfied = condition.isSatisfied();
     }
     return conditionSatisfied;
+  }
+
+  /**
+   * A retry for use in junit tests when testing asynchronous conditions that are expected to
+   * eventually meet the condition or fail the test. Using this method should be used instead of an
+   * arbitrary sleep and hoping to catch the condition in the expected state.
+   */
+  public static void assertTrueWithRetry(final Wait.Condition condition) throws Exception {
+    assertTrue(waitFor(condition));
   }
 }


### PR DESCRIPTION
Fix low memory detector to clear/proceed when memory is available.
Update memory calculation to account for JVM resizing.
Update tests.

The low memory detector metric test(s) reveled an issue with the method that low memory detector was calculating free memory and also would clear the low memory flag without checking that memory was available.  The previous tests were passing because the low memory flag would clear, not that memory was available.  This PR fixes both the low memory detector flag set / reset issue and improves the tests to free memory in the low memory condition.

- resolves issue #3372 
- replaces PR #3384 