### PR TITLE
Simplify isPropertySet and remove redundant code

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfiguration.java
@@ -81,20 +81,6 @@ public class TableConfiguration extends ZooBasedConfiguration {
   }
 
   @Override
-  public boolean isPropertySet(Property prop) {
-    if (_isPropertySet(prop)) {
-      return true;
-    }
-
-    return getParent().isPropertySet(prop);
-  }
-
-  private boolean _isPropertySet(Property property) {
-    Map<String,String> propMap = getSnapshot();
-    return propMap.get(property.getKey()) != null;
-  }
-
-  @Override
   public String get(Property property) {
     String value = _get(property);
     if (value != null) {

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/ZooBasedConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/ZooBasedConfiguration.java
@@ -141,15 +141,7 @@ public class ZooBasedConfiguration extends AccumuloConfiguration {
 
   @Override
   public boolean isPropertySet(final Property property) {
-
-    Map<String,String> theseProps = getSnapshot();
-
-    if (theseProps.get(property.getKey()) != null) {
-      return true;
-    }
-
-    return getParent().isPropertySet(property);
-
+    return getSnapshot().get(property.getKey()) != null || getParent().isPropertySet(property);
   }
 
   public @NonNull Map<String,String> getSnapshot() {


### PR DESCRIPTION
* Simplify ZooBasedConfiguration's implementation of isPropertySet, and
* Remove TableConfiguration's redundant implementation, as it's the same as its super class (it just didn't look the same until it was simplified)