### PR TITLE
Execute compaction configurer plugin set on table

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
@@ -45,7 +45,6 @@ import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
-import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.admin.CompactionConfig;
 import org.apache.accumulo.core.clientImpl.thrift.SecurityErrorCode;
@@ -471,26 +470,13 @@ public class CompactionCoordinator implements CompactionCoordinatorService.Iface
   TExternalCompactionJob createThriftJob(String externalCompactionId,
       ExternalCompactionMetadata ecm, CompactionJobQueues.MetaJob metaJob) {
 
-    List<IteratorSetting> iters = List.of();
+    Optional<CompactionConfig> compactionConfig = getCompactionConfig(metaJob);
 
-    Map<String,String> overrides = null;
+    Map<String,String> overrides = CompactionPluginUtils.computeOverrides(compactionConfig, ctx,
+        metaJob.getTabletMetadata().getExtent(), metaJob.getJob().getFiles());
 
-    if (metaJob.getJob().getKind() == CompactionKind.USER) {
-      try {
-        Pair<Long,CompactionConfig> cconf =
-            CompactionConfigStorage.getCompactionID(ctx, metaJob.getTabletMetadata().getExtent());
-        if (cconf != null) {
-          iters = cconf.getSecond().getIterators();
-
-          overrides = CompactionPluginUtils.computeOverrides(cconf.getSecond(), ctx,
-              metaJob.getTabletMetadata().getExtent(), metaJob.getJob().getFiles());
-        }
-      } catch (KeeperException.NoNodeException e) {
-        throw new RuntimeException(e);
-      }
-    }
-
-    IteratorConfig iteratorSettings = SystemIteratorUtil.toIteratorConfig(iters);
+    IteratorConfig iteratorSettings = SystemIteratorUtil
+        .toIteratorConfig(compactionConfig.map(CompactionConfig::getIterators).orElse(List.of()));
 
     var files = ecm.getJobFiles().stream().map(storedTabletFile -> {
       var dfv = metaJob.getTabletMetadata().getFilesMap().get(storedTabletFile);
@@ -498,15 +484,29 @@ public class CompactionCoordinator implements CompactionCoordinatorService.Iface
           dfv.getNumEntries(), dfv.getTime());
     }).collect(Collectors.toList());
 
-    if (overrides == null) {
-      overrides = Map.of();
-    }
-
     return new TExternalCompactionJob(externalCompactionId,
         metaJob.getTabletMetadata().getExtent().toThrift(), files, iteratorSettings,
         ecm.getCompactTmpName().getNormalizedPathStr(), ecm.getPropagateDeletes(),
         TCompactionKind.valueOf(ecm.getKind().name()),
         ecm.getCompactionId() == null ? 0 : ecm.getCompactionId(), overrides);
+  }
+
+  private Optional<CompactionConfig> getCompactionConfig(CompactionJobQueues.MetaJob metaJob) {
+    Optional<CompactionConfig> compactionConfig = Optional.empty();
+
+    if (metaJob.getJob().getKind() == CompactionKind.USER
+        || metaJob.getJob().getKind() == CompactionKind.SELECTOR) {
+      try {
+        Pair<Long,CompactionConfig> cconf =
+            CompactionConfigStorage.getCompactionID(ctx, metaJob.getTabletMetadata().getExtent());
+        if (cconf != null) {
+          compactionConfig = Optional.of(cconf.getSecond());
+        }
+      } catch (KeeperException.NoNodeException e) {
+        throw new RuntimeException(e);
+      }
+    }
+    return compactionConfig;
   }
 
   /**


### PR DESCRIPTION
Any compaction initiated in the manager should now execute a compaction
configurer plugin if its set on the table.

Fixes #3468

Marking this PR as draft because it includes commits from #3513.   Once #3513 is merged can take this out of draft.