### PR TITLE
Remove unused validate method in StoredTabletFile

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/StoredTabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/StoredTabletFile.java
@@ -60,15 +60,4 @@ public class StoredTabletFile extends TabletFile {
     return new Text(getMetaUpdateDelete());
   }
 
-  /**
-   * Validate that the provided reference matches what is in the metadata table.
-   *
-   * @param reference the relative path to check against
-   */
-  public void validate(String reference) {
-    if (!metadataEntry.equals(reference)) {
-      throw new IllegalStateException("The reference " + reference
-          + " does not match what was in the metadata: " + metadataEntry);
-    }
-  }
 }


### PR DESCRIPTION
A validation method was added as part of #2688 but is not used anywhere so this removes it.

This targets 2.1 but I could change the PR to be based on main instead but I think it makes sense to clean it up from 2.1 as well since it's not actually called.