### PR TITLE
Fix the compactor prefix format

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metrics/MetricsProducer.java
+++ b/core/src/main/java/org/apache/accumulo/core/metrics/MetricsProducer.java
@@ -602,7 +602,7 @@ public interface MetricsProducer {
 
   Logger LOG = LoggerFactory.getLogger(MetricsProducer.class);
 
-  String METRICS_COMPACTOR_PREFIX = "accumulo.compactor";
+  String METRICS_COMPACTOR_PREFIX = "accumulo.compactor.";
   String METRICS_COMPACTOR_MAJC_STUCK = METRICS_COMPACTOR_PREFIX + "majc.stuck";
 
   String METRICS_FATE_PREFIX = "accumulo.fate.";


### PR DESCRIPTION
The major compaction stuck metric is currently showing up as `accumulo.compactormajc.stuck`.

This commit fixes the metric prefix format so the metric is reported correctly as `accumulo.compactor.majc.stuck`
