### PR TITLE
Add secure random to LazySingletons

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -28,7 +28,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LOCATION;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.PREV_ROW;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.apache.accumulo.core.util.Validators.EXISTING_TABLE_NAME;
 import static org.apache.accumulo.core.util.Validators.NEW_TABLE_NAME;
 
@@ -1228,7 +1228,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
 
       log.warn("Unable to locate bins for specified range. Retrying.");
       // sleep randomly between 100 and 200ms
-      sleepUninterruptibly(100 + SECURE_RANDOM.get().nextInt(100), MILLISECONDS);
+      sleepUninterruptibly(100 + RANDOM.get().nextInt(100), MILLISECONDS);
       binnedRanges.clear();
       tl.invalidateCache();
     }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -28,6 +28,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LOCATION;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.PREV_ROW;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.apache.accumulo.core.util.Validators.EXISTING_TABLE_NAME;
 import static org.apache.accumulo.core.util.Validators.NEW_TABLE_NAME;
 
@@ -36,7 +37,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.ByteBuffer;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -158,8 +158,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.net.HostAndPort;
 
 public class TableOperationsImpl extends TableOperationsHelper {
-
-  private static final SecureRandom random = new SecureRandom();
 
   public static final String PROPERTY_EXCLUDE_PREFIX = "!";
   public static final String COMPACTION_CANCELED_MSG = "Compaction canceled";
@@ -1230,7 +1228,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
 
       log.warn("Unable to locate bins for specified range. Retrying.");
       // sleep randomly between 100 and 200ms
-      sleepUninterruptibly(100 + random.nextInt(100), MILLISECONDS);
+      sleepUninterruptibly(100 + SECURE_RANDOM.get().nextInt(100), MILLISECONDS);
       binnedRanges.clear();
       tl.invalidateCache();
     }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftScanner.java
@@ -19,9 +19,9 @@
 package org.apache.accumulo.core.clientImpl;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 
 import java.io.IOException;
-import java.security.SecureRandom;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -101,7 +101,6 @@ public class ThriftScanner {
   // metadata
   public static final Map<TabletType,Set<String>> serversWaitedForWrites =
       new EnumMap<>(TabletType.class);
-  private static final SecureRandom random = new SecureRandom();
 
   static {
     for (TabletType ttype : TabletType.values()) {
@@ -277,7 +276,7 @@ public class ThriftScanner {
       Thread.sleep(millis);
     }
     // wait 2 * last time, with +-10% random jitter
-    return (long) (Math.min(millis * 2, maxSleep) * (.9 + random.nextDouble() / 5));
+    return (long) (Math.min(millis * 2, maxSleep) * (.9 + SECURE_RANDOM.get().nextDouble() / 5));
   }
 
   public static List<KeyValue> scan(ClientContext context, ScanState scanState, long timeOut)

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftScanner.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.core.clientImpl;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -276,7 +276,7 @@ public class ThriftScanner {
       Thread.sleep(millis);
     }
     // wait 2 * last time, with +-10% random jitter
-    return (long) (Math.min(millis * 2, maxSleep) * (.9 + SECURE_RANDOM.get().nextDouble() / 5));
+    return (long) (Math.min(millis * 2, maxSleep) * (.9 + RANDOM.get().nextDouble() / 5));
   }
 
   public static List<KeyValue> scan(ClientContext context, ScanState scanState, long timeOut)

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportPool.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportPool.java
@@ -20,8 +20,8 @@ package org.apache.accumulo.core.clientImpl;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 
-import java.security.SecureRandom;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -58,7 +58,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public class ThriftTransportPool {
 
   private static final Logger log = LoggerFactory.getLogger(ThriftTransportPool.class);
-  private static final SecureRandom random = new SecureRandom();
   private static final long ERROR_THRESHOLD = 20L;
   private static final long STUCK_THRESHOLD = MINUTES.toMillis(2);
 
@@ -138,7 +137,7 @@ public class ThriftTransportPool {
 
       if (!serversSet.isEmpty()) {
         ArrayList<ThriftTransportKey> cachedServers = new ArrayList<>(serversSet);
-        Collections.shuffle(cachedServers, random);
+        Collections.shuffle(cachedServers, SECURE_RANDOM.get());
 
         for (ThriftTransportKey ttk : cachedServers) {
           CachedConnection connection = connectionPool.reserveAny(ttk);
@@ -155,7 +154,7 @@ public class ThriftTransportPool {
     int retryCount = 0;
     while (!servers.isEmpty() && retryCount < 10) {
 
-      int index = random.nextInt(servers.size());
+      int index = SECURE_RANDOM.get().nextInt(servers.size());
       ThriftTransportKey ttk = servers.get(index);
 
       if (preferCachedConnection) {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportPool.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportPool.java
@@ -20,7 +20,7 @@ package org.apache.accumulo.core.clientImpl;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -137,7 +137,7 @@ public class ThriftTransportPool {
 
       if (!serversSet.isEmpty()) {
         ArrayList<ThriftTransportKey> cachedServers = new ArrayList<>(serversSet);
-        Collections.shuffle(cachedServers, SECURE_RANDOM.get());
+        Collections.shuffle(cachedServers, RANDOM.get());
 
         for (ThriftTransportKey ttk : cachedServers) {
           CachedConnection connection = connectionPool.reserveAny(ttk);
@@ -154,7 +154,7 @@ public class ThriftTransportPool {
     int retryCount = 0;
     while (!servers.isEmpty() && retryCount < 10) {
 
-      int index = SECURE_RANDOM.get().nextInt(servers.size());
+      int index = RANDOM.get().nextInt(servers.size());
       ThriftTransportKey ttk = servers.get(index);
 
       if (preferCachedConnection) {

--- a/core/src/main/java/org/apache/accumulo/core/fate/ZooStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/ZooStore.java
@@ -21,7 +21,7 @@ package org.apache.accumulo.core.fate;
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -123,7 +123,7 @@ public class ZooStore<T> implements TStore<T> {
     while (true) {
       try {
         // looking at the code for SecureRandom, it appears to be thread safe
-        long tid = SECURE_RANDOM.get().nextLong() & 0x7fffffffffffffffL;
+        long tid = RANDOM.get().nextLong() & 0x7fffffffffffffffL;
         zk.putPersistentData(getTXPath(tid), TStatus.NEW.name().getBytes(UTF_8),
             NodeExistsPolicy.FAIL);
         return tid;

--- a/core/src/main/java/org/apache/accumulo/core/fate/ZooStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/ZooStore.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.core.fate;
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -29,7 +30,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.io.UncheckedIOException;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -63,7 +63,6 @@ public class ZooStore<T> implements TStore<T> {
   private String lastReserved = "";
   private Set<Long> reserved;
   private Map<Long,Long> defered;
-  private static final SecureRandom random = new SecureRandom();
   private long statusChangeEvents = 0;
   private int reservationsWaiting = 0;
 
@@ -124,7 +123,7 @@ public class ZooStore<T> implements TStore<T> {
     while (true) {
       try {
         // looking at the code for SecureRandom, it appears to be thread safe
-        long tid = random.nextLong() & 0x7fffffffffffffffL;
+        long tid = SECURE_RANDOM.get().nextLong() & 0x7fffffffffffffffL;
         zk.putPersistentData(getTXPath(tid), TStatus.NEW.name().getBytes(UTF_8),
             NodeExistsPolicy.FAIL);
         return tid;

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooCache.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.core.fate.zookeeper;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.util.Collections;
 import java.util.ConcurrentModificationException;
@@ -272,7 +272,7 @@ public class ZooCache {
         }
         LockSupport.parkNanos(sleepTime);
         if (sleepTime < 10_000) {
-          sleepTime = (int) (sleepTime + sleepTime * SECURE_RANDOM.get().nextDouble());
+          sleepTime = (int) (sleepTime + sleepTime * RANDOM.get().nextDouble());
         }
       }
     }

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooCache.java
@@ -19,8 +19,8 @@
 package org.apache.accumulo.core.fate.zookeeper;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 
-import java.security.SecureRandom;
 import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.HashMap;
@@ -65,7 +65,6 @@ public class ZooCache {
   private final HashMap<String,List<String>> childrenCache;
 
   private final ZooReader zReader;
-  private static final SecureRandom random = new SecureRandom();
 
   private volatile boolean closed = false;
 
@@ -273,7 +272,7 @@ public class ZooCache {
         }
         LockSupport.parkNanos(sleepTime);
         if (sleepTime < 10_000) {
-          sleepTime = (int) (sleepTime + sleepTime * random.nextDouble());
+          sleepTime = (int) (sleepTime + sleepTime * SECURE_RANDOM.get().nextDouble());
         }
       }
     }

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooSession.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooSession.java
@@ -20,7 +20,7 @@ package org.apache.accumulo.core.fate.zookeeper;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.io.IOException;
 import java.net.UnknownHostException;
@@ -169,7 +169,7 @@ public class ZooSession {
         }
         UtilWaitThread.sleep(sleepTime);
         if (sleepTime < 10000) {
-          sleepTime = sleepTime + (long) (sleepTime * SECURE_RANDOM.get().nextDouble());
+          sleepTime = sleepTime + (long) (sleepTime * RANDOM.get().nextDouble());
         }
       }
     }

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooSession.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooSession.java
@@ -20,10 +20,10 @@ package org.apache.accumulo.core.fate.zookeeper;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 
 import java.io.IOException;
 import java.net.UnknownHostException;
-import java.security.SecureRandom;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -62,8 +62,6 @@ public class ZooSession {
   }
 
   private static Map<String,ZooSessionInfo> sessions = new HashMap<>();
-
-  private static final SecureRandom random = new SecureRandom();
 
   static {
     SingletonManager.register(new SingletonService() {
@@ -171,7 +169,7 @@ public class ZooSession {
         }
         UtilWaitThread.sleep(sleepTime);
         if (sleepTime < 10000) {
-          sleepTime = sleepTime + (long) (sleepTime * random.nextDouble());
+          sleepTime = sleepTime + (long) (sleepTime * SECURE_RANDOM.get().nextDouble());
         }
       }
     }

--- a/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.core.file;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -456,7 +456,7 @@ public class BloomFilterLayer {
     HashSet<Integer> valsSet = new HashSet<>();
 
     for (int i = 0; i < 100000; i++) {
-      valsSet.add(SECURE_RANDOM.get().nextInt(Integer.MAX_VALUE));
+      valsSet.add(RANDOM.get().nextInt(Integer.MAX_VALUE));
     }
 
     ArrayList<Integer> vals = new ArrayList<>(valsSet);
@@ -508,7 +508,7 @@ public class BloomFilterLayer {
 
     int hits = 0;
     for (int i = 0; i < 5000; i++) {
-      int row = SECURE_RANDOM.get().nextInt(Integer.MAX_VALUE);
+      int row = RANDOM.get().nextInt(Integer.MAX_VALUE);
       String fi = String.format("%010d", row);
       // bmfr.seek(new Range(new Text("r"+fi)));
       org.apache.accumulo.core.data.Key k1 =

--- a/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
@@ -19,12 +19,12 @@
 package org.apache.accumulo.core.file;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -68,7 +68,6 @@ import org.slf4j.LoggerFactory;
  */
 public class BloomFilterLayer {
 
-  private static final SecureRandom random = new SecureRandom();
   private static final Logger LOG = LoggerFactory.getLogger(BloomFilterLayer.class);
   public static final String BLOOM_FILE_NAME = "acu_bloom";
   public static final int HASH_COUNT = 5;
@@ -457,7 +456,7 @@ public class BloomFilterLayer {
     HashSet<Integer> valsSet = new HashSet<>();
 
     for (int i = 0; i < 100000; i++) {
-      valsSet.add(random.nextInt(Integer.MAX_VALUE));
+      valsSet.add(SECURE_RANDOM.get().nextInt(Integer.MAX_VALUE));
     }
 
     ArrayList<Integer> vals = new ArrayList<>(valsSet);
@@ -509,7 +508,7 @@ public class BloomFilterLayer {
 
     int hits = 0;
     for (int i = 0; i < 5000; i++) {
-      int row = random.nextInt(Integer.MAX_VALUE);
+      int row = SECURE_RANDOM.get().nextInt(Integer.MAX_VALUE);
       String fi = String.format("%010d", row);
       // bmfr.seek(new Range(new Text("r"+fi)));
       org.apache.accumulo.core.data.Key k1 =

--- a/core/src/main/java/org/apache/accumulo/core/rpc/ThriftUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/ThriftUtil.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.core.rpc;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -385,7 +385,7 @@ public class ThriftUtil {
 
         // Avoid the replay attack protection, sleep 1 to 5000ms
         try {
-          Thread.sleep(SECURE_RANDOM.get().nextInt(RELOGIN_MAX_BACKOFF) + 1);
+          Thread.sleep(RANDOM.get().nextInt(RELOGIN_MAX_BACKOFF) + 1);
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
           return;

--- a/core/src/main/java/org/apache/accumulo/core/rpc/ThriftUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/ThriftUtil.java
@@ -18,13 +18,14 @@
  */
 package org.apache.accumulo.core.rpc;
 
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.InetAddress;
 import java.nio.channels.ClosedByInterruptException;
 import java.security.KeyStore;
-import java.security.SecureRandom;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -70,7 +71,6 @@ public class ThriftUtil {
 
   public static final String GSSAPI = "GSSAPI", DIGEST_MD5 = "DIGEST-MD5";
 
-  private static final SecureRandom random = new SecureRandom();
   private static final int RELOGIN_MAX_BACKOFF = 5000;
 
   /**
@@ -385,7 +385,7 @@ public class ThriftUtil {
 
         // Avoid the replay attack protection, sleep 1 to 5000ms
         try {
-          Thread.sleep(random.nextInt(RELOGIN_MAX_BACKOFF) + 1);
+          Thread.sleep(SECURE_RANDOM.get().nextInt(RELOGIN_MAX_BACKOFF) + 1);
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
           return;

--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancer.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.core.spi.balancer;
 
 import static java.util.concurrent.TimeUnit.HOURS;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -415,7 +415,7 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer {
                 String poolName = getPoolNameForTable(table);
                 SortedMap<TabletServerId,TServerStatus> currentView = currentGrouped.get(poolName);
                 if (currentView != null) {
-                  int skip = SECURE_RANDOM.get().nextInt(currentView.size());
+                  int skip = RANDOM.get().nextInt(currentView.size());
                   Iterator<TabletServerId> iter = currentView.keySet().iterator();
                   for (int i = 0; i < skip; i++) {
                     iter.next();

--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancer.java
@@ -19,10 +19,10 @@
 package org.apache.accumulo.core.spi.balancer;
 
 import static java.util.concurrent.TimeUnit.HOURS;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -92,7 +92,6 @@ import com.google.common.collect.Multimap;
  */
 public class HostRegexTableLoadBalancer extends TableLoadBalancer {
 
-  private static final SecureRandom random = new SecureRandom();
   private static final String PROP_PREFIX = Property.TABLE_ARBITRARY_PROP_PREFIX.getKey();
 
   private static final Logger LOG = LoggerFactory.getLogger(HostRegexTableLoadBalancer.class);
@@ -416,7 +415,7 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer {
                 String poolName = getPoolNameForTable(table);
                 SortedMap<TabletServerId,TServerStatus> currentView = currentGrouped.get(poolName);
                 if (currentView != null) {
-                  int skip = random.nextInt(currentView.size());
+                  int skip = SECURE_RANDOM.get().nextInt(currentView.size());
                   Iterator<TabletServerId> iter = currentView.keySet().iterator();
                   for (int i = 0; i < skip; i++) {
                     iter.next();

--- a/core/src/main/java/org/apache/accumulo/core/spi/crypto/AESCryptoService.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/crypto/AESCryptoService.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.core.spi.crypto;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -78,7 +79,6 @@ public class AESCryptoService implements CryptoService {
   private static final String NO_CRYPTO_VERSION = "U+1F47B";
   private static final String URI = "uri";
   private static final String KEY_WRAP_TRANSFORM = "AESWrap";
-  private static final SecureRandom random = new SecureRandom();
 
   private Key encryptingKek = null;
   private String keyLocation = null;
@@ -358,8 +358,8 @@ public class AESCryptoService implements CryptoService {
         } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
           throw new CryptoException("Error obtaining cipher for transform " + transformation, e);
         }
-        this.fek = generateKey(random, KEY_LENGTH_IN_BYTES);
-        random.nextBytes(this.initVector);
+        this.fek = generateKey(SECURE_RANDOM.get(), KEY_LENGTH_IN_BYTES);
+        SECURE_RANDOM.get().nextBytes(this.initVector);
         this.firstInitVector = Arrays.copyOf(this.initVector, this.initVector.length);
         this.decryptionParameters =
             createCryptoParameters(VERSION, encryptingKek, keyLocation, keyManager, fek);
@@ -499,14 +499,14 @@ public class AESCryptoService implements CryptoService {
         } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
           throw new CryptoException("Error obtaining cipher for transform " + transformation, e);
         }
-        this.fek = generateKey(random, KEY_LENGTH_IN_BYTES);
+        this.fek = generateKey(SECURE_RANDOM.get(), KEY_LENGTH_IN_BYTES);
         this.decryptionParameters =
             createCryptoParameters(VERSION, encryptingKek, keyLocation, keyManager, fek);
       }
 
       @Override
       public OutputStream encryptStream(OutputStream outputStream) throws CryptoException {
-        random.nextBytes(initVector);
+        SECURE_RANDOM.get().nextBytes(initVector);
         try {
           outputStream.write(initVector);
         } catch (IOException e) {

--- a/core/src/main/java/org/apache/accumulo/core/spi/crypto/AESCryptoService.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/crypto/AESCryptoService.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.core.spi.crypto;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -358,8 +358,8 @@ public class AESCryptoService implements CryptoService {
         } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
           throw new CryptoException("Error obtaining cipher for transform " + transformation, e);
         }
-        this.fek = generateKey(SECURE_RANDOM.get(), KEY_LENGTH_IN_BYTES);
-        SECURE_RANDOM.get().nextBytes(this.initVector);
+        this.fek = generateKey(RANDOM.get(), KEY_LENGTH_IN_BYTES);
+        RANDOM.get().nextBytes(this.initVector);
         this.firstInitVector = Arrays.copyOf(this.initVector, this.initVector.length);
         this.decryptionParameters =
             createCryptoParameters(VERSION, encryptingKek, keyLocation, keyManager, fek);
@@ -499,14 +499,14 @@ public class AESCryptoService implements CryptoService {
         } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
           throw new CryptoException("Error obtaining cipher for transform " + transformation, e);
         }
-        this.fek = generateKey(SECURE_RANDOM.get(), KEY_LENGTH_IN_BYTES);
+        this.fek = generateKey(RANDOM.get(), KEY_LENGTH_IN_BYTES);
         this.decryptionParameters =
             createCryptoParameters(VERSION, encryptingKek, keyLocation, keyManager, fek);
       }
 
       @Override
       public OutputStream encryptStream(OutputStream outputStream) throws CryptoException {
-        SECURE_RANDOM.get().nextBytes(initVector);
+        RANDOM.get().nextBytes(initVector);
         try {
           outputStream.write(initVector);
         } catch (IOException e) {

--- a/core/src/main/java/org/apache/accumulo/core/spi/fs/RandomVolumeChooser.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/fs/RandomVolumeChooser.java
@@ -18,7 +18,8 @@
  */
 package org.apache.accumulo.core.spi.fs;
 
-import java.security.SecureRandom;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+
 import java.util.Set;
 
 /**
@@ -27,7 +28,6 @@ import java.util.Set;
  * @since 2.1.0
  */
 public class RandomVolumeChooser implements VolumeChooser {
-  private static final SecureRandom random = new SecureRandom();
 
   /**
    * Selects a volume at random from the provided set of volumes. The environment scope is not
@@ -36,7 +36,7 @@ public class RandomVolumeChooser implements VolumeChooser {
   @Override
   public String choose(VolumeChooserEnvironment env, Set<String> options) {
     String[] optionsArray = options.toArray(new String[0]);
-    return optionsArray[random.nextInt(optionsArray.length)];
+    return optionsArray[SECURE_RANDOM.get().nextInt(optionsArray.length)];
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/spi/fs/RandomVolumeChooser.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/fs/RandomVolumeChooser.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.core.spi.fs;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.util.Set;
 
@@ -36,7 +36,7 @@ public class RandomVolumeChooser implements VolumeChooser {
   @Override
   public String choose(VolumeChooserEnvironment env, Set<String> options) {
     String[] optionsArray = options.toArray(new String[0]);
-    return optionsArray[SECURE_RANDOM.get().nextInt(optionsArray.length)];
+    return optionsArray[RANDOM.get().nextInt(optionsArray.length)];
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/spi/fs/SpaceAwareVolumeChooser.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/fs/SpaceAwareVolumeChooser.java
@@ -19,9 +19,9 @@
 package org.apache.accumulo.core.spi.fs;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 
 import java.io.IOException;
-import java.security.SecureRandom;
 import java.util.NavigableMap;
 import java.util.Set;
 import java.util.TreeMap;
@@ -45,8 +45,6 @@ import com.github.benmanes.caffeine.cache.LoadingCache;
  * @since 2.1.0
  */
 public class SpaceAwareVolumeChooser extends PreferredVolumeChooser {
-
-  private static final SecureRandom random = new SecureRandom();
 
   public static final String RECOMPUTE_INTERVAL = "spaceaware.volume.chooser.recompute.interval";
 
@@ -123,7 +121,7 @@ public class SpaceAwareVolumeChooser extends PreferredVolumeChooser {
     }
 
     public String next() {
-      double value = random.nextDouble() * total;
+      double value = SECURE_RANDOM.get().nextDouble() * total;
       return map.higherEntry(value).getValue();
     }
   }

--- a/core/src/main/java/org/apache/accumulo/core/spi/fs/SpaceAwareVolumeChooser.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/fs/SpaceAwareVolumeChooser.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.core.spi.fs;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.io.IOException;
 import java.util.NavigableMap;
@@ -121,7 +121,7 @@ public class SpaceAwareVolumeChooser extends PreferredVolumeChooser {
     }
 
     public String next() {
-      double value = SECURE_RANDOM.get().nextDouble() * total;
+      double value = RANDOM.get().nextDouble() * total;
       return map.higherEntry(value).getValue();
     }
   }

--- a/core/src/main/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelector.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelector.java
@@ -20,7 +20,7 @@ package org.apache.accumulo.core.spi.scan;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.core.util.LazySingletons.GSON;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.lang.reflect.Type;
 import java.time.Duration;
@@ -363,7 +363,7 @@ public class ConfigurableScanServerSelector implements ScanServerSelector {
 
       var hashCode = hashTablet(tablet, profile.getSalt(attempts));
 
-      int serverIndex = (Math.abs(hashCode.asInt()) + SECURE_RANDOM.get().nextInt(numServers))
+      int serverIndex = (Math.abs(hashCode.asInt()) + RANDOM.get().nextInt(numServers))
           % orderedScanServers.size();
 
       serverToUse = orderedScanServers.get(serverIndex);

--- a/core/src/main/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelector.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelector.java
@@ -20,9 +20,9 @@ package org.apache.accumulo.core.spi.scan;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.core.util.LazySingletons.GSON;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 
 import java.lang.reflect.Type;
-import java.security.SecureRandom;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -149,7 +149,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  */
 public class ConfigurableScanServerSelector implements ScanServerSelector {
 
-  private static final SecureRandom RANDOM = new SecureRandom();
   public static final String PROFILES_DEFAULT = "[{'isDefault':true,'maxBusyTimeout':'5m',"
       + "'busyTimeoutMultiplier':8, 'scanTypeActivations':[], "
       + "'attemptPlans':[{'servers':'3', 'busyTimeout':'33ms', 'salt':'one'},"
@@ -364,8 +363,8 @@ public class ConfigurableScanServerSelector implements ScanServerSelector {
 
       var hashCode = hashTablet(tablet, profile.getSalt(attempts));
 
-      int serverIndex =
-          (Math.abs(hashCode.asInt()) + RANDOM.nextInt(numServers)) % orderedScanServers.size();
+      int serverIndex = (Math.abs(hashCode.asInt()) + SECURE_RANDOM.get().nextInt(numServers))
+          % orderedScanServers.size();
 
       serverToUse = orderedScanServers.get(serverIndex);
 

--- a/core/src/main/java/org/apache/accumulo/core/util/LazySingletons.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/LazySingletons.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.util;
 
+import java.security.SecureRandom;
 import java.util.function.Supplier;
 
 import com.google.common.base.Suppliers;
@@ -36,5 +37,7 @@ public class LazySingletons {
    * A Gson instance constructed with defaults. Construct your own if you need custom settings.
    */
   public static final Supplier<Gson> GSON = Suppliers.memoize(Gson::new);
+
+  public static final Supplier<SecureRandom> SECURE_RANDOM = Suppliers.memoize(SecureRandom::new);
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/util/LazySingletons.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/LazySingletons.java
@@ -38,6 +38,9 @@ public class LazySingletons {
    */
   public static final Supplier<Gson> GSON = Suppliers.memoize(Gson::new);
 
+  /**
+   * A SecureRandom instance created with the default constructor.
+   */
   public static final Supplier<SecureRandom> SECURE_RANDOM = Suppliers.memoize(SecureRandom::new);
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/util/LazySingletons.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/LazySingletons.java
@@ -41,6 +41,6 @@ public class LazySingletons {
   /**
    * A SecureRandom instance created with the default constructor.
    */
-  public static final Supplier<SecureRandom> SECURE_RANDOM = Suppliers.memoize(SecureRandom::new);
+  public static final Supplier<SecureRandom> RANDOM = Suppliers.memoize(SecureRandom::new);
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/util/Retry.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/Retry.java
@@ -20,8 +20,8 @@ package org.apache.accumulo.core.util;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 
-import java.security.SecureRandom;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
@@ -46,7 +46,6 @@ public class Retry {
   private boolean hasNeverLogged;
   private boolean hasLoggedWarn = false;
   private long lastRetryLog;
-  private static final SecureRandom random = new SecureRandom();
   private double currentBackOffFactor;
   private boolean doTimeJitter = true;
 
@@ -171,7 +170,8 @@ public class Retry {
   public void waitForNextAttempt(Logger log, String operationDescription)
       throws InterruptedException {
 
-    double waitFactor = (1 + (random.nextDouble() - 0.5) / 10.0) * currentBackOffFactor;
+    double waitFactor =
+        (1 + (SECURE_RANDOM.get().nextDouble() - 0.5) / 10.0) * currentBackOffFactor;
     if (!doTimeJitter) {
       waitFactor = currentBackOffFactor;
     }

--- a/core/src/main/java/org/apache/accumulo/core/util/Retry.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/Retry.java
@@ -20,7 +20,7 @@ package org.apache.accumulo.core.util;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.util.concurrent.TimeUnit;
 
@@ -170,8 +170,7 @@ public class Retry {
   public void waitForNextAttempt(Logger log, String operationDescription)
       throws InterruptedException {
 
-    double waitFactor =
-        (1 + (SECURE_RANDOM.get().nextDouble() - 0.5) / 10.0) * currentBackOffFactor;
+    double waitFactor = (1 + (RANDOM.get().nextDouble() - 0.5) / 10.0) * currentBackOffFactor;
     if (!doTimeJitter) {
       waitFactor = currentBackOffFactor;
     }

--- a/core/src/test/java/org/apache/accumulo/core/cli/PasswordConverterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/cli/PasswordConverterTest.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.core.cli;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -28,7 +29,6 @@ import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
-import java.security.SecureRandom;
 import java.util.Scanner;
 
 import org.junit.jupiter.api.AfterEach;
@@ -41,8 +41,6 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 
 public class PasswordConverterTest {
-
-  private static final SecureRandom random = new SecureRandom();
 
   private class Password {
     @Parameter(names = "--password", converter = ClientOpts.PasswordConverter.class)
@@ -79,7 +77,7 @@ public class PasswordConverterTest {
 
   @Test
   public void testPass() {
-    String expected = String.valueOf(random.nextDouble());
+    String expected = String.valueOf(SECURE_RANDOM.get().nextDouble());
     argv[1] = "pass:" + expected;
     new JCommander(password).parse(argv);
     assertEquals(expected, password.password);

--- a/core/src/test/java/org/apache/accumulo/core/cli/PasswordConverterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/cli/PasswordConverterTest.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.core.cli;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -77,7 +77,7 @@ public class PasswordConverterTest {
 
   @Test
   public void testPass() {
-    String expected = String.valueOf(SECURE_RANDOM.get().nextDouble());
+    String expected = String.valueOf(RANDOM.get().nextDouble());
     argv[1] = "pass:" + expected;
     new JCommander(password).parse(argv);
     assertEquals(expected, password.password);

--- a/core/src/test/java/org/apache/accumulo/core/client/rfile/RFileClientTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/rfile/RFileClientTest.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.core.client.rfile;
 
 import static com.google.common.collect.MoreCollectors.onlyElement;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -27,7 +28,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
-import java.security.SecureRandom;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -74,8 +74,6 @@ import org.junit.jupiter.api.Test;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class RFileClientTest {
-
-  private static final SecureRandom random = new SecureRandom();
 
   @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path is set by test, not user")
   private String createTmpTestFile() throws IOException {
@@ -521,7 +519,7 @@ public class RFileClientTest {
     Scanner scanner = RFile.newScanner().from(testFile).withFileSystem(localFs)
         .withIndexCache(1000000).withDataCache(10000000).build();
 
-    random.ints(100, 0, 10_000).forEach(r -> {
+    SECURE_RANDOM.get().ints(100, 0, 10_000).forEach(r -> {
       scanner.setRange(new Range(rowStr(r)));
       String actual = scanner.stream().collect(onlyElement()).getKey().getRow().toString();
       assertEquals(rowStr(r), actual);

--- a/core/src/test/java/org/apache/accumulo/core/client/rfile/RFileClientTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/rfile/RFileClientTest.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.core.client.rfile;
 
 import static com.google.common.collect.MoreCollectors.onlyElement;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -519,7 +519,7 @@ public class RFileClientTest {
     Scanner scanner = RFile.newScanner().from(testFile).withFileSystem(localFs)
         .withIndexCache(1000000).withDataCache(10000000).build();
 
-    SECURE_RANDOM.get().ints(100, 0, 10_000).forEach(r -> {
+    RANDOM.get().ints(100, 0, 10_000).forEach(r -> {
       scanner.setRange(new Range(rowStr(r)));
       String actual = scanner.stream().collect(onlyElement()).getKey().getRow().toString();
       assertEquals(rowStr(r), actual);

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/bulk/ConcurrentKeyExtentCacheTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/bulk/ConcurrentKeyExtentCacheTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.core.clientImpl.bulk;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -98,14 +98,14 @@ public class ConcurrentKeyExtentCacheTest {
 
     TestCache tc = new TestCache();
 
-    SECURE_RANDOM.get().ints(20000, 0, 256).mapToObj(i -> new Text(String.format("%02x", i)))
-        .sequential().forEach(lookupRow -> testLookup(tc, lookupRow));
+    RANDOM.get().ints(20000, 0, 256).mapToObj(i -> new Text(String.format("%02x", i))).sequential()
+        .forEach(lookupRow -> testLookup(tc, lookupRow));
     assertEquals(extentsSet, tc.seen);
 
     // try parallel
     TestCache tc2 = new TestCache();
-    SECURE_RANDOM.get().ints(20000, 0, 256).mapToObj(i -> new Text(String.format("%02x", i)))
-        .parallel().forEach(lookupRow -> testLookup(tc2, lookupRow));
+    RANDOM.get().ints(20000, 0, 256).mapToObj(i -> new Text(String.format("%02x", i))).parallel()
+        .forEach(lookupRow -> testLookup(tc2, lookupRow));
     assertEquals(extentsSet, tc.seen);
   }
 
@@ -113,13 +113,13 @@ public class ConcurrentKeyExtentCacheTest {
   public void testRandom() {
     TestCache tc = new TestCache();
 
-    SECURE_RANDOM.get().ints(20000).mapToObj(i -> new Text(String.format("%08x", i))).sequential()
+    RANDOM.get().ints(20000).mapToObj(i -> new Text(String.format("%08x", i))).sequential()
         .forEach(lookupRow -> testLookup(tc, lookupRow));
     assertEquals(extentsSet, tc.seen);
 
     // try parallel
     TestCache tc2 = new TestCache();
-    SECURE_RANDOM.get().ints(20000).mapToObj(i -> new Text(String.format("%08x", i))).parallel()
+    RANDOM.get().ints(20000).mapToObj(i -> new Text(String.format("%08x", i))).parallel()
         .forEach(lookupRow -> testLookup(tc2, lookupRow));
     assertEquals(extentsSet, tc2.seen);
   }

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/bulk/ConcurrentKeyExtentCacheTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/bulk/ConcurrentKeyExtentCacheTest.java
@@ -18,10 +18,10 @@
  */
 package org.apache.accumulo.core.clientImpl.bulk;
 
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -36,8 +36,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class ConcurrentKeyExtentCacheTest {
-
-  private static final SecureRandom random = new SecureRandom();
 
   private static List<KeyExtent> extents = new ArrayList<>();
   private static Set<KeyExtent> extentsSet = new HashSet<>();
@@ -100,14 +98,14 @@ public class ConcurrentKeyExtentCacheTest {
 
     TestCache tc = new TestCache();
 
-    random.ints(20000, 0, 256).mapToObj(i -> new Text(String.format("%02x", i))).sequential()
-        .forEach(lookupRow -> testLookup(tc, lookupRow));
+    SECURE_RANDOM.get().ints(20000, 0, 256).mapToObj(i -> new Text(String.format("%02x", i)))
+        .sequential().forEach(lookupRow -> testLookup(tc, lookupRow));
     assertEquals(extentsSet, tc.seen);
 
     // try parallel
     TestCache tc2 = new TestCache();
-    random.ints(20000, 0, 256).mapToObj(i -> new Text(String.format("%02x", i))).parallel()
-        .forEach(lookupRow -> testLookup(tc2, lookupRow));
+    SECURE_RANDOM.get().ints(20000, 0, 256).mapToObj(i -> new Text(String.format("%02x", i)))
+        .parallel().forEach(lookupRow -> testLookup(tc2, lookupRow));
     assertEquals(extentsSet, tc.seen);
   }
 
@@ -115,13 +113,13 @@ public class ConcurrentKeyExtentCacheTest {
   public void testRandom() {
     TestCache tc = new TestCache();
 
-    random.ints(20000).mapToObj(i -> new Text(String.format("%08x", i))).sequential()
+    SECURE_RANDOM.get().ints(20000).mapToObj(i -> new Text(String.format("%08x", i))).sequential()
         .forEach(lookupRow -> testLookup(tc, lookupRow));
     assertEquals(extentsSet, tc.seen);
 
     // try parallel
     TestCache tc2 = new TestCache();
-    random.ints(20000).mapToObj(i -> new Text(String.format("%08x", i))).parallel()
+    SECURE_RANDOM.get().ints(20000).mapToObj(i -> new Text(String.format("%08x", i))).parallel()
         .forEach(lookupRow -> testLookup(tc2, lookupRow));
     assertEquals(extentsSet, tc2.seen);
   }

--- a/core/src/test/java/org/apache/accumulo/core/crypto/CryptoTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/crypto/CryptoTest.java
@@ -23,7 +23,7 @@ import static org.apache.accumulo.core.conf.Property.INSTANCE_CRYPTO_FACTORY;
 import static org.apache.accumulo.core.crypto.CryptoUtils.getFileDecrypter;
 import static org.apache.accumulo.core.spi.crypto.CryptoEnvironment.Scope.TABLE;
 import static org.apache.accumulo.core.spi.crypto.CryptoEnvironment.Scope.WAL;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -409,11 +409,11 @@ public class CryptoTest {
       NoSuchProviderException, NoSuchPaddingException, InvalidKeyException {
     // verify valid key sizes (corresponds to 128, 192, and 256 bits)
     for (int i : new int[] {16, 24, 32}) {
-      verifyKeySizeForCBC(SECURE_RANDOM.get(), i);
+      verifyKeySizeForCBC(RANDOM.get(), i);
     }
     // verify invalid key sizes
     for (int i : new int[] {1, 2, 8, 11, 15, 64, 128}) {
-      assertThrows(InvalidKeyException.class, () -> verifyKeySizeForCBC(SECURE_RANDOM.get(), i));
+      assertThrows(InvalidKeyException.class, () -> verifyKeySizeForCBC(RANDOM.get(), i));
     }
   }
 
@@ -429,8 +429,8 @@ public class CryptoTest {
   @Test
   public void testAESKeyUtilsWrapAndUnwrap()
       throws NoSuchAlgorithmException, NoSuchProviderException {
-    java.security.Key kek = AESCryptoService.generateKey(SECURE_RANDOM.get(), 16);
-    java.security.Key fek = AESCryptoService.generateKey(SECURE_RANDOM.get(), 16);
+    java.security.Key kek = AESCryptoService.generateKey(RANDOM.get(), 16);
+    java.security.Key fek = AESCryptoService.generateKey(RANDOM.get(), 16);
     byte[] wrapped = AESCryptoService.wrapKey(fek, kek);
     assertFalse(Arrays.equals(fek.getEncoded(), wrapped));
     java.security.Key unwrapped = AESCryptoService.unwrapKey(wrapped, kek);
@@ -440,8 +440,8 @@ public class CryptoTest {
   @Test
   public void testAESKeyUtilsFailUnwrapWithWrongKEK()
       throws NoSuchAlgorithmException, NoSuchProviderException {
-    java.security.Key kek = AESCryptoService.generateKey(SECURE_RANDOM.get(), 16);
-    java.security.Key fek = AESCryptoService.generateKey(SECURE_RANDOM.get(), 16);
+    java.security.Key kek = AESCryptoService.generateKey(RANDOM.get(), 16);
+    java.security.Key fek = AESCryptoService.generateKey(RANDOM.get(), 16);
     byte[] wrongBytes = kek.getEncoded();
     wrongBytes[0]++;
     java.security.Key wrongKek = new SecretKeySpec(wrongBytes, "AES");

--- a/core/src/test/java/org/apache/accumulo/core/crypto/CryptoTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/crypto/CryptoTest.java
@@ -23,6 +23,7 @@ import static org.apache.accumulo.core.conf.Property.INSTANCE_CRYPTO_FACTORY;
 import static org.apache.accumulo.core.crypto.CryptoUtils.getFileDecrypter;
 import static org.apache.accumulo.core.spi.crypto.CryptoEnvironment.Scope.TABLE;
 import static org.apache.accumulo.core.spi.crypto.CryptoEnvironment.Scope.WAL;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -87,7 +88,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class CryptoTest {
 
-  private static final SecureRandom random = new SecureRandom();
   private static final int MARKER_INT = 0xCADEFEDD;
   private static final String MARKER_STRING = "1 2 3 4 5 6 7 8 a b c d e f g h ";
   private static final Configuration hadoopConf = new Configuration();
@@ -409,11 +409,11 @@ public class CryptoTest {
       NoSuchProviderException, NoSuchPaddingException, InvalidKeyException {
     // verify valid key sizes (corresponds to 128, 192, and 256 bits)
     for (int i : new int[] {16, 24, 32}) {
-      verifyKeySizeForCBC(random, i);
+      verifyKeySizeForCBC(SECURE_RANDOM.get(), i);
     }
     // verify invalid key sizes
     for (int i : new int[] {1, 2, 8, 11, 15, 64, 128}) {
-      assertThrows(InvalidKeyException.class, () -> verifyKeySizeForCBC(random, i));
+      assertThrows(InvalidKeyException.class, () -> verifyKeySizeForCBC(SECURE_RANDOM.get(), i));
     }
   }
 
@@ -429,8 +429,8 @@ public class CryptoTest {
   @Test
   public void testAESKeyUtilsWrapAndUnwrap()
       throws NoSuchAlgorithmException, NoSuchProviderException {
-    java.security.Key kek = AESCryptoService.generateKey(random, 16);
-    java.security.Key fek = AESCryptoService.generateKey(random, 16);
+    java.security.Key kek = AESCryptoService.generateKey(SECURE_RANDOM.get(), 16);
+    java.security.Key fek = AESCryptoService.generateKey(SECURE_RANDOM.get(), 16);
     byte[] wrapped = AESCryptoService.wrapKey(fek, kek);
     assertFalse(Arrays.equals(fek.getEncoded(), wrapped));
     java.security.Key unwrapped = AESCryptoService.unwrapKey(wrapped, kek);
@@ -440,8 +440,8 @@ public class CryptoTest {
   @Test
   public void testAESKeyUtilsFailUnwrapWithWrongKEK()
       throws NoSuchAlgorithmException, NoSuchProviderException {
-    java.security.Key kek = AESCryptoService.generateKey(random, 16);
-    java.security.Key fek = AESCryptoService.generateKey(random, 16);
+    java.security.Key kek = AESCryptoService.generateKey(SECURE_RANDOM.get(), 16);
+    java.security.Key fek = AESCryptoService.generateKey(SECURE_RANDOM.get(), 16);
     byte[] wrongBytes = kek.getEncoded();
     wrongBytes[0]++;
     java.security.Key wrongKek = new SecretKeySpec(wrongBytes, "AES");

--- a/core/src/test/java/org/apache/accumulo/core/file/BloomFilterLayerLookupTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/BloomFilterLayerLookupTest.java
@@ -18,11 +18,11 @@
  */
 package org.apache.accumulo.core.file;
 
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -54,7 +54,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public class BloomFilterLayerLookupTest extends WithTestNames {
 
   private static final Logger log = LoggerFactory.getLogger(BloomFilterLayerLookupTest.class);
-  private static final SecureRandom random = new SecureRandom();
 
   @TempDir
   private static File tempDir;
@@ -63,7 +62,7 @@ public class BloomFilterLayerLookupTest extends WithTestNames {
   public void test() throws IOException {
     HashSet<Integer> valsSet = new HashSet<>();
     for (int i = 0; i < 100000; i++) {
-      valsSet.add(random.nextInt(Integer.MAX_VALUE));
+      valsSet.add(SECURE_RANDOM.get().nextInt(Integer.MAX_VALUE));
     }
 
     ArrayList<Integer> vals = new ArrayList<>(valsSet);
@@ -111,7 +110,7 @@ public class BloomFilterLayerLookupTest extends WithTestNames {
     int hits = 0;
     t1 = System.currentTimeMillis();
     for (int i = 0; i < 5000; i++) {
-      int row = random.nextInt(Integer.MAX_VALUE);
+      int row = SECURE_RANDOM.get().nextInt(Integer.MAX_VALUE);
       seek(bmfr, row);
       if (valsSet.contains(row)) {
         hits++;

--- a/core/src/test/java/org/apache/accumulo/core/file/BloomFilterLayerLookupTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/BloomFilterLayerLookupTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.core.file;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -62,7 +62,7 @@ public class BloomFilterLayerLookupTest extends WithTestNames {
   public void test() throws IOException {
     HashSet<Integer> valsSet = new HashSet<>();
     for (int i = 0; i < 100000; i++) {
-      valsSet.add(SECURE_RANDOM.get().nextInt(Integer.MAX_VALUE));
+      valsSet.add(RANDOM.get().nextInt(Integer.MAX_VALUE));
     }
 
     ArrayList<Integer> vals = new ArrayList<>(valsSet);
@@ -110,7 +110,7 @@ public class BloomFilterLayerLookupTest extends WithTestNames {
     int hits = 0;
     t1 = System.currentTimeMillis();
     for (int i = 0; i < 5000; i++) {
-      int row = SECURE_RANDOM.get().nextInt(Integer.MAX_VALUE);
+      int row = RANDOM.get().nextInt(Integer.MAX_VALUE);
       seek(bmfr, row);
       if (valsSet.contains(row)) {
         hits++;

--- a/core/src/test/java/org/apache/accumulo/core/file/blockfile/cache/TestLruBlockCache.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/blockfile/cache/TestLruBlockCache.java
@@ -18,14 +18,13 @@
  */
 package org.apache.accumulo.core.file.blockfile.cache;
 
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.security.SecureRandom;
 
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
@@ -51,8 +50,6 @@ import org.junit.jupiter.api.Test;
  * and do what they should, and that cached blocks are accessible when expected to be.
  */
 public class TestLruBlockCache {
-
-  private static final SecureRandom random = new SecureRandom();
 
   @Test
   public void testConfiguration() {
@@ -506,7 +503,7 @@ public class TestLruBlockCache {
   private Block[] generateRandomBlocks(int numBlocks, long maxSize) {
     Block[] blocks = new Block[numBlocks];
     for (int i = 0; i < numBlocks; i++) {
-      blocks[i] = new Block("block" + i, random.nextInt((int) maxSize) + 1);
+      blocks[i] = new Block("block" + i, SECURE_RANDOM.get().nextInt((int) maxSize) + 1);
     }
     return blocks;
   }

--- a/core/src/test/java/org/apache/accumulo/core/file/blockfile/cache/TestLruBlockCache.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/blockfile/cache/TestLruBlockCache.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.core.file.blockfile.cache;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -503,7 +503,7 @@ public class TestLruBlockCache {
   private Block[] generateRandomBlocks(int numBlocks, long maxSize) {
     Block[] blocks = new Block[numBlocks];
     for (int i = 0; i < numBlocks; i++) {
-      blocks[i] = new Block("block" + i, SECURE_RANDOM.get().nextInt((int) maxSize) + 1);
+      blocks[i] = new Block("block" + i, RANDOM.get().nextInt((int) maxSize) + 1);
     }
     return blocks;
   }

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiLevelIndexTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiLevelIndexTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.core.file.rfile;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
@@ -119,7 +119,7 @@ public class MultiLevelIndexTest {
     liter = reader.lookup(new Key(String.format("%05d000", num + 1)));
     assertFalse(liter.hasNext());
 
-    SECURE_RANDOM.get().ints(100, 0, num * 1_000).forEach(k -> {
+    RANDOM.get().ints(100, 0, num * 1_000).forEach(k -> {
       int expected;
       if (k % 1000 == 0) {
         expected = k / 1000; // end key is inclusive

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiLevelIndexTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiLevelIndexTest.java
@@ -18,13 +18,13 @@
  */
 package org.apache.accumulo.core.file.rfile;
 
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.security.SecureRandom;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
@@ -47,7 +47,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.junit.jupiter.api.Test;
 
 public class MultiLevelIndexTest {
-  private static final SecureRandom random = new SecureRandom();
   private Configuration hadoopConf = new Configuration();
 
   @Test
@@ -120,7 +119,7 @@ public class MultiLevelIndexTest {
     liter = reader.lookup(new Key(String.format("%05d000", num + 1)));
     assertFalse(liter.hasNext());
 
-    random.ints(100, 0, num * 1_000).forEach(k -> {
+    SECURE_RANDOM.get().ints(100, 0, num * 1_000).forEach(k -> {
       int expected;
       if (k % 1000 == 0) {
         expected = k / 1000; // end key is inclusive

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
@@ -20,7 +20,7 @@ package org.apache.accumulo.core.file.rfile;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -285,7 +285,7 @@ public class MultiThreadedRFileTest {
   }
 
   private void validate(TestRFile trf) throws IOException {
-    SECURE_RANDOM.get().ints(10, 0, 4).forEach(part -> {
+    RANDOM.get().ints(10, 0, 4).forEach(part -> {
       try {
         Range range = new Range(getKey(part, 0, 0), true, getKey(part, 4, 2048), true);
         trf.iter.seek(range, EMPTY_COL_FAMS, false);

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.core.file.rfile;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -29,7 +30,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.UncheckedIOException;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -71,7 +71,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
 public class MultiThreadedRFileTest {
 
-  private static final SecureRandom random = new SecureRandom();
   private static final Logger LOG = LoggerFactory.getLogger(MultiThreadedRFileTest.class);
   private static final Collection<ByteSequence> EMPTY_COL_FAMS = new ArrayList<>();
 
@@ -286,7 +285,7 @@ public class MultiThreadedRFileTest {
   }
 
   private void validate(TestRFile trf) throws IOException {
-    random.ints(10, 0, 4).forEach(part -> {
+    SECURE_RANDOM.get().ints(10, 0, 4).forEach(part -> {
       try {
         Range range = new Range(getKey(part, 0, 0), true, getKey(part, 4, 2048), true);
         trf.iter.seek(range, EMPTY_COL_FAMS, false);

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.core.file.rfile;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -551,7 +551,7 @@ public class RFileTest {
     // test seeking to random location and reading all data from that point
     // there was an off by one bug with this in the transient index
     for (int i = 0; i < 12; i++) {
-      index = SECURE_RANDOM.get().nextInt(expectedKeys.size());
+      index = RANDOM.get().nextInt(expectedKeys.size());
       trf.seek(expectedKeys.get(index));
       for (; index < expectedKeys.size(); index++) {
         assertTrue(trf.iter.hasTop());
@@ -1644,13 +1644,13 @@ public class RFileTest {
 
     for (int count = 0; count < 100; count++) {
 
-      int start = SECURE_RANDOM.get().nextInt(2300);
+      int start = RANDOM.get().nextInt(2300);
       Range range = new Range(newKey(formatString("r_", start), "cf1", "cq1", "L1", 42),
           newKey(formatString("r_", start + 100), "cf1", "cq1", "L1", 42));
 
       trf.reader.seek(range, cfs, false);
 
-      int numToScan = SECURE_RANDOM.get().nextInt(100);
+      int numToScan = RANDOM.get().nextInt(100);
 
       for (int j = 0; j < numToScan; j++) {
         assertTrue(trf.reader.hasTop());
@@ -1666,8 +1666,8 @@ public class RFileTest {
       // seek a little forward from the last range and read a few keys within the unconsumed portion
       // of the last range
 
-      int start2 = start + numToScan + SECURE_RANDOM.get().nextInt(3);
-      int end2 = start2 + SECURE_RANDOM.get().nextInt(3);
+      int start2 = start + numToScan + RANDOM.get().nextInt(3);
+      int end2 = start2 + RANDOM.get().nextInt(3);
 
       range = new Range(newKey(formatString("r_", start2), "cf1", "cq1", "L1", 42),
           newKey(formatString("r_", end2), "cf1", "cq1", "L1", 42));
@@ -2003,24 +2003,24 @@ public class RFileTest {
       boolean endInclusive = false;
       int endIndex = sampleData.size();
 
-      if (SECURE_RANDOM.get().nextBoolean()) {
-        startIndex = SECURE_RANDOM.get().nextInt(sampleData.size());
+      if (RANDOM.get().nextBoolean()) {
+        startIndex = RANDOM.get().nextInt(sampleData.size());
         startKey = sampleData.get(startIndex).getKey();
-        startInclusive = SECURE_RANDOM.get().nextBoolean();
+        startInclusive = RANDOM.get().nextBoolean();
         if (!startInclusive) {
           startIndex++;
         }
       }
 
-      if (startIndex < endIndex && SECURE_RANDOM.get().nextBoolean()) {
-        endIndex -= SECURE_RANDOM.get().nextInt(endIndex - startIndex);
+      if (startIndex < endIndex && RANDOM.get().nextBoolean()) {
+        endIndex -= RANDOM.get().nextInt(endIndex - startIndex);
         endKey = sampleData.get(endIndex - 1).getKey();
-        endInclusive = SECURE_RANDOM.get().nextBoolean();
+        endInclusive = RANDOM.get().nextBoolean();
         if (!endInclusive) {
           endIndex--;
         }
       } else if (startIndex == endIndex) {
-        endInclusive = SECURE_RANDOM.get().nextBoolean();
+        endInclusive = RANDOM.get().nextBoolean();
       }
 
       sample.seek(new Range(startKey, startInclusive, endKey, endInclusive), columnFamilies,

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.file.rfile;
 
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -33,7 +34,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.security.SecureRandom;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -104,8 +104,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
 public class RFileTest {
-
-  private static final SecureRandom random = new SecureRandom();
 
   public static class SampleIE implements IteratorEnvironment {
 
@@ -553,7 +551,7 @@ public class RFileTest {
     // test seeking to random location and reading all data from that point
     // there was an off by one bug with this in the transient index
     for (int i = 0; i < 12; i++) {
-      index = random.nextInt(expectedKeys.size());
+      index = SECURE_RANDOM.get().nextInt(expectedKeys.size());
       trf.seek(expectedKeys.get(index));
       for (; index < expectedKeys.size(); index++) {
         assertTrue(trf.iter.hasTop());
@@ -1646,13 +1644,13 @@ public class RFileTest {
 
     for (int count = 0; count < 100; count++) {
 
-      int start = random.nextInt(2300);
+      int start = SECURE_RANDOM.get().nextInt(2300);
       Range range = new Range(newKey(formatString("r_", start), "cf1", "cq1", "L1", 42),
           newKey(formatString("r_", start + 100), "cf1", "cq1", "L1", 42));
 
       trf.reader.seek(range, cfs, false);
 
-      int numToScan = random.nextInt(100);
+      int numToScan = SECURE_RANDOM.get().nextInt(100);
 
       for (int j = 0; j < numToScan; j++) {
         assertTrue(trf.reader.hasTop());
@@ -1668,8 +1666,8 @@ public class RFileTest {
       // seek a little forward from the last range and read a few keys within the unconsumed portion
       // of the last range
 
-      int start2 = start + numToScan + random.nextInt(3);
-      int end2 = start2 + random.nextInt(3);
+      int start2 = start + numToScan + SECURE_RANDOM.get().nextInt(3);
+      int end2 = start2 + SECURE_RANDOM.get().nextInt(3);
 
       range = new Range(newKey(formatString("r_", start2), "cf1", "cq1", "L1", 42),
           newKey(formatString("r_", end2), "cf1", "cq1", "L1", 42));
@@ -2005,24 +2003,24 @@ public class RFileTest {
       boolean endInclusive = false;
       int endIndex = sampleData.size();
 
-      if (random.nextBoolean()) {
-        startIndex = random.nextInt(sampleData.size());
+      if (SECURE_RANDOM.get().nextBoolean()) {
+        startIndex = SECURE_RANDOM.get().nextInt(sampleData.size());
         startKey = sampleData.get(startIndex).getKey();
-        startInclusive = random.nextBoolean();
+        startInclusive = SECURE_RANDOM.get().nextBoolean();
         if (!startInclusive) {
           startIndex++;
         }
       }
 
-      if (startIndex < endIndex && random.nextBoolean()) {
-        endIndex -= random.nextInt(endIndex - startIndex);
+      if (startIndex < endIndex && SECURE_RANDOM.get().nextBoolean()) {
+        endIndex -= SECURE_RANDOM.get().nextInt(endIndex - startIndex);
         endKey = sampleData.get(endIndex - 1).getKey();
-        endInclusive = random.nextBoolean();
+        endInclusive = SECURE_RANDOM.get().nextBoolean();
         if (!endInclusive) {
           endIndex--;
         }
       } else if (startIndex == endIndex) {
-        endInclusive = random.nextBoolean();
+        endInclusive = SECURE_RANDOM.get().nextBoolean();
       }
 
       sample.seek(new Range(startKey, startInclusive, endKey, endInclusive), columnFamilies,

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RollingStatsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RollingStatsTest.java
@@ -18,9 +18,9 @@
  */
 package org.apache.accumulo.core.file.rfile;
 
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.security.SecureRandom;
 import java.util.function.IntSupplier;
 
 import org.apache.commons.math3.distribution.NormalDistribution;
@@ -34,7 +34,6 @@ import com.google.common.math.DoubleMath;
 public class RollingStatsTest {
 
   private static final double TOLERANCE = 1.0 / 1000;
-  private static final SecureRandom random = new SecureRandom();
 
   private static void assertFuzzyEquals(double expected, double actual) {
     assertTrue(DoubleMath.fuzzyEquals(expected, actual, TOLERANCE), String.format(
@@ -80,7 +79,7 @@ public class RollingStatsTest {
       rsp.addValue(v);
       checkAgreement(ds, rs);
 
-      if (random.nextDouble() < 0.001) {
+      if (SECURE_RANDOM.get().nextDouble() < 0.001) {
         checkAgreement(ds, rsp);
       }
     }
@@ -95,7 +94,7 @@ public class RollingStatsTest {
     StatTester st = new StatTester(1019);
     int[] keySizes = {103, 113, 123, 2345};
     for (int i = 0; i < 10000; i++) {
-      st.addValue(keySizes[random.nextInt(keySizes.length)]);
+      st.addValue(keySizes[SECURE_RANDOM.get().nextInt(keySizes.length)]);
     }
     st.check();
   }
@@ -120,7 +119,7 @@ public class RollingStatsTest {
       StatTester st = new StatTester(windowSize);
 
       for (int i = 0; i < 1000; i++) {
-        int v = 200 + random.nextInt(50);
+        int v = 200 + SECURE_RANDOM.get().nextInt(50);
 
         st.addValue(v);
       }
@@ -177,9 +176,9 @@ public class RollingStatsTest {
     for (int i = 0; i < 13; i++) {
 
       // write small keys
-      int numSmall = 1000 + random.nextInt(1000);
+      int numSmall = 1000 + SECURE_RANDOM.get().nextInt(1000);
       for (int s = 0; s < numSmall; s++) {
-        int sks = 50 + random.nextInt(100);
+        int sks = 50 + SECURE_RANDOM.get().nextInt(100);
         // simulate row with multiple cols
         for (int c = 0; c < 3; c++) {
           st.addValue(sks);
@@ -187,9 +186,9 @@ public class RollingStatsTest {
       }
 
       // write a few large keys
-      int numLarge = 1 + random.nextInt(1);
+      int numLarge = 1 + SECURE_RANDOM.get().nextInt(1);
       for (int l = 0; l < numLarge; l++) {
-        int lks = 500000 + random.nextInt(1000000);
+        int lks = 500000 + SECURE_RANDOM.get().nextInt(1000000);
         for (int c = 0; c < 3; c++) {
           st.addValue(lks);
         }

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RollingStatsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RollingStatsTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.core.file.rfile;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.function.IntSupplier;
@@ -79,7 +79,7 @@ public class RollingStatsTest {
       rsp.addValue(v);
       checkAgreement(ds, rs);
 
-      if (SECURE_RANDOM.get().nextDouble() < 0.001) {
+      if (RANDOM.get().nextDouble() < 0.001) {
         checkAgreement(ds, rsp);
       }
     }
@@ -94,7 +94,7 @@ public class RollingStatsTest {
     StatTester st = new StatTester(1019);
     int[] keySizes = {103, 113, 123, 2345};
     for (int i = 0; i < 10000; i++) {
-      st.addValue(keySizes[SECURE_RANDOM.get().nextInt(keySizes.length)]);
+      st.addValue(keySizes[RANDOM.get().nextInt(keySizes.length)]);
     }
     st.check();
   }
@@ -119,7 +119,7 @@ public class RollingStatsTest {
       StatTester st = new StatTester(windowSize);
 
       for (int i = 0; i < 1000; i++) {
-        int v = 200 + SECURE_RANDOM.get().nextInt(50);
+        int v = 200 + RANDOM.get().nextInt(50);
 
         st.addValue(v);
       }
@@ -176,9 +176,9 @@ public class RollingStatsTest {
     for (int i = 0; i < 13; i++) {
 
       // write small keys
-      int numSmall = 1000 + SECURE_RANDOM.get().nextInt(1000);
+      int numSmall = 1000 + RANDOM.get().nextInt(1000);
       for (int s = 0; s < numSmall; s++) {
-        int sks = 50 + SECURE_RANDOM.get().nextInt(100);
+        int sks = 50 + RANDOM.get().nextInt(100);
         // simulate row with multiple cols
         for (int c = 0; c < 3; c++) {
           st.addValue(sks);
@@ -186,9 +186,9 @@ public class RollingStatsTest {
       }
 
       // write a few large keys
-      int numLarge = 1 + SECURE_RANDOM.get().nextInt(1);
+      int numLarge = 1 + RANDOM.get().nextInt(1);
       for (int l = 0; l < numLarge; l++) {
-        int lks = 500000 + SECURE_RANDOM.get().nextInt(1000000);
+        int lks = 500000 + RANDOM.get().nextInt(1000000);
         for (int c = 0; c < 3; c++) {
           st.addValue(lks);
         }

--- a/core/src/test/java/org/apache/accumulo/core/file/streams/RateLimitedInputStreamTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/streams/RateLimitedInputStreamTest.java
@@ -18,10 +18,10 @@
  */
 package org.apache.accumulo.core.file.streams;
 
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.InputStream;
-import java.security.SecureRandom;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.accumulo.core.util.ratelimit.RateLimiter;
@@ -30,8 +30,6 @@ import org.easymock.EasyMock;
 import org.junit.jupiter.api.Test;
 
 public class RateLimitedInputStreamTest {
-
-  private static final SecureRandom random = new SecureRandom();
 
   @Test
   public void permitsAreProperlyAcquired() throws Exception {
@@ -49,7 +47,7 @@ public class RateLimitedInputStreamTest {
     long bytesRetrieved = 0;
     try (InputStream is = new RateLimitedInputStream(new RandomInputStream(), rateLimiter)) {
       for (int i = 0; i < 100; ++i) {
-        int count = Math.abs(random.nextInt()) % 65536;
+        int count = Math.abs(SECURE_RANDOM.get().nextInt()) % 65536;
         int countRead = is.read(new byte[count]);
         assertEquals(count, countRead);
         bytesRetrieved += count;
@@ -62,7 +60,7 @@ public class RateLimitedInputStreamTest {
 
     @Override
     public int read() {
-      return random.nextInt() & 0xff;
+      return SECURE_RANDOM.get().nextInt() & 0xff;
     }
 
     @Override

--- a/core/src/test/java/org/apache/accumulo/core/file/streams/RateLimitedInputStreamTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/streams/RateLimitedInputStreamTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.core.file.streams;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.InputStream;
@@ -47,7 +47,7 @@ public class RateLimitedInputStreamTest {
     long bytesRetrieved = 0;
     try (InputStream is = new RateLimitedInputStream(new RandomInputStream(), rateLimiter)) {
       for (int i = 0; i < 100; ++i) {
-        int count = Math.abs(SECURE_RANDOM.get().nextInt()) % 65536;
+        int count = Math.abs(RANDOM.get().nextInt()) % 65536;
         int countRead = is.read(new byte[count]);
         assertEquals(count, countRead);
         bytesRetrieved += count;
@@ -60,7 +60,7 @@ public class RateLimitedInputStreamTest {
 
     @Override
     public int read() {
-      return SECURE_RANDOM.get().nextInt() & 0xff;
+      return RANDOM.get().nextInt() & 0xff;
     }
 
     @Override

--- a/core/src/test/java/org/apache/accumulo/core/file/streams/RateLimitedOutputStreamTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/streams/RateLimitedOutputStreamTest.java
@@ -18,10 +18,10 @@
  */
 package org.apache.accumulo.core.file.streams;
 
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.OutputStream;
-import java.security.SecureRandom;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.accumulo.core.util.ratelimit.RateLimiter;
@@ -32,8 +32,6 @@ import org.junit.jupiter.api.Test;
 import com.google.common.io.CountingOutputStream;
 
 public class RateLimitedOutputStreamTest {
-
-  private static final SecureRandom random = new SecureRandom();
 
   @Test
   public void permitsAreProperlyAcquired() throws Exception {
@@ -52,7 +50,7 @@ public class RateLimitedOutputStreamTest {
     try (RateLimitedOutputStream os =
         new RateLimitedOutputStream(new NullOutputStream(), rateLimiter)) {
       for (int i = 0; i < 100; ++i) {
-        byte[] bytes = new byte[Math.abs(random.nextInt() % 65536)];
+        byte[] bytes = new byte[Math.abs(SECURE_RANDOM.get().nextInt() % 65536)];
         os.write(bytes);
         bytesWritten += bytes.length;
       }

--- a/core/src/test/java/org/apache/accumulo/core/file/streams/RateLimitedOutputStreamTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/streams/RateLimitedOutputStreamTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.core.file.streams;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.OutputStream;
@@ -50,7 +50,7 @@ public class RateLimitedOutputStreamTest {
     try (RateLimitedOutputStream os =
         new RateLimitedOutputStream(new NullOutputStream(), rateLimiter)) {
       for (int i = 0; i < 100; ++i) {
-        byte[] bytes = new byte[Math.abs(SECURE_RANDOM.get().nextInt() % 65536)];
+        byte[] bytes = new byte[Math.abs(RANDOM.get().nextInt() % 65536)];
         os.write(bytes);
         bytesWritten += bytes.length;
       }

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/IndexedDocIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/IndexedDocIteratorTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.core.iterators.user;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -92,7 +92,7 @@ public class IndexedDocIteratorTest {
         doc.append(nullByte, 0, 1);
         doc.append(String.format("%010d", docid).getBytes(), 0, 10);
         for (int j = 0; j < columnFamilies.length; j++) {
-          if (SECURE_RANDOM.get().nextFloat() < hitRatio) {
+          if (RANDOM.get().nextFloat() < hitRatio) {
             Text colq = new Text(columnFamilies[j]);
             colq.append(nullByte, 0, 1);
             colq.append(doc.getBytes(), 0, doc.getLength());
@@ -115,7 +115,7 @@ public class IndexedDocIteratorTest {
           docs.add(doc);
         }
         for (Text cf : otherColumnFamilies) {
-          if (SECURE_RANDOM.get().nextFloat() < hitRatio) {
+          if (RANDOM.get().nextFloat() < hitRatio) {
             Text colq = new Text(cf);
             colq.append(nullByte, 0, 1);
             colq.append(doc.getBytes(), 0, doc.getLength());

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/IndexedDocIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/IndexedDocIteratorTest.java
@@ -18,11 +18,11 @@
  */
 package org.apache.accumulo.core.iterators.user;
 
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -46,7 +46,6 @@ import org.junit.jupiter.api.Test;
 
 public class IndexedDocIteratorTest {
 
-  private static final SecureRandom random = new SecureRandom();
   private static final Collection<ByteSequence> EMPTY_COL_FAMS = new ArrayList<>();
   private static final byte[] nullByte = {0};
 
@@ -93,7 +92,7 @@ public class IndexedDocIteratorTest {
         doc.append(nullByte, 0, 1);
         doc.append(String.format("%010d", docid).getBytes(), 0, 10);
         for (int j = 0; j < columnFamilies.length; j++) {
-          if (random.nextFloat() < hitRatio) {
+          if (SECURE_RANDOM.get().nextFloat() < hitRatio) {
             Text colq = new Text(columnFamilies[j]);
             colq.append(nullByte, 0, 1);
             colq.append(doc.getBytes(), 0, doc.getLength());
@@ -116,7 +115,7 @@ public class IndexedDocIteratorTest {
           docs.add(doc);
         }
         for (Text cf : otherColumnFamilies) {
-          if (random.nextFloat() < hitRatio) {
+          if (SECURE_RANDOM.get().nextFloat() < hitRatio) {
             Text colq = new Text(cf);
             colq.append(nullByte, 0, 1);
             colq.append(doc.getBytes(), 0, doc.getLength());

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/IntersectingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/IntersectingIteratorTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.core.iterators.user;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -77,7 +77,7 @@ public class IntersectingIteratorTest {
         boolean docHits = true;
         Text doc = new Text(String.format("%010d", docid));
         for (int j = 0; j < columnFamilies.length; j++) {
-          if (SECURE_RANDOM.get().nextFloat() < hitRatio) {
+          if (RANDOM.get().nextFloat() < hitRatio) {
             Key k = new Key(row, columnFamilies[j], doc);
             map.put(k, v);
             if (negateMask[j]) {
@@ -93,7 +93,7 @@ public class IntersectingIteratorTest {
           docs.add(doc);
         }
         for (Text cf : otherColumnFamilies) {
-          if (SECURE_RANDOM.get().nextFloat() < hitRatio) {
+          if (RANDOM.get().nextFloat() < hitRatio) {
             Key k = new Key(row, cf, doc);
             map.put(k, v);
           }

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/IntersectingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/IntersectingIteratorTest.java
@@ -18,11 +18,11 @@
  */
 package org.apache.accumulo.core.iterators.user;
 
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -43,7 +43,6 @@ import org.junit.jupiter.api.Test;
 
 public class IntersectingIteratorTest {
 
-  private static final SecureRandom random = new SecureRandom();
   private static final Collection<ByteSequence> EMPTY_COL_FAMS = new ArrayList<>();
   private static IteratorEnvironment env = new DefaultIteratorEnvironment();
 
@@ -78,7 +77,7 @@ public class IntersectingIteratorTest {
         boolean docHits = true;
         Text doc = new Text(String.format("%010d", docid));
         for (int j = 0; j < columnFamilies.length; j++) {
-          if (random.nextFloat() < hitRatio) {
+          if (SECURE_RANDOM.get().nextFloat() < hitRatio) {
             Key k = new Key(row, columnFamilies[j], doc);
             map.put(k, v);
             if (negateMask[j]) {
@@ -94,7 +93,7 @@ public class IntersectingIteratorTest {
           docs.add(doc);
         }
         for (Text cf : otherColumnFamilies) {
-          if (random.nextFloat() < hitRatio) {
+          if (SECURE_RANDOM.get().nextFloat() < hitRatio) {
             Key k = new Key(row, cf, doc);
             map.put(k, v);
           }

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/TestCfCqSlice.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/TestCfCqSlice.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.core.iterators.user;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -380,7 +380,7 @@ public abstract class TestCfCqSlice {
       assertFalse(foundKvs[row][cf][cq], "Duplicate " + row + " " + cf + " " + cq);
       foundKvs[row][cf][cq] = true;
 
-      if (SECURE_RANDOM.get().nextInt(100) == 0) {
+      if (RANDOM.get().nextInt(100) == 0) {
         skvi.seek(new Range(k, false, range.getEndKey(), range.isEndKeyInclusive()), EMPTY_CF_SET,
             false);
       } else {

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/TestCfCqSlice.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/TestCfCqSlice.java
@@ -19,10 +19,10 @@
 package org.apache.accumulo.core.iterators.user;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.security.SecureRandom;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -45,7 +45,6 @@ import org.junit.jupiter.api.Test;
 
 public abstract class TestCfCqSlice {
 
-  private static final SecureRandom random = new SecureRandom();
   private static final Range INFINITY = new Range();
   private static final Lexicoder<Long> LONG_LEX = new ReadableLongLexicoder(4);
   private static final AtomicLong ROW_ID_GEN = new AtomicLong();
@@ -381,7 +380,7 @@ public abstract class TestCfCqSlice {
       assertFalse(foundKvs[row][cf][cq], "Duplicate " + row + " " + cf + " " + cq);
       foundKvs[row][cf][cq] = true;
 
-      if (random.nextInt(100) == 0) {
+      if (SECURE_RANDOM.get().nextInt(100) == 0) {
         skvi.seek(new Range(k, false, range.getEndKey(), range.isEndKeyInclusive()), EMPTY_CF_SET,
             false);
       } else {

--- a/core/src/test/java/org/apache/accumulo/core/security/AuthenticationTokenTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/security/AuthenticationTokenTest.java
@@ -18,10 +18,10 @@
  */
 package org.apache.accumulo.core.security;
 
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.security.SecureRandom;
 import java.util.stream.IntStream;
 
 import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
@@ -32,14 +32,12 @@ import org.junit.jupiter.api.Test;
 
 public class AuthenticationTokenTest {
 
-  private static final SecureRandom random = new SecureRandom();
-
   @Test
   public void testSerializeDeserializeToken() {
     byte[] randomBytes = new byte[12];
     do {
       // random fill, but avoid all zeros case
-      random.nextBytes(randomBytes);
+      SECURE_RANDOM.get().nextBytes(randomBytes);
     } while (IntStream.range(0, randomBytes.length).allMatch(i -> randomBytes[i] == 0));
 
     byte[] serialized = AuthenticationTokenSerializer.serialize(new PasswordToken(randomBytes));

--- a/core/src/test/java/org/apache/accumulo/core/security/AuthenticationTokenTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/security/AuthenticationTokenTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.core.security;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -37,7 +37,7 @@ public class AuthenticationTokenTest {
     byte[] randomBytes = new byte[12];
     do {
       // random fill, but avoid all zeros case
-      SECURE_RANDOM.get().nextBytes(randomBytes);
+      RANDOM.get().nextBytes(randomBytes);
     } while (IntStream.range(0, randomBytes.length).allMatch(i -> randomBytes[i] == 0));
 
     byte[] serialized = AuthenticationTokenSerializer.serialize(new PasswordToken(randomBytes));

--- a/core/src/test/java/org/apache/accumulo/core/spi/balancer/GroupBalancerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/balancer/GroupBalancerTest.java
@@ -18,10 +18,10 @@
  */
 package org.apache.accumulo.core.spi.balancer;
 
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -48,8 +48,6 @@ import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.Test;
 
 public class GroupBalancerTest {
-
-  private static final SecureRandom random = new SecureRandom();
 
   private static final Function<TabletId,String> partitioner =
       input -> (input == null || input.getEndRow() == null) ? null
@@ -326,8 +324,8 @@ public class GroupBalancerTest {
 
     for (int g = 1; g <= 60; g++) {
       for (int t = 1; t <= 241; t++) {
-        tservers.addTablet(String.format("%02d:%d", g, t), "192.168.1." + (random.nextInt(249) + 1),
-            9997);
+        tservers.addTablet(String.format("%02d:%d", g, t),
+            "192.168.1." + (SECURE_RANDOM.get().nextInt(249) + 1), 9997);
       }
     }
 
@@ -343,9 +341,9 @@ public class GroupBalancerTest {
     TabletServers tservers = new TabletServers();
 
     for (int g = 1; g <= 60; g++) {
-      for (int t = 1; t <= random.nextInt(1000); t++) {
-        tservers.addTablet(String.format("%02d:%d", g, t), "192.168.1." + (random.nextInt(249) + 1),
-            9997);
+      for (int t = 1; t <= SECURE_RANDOM.get().nextInt(1000); t++) {
+        tservers.addTablet(String.format("%02d:%d", g, t),
+            "192.168.1." + (SECURE_RANDOM.get().nextInt(249) + 1), 9997);
       }
     }
 

--- a/core/src/test/java/org/apache/accumulo/core/spi/balancer/GroupBalancerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/balancer/GroupBalancerTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.core.spi.balancer;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -325,7 +325,7 @@ public class GroupBalancerTest {
     for (int g = 1; g <= 60; g++) {
       for (int t = 1; t <= 241; t++) {
         tservers.addTablet(String.format("%02d:%d", g, t),
-            "192.168.1." + (SECURE_RANDOM.get().nextInt(249) + 1), 9997);
+            "192.168.1." + (RANDOM.get().nextInt(249) + 1), 9997);
       }
     }
 
@@ -341,9 +341,9 @@ public class GroupBalancerTest {
     TabletServers tservers = new TabletServers();
 
     for (int g = 1; g <= 60; g++) {
-      for (int t = 1; t <= SECURE_RANDOM.get().nextInt(1000); t++) {
+      for (int t = 1; t <= RANDOM.get().nextInt(1000); t++) {
         tservers.addTablet(String.format("%02d:%d", g, t),
-            "192.168.1." + (SECURE_RANDOM.get().nextInt(249) + 1), 9997);
+            "192.168.1." + (RANDOM.get().nextInt(249) + 1), 9997);
       }
     }
 

--- a/core/src/test/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelectorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelectorTest.java
@@ -18,12 +18,12 @@
  */
 package org.apache.accumulo.core.spi.scan;
 
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.security.SecureRandom;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.HashMap;
@@ -253,12 +253,11 @@ public class ConfigurableScanServerSelectorTest {
 
     Map<String,Long> allServersSeen = new HashMap<>();
 
-    SecureRandom rand = new SecureRandom();
-
     for (int t = 0; t < 10000; t++) {
       Set<String> serversSeen = new HashSet<>();
 
-      String endRow = Long.toString(Math.abs(Math.max(rand.nextLong(), Long.MIN_VALUE + 1)), 36);
+      String endRow =
+          Long.toString(Math.abs(Math.max(SECURE_RANDOM.get().nextLong(), Long.MIN_VALUE + 1)), 36);
 
       var tabletId = t % 1000 == 0 ? nti("" + t, null) : nti("" + t, endRow);
 

--- a/core/src/test/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelectorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelectorTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.core.spi.scan;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -257,7 +257,7 @@ public class ConfigurableScanServerSelectorTest {
       Set<String> serversSeen = new HashSet<>();
 
       String endRow =
-          Long.toString(Math.abs(Math.max(SECURE_RANDOM.get().nextLong(), Long.MIN_VALUE + 1)), 36);
+          Long.toString(Math.abs(Math.max(RANDOM.get().nextLong(), Long.MIN_VALUE + 1)), 36);
 
       var tabletId = t % 1000 == 0 ? nti("" + t, null) : nti("" + t, endRow);
 

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapred/AccumuloRecordReader.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapred/AccumuloRecordReader.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.hadoopImpl.mapred;
 
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -336,7 +336,7 @@ public abstract class AccumuloRecordReader<K,V> implements RecordReader<K,V> {
             while (binnedRanges == null) {
               // Some tablets were still online, try again
               // sleep randomly between 100 and 200 ms
-              sleepUninterruptibly(100 + SECURE_RANDOM.get().nextInt(100), TimeUnit.MILLISECONDS);
+              sleepUninterruptibly(100 + RANDOM.get().nextInt(100), TimeUnit.MILLISECONDS);
               binnedRanges = binOfflineTable(job, tableId, ranges, callingClass);
             }
           } else {
@@ -352,7 +352,7 @@ public abstract class AccumuloRecordReader<K,V> implements RecordReader<K,V> {
               binnedRanges.clear();
               log.warn("Unable to locate bins for specified ranges. Retrying.");
               // sleep randomly between 100 and 200 ms
-              sleepUninterruptibly(100 + SECURE_RANDOM.get().nextInt(100), TimeUnit.MILLISECONDS);
+              sleepUninterruptibly(100 + RANDOM.get().nextInt(100), TimeUnit.MILLISECONDS);
               tl.invalidateCache();
             }
           }

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapred/AccumuloRecordReader.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapred/AccumuloRecordReader.java
@@ -19,10 +19,10 @@
 package org.apache.accumulo.hadoopImpl.mapred;
 
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 
 import java.io.IOException;
 import java.net.InetAddress;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -72,7 +72,6 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class AccumuloRecordReader<K,V> implements RecordReader<K,V> {
 
-  private static final SecureRandom random = new SecureRandom();
   // class to serialize configuration under in the job
   private final Class<?> CLASS;
   private static final Logger log = LoggerFactory.getLogger(AccumuloRecordReader.class);
@@ -337,7 +336,7 @@ public abstract class AccumuloRecordReader<K,V> implements RecordReader<K,V> {
             while (binnedRanges == null) {
               // Some tablets were still online, try again
               // sleep randomly between 100 and 200 ms
-              sleepUninterruptibly(100 + random.nextInt(100), TimeUnit.MILLISECONDS);
+              sleepUninterruptibly(100 + SECURE_RANDOM.get().nextInt(100), TimeUnit.MILLISECONDS);
               binnedRanges = binOfflineTable(job, tableId, ranges, callingClass);
             }
           } else {
@@ -353,7 +352,7 @@ public abstract class AccumuloRecordReader<K,V> implements RecordReader<K,V> {
               binnedRanges.clear();
               log.warn("Unable to locate bins for specified ranges. Retrying.");
               // sleep randomly between 100 and 200 ms
-              sleepUninterruptibly(100 + random.nextInt(100), TimeUnit.MILLISECONDS);
+              sleepUninterruptibly(100 + SECURE_RANDOM.get().nextInt(100), TimeUnit.MILLISECONDS);
               tl.invalidateCache();
             }
           }

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/AccumuloRecordReader.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/AccumuloRecordReader.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.hadoopImpl.mapreduce;
 
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -368,7 +368,7 @@ public abstract class AccumuloRecordReader<K,V> extends RecordReader<K,V> {
             while (binnedRanges == null) {
               // Some tablets were still online, try again
               // sleep randomly between 100 and 200 ms
-              sleepUninterruptibly(100 + SECURE_RANDOM.get().nextInt(100), TimeUnit.MILLISECONDS);
+              sleepUninterruptibly(100 + RANDOM.get().nextInt(100), TimeUnit.MILLISECONDS);
               binnedRanges = binOfflineTable(context, tableId, ranges, callingClass);
 
             }
@@ -385,7 +385,7 @@ public abstract class AccumuloRecordReader<K,V> extends RecordReader<K,V> {
               binnedRanges.clear();
               log.warn("Unable to locate bins for specified ranges. Retrying.");
               // sleep randomly between 100 and 200 ms
-              sleepUninterruptibly(100 + SECURE_RANDOM.get().nextInt(100), TimeUnit.MILLISECONDS);
+              sleepUninterruptibly(100 + RANDOM.get().nextInt(100), TimeUnit.MILLISECONDS);
               tl.invalidateCache();
             }
           }

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/AccumuloRecordReader.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/AccumuloRecordReader.java
@@ -19,10 +19,10 @@
 package org.apache.accumulo.hadoopImpl.mapreduce;
 
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 
 import java.io.IOException;
 import java.net.InetAddress;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -72,7 +72,6 @@ import org.slf4j.LoggerFactory;
  * the user's K/V types.
  */
 public abstract class AccumuloRecordReader<K,V> extends RecordReader<K,V> {
-  private static final SecureRandom random = new SecureRandom();
   private static final Logger log = LoggerFactory.getLogger(AccumuloRecordReader.class);
   // class to serialize configuration under in the job
   private final Class<?> CLASS;
@@ -369,7 +368,7 @@ public abstract class AccumuloRecordReader<K,V> extends RecordReader<K,V> {
             while (binnedRanges == null) {
               // Some tablets were still online, try again
               // sleep randomly between 100 and 200 ms
-              sleepUninterruptibly(100 + random.nextInt(100), TimeUnit.MILLISECONDS);
+              sleepUninterruptibly(100 + SECURE_RANDOM.get().nextInt(100), TimeUnit.MILLISECONDS);
               binnedRanges = binOfflineTable(context, tableId, ranges, callingClass);
 
             }
@@ -386,7 +385,7 @@ public abstract class AccumuloRecordReader<K,V> extends RecordReader<K,V> {
               binnedRanges.clear();
               log.warn("Unable to locate bins for specified ranges. Retrying.");
               // sleep randomly between 100 and 200 ms
-              sleepUninterruptibly(100 + random.nextInt(100), TimeUnit.MILLISECONDS);
+              sleepUninterruptibly(100 + SECURE_RANDOM.get().nextInt(100), TimeUnit.MILLISECONDS);
               tl.invalidateCache();
             }
           }

--- a/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/IsolatedDeepCopiesTestCase.java
+++ b/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/IsolatedDeepCopiesTestCase.java
@@ -18,8 +18,9 @@
  */
 package org.apache.accumulo.iteratortest.testcases;
 
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+
 import java.io.IOException;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -42,8 +43,6 @@ import org.slf4j.LoggerFactory;
  */
 public class IsolatedDeepCopiesTestCase implements IteratorTestCase {
   private static final Logger log = LoggerFactory.getLogger(IsolatedDeepCopiesTestCase.class);
-
-  private static final SecureRandom random = new SecureRandom();
 
   @Override
   public IteratorTestOutput test(IteratorTestInput testInput) {
@@ -81,7 +80,7 @@ public class IsolatedDeepCopiesTestCase implements IteratorTestCase {
     // All of the copies should have consistent results from concurrent use
     while (allHasTop(iterators)) {
       // occasionally deep copy one of the existing iterators
-      if (random.nextInt(3) == 0) {
+      if (SECURE_RANDOM.get().nextInt(3) == 0) {
         log.debug("Deep-copying and re-seeking an iterator");
         SortedKeyValueIterator<Key,Value> newcopy = getRandomElement(iterators).deepCopy(iterEnv);
         newcopy.seek(
@@ -109,7 +108,7 @@ public class IsolatedDeepCopiesTestCase implements IteratorTestCase {
     if (iterators == null || iterators.isEmpty()) {
       throw new IllegalArgumentException("should not pass an empty collection");
     }
-    int num = random.nextInt(iterators.size());
+    int num = SECURE_RANDOM.get().nextInt(iterators.size());
     for (E e : iterators) {
       if (num-- == 0) {
         return e;

--- a/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/IsolatedDeepCopiesTestCase.java
+++ b/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/IsolatedDeepCopiesTestCase.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.iteratortest.testcases;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -80,7 +80,7 @@ public class IsolatedDeepCopiesTestCase implements IteratorTestCase {
     // All of the copies should have consistent results from concurrent use
     while (allHasTop(iterators)) {
       // occasionally deep copy one of the existing iterators
-      if (SECURE_RANDOM.get().nextInt(3) == 0) {
+      if (RANDOM.get().nextInt(3) == 0) {
         log.debug("Deep-copying and re-seeking an iterator");
         SortedKeyValueIterator<Key,Value> newcopy = getRandomElement(iterators).deepCopy(iterEnv);
         newcopy.seek(
@@ -108,7 +108,7 @@ public class IsolatedDeepCopiesTestCase implements IteratorTestCase {
     if (iterators == null || iterators.isEmpty()) {
       throw new IllegalArgumentException("should not pass an empty collection");
     }
-    int num = SECURE_RANDOM.get().nextInt(iterators.size());
+    int num = RANDOM.get().nextInt(iterators.size());
     for (E e : iterators) {
       if (num-- == 0) {
         return e;

--- a/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/MultipleHasTopCalls.java
+++ b/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/MultipleHasTopCalls.java
@@ -18,8 +18,9 @@
  */
 package org.apache.accumulo.iteratortest.testcases;
 
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+
 import java.io.IOException;
-import java.security.SecureRandom;
 import java.util.TreeMap;
 
 import org.apache.accumulo.core.data.Key;
@@ -39,8 +40,6 @@ import org.apache.accumulo.iteratortest.IteratorTestOutput;
  */
 public class MultipleHasTopCalls implements IteratorTestCase {
 
-  private static final SecureRandom random = new SecureRandom();
-
   @Override
   public IteratorTestOutput test(IteratorTestInput testInput) {
     final SortedKeyValueIterator<Key,Value> skvi = IteratorTestUtil.instantiateIterator(testInput);
@@ -59,7 +58,7 @@ public class MultipleHasTopCalls implements IteratorTestCase {
     TreeMap<Key,Value> data = new TreeMap<>();
     while (skvi.hasTop()) {
       // Check 1 to 5 times. If hasTop returned true, it should continue to return true.
-      for (int i = 0; i < random.nextInt(5) + 1; i++) {
+      for (int i = 0; i < SECURE_RANDOM.get().nextInt(5) + 1; i++) {
         if (!skvi.hasTop()) {
           throw badStateException(true);
         }
@@ -70,7 +69,7 @@ public class MultipleHasTopCalls implements IteratorTestCase {
     }
 
     // Check 1 to 5 times. Once hasTop returned false, it should continue to return false
-    for (int i = 0; i < random.nextInt(5) + 1; i++) {
+    for (int i = 0; i < SECURE_RANDOM.get().nextInt(5) + 1; i++) {
       if (skvi.hasTop()) {
         throw badStateException(false);
       }

--- a/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/MultipleHasTopCalls.java
+++ b/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/MultipleHasTopCalls.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.iteratortest.testcases;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.io.IOException;
 import java.util.TreeMap;
@@ -58,7 +58,7 @@ public class MultipleHasTopCalls implements IteratorTestCase {
     TreeMap<Key,Value> data = new TreeMap<>();
     while (skvi.hasTop()) {
       // Check 1 to 5 times. If hasTop returned true, it should continue to return true.
-      for (int i = 0; i < SECURE_RANDOM.get().nextInt(5) + 1; i++) {
+      for (int i = 0; i < RANDOM.get().nextInt(5) + 1; i++) {
         if (!skvi.hasTop()) {
           throw badStateException(true);
         }
@@ -69,7 +69,7 @@ public class MultipleHasTopCalls implements IteratorTestCase {
     }
 
     // Check 1 to 5 times. Once hasTop returned false, it should continue to return false
-    for (int i = 0; i < SECURE_RANDOM.get().nextInt(5) + 1; i++) {
+    for (int i = 0; i < RANDOM.get().nextInt(5) + 1; i++) {
       if (skvi.hasTop()) {
         throw badStateException(false);
       }

--- a/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/ReSeekTestCase.java
+++ b/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/ReSeekTestCase.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.iteratortest.testcases;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -67,7 +67,7 @@ public class ReSeekTestCase implements IteratorTestCase {
     final Range origRange = testInput.getRange();
     final Collection<ByteSequence> origFamilies = testInput.getFamilies();
     final boolean origInclusive = testInput.isInclusive();
-    int reseekCount = SECURE_RANDOM.get().nextInt(RESEEK_INTERVAL);
+    int reseekCount = RANDOM.get().nextInt(RESEEK_INTERVAL);
 
     int i = 0;
     while (skvi.hasTop()) {

--- a/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/ReSeekTestCase.java
+++ b/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/ReSeekTestCase.java
@@ -18,8 +18,9 @@
  */
 package org.apache.accumulo.iteratortest.testcases;
 
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+
 import java.io.IOException;
-import java.security.SecureRandom;
 import java.util.Collection;
 import java.util.TreeMap;
 
@@ -38,7 +39,6 @@ import org.slf4j.LoggerFactory;
  * Test case that verifies that an iterator can use the generated instance from {@code deepCopy}.
  */
 public class ReSeekTestCase implements IteratorTestCase {
-  private static final SecureRandom random = new SecureRandom();
   private static final Logger log = LoggerFactory.getLogger(ReSeekTestCase.class);
 
   /**
@@ -67,7 +67,7 @@ public class ReSeekTestCase implements IteratorTestCase {
     final Range origRange = testInput.getRange();
     final Collection<ByteSequence> origFamilies = testInput.getFamilies();
     final boolean origInclusive = testInput.isInclusive();
-    int reseekCount = random.nextInt(RESEEK_INTERVAL);
+    int reseekCount = SECURE_RANDOM.get().nextInt(RESEEK_INTERVAL);
 
     int i = 0;
     while (skvi.hasTop()) {

--- a/server/base/src/main/java/org/apache/accumulo/server/tablets/UniqueNameAllocator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tablets/UniqueNameAllocator.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.server.tablets;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.util.FastFormat;
@@ -46,7 +46,7 @@ public class UniqueNameAllocator {
   public synchronized String getNextName() {
 
     while (next >= maxAllocated) {
-      final int allocate = 100 + SECURE_RANDOM.get().nextInt(100);
+      final int allocate = 100 + RANDOM.get().nextInt(100);
 
       try {
         byte[] max = context.getZooReaderWriter().mutateExisting(nextNamePath, currentValue -> {

--- a/server/base/src/main/java/org/apache/accumulo/server/tablets/UniqueNameAllocator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tablets/UniqueNameAllocator.java
@@ -19,8 +19,7 @@
 package org.apache.accumulo.server.tablets;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-
-import java.security.SecureRandom;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.util.FastFormat;
@@ -38,7 +37,6 @@ public class UniqueNameAllocator {
   private long next = 0;
   private long maxAllocated = 0;
   private String nextNamePath;
-  private static final SecureRandom random = new SecureRandom();
 
   public UniqueNameAllocator(ServerContext context) {
     this.context = context;
@@ -48,7 +46,7 @@ public class UniqueNameAllocator {
   public synchronized String getNextName() {
 
     while (next >= maxAllocated) {
-      final int allocate = 100 + random.nextInt(100);
+      final int allocate = 100 + SECURE_RANDOM.get().nextInt(100);
 
       try {
         byte[] max = context.getZooReaderWriter().mutateExisting(nextNamePath, currentValue -> {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
@@ -18,9 +18,10 @@
  */
 package org.apache.accumulo.server.util;
 
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -59,8 +60,6 @@ import org.slf4j.LoggerFactory;
 
 public class FileUtil {
 
-  private static final SecureRandom random = new SecureRandom();
-
   public static class FileInfo {
     Key firstKey = new Key();
     Key lastKey = new Key();
@@ -89,7 +88,7 @@ public class FileUtil {
     Path result = null;
     while (result == null) {
       result = new Path(tabletDirectory + Path.SEPARATOR + "tmp/idxReduce_"
-          + String.format("%09d", random.nextInt(Integer.MAX_VALUE)));
+          + String.format("%09d", SECURE_RANDOM.get().nextInt(Integer.MAX_VALUE)));
       try {
         fs.getFileStatus(result);
         result = null;

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.server.util;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -88,7 +88,7 @@ public class FileUtil {
     Path result = null;
     while (result == null) {
       result = new Path(tabletDirectory + Path.SEPARATOR + "tmp/idxReduce_"
-          + String.format("%09d", SECURE_RANDOM.get().nextInt(Integer.MAX_VALUE)));
+          + String.format("%09d", RANDOM.get().nextInt(Integer.MAX_VALUE)));
       try {
         fs.getFileStatus(result);
         result = null;

--- a/server/base/src/main/java/org/apache/accumulo/server/util/RandomWriter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/RandomWriter.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.server.util;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.util.Iterator;
 import java.util.Properties;
@@ -62,13 +62,13 @@ public class RandomWriter {
 
     @Override
     public Mutation next() {
-      Text row_value = new Text(Long.toString(
-          ((SECURE_RANDOM.get().nextLong() & 0x7fffffffffffffffL) / 177) % 100000000000L));
+      Text row_value = new Text(
+          Long.toString(((RANDOM.get().nextLong() & 0x7fffffffffffffffL) / 177) % 100000000000L));
       Mutation m = new Mutation(row_value);
       for (int column = 0; column < num_columns_per_row; column++) {
         Text column_fam = new Text("col_fam");
         byte[] bytes = new byte[num_payload_bytes];
-        SECURE_RANDOM.get().nextBytes(bytes);
+        RANDOM.get().nextBytes(bytes);
         m.put(column_fam, new Text("" + column), new Value(bytes));
       }
       mutations_so_far++;

--- a/server/base/src/main/java/org/apache/accumulo/server/util/RandomWriter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/RandomWriter.java
@@ -18,7 +18,8 @@
  */
 package org.apache.accumulo.server.util;
 
-import java.security.SecureRandom;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+
 import java.util.Iterator;
 import java.util.Properties;
 
@@ -44,7 +45,6 @@ public class RandomWriter {
   private static int num_columns_per_row = 1;
   private static int num_payload_bytes = 1024;
   private static final Logger log = LoggerFactory.getLogger(RandomWriter.class);
-  private static final SecureRandom random = new SecureRandom();
 
   public static class RandomMutationGenerator implements Iterable<Mutation>, Iterator<Mutation> {
     private long max_mutations;
@@ -62,13 +62,13 @@ public class RandomWriter {
 
     @Override
     public Mutation next() {
-      Text row_value = new Text(
-          Long.toString(((random.nextLong() & 0x7fffffffffffffffL) / 177) % 100000000000L));
+      Text row_value = new Text(Long.toString(
+          ((SECURE_RANDOM.get().nextLong() & 0x7fffffffffffffffL) / 177) % 100000000000L));
       Mutation m = new Mutation(row_value);
       for (int column = 0; column < num_columns_per_row; column++) {
         Text column_fam = new Text("col_fam");
         byte[] bytes = new byte[num_payload_bytes];
-        random.nextBytes(bytes);
+        SECURE_RANDOM.get().nextBytes(bytes);
         m.put(column_fam, new Text("" + column), new Value(bytes));
       }
       mutations_so_far++;

--- a/server/base/src/main/java/org/apache/accumulo/server/zookeeper/DistributedWorkQueue.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/zookeeper/DistributedWorkQueue.java
@@ -21,7 +21,7 @@ package org.apache.accumulo.server.zookeeper;
 import static java.lang.Math.toIntExact;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.MINUTES;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -74,7 +74,7 @@ public class DistributedWorkQueue {
       return;
     }
 
-    Collections.shuffle(children, SECURE_RANDOM.get());
+    Collections.shuffle(children, RANDOM.get());
     try {
       for (final String child : children) {
 
@@ -169,7 +169,7 @@ public class DistributedWorkQueue {
 
   public DistributedWorkQueue(String path, AccumuloConfiguration config, ServerContext context) {
     // Preserve the old delay and period
-    this(path, config, context, SECURE_RANDOM.get().nextInt(toIntExact(MINUTES.toMillis(1))),
+    this(path, config, context, RANDOM.get().nextInt(toIntExact(MINUTES.toMillis(1))),
         MINUTES.toMillis(1));
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/zookeeper/DistributedWorkQueue.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/zookeeper/DistributedWorkQueue.java
@@ -21,8 +21,8 @@ package org.apache.accumulo.server.zookeeper;
 import static java.lang.Math.toIntExact;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -53,7 +53,6 @@ import org.slf4j.LoggerFactory;
  */
 public class DistributedWorkQueue {
 
-  private static final SecureRandom random = new SecureRandom();
   private static final String LOCKS_NODE = "locks";
 
   private static final Logger log = LoggerFactory.getLogger(DistributedWorkQueue.class);
@@ -75,7 +74,7 @@ public class DistributedWorkQueue {
       return;
     }
 
-    Collections.shuffle(children, random);
+    Collections.shuffle(children, SECURE_RANDOM.get());
     try {
       for (final String child : children) {
 
@@ -170,7 +169,7 @@ public class DistributedWorkQueue {
 
   public DistributedWorkQueue(String path, AccumuloConfiguration config, ServerContext context) {
     // Preserve the old delay and period
-    this(path, config, context, random.nextInt(toIntExact(MINUTES.toMillis(1))),
+    this(path, config, context, SECURE_RANDOM.get().nextInt(toIntExact(MINUTES.toMillis(1))),
         MINUTES.toMillis(1));
   }
 

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/codec/VersionedPropEncryptCodec.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/codec/VersionedPropEncryptCodec.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.server.conf.codec;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
@@ -216,7 +216,7 @@ public class VersionedPropEncryptCodec extends VersionedPropCodec {
     // utils
     public static GCMParameterSpec buildGCMParameterSpec() {
       byte[] iv = new byte[16];
-      SECURE_RANDOM.get().nextBytes(iv);
+      RANDOM.get().nextBytes(iv);
       return new GCMParameterSpec(128, iv);
     }
 

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/codec/VersionedPropEncryptCodec.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/codec/VersionedPropEncryptCodec.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.server.conf.codec;
 
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -27,7 +29,6 @@ import java.io.OutputStream;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
 import java.util.Map;
@@ -53,8 +54,6 @@ import javax.crypto.spec.SecretKeySpec;
  * stored in the external store.
  */
 public class VersionedPropEncryptCodec extends VersionedPropCodec {
-
-  private static final SecureRandom random = new SecureRandom();
 
   // testing version (999 or higher)
   public static final int EXPERIMENTAL_CIPHER_ENCODING_1_0 = 999;
@@ -217,7 +216,7 @@ public class VersionedPropEncryptCodec extends VersionedPropCodec {
     // utils
     public static GCMParameterSpec buildGCMParameterSpec() {
       byte[] iv = new byte[16];
-      random.nextBytes(iv);
+      SECURE_RANDOM.get().nextBytes(iv);
       return new GCMParameterSpec(128, iv);
     }
 

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -21,7 +21,7 @@ package org.apache.accumulo.compactor;
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.MINUTES;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -573,7 +573,7 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
     sleepTime = Math.min(300_000L, sleepTime);
     // Add some random jitter to the sleep time, that averages out to sleep time. This will spread
     // compactors out evenly over time.
-    sleepTime = (long) (.9 * sleepTime + sleepTime * .2 * SECURE_RANDOM.get().nextDouble());
+    sleepTime = (long) (.9 * sleepTime + sleepTime * .2 * RANDOM.get().nextDouble());
     LOG.trace("Sleeping {}ms based on {} compactors", sleepTime, numCompactors);
     return sleepTime;
   }

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -21,11 +21,11 @@ package org.apache.accumulo.compactor;
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.UnknownHostException;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -118,8 +118,6 @@ import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.MeterRegistry;
 
 public class Compactor extends AbstractServer implements MetricsProducer, CompactorService.Iface {
-
-  private static final SecureRandom random = new SecureRandom();
 
   private static final Logger LOG = LoggerFactory.getLogger(Compactor.class);
   private static final long TIME_BETWEEN_CANCEL_CHECKS = MINUTES.toMillis(5);
@@ -575,7 +573,7 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
     sleepTime = Math.min(300_000L, sleepTime);
     // Add some random jitter to the sleep time, that averages out to sleep time. This will spread
     // compactors out evenly over time.
-    sleepTime = (long) (.9 * sleepTime + sleepTime * .2 * random.nextDouble());
+    sleepTime = (long) (.9 * sleepTime + sleepTime * .2 * SECURE_RANDOM.get().nextDouble());
     LOG.trace("Sleeping {}ms based on {} compactors", sleepTime, numCompactors);
     return sleepTime;
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -23,7 +23,7 @@ import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.FILES;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LOGS;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.PREV_ROW;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.apache.accumulo.core.util.threads.ThreadPools.watchCriticalFixedDelay;
 import static org.apache.accumulo.core.util.threads.ThreadPools.watchCriticalScheduledTask;
 import static org.apache.accumulo.core.util.threads.ThreadPools.watchNonCriticalScheduledTask;
@@ -370,7 +370,7 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
 
   private static long jitter() {
     // add a random 10% wait
-    return (long) ((1. + (SECURE_RANDOM.get().nextDouble() / 10))
+    return (long) ((1. + (RANDOM.get().nextDouble() / 10))
         * TabletServer.TIME_BETWEEN_LOCATOR_CACHE_CLEARS);
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -23,6 +23,7 @@ import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.FILES;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LOGS;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.PREV_ROW;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.apache.accumulo.core.util.threads.ThreadPools.watchCriticalFixedDelay;
 import static org.apache.accumulo.core.util.threads.ThreadPools.watchCriticalScheduledTask;
 import static org.apache.accumulo.core.util.threads.ThreadPools.watchNonCriticalScheduledTask;
@@ -31,7 +32,6 @@ import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.lang.reflect.InvocationTargetException;
 import java.net.UnknownHostException;
-import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -174,7 +174,6 @@ import io.opentelemetry.context.Scope;
 
 public class TabletServer extends AbstractServer implements TabletHostingServer {
 
-  private static final SecureRandom random = new SecureRandom();
   private static final Logger log = LoggerFactory.getLogger(TabletServer.class);
   private static final long TIME_BETWEEN_LOCATOR_CACHE_CLEARS = TimeUnit.HOURS.toMillis(1);
 
@@ -371,7 +370,7 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
 
   private static long jitter() {
     // add a random 10% wait
-    return (long) ((1. + (random.nextDouble() / 10))
+    return (long) ((1. + (SECURE_RANDOM.get().nextDouble() / 10))
         * TabletServer.TIME_BETWEEN_LOCATOR_CACHE_CLEARS);
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SessionManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SessionManager.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.tserver.session;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -79,7 +79,7 @@ public class SessionManager {
   }
 
   public long createSession(Session session, boolean reserve) {
-    long sid = SECURE_RANDOM.get().nextLong();
+    long sid = RANDOM.get().nextLong();
 
     synchronized (session) {
       Preconditions.checkArgument(session.state == State.NEW);
@@ -88,7 +88,7 @@ public class SessionManager {
     }
 
     while (sessions.putIfAbsent(sid, session) != null) {
-      sid = SECURE_RANDOM.get().nextLong();
+      sid = RANDOM.get().nextLong();
     }
 
     return sid;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SessionManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SessionManager.java
@@ -18,7 +18,8 @@
  */
 package org.apache.accumulo.tserver.session;
 
-import java.security.SecureRandom;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -57,7 +58,6 @@ import com.google.common.collect.Maps;
 public class SessionManager {
   private static final Logger log = LoggerFactory.getLogger(SessionManager.class);
 
-  private static final SecureRandom random = new SecureRandom();
   private final ConcurrentMap<Long,Session> sessions = new ConcurrentHashMap<>();
   private final long maxIdle;
   private final long maxUpdateIdle;
@@ -79,7 +79,7 @@ public class SessionManager {
   }
 
   public long createSession(Session session, boolean reserve) {
-    long sid = random.nextLong();
+    long sid = SECURE_RANDOM.get().nextLong();
 
     synchronized (session) {
       Preconditions.checkArgument(session.state == State.NEW);
@@ -88,7 +88,7 @@ public class SessionManager {
     }
 
     while (sessions.putIfAbsent(sid, session) != null) {
-      sid = random.nextLong();
+      sid = SECURE_RANDOM.get().nextLong();
     }
 
     return sid;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.tserver.tablet;
 
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -131,7 +131,7 @@ public class MinorCompactor extends FileCompactor {
           throw new IllegalStateException(e);
         }
 
-        int sleep = sleepTime + SECURE_RANDOM.get().nextInt(sleepTime);
+        int sleep = sleepTime + RANDOM.get().nextInt(sleepTime);
         log.debug("MinC failed sleeping {} ms before retrying", sleep);
         sleepUninterruptibly(sleep, TimeUnit.MILLISECONDS);
         sleepTime = (int) Math.round(Math.min(maxSleepTime, sleepTime * growthFactor));

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
@@ -19,9 +19,9 @@
 package org.apache.accumulo.tserver.tablet;
 
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 
 import java.io.IOException;
-import java.security.SecureRandom;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -47,7 +47,6 @@ import org.slf4j.LoggerFactory;
 
 public class MinorCompactor extends FileCompactor {
 
-  private static final SecureRandom random = new SecureRandom();
   private static final Logger log = LoggerFactory.getLogger(MinorCompactor.class);
 
   private final TabletServer tabletServer;
@@ -132,7 +131,7 @@ public class MinorCompactor extends FileCompactor {
           throw new IllegalStateException(e);
         }
 
-        int sleep = sleepTime + random.nextInt(sleepTime);
+        int sleep = sleepTime + SECURE_RANDOM.get().nextInt(sleepTime);
         log.debug("MinC failed sleeping {} ms before retrying", sleep);
         sleepUninterruptibly(sleep, TimeUnit.MILLISECONDS);
         sleepTime = (int) Math.round(Math.min(maxSleepTime, sleepTime * growthFactor));

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/HiddenCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/HiddenCommand.java
@@ -19,8 +19,8 @@
 package org.apache.accumulo.shell.commands;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 
-import java.security.SecureRandom;
 import java.util.Base64;
 
 import org.apache.accumulo.shell.Shell;
@@ -31,7 +31,6 @@ import org.apache.commons.cli.CommandLine;
 import org.jline.utils.InfoCmp;
 
 public class HiddenCommand extends Command {
-  private static final SecureRandom random = new SecureRandom();
 
   @Override
   public String description() {
@@ -41,7 +40,7 @@ public class HiddenCommand extends Command {
   @Override
   public int execute(final String fullCommand, final CommandLine cl, final Shell shellState)
       throws Exception {
-    if (random.nextInt(10) == 0) {
+    if (SECURE_RANDOM.get().nextInt(10) == 0) {
       shellState.getTerminal().puts(InfoCmp.Capability.bell);
       shellState.getWriter().println();
       shellState.getWriter()

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/HiddenCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/HiddenCommand.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.shell.commands;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.util.Base64;
 
@@ -40,7 +40,7 @@ public class HiddenCommand extends Command {
   @Override
   public int execute(final String fullCommand, final CommandLine cl, final Shell shellState)
       throws Exception {
-    if (SECURE_RANDOM.get().nextInt(10) == 0) {
+    if (RANDOM.get().nextInt(10) == 0) {
       shellState.getTerminal().puts(InfoCmp.Capability.bell);
       shellState.getWriter().println();
       shellState.getWriter()

--- a/test/src/main/java/org/apache/accumulo/harness/AccumuloITBase.java
+++ b/test/src/main/java/org/apache/accumulo/harness/AccumuloITBase.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.security.SecureRandom;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Map.Entry;
@@ -43,7 +42,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * Methods, setup and/or infrastructure which are common to any Accumulo integration test.
  */
 public class AccumuloITBase extends WithTestNames {
-  public static final SecureRandom random = new SecureRandom();
   private static final Logger log = LoggerFactory.getLogger(AccumuloITBase.class);
 
   public static final String STANDALONE_CAPABLE_CLUSTER = "StandaloneCapableCluster";
@@ -137,7 +135,7 @@ public class AccumuloITBase extends WithTestNames {
   });
 
   /**
-   * Time to wait per-method before declaring a timeout, in seconds.
+   * Time to wait per-method before declaring a timeout.
    */
   protected Duration defaultTimeout() {
     return Duration.ofMinutes(10);

--- a/test/src/main/java/org/apache/accumulo/harness/SharedMiniClusterBase.java
+++ b/test/src/main/java/org/apache/accumulo/harness/SharedMiniClusterBase.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.harness;
 
 import static java.lang.StackWalker.Option.RETAIN_CLASS_REFERENCE;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.apache.accumulo.harness.AccumuloITBase.MINI_CLUSTER_ONLY;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -124,7 +125,7 @@ public abstract class SharedMiniClusterBase extends AccumuloITBase implements Cl
         StackWalker.getInstance(RETAIN_CLASS_REFERENCE).walk(findCallerITClass).map(Class::getName);
     // use the calling class name, or default to a unique name if IT class can't be found
     return callerClassName.orElse(String.format("UnknownITClass-%d-%d", System.currentTimeMillis(),
-        random.nextInt(Short.MAX_VALUE)));
+        SECURE_RANDOM.get().nextInt(Short.MAX_VALUE)));
   }
 
   /**

--- a/test/src/main/java/org/apache/accumulo/harness/SharedMiniClusterBase.java
+++ b/test/src/main/java/org/apache/accumulo/harness/SharedMiniClusterBase.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.harness;
 
 import static java.lang.StackWalker.Option.RETAIN_CLASS_REFERENCE;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.apache.accumulo.harness.AccumuloITBase.MINI_CLUSTER_ONLY;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -125,7 +125,7 @@ public abstract class SharedMiniClusterBase extends AccumuloITBase implements Cl
         StackWalker.getInstance(RETAIN_CLASS_REFERENCE).walk(findCallerITClass).map(Class::getName);
     // use the calling class name, or default to a unique name if IT class can't be found
     return callerClassName.orElse(String.format("UnknownITClass-%d-%d", System.currentTimeMillis(),
-        SECURE_RANDOM.get().nextInt(Short.MAX_VALUE)));
+        RANDOM.get().nextInt(Short.MAX_VALUE)));
   }
 
   /**

--- a/test/src/main/java/org/apache/accumulo/test/ChaoticLoadBalancer.java
+++ b/test/src/main/java/org/apache/accumulo/test/ChaoticLoadBalancer.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test;
 
-import static org.apache.accumulo.harness.AccumuloITBase.random;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -85,7 +85,7 @@ public class ChaoticLoadBalancer implements TabletBalancer {
     }
 
     for (TabletId tabletId : params.unassignedTablets().keySet()) {
-      int index = random.nextInt(tServerArray.size());
+      int index = SECURE_RANDOM.get().nextInt(tServerArray.size());
       TabletServerId dest = tServerArray.get(index);
       params.addAssignment(tabletId, dest);
       long remaining = toAssign.get(dest) - 1;
@@ -115,7 +115,7 @@ public class ChaoticLoadBalancer implements TabletBalancer {
     }
     problemReporter.clearProblemReportTimes();
 
-    boolean moveMetadata = random.nextInt(4) == 0;
+    boolean moveMetadata = SECURE_RANDOM.get().nextInt(4) == 0;
     long totalTablets = 0;
     for (Entry<TabletServerId,TServerStatus> e : params.currentStatus().entrySet()) {
       long tabletCount = 0;
@@ -138,7 +138,7 @@ public class ChaoticLoadBalancer implements TabletBalancer {
         }
         try {
           for (TabletStatistics ts : getOnlineTabletsForTable(e.getKey(), id)) {
-            int index = random.nextInt(underCapacityTServer.size());
+            int index = SECURE_RANDOM.get().nextInt(underCapacityTServer.size());
             TabletServerId dest = underCapacityTServer.get(index);
             if (dest.equals(e.getKey())) {
               continue;

--- a/test/src/main/java/org/apache/accumulo/test/ChaoticLoadBalancer.java
+++ b/test/src/main/java/org/apache/accumulo/test/ChaoticLoadBalancer.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -85,7 +85,7 @@ public class ChaoticLoadBalancer implements TabletBalancer {
     }
 
     for (TabletId tabletId : params.unassignedTablets().keySet()) {
-      int index = SECURE_RANDOM.get().nextInt(tServerArray.size());
+      int index = RANDOM.get().nextInt(tServerArray.size());
       TabletServerId dest = tServerArray.get(index);
       params.addAssignment(tabletId, dest);
       long remaining = toAssign.get(dest) - 1;
@@ -115,7 +115,7 @@ public class ChaoticLoadBalancer implements TabletBalancer {
     }
     problemReporter.clearProblemReportTimes();
 
-    boolean moveMetadata = SECURE_RANDOM.get().nextInt(4) == 0;
+    boolean moveMetadata = RANDOM.get().nextInt(4) == 0;
     long totalTablets = 0;
     for (Entry<TabletServerId,TServerStatus> e : params.currentStatus().entrySet()) {
       long tabletCount = 0;
@@ -138,7 +138,7 @@ public class ChaoticLoadBalancer implements TabletBalancer {
         }
         try {
           for (TabletStatistics ts : getOnlineTabletsForTable(e.getKey(), id)) {
-            int index = SECURE_RANDOM.get().nextInt(underCapacityTServer.size());
+            int index = RANDOM.get().nextInt(underCapacityTServer.size());
             TabletServerId dest = underCapacityTServer.get(index);
             if (dest.equals(e.getKey())) {
               continue;

--- a/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
@@ -21,7 +21,7 @@ package org.apache.accumulo.test;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -893,7 +893,7 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
       byte[] e = new byte[0];
 
       for (int i = 0; i < num; i++) {
-        rows.add(FastFormat.toZeroPaddedString(abs(SECURE_RANDOM.get().nextLong()), 16, 16, e));
+        rows.add(FastFormat.toZeroPaddedString(abs(RANDOM.get().nextLong()), 16, 16, e));
       }
 
       for (int i = 0; i < num; i++) {
@@ -968,7 +968,7 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
       ColumnVisibility cvaob = new ColumnVisibility("A|B");
       ColumnVisibility cvaab = new ColumnVisibility("A&B");
 
-      switch (SECURE_RANDOM.get().nextInt(3)) {
+      switch (RANDOM.get().nextInt(3)) {
         case 1:
           client.tableOperations().addSplits(tableName, nss("6"));
           break;
@@ -1197,20 +1197,19 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
           new IsolatedScanner(client.createScanner(tableName, Authorizations.EMPTY))) {
 
         for (int i = 0; i < 20; i++) {
-          int numRows = SECURE_RANDOM.get().nextInt(10) + 1;
+          int numRows = RANDOM.get().nextInt(10) + 1;
 
           ArrayList<ByteSequence> changes = new ArrayList<>(numRows);
           ArrayList<ConditionalMutation> mutations = new ArrayList<>();
 
           for (int j = 0; j < numRows; j++) {
-            changes.add(rows.get(SECURE_RANDOM.get().nextInt(rows.size())));
+            changes.add(rows.get(RANDOM.get().nextInt(rows.size())));
           }
 
           for (ByteSequence row : changes) {
             scanner.setRange(new Range(row.toString()));
             Stats stats = new Stats(scanner.iterator());
-            stats.set(SECURE_RANDOM.get().nextInt(10),
-                SECURE_RANDOM.get().nextInt(Integer.MAX_VALUE));
+            stats.set(RANDOM.get().nextInt(10), RANDOM.get().nextInt(Integer.MAX_VALUE));
             mutations.add(stats.toMutation());
           }
 
@@ -1242,7 +1241,7 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
 
       NewTableConfiguration ntc = new NewTableConfiguration();
 
-      switch (SECURE_RANDOM.get().nextInt(3)) {
+      switch (RANDOM.get().nextInt(3)) {
         case 1:
           ntc = ntc.withSplits(nss("4"));
           break;
@@ -1258,8 +1257,8 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
         ArrayList<ByteSequence> rows = new ArrayList<>();
 
         for (int i = 0; i < 1000; i++) {
-          rows.add(new ArrayByteSequence(FastFormat
-              .toZeroPaddedString(abs(SECURE_RANDOM.get().nextLong()), 16, 16, new byte[0])));
+          rows.add(new ArrayByteSequence(
+              FastFormat.toZeroPaddedString(abs(RANDOM.get().nextLong()), 16, 16, new byte[0])));
         }
 
         ArrayList<ConditionalMutation> mutations = new ArrayList<>();

--- a/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.test;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -892,7 +893,7 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
       byte[] e = new byte[0];
 
       for (int i = 0; i < num; i++) {
-        rows.add(FastFormat.toZeroPaddedString(abs(random.nextLong()), 16, 16, e));
+        rows.add(FastFormat.toZeroPaddedString(abs(SECURE_RANDOM.get().nextLong()), 16, 16, e));
       }
 
       for (int i = 0; i < num; i++) {
@@ -967,7 +968,7 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
       ColumnVisibility cvaob = new ColumnVisibility("A|B");
       ColumnVisibility cvaab = new ColumnVisibility("A&B");
 
-      switch (random.nextInt(3)) {
+      switch (SECURE_RANDOM.get().nextInt(3)) {
         case 1:
           client.tableOperations().addSplits(tableName, nss("6"));
           break;
@@ -1196,19 +1197,20 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
           new IsolatedScanner(client.createScanner(tableName, Authorizations.EMPTY))) {
 
         for (int i = 0; i < 20; i++) {
-          int numRows = random.nextInt(10) + 1;
+          int numRows = SECURE_RANDOM.get().nextInt(10) + 1;
 
           ArrayList<ByteSequence> changes = new ArrayList<>(numRows);
           ArrayList<ConditionalMutation> mutations = new ArrayList<>();
 
           for (int j = 0; j < numRows; j++) {
-            changes.add(rows.get(random.nextInt(rows.size())));
+            changes.add(rows.get(SECURE_RANDOM.get().nextInt(rows.size())));
           }
 
           for (ByteSequence row : changes) {
             scanner.setRange(new Range(row.toString()));
             Stats stats = new Stats(scanner.iterator());
-            stats.set(random.nextInt(10), random.nextInt(Integer.MAX_VALUE));
+            stats.set(SECURE_RANDOM.get().nextInt(10),
+                SECURE_RANDOM.get().nextInt(Integer.MAX_VALUE));
             mutations.add(stats.toMutation());
           }
 
@@ -1240,7 +1242,7 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
 
       NewTableConfiguration ntc = new NewTableConfiguration();
 
-      switch (random.nextInt(3)) {
+      switch (SECURE_RANDOM.get().nextInt(3)) {
         case 1:
           ntc = ntc.withSplits(nss("4"));
           break;
@@ -1256,8 +1258,8 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
         ArrayList<ByteSequence> rows = new ArrayList<>();
 
         for (int i = 0; i < 1000; i++) {
-          rows.add(new ArrayByteSequence(
-              FastFormat.toZeroPaddedString(abs(random.nextLong()), 16, 16, new byte[0])));
+          rows.add(new ArrayByteSequence(FastFormat
+              .toZeroPaddedString(abs(SECURE_RANDOM.get().nextLong()), 16, 16, new byte[0])));
         }
 
         ArrayList<ConditionalMutation> mutations = new ArrayList<>();

--- a/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.test;
 
 import static org.apache.accumulo.core.Constants.IMPORT_MAPPINGS_FILE;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -153,7 +153,7 @@ public class ImportExportIT extends AccumuloClusterHarness {
       while ((line = reader.readLine()) != null) {
         Path p = new Path(line.substring(5));
         assertTrue(fs.exists(p), "File doesn't exist: " + p);
-        Path importDir = importDirAry[SECURE_RANDOM.get().nextInt(importDirAry.length)];
+        Path importDir = importDirAry[RANDOM.get().nextInt(importDirAry.length)];
         Path dest = new Path(importDir, p.getName());
         assertFalse(fs.exists(dest), "Did not expect " + dest + " to exist");
         FileUtil.copy(fs, p, fs, dest, false, fs.getConf());
@@ -271,7 +271,7 @@ public class ImportExportIT extends AccumuloClusterHarness {
       while ((line = reader.readLine()) != null) {
         Path p = new Path(line.substring(5));
         assertTrue(fs.exists(p), "File doesn't exist: " + p);
-        Path importDir = importDirAry[SECURE_RANDOM.get().nextInt(importDirAry.length)];
+        Path importDir = importDirAry[RANDOM.get().nextInt(importDirAry.length)];
         Path dest = new Path(importDir, p.getName());
         assertFalse(fs.exists(dest), "Did not expect " + dest + " to exist");
         FileUtil.copy(fs, p, fs, dest, false, fs.getConf());

--- a/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.test;
 
 import static org.apache.accumulo.core.Constants.IMPORT_MAPPINGS_FILE;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -152,7 +153,7 @@ public class ImportExportIT extends AccumuloClusterHarness {
       while ((line = reader.readLine()) != null) {
         Path p = new Path(line.substring(5));
         assertTrue(fs.exists(p), "File doesn't exist: " + p);
-        Path importDir = importDirAry[random.nextInt(importDirAry.length)];
+        Path importDir = importDirAry[SECURE_RANDOM.get().nextInt(importDirAry.length)];
         Path dest = new Path(importDir, p.getName());
         assertFalse(fs.exists(dest), "Did not expect " + dest + " to exist");
         FileUtil.copy(fs, p, fs, dest, false, fs.getConf());
@@ -270,7 +271,7 @@ public class ImportExportIT extends AccumuloClusterHarness {
       while ((line = reader.readLine()) != null) {
         Path p = new Path(line.substring(5));
         assertTrue(fs.exists(p), "File doesn't exist: " + p);
-        Path importDir = importDirAry[random.nextInt(importDirAry.length)];
+        Path importDir = importDirAry[SECURE_RANDOM.get().nextInt(importDirAry.length)];
         Path dest = new Path(importDir, p.getName());
         assertFalse(fs.exists(dest), "Did not expect " + dest + " to exist");
         FileUtil.copy(fs, p, fs, dest, false, fs.getConf());

--- a/test/src/main/java/org/apache/accumulo/test/MetaGetsReadersIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MetaGetsReadersIT.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -86,7 +86,7 @@ public class MetaGetsReadersIT extends ConfigurableMacBase {
       try (BatchWriter bw = c.createBatchWriter(tableName)) {
         for (int i = 0; i < 50000; i++) {
           byte[] row = new byte[100];
-          SECURE_RANDOM.get().nextBytes(row);
+          RANDOM.get().nextBytes(row);
           Mutation m = new Mutation(row);
           m.put("", "", "");
           bw.addMutation(m);

--- a/test/src/main/java/org/apache/accumulo/test/MetaGetsReadersIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MetaGetsReadersIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.test;
 
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -85,7 +86,7 @@ public class MetaGetsReadersIT extends ConfigurableMacBase {
       try (BatchWriter bw = c.createBatchWriter(tableName)) {
         for (int i = 0; i < 50000; i++) {
           byte[] row = new byte[100];
-          random.nextBytes(row);
+          SECURE_RANDOM.get().nextBytes(row);
           Mutation m = new Mutation(row);
           m.put("", "", "");
           bw.addMutation(m);

--- a/test/src/main/java/org/apache/accumulo/test/MultiTableRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MultiTableRecoveryIT.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.test;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -84,7 +85,7 @@ public class MultiTableRecoveryIT extends ConfigurableMacBase {
       System.out.println("writing");
       for (i = 0; i < 1_000_000; i++) {
         // make non-negative avoiding Math.abs, because that can still be negative
-        long randomRow = random.nextLong() & Long.MAX_VALUE;
+        long randomRow = SECURE_RANDOM.get().nextLong() & Long.MAX_VALUE;
         assertTrue(randomRow >= 0);
         final int table = (int) (randomRow % N);
         final Mutation m = new Mutation(Long.toHexString(randomRow));

--- a/test/src/main/java/org/apache/accumulo/test/MultiTableRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MultiTableRecoveryIT.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.test;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -85,7 +85,7 @@ public class MultiTableRecoveryIT extends ConfigurableMacBase {
       System.out.println("writing");
       for (i = 0; i < 1_000_000; i++) {
         // make non-negative avoiding Math.abs, because that can still be negative
-        long randomRow = SECURE_RANDOM.get().nextLong() & Long.MAX_VALUE;
+        long randomRow = RANDOM.get().nextLong() & Long.MAX_VALUE;
         assertTrue(randomRow >= 0);
         final int table = (int) (randomRow % N);
         final Mutation m = new Mutation(Long.toHexString(randomRow));

--- a/test/src/main/java/org/apache/accumulo/test/TableConfigurationUpdateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TableConfigurationUpdateIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.test;
 
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -124,7 +125,7 @@ public class TableConfigurationUpdateIT extends AccumuloClusterHarness {
 
       String t = Thread.currentThread().getName() + " ";
       try {
-        random.ints(iterations, 0, randMax).forEach(choice -> {
+        SECURE_RANDOM.get().ints(iterations, 0, randMax).forEach(choice -> {
           if (choice < 1) {
             tableConf.invalidateCache();
           } else {

--- a/test/src/main/java/org/apache/accumulo/test/TableConfigurationUpdateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TableConfigurationUpdateIT.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -125,7 +125,7 @@ public class TableConfigurationUpdateIT extends AccumuloClusterHarness {
 
       String t = Thread.currentThread().getName() + " ";
       try {
-        SECURE_RANDOM.get().ints(iterations, 0, randMax).forEach(choice -> {
+        RANDOM.get().ints(iterations, 0, randMax).forEach(choice -> {
           if (choice < 1) {
             tableConf.invalidateCache();
           } else {

--- a/test/src/main/java/org/apache/accumulo/test/TestBinaryRows.java
+++ b/test/src/main/java/org/apache/accumulo/test/TestBinaryRows.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.accumulo.harness.AccumuloITBase.random;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 
 import java.util.Iterator;
 import java.util.Map.Entry;
@@ -166,7 +166,7 @@ public class TestBinaryRows {
       long t1 = System.currentTimeMillis();
 
       for (int i = 0; i < numLookups; i++) {
-        long row = ((random.nextLong() & 0x7fffffffffffffffL) % opts.num) + opts.start;
+        long row = ((SECURE_RANDOM.get().nextLong() & 0x7fffffffffffffffL) % opts.num) + opts.start;
 
         try (Scanner s = accumuloClient.createScanner(opts.tableName, opts.auths)) {
           Key startKey = new Key(encodeLong(row), CF_BYTES, CQ_BYTES, new byte[0], Long.MAX_VALUE);

--- a/test/src/main/java/org/apache/accumulo/test/TestBinaryRows.java
+++ b/test/src/main/java/org/apache/accumulo/test/TestBinaryRows.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.util.Iterator;
 import java.util.Map.Entry;
@@ -166,7 +166,7 @@ public class TestBinaryRows {
       long t1 = System.currentTimeMillis();
 
       for (int i = 0; i < numLookups; i++) {
-        long row = ((SECURE_RANDOM.get().nextLong() & 0x7fffffffffffffffL) % opts.num) + opts.start;
+        long row = ((RANDOM.get().nextLong() & 0x7fffffffffffffffL) % opts.num) + opts.start;
 
         try (Scanner s = accumuloClient.createScanner(opts.tableName, opts.auths)) {
           Key startKey = new Key(encodeLong(row), CF_BYTES, CQ_BYTES, new byte[0], Long.MAX_VALUE);

--- a/test/src/main/java/org/apache/accumulo/test/TotalQueuedIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TotalQueuedIT.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.test;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
@@ -79,7 +80,7 @@ public class TotalQueuedIT extends ConfigurableMacBase {
       long bytesSent = 0;
       try (BatchWriter bw = c.createBatchWriter(tableName, cfg)) {
         for (int i = 0; i < N; i++) {
-          random.nextBytes(row);
+          SECURE_RANDOM.get().nextBytes(row);
           Mutation m = new Mutation(row);
           m.put("", "", "");
           bw.addMutation(m);
@@ -105,7 +106,7 @@ public class TotalQueuedIT extends ConfigurableMacBase {
         now = System.currentTimeMillis();
         bytesSent = 0;
         for (int i = 0; i < N; i++) {
-          random.nextBytes(row);
+          SECURE_RANDOM.get().nextBytes(row);
           Mutation m = new Mutation(row);
           m.put("", "", "");
           bw.addMutation(m);

--- a/test/src/main/java/org/apache/accumulo/test/TotalQueuedIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TotalQueuedIT.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.test;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
@@ -80,7 +80,7 @@ public class TotalQueuedIT extends ConfigurableMacBase {
       long bytesSent = 0;
       try (BatchWriter bw = c.createBatchWriter(tableName, cfg)) {
         for (int i = 0; i < N; i++) {
-          SECURE_RANDOM.get().nextBytes(row);
+          RANDOM.get().nextBytes(row);
           Mutation m = new Mutation(row);
           m.put("", "", "");
           bw.addMutation(m);
@@ -106,7 +106,7 @@ public class TotalQueuedIT extends ConfigurableMacBase {
         now = System.currentTimeMillis();
         bytesSent = 0;
         for (int i = 0; i < N; i++) {
-          SECURE_RANDOM.get().nextBytes(row);
+          RANDOM.get().nextBytes(row);
           Mutation m = new Mutation(row);
           m.put("", "", "");
           bw.addMutation(m);

--- a/test/src/main/java/org/apache/accumulo/test/VerifySerialRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/VerifySerialRecoveryIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.test;
 
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -57,7 +58,7 @@ public class VerifySerialRecoveryIT extends ConfigurableMacBase {
   public static byte[] randomHex(int n) {
     byte[] binary = new byte[n];
     byte[] hex = new byte[n * 2];
-    random.nextBytes(binary);
+    SECURE_RANDOM.get().nextBytes(binary);
     int count = 0;
     for (byte x : binary) {
       hex[count++] = HEXCHARS[(x >> 4) & 0xf];

--- a/test/src/main/java/org/apache/accumulo/test/VerifySerialRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/VerifySerialRecoveryIT.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -58,7 +58,7 @@ public class VerifySerialRecoveryIT extends ConfigurableMacBase {
   public static byte[] randomHex(int n) {
     byte[] binary = new byte[n];
     byte[] hex = new byte[n * 2];
-    SECURE_RANDOM.get().nextBytes(binary);
+    RANDOM.get().nextBytes(binary);
     int count = 0;
     for (byte x : binary) {
       hex[count++] = HEXCHARS[(x >> 4) & 0xf];

--- a/test/src/main/java/org/apache/accumulo/test/compaction/CompactionExecutorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/CompactionExecutorIT.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test.compaction;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -107,9 +107,9 @@ public class CompactionExecutorIT extends SharedMiniClusterBase {
     @Override
     public CompactionPlan makePlan(PlanningParameters params) {
       if (Boolean.parseBoolean(params.getExecutionHints().getOrDefault("compact_all", "false"))) {
-        return params.createPlanBuilder()
-            .addJob((short) 1, executorIds.get(SECURE_RANDOM.get().nextInt(executorIds.size())),
-                params.getCandidates())
+        return params
+            .createPlanBuilder().addJob((short) 1,
+                executorIds.get(RANDOM.get().nextInt(executorIds.size())), params.getCandidates())
             .build();
       }
 
@@ -123,7 +123,7 @@ public class CompactionExecutorIT extends SharedMiniClusterBase {
             .values().forEach(files -> {
               for (int i = filesPerCompaction; i <= files.size(); i += filesPerCompaction) {
                 planBuilder.addJob((short) 1,
-                    executorIds.get(SECURE_RANDOM.get().nextInt(executorIds.size())),
+                    executorIds.get(RANDOM.get().nextInt(executorIds.size())),
                     files.subList(i - filesPerCompaction, i));
               }
             });

--- a/test/src/main/java/org/apache/accumulo/test/compaction/CompactionExecutorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/CompactionExecutorIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.test.compaction;
 
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -106,9 +107,9 @@ public class CompactionExecutorIT extends SharedMiniClusterBase {
     @Override
     public CompactionPlan makePlan(PlanningParameters params) {
       if (Boolean.parseBoolean(params.getExecutionHints().getOrDefault("compact_all", "false"))) {
-        return params
-            .createPlanBuilder().addJob((short) 1,
-                executorIds.get(random.nextInt(executorIds.size())), params.getCandidates())
+        return params.createPlanBuilder()
+            .addJob((short) 1, executorIds.get(SECURE_RANDOM.get().nextInt(executorIds.size())),
+                params.getCandidates())
             .build();
       }
 
@@ -121,7 +122,8 @@ public class CompactionExecutorIT extends SharedMiniClusterBase {
         params.getCandidates().stream().collect(Collectors.groupingBy(TestPlanner::getFirstChar))
             .values().forEach(files -> {
               for (int i = filesPerCompaction; i <= files.size(); i += filesPerCompaction) {
-                planBuilder.addJob((short) 1, executorIds.get(random.nextInt(executorIds.size())),
+                planBuilder.addJob((short) 1,
+                    executorIds.get(SECURE_RANDOM.get().nextInt(executorIds.size())),
                     files.subList(i - filesPerCompaction, i));
               }
             });

--- a/test/src/main/java/org/apache/accumulo/test/compaction/CompactionRateLimitingIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/CompactionRateLimitingIT.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test.compaction;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
@@ -77,13 +77,13 @@ public class CompactionRateLimitingIT extends ConfigurableMacBase {
         try (BatchWriter bw = client.createBatchWriter(tableName)) {
           while (bytesWritten < BYTES_TO_WRITE) {
             byte[] rowKey = new byte[32];
-            SECURE_RANDOM.get().nextBytes(rowKey);
+            RANDOM.get().nextBytes(rowKey);
 
             byte[] qual = new byte[32];
-            SECURE_RANDOM.get().nextBytes(qual);
+            RANDOM.get().nextBytes(qual);
 
             byte[] value = new byte[1024];
-            SECURE_RANDOM.get().nextBytes(value);
+            RANDOM.get().nextBytes(value);
 
             Mutation m = new Mutation(rowKey);
             m.put(new byte[0], qual, value);

--- a/test/src/main/java/org/apache/accumulo/test/compaction/CompactionRateLimitingIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/CompactionRateLimitingIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.test.compaction;
 
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
@@ -76,13 +77,13 @@ public class CompactionRateLimitingIT extends ConfigurableMacBase {
         try (BatchWriter bw = client.createBatchWriter(tableName)) {
           while (bytesWritten < BYTES_TO_WRITE) {
             byte[] rowKey = new byte[32];
-            random.nextBytes(rowKey);
+            SECURE_RANDOM.get().nextBytes(rowKey);
 
             byte[] qual = new byte[32];
-            random.nextBytes(qual);
+            SECURE_RANDOM.get().nextBytes(qual);
 
             byte[] value = new byte[1024];
-            random.nextBytes(value);
+            SECURE_RANDOM.get().nextBytes(value);
 
             Mutation m = new Mutation(rowKey);
             m.put(new byte[0], qual, value);

--- a/test/src/main/java/org/apache/accumulo/test/functional/BatchScanSplitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BatchScanSplitIT.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.test.functional;
 
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -85,7 +87,7 @@ public class BatchScanSplitIT extends AccumuloClusterHarness {
       HashMap<Text,Value> expected = new HashMap<>();
       ArrayList<Range> ranges = new ArrayList<>();
       for (int i = 0; i < 100; i++) {
-        int r = random.nextInt(numRows);
+        int r = SECURE_RANDOM.get().nextInt(numRows);
         Text row = new Text(String.format("%09x", r));
         expected.put(row, new Value(String.format("%016x", numRows - r)));
         ranges.add(new Range(row));

--- a/test/src/main/java/org/apache/accumulo/test/functional/BatchScanSplitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BatchScanSplitIT.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -87,7 +87,7 @@ public class BatchScanSplitIT extends AccumuloClusterHarness {
       HashMap<Text,Value> expected = new HashMap<>();
       ArrayList<Range> ranges = new ArrayList<>();
       for (int i = 0; i < 100; i++) {
-        int r = SECURE_RANDOM.get().nextInt(numRows);
+        int r = RANDOM.get().nextInt(numRows);
         Text row = new Text(String.format("%09x", r));
         expected.put(row, new Value(String.format("%016x", numRows - r)));
         ranges.add(new Range(row));

--- a/test/src/main/java/org/apache/accumulo/test/functional/BatchWriterFlushIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BatchWriterFlushIT.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.test.functional;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -125,7 +126,7 @@ public class BatchWriterFlushIT extends AccumuloClusterHarness {
         // do a few random lookups into the data just flushed
 
         for (int k = 0; k < 10; k++) {
-          int rowToLookup = random.nextInt(NUM_TO_FLUSH) + i * NUM_TO_FLUSH;
+          int rowToLookup = SECURE_RANDOM.get().nextInt(NUM_TO_FLUSH) + i * NUM_TO_FLUSH;
 
           scanner.setRange(new Range(new Text(String.format("r_%10d", rowToLookup))));
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/BatchWriterFlushIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BatchWriterFlushIT.java
@@ -21,7 +21,7 @@ package org.apache.accumulo.test.functional;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -126,7 +126,7 @@ public class BatchWriterFlushIT extends AccumuloClusterHarness {
         // do a few random lookups into the data just flushed
 
         for (int k = 0; k < 10; k++) {
-          int rowToLookup = SECURE_RANDOM.get().nextInt(NUM_TO_FLUSH) + i * NUM_TO_FLUSH;
+          int rowToLookup = RANDOM.get().nextInt(NUM_TO_FLUSH) + i * NUM_TO_FLUSH;
 
           scanner.setRange(new Range(new Text(String.format("r_%10d", rowToLookup))));
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/BloomFilterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BloomFilterIT.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.test.functional;
 
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -187,7 +189,7 @@ public class BloomFilterIT extends AccumuloClusterHarness {
     Text row = new Text("row"), cq = new Text("cq"), cf = new Text("cf");
 
     for (int i = 0; i < num; ++i) {
-      Long k = ((random.nextLong() & 0x7fffffffffffffffL) % (end - start)) + start;
+      Long k = ((SECURE_RANDOM.get().nextLong() & 0x7fffffffffffffffL) % (end - start)) + start;
       key.set(String.format("k_%010d", k));
       Range range = null;
       Key acuKey;

--- a/test/src/main/java/org/apache/accumulo/test/functional/BloomFilterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BloomFilterIT.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -189,7 +189,7 @@ public class BloomFilterIT extends AccumuloClusterHarness {
     Text row = new Text("row"), cq = new Text("cq"), cf = new Text("cf");
 
     for (int i = 0; i < num; ++i) {
-      Long k = ((SECURE_RANDOM.get().nextLong() & 0x7fffffffffffffffL) % (end - start)) + start;
+      Long k = ((RANDOM.get().nextLong() & 0x7fffffffffffffffL) % (end - start)) + start;
       key.set(String.format("k_%010d", k));
       Range range = null;
       Key acuKey;

--- a/test/src/main/java/org/apache/accumulo/test/functional/CacheTestWriter.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CacheTestWriter.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.test.functional;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.accumulo.harness.AccumuloITBase.random;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -69,15 +69,15 @@ public class CacheTestWriter {
       Map<String,String> expectedData = null;
       // change children in dir
 
-      for (int u = 0; u < random.nextInt(4) + 1; u++) {
+      for (int u = 0; u < SECURE_RANDOM.get().nextInt(4) + 1; u++) {
         expectedData = new TreeMap<>();
 
-        if (random.nextFloat() < .5) {
+        if (SECURE_RANDOM.get().nextFloat() < .5) {
           String child = UUID.randomUUID().toString();
           zk.putPersistentData(rootDir + "/dir/" + child, new byte[0], NodeExistsPolicy.SKIP);
           children.add(child);
         } else if (!children.isEmpty()) {
-          int index = random.nextInt(children.size());
+          int index = SECURE_RANDOM.get().nextInt(children.size());
           String child = children.remove(index);
           zk.recursiveDelete(rootDir + "/dir/" + child, NodeMissingPolicy.FAIL);
         }
@@ -88,15 +88,15 @@ public class CacheTestWriter {
 
         // change values
         for (int i = 0; i < numData; i++) {
-          byte[] data = Long.toString(random.nextLong(), 16).getBytes(UTF_8);
+          byte[] data = Long.toString(SECURE_RANDOM.get().nextLong(), 16).getBytes(UTF_8);
           zk.putPersistentData(rootDir + "/data" + i, data, NodeExistsPolicy.OVERWRITE);
           expectedData.put(rootDir + "/data" + i, new String(data, UTF_8));
         }
 
         // test a data node that does not always exists...
-        if (random.nextFloat() < .5) {
+        if (SECURE_RANDOM.get().nextFloat() < .5) {
 
-          byte[] data = Long.toString(random.nextLong(), 16).getBytes(UTF_8);
+          byte[] data = Long.toString(SECURE_RANDOM.get().nextLong(), 16).getBytes(UTF_8);
 
           if (dataSExists) {
             zk.putPersistentData(rootDir + "/dataS", data, NodeExistsPolicy.OVERWRITE);

--- a/test/src/main/java/org/apache/accumulo/test/functional/CacheTestWriter.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CacheTestWriter.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.test.functional;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -69,15 +69,15 @@ public class CacheTestWriter {
       Map<String,String> expectedData = null;
       // change children in dir
 
-      for (int u = 0; u < SECURE_RANDOM.get().nextInt(4) + 1; u++) {
+      for (int u = 0; u < RANDOM.get().nextInt(4) + 1; u++) {
         expectedData = new TreeMap<>();
 
-        if (SECURE_RANDOM.get().nextFloat() < .5) {
+        if (RANDOM.get().nextFloat() < .5) {
           String child = UUID.randomUUID().toString();
           zk.putPersistentData(rootDir + "/dir/" + child, new byte[0], NodeExistsPolicy.SKIP);
           children.add(child);
         } else if (!children.isEmpty()) {
-          int index = SECURE_RANDOM.get().nextInt(children.size());
+          int index = RANDOM.get().nextInt(children.size());
           String child = children.remove(index);
           zk.recursiveDelete(rootDir + "/dir/" + child, NodeMissingPolicy.FAIL);
         }
@@ -88,15 +88,15 @@ public class CacheTestWriter {
 
         // change values
         for (int i = 0; i < numData; i++) {
-          byte[] data = Long.toString(SECURE_RANDOM.get().nextLong(), 16).getBytes(UTF_8);
+          byte[] data = Long.toString(RANDOM.get().nextLong(), 16).getBytes(UTF_8);
           zk.putPersistentData(rootDir + "/data" + i, data, NodeExistsPolicy.OVERWRITE);
           expectedData.put(rootDir + "/data" + i, new String(data, UTF_8));
         }
 
         // test a data node that does not always exists...
-        if (SECURE_RANDOM.get().nextFloat() < .5) {
+        if (RANDOM.get().nextFloat() < .5) {
 
-          byte[] data = Long.toString(SECURE_RANDOM.get().nextLong(), 16).getBytes(UTF_8);
+          byte[] data = Long.toString(RANDOM.get().nextLong(), 16).getBytes(UTF_8);
 
           if (dataSExists) {
             zk.putPersistentData(rootDir + "/dataS", data, NodeExistsPolicy.OVERWRITE);

--- a/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.test.functional;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -630,10 +631,10 @@ public class CompactionIT extends AccumuloClusterHarness {
 
   private void writeRandomValue(AccumuloClient c, String tableName, int size) throws Exception {
     byte[] data1 = new byte[size];
-    random.nextBytes(data1);
+    SECURE_RANDOM.get().nextBytes(data1);
 
     try (BatchWriter bw = c.createBatchWriter(tableName)) {
-      Mutation m1 = new Mutation("r" + random.nextInt(909090));
+      Mutation m1 = new Mutation("r" + SECURE_RANDOM.get().nextInt(909090));
       m1.put("data", "bl0b", new Value(data1));
       bw.addMutation(m1);
     }

--- a/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.test.functional;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -631,10 +631,10 @@ public class CompactionIT extends AccumuloClusterHarness {
 
   private void writeRandomValue(AccumuloClient c, String tableName, int size) throws Exception {
     byte[] data1 = new byte[size];
-    SECURE_RANDOM.get().nextBytes(data1);
+    RANDOM.get().nextBytes(data1);
 
     try (BatchWriter bw = c.createBatchWriter(tableName)) {
-      Mutation m1 = new Mutation("r" + SECURE_RANDOM.get().nextInt(909090));
+      Mutation m1 = new Mutation("r" + RANDOM.get().nextInt(909090));
       m1.put("data", "bl0b", new Value(data1));
       bw.addMutation(m1);
     }

--- a/test/src/main/java/org/apache/accumulo/test/functional/ConcurrentDeleteTableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ConcurrentDeleteTableIT.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -268,7 +268,7 @@ public class ConcurrentDeleteTableIT extends AccumuloClusterHarness {
       throws TableNotFoundException, MutationsRejectedException {
     try (BatchWriter bw = c.createBatchWriter(table)) {
       for (int i = 0; i < 1_000; i++) {
-        Mutation m = new Mutation(String.format("%09x", SECURE_RANDOM.get().nextInt(100_000_000)));
+        Mutation m = new Mutation(String.format("%09x", RANDOM.get().nextInt(100_000_000)));
         m.put("m", "order", "" + i);
         bw.addMutation(m);
       }

--- a/test/src/main/java/org/apache/accumulo/test/functional/ConcurrentDeleteTableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ConcurrentDeleteTableIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.test.functional;
 
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -267,7 +268,7 @@ public class ConcurrentDeleteTableIT extends AccumuloClusterHarness {
       throws TableNotFoundException, MutationsRejectedException {
     try (BatchWriter bw = c.createBatchWriter(table)) {
       for (int i = 0; i < 1_000; i++) {
-        Mutation m = new Mutation(String.format("%09x", random.nextInt(100_000_000)));
+        Mutation m = new Mutation(String.format("%09x", SECURE_RANDOM.get().nextInt(100_000_000)));
         m.put("m", "order", "" + i);
         bw.addMutation(m);
       }

--- a/test/src/main/java/org/apache/accumulo/test/functional/CreateInitialSplitsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CreateInitialSplitsIT.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -211,7 +211,7 @@ public class CreateInitialSplitsIT extends AccumuloClusterHarness {
     SortedSet<Text> splits = new TreeSet<>();
     for (int i = 0; i < numItems; i++) {
       byte[] split = new byte[len];
-      SECURE_RANDOM.get().nextBytes(split);
+      RANDOM.get().nextBytes(split);
       splits.add(encode(new Text(split), useB64));
     }
     return splits;

--- a/test/src/main/java/org/apache/accumulo/test/functional/CreateInitialSplitsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CreateInitialSplitsIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.test.functional;
 
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -210,7 +211,7 @@ public class CreateInitialSplitsIT extends AccumuloClusterHarness {
     SortedSet<Text> splits = new TreeSet<>();
     for (int i = 0; i < numItems; i++) {
       byte[] split = new byte[len];
-      random.nextBytes(split);
+      SECURE_RANDOM.get().nextBytes(split);
       splits.add(encode(new Text(split), useB64));
     }
     return splits;

--- a/test/src/main/java/org/apache/accumulo/test/functional/FateStarvationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FateStarvationIT.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -59,8 +59,8 @@ public class FateStarvationIT extends AccumuloClusterHarness {
       List<Text> splits = new ArrayList<>(TestIngest.getSplitPoints(0, 100000, 67));
 
       for (int i = 0; i < 100; i++) {
-        int idx1 = SECURE_RANDOM.get().nextInt(splits.size() - 1);
-        int idx2 = SECURE_RANDOM.get().nextInt(splits.size() - (idx1 + 1)) + idx1 + 1;
+        int idx1 = RANDOM.get().nextInt(splits.size() - 1);
+        int idx2 = RANDOM.get().nextInt(splits.size() - (idx1 + 1)) + idx1 + 1;
 
         c.tableOperations().compact(tableName, splits.get(idx1), splits.get(idx2), false, false);
       }

--- a/test/src/main/java/org/apache/accumulo/test/functional/FateStarvationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FateStarvationIT.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.test.functional;
 
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -57,8 +59,8 @@ public class FateStarvationIT extends AccumuloClusterHarness {
       List<Text> splits = new ArrayList<>(TestIngest.getSplitPoints(0, 100000, 67));
 
       for (int i = 0; i < 100; i++) {
-        int idx1 = random.nextInt(splits.size() - 1);
-        int idx2 = random.nextInt(splits.size() - (idx1 + 1)) + idx1 + 1;
+        int idx1 = SECURE_RANDOM.get().nextInt(splits.size() - 1);
+        int idx2 = SECURE_RANDOM.get().nextInt(splits.size() - (idx1 + 1)) + idx1 + 1;
 
         c.tableOperations().compact(tableName, splits.get(idx1), splits.get(idx2), false, false);
       }

--- a/test/src/main/java/org/apache/accumulo/test/functional/ManyWriteAheadLogsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ManyWriteAheadLogsIT.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Base64;
@@ -152,7 +152,7 @@ public class ManyWriteAheadLogsIT extends AccumuloClusterHarness {
           for (int j = 0; j < 10; j++) {
             int row = startRow + j;
             Mutation m = new Mutation(String.format("%05x", row));
-            SECURE_RANDOM.get().nextBytes(val);
+            RANDOM.get().nextBytes(val);
             m.put("f", "q", "v");
 
             manyWALsWriter.addMutation(m);
@@ -162,7 +162,7 @@ public class ManyWriteAheadLogsIT extends AccumuloClusterHarness {
           // write a lot of data to second table to forces the logs to roll
           for (int j = 0; j < 1000; j++) {
             Mutation m = new Mutation(String.format("%03d", j));
-            SECURE_RANDOM.get().nextBytes(val);
+            RANDOM.get().nextBytes(val);
 
             m.put("f", "q", Base64.getEncoder().encodeToString(val));
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/ManyWriteAheadLogsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ManyWriteAheadLogsIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.test.functional;
 
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Base64;
@@ -151,7 +152,7 @@ public class ManyWriteAheadLogsIT extends AccumuloClusterHarness {
           for (int j = 0; j < 10; j++) {
             int row = startRow + j;
             Mutation m = new Mutation(String.format("%05x", row));
-            random.nextBytes(val);
+            SECURE_RANDOM.get().nextBytes(val);
             m.put("f", "q", "v");
 
             manyWALsWriter.addMutation(m);
@@ -161,7 +162,7 @@ public class ManyWriteAheadLogsIT extends AccumuloClusterHarness {
           // write a lot of data to second table to forces the logs to roll
           for (int j = 0; j < 1000; j++) {
             Mutation m = new Mutation(String.format("%03d", j));
-            random.nextBytes(val);
+            SECURE_RANDOM.get().nextBytes(val);
 
             m.put("f", "q", Base64.getEncoder().encodeToString(val));
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/MonitorSslIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MonitorSslIT.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -64,7 +64,7 @@ public class MonitorSslIT extends ConfigurableMacBase {
   public static void initHttps() throws NoSuchAlgorithmException, KeyManagementException {
     SSLContext ctx = SSLContext.getInstance("TLSv1.2");
     TrustManager[] tm = {new TestTrustManager()};
-    ctx.init(new KeyManager[0], tm, SECURE_RANDOM.get());
+    ctx.init(new KeyManager[0], tm, RANDOM.get());
     SSLContext.setDefault(ctx);
     HttpsURLConnection.setDefaultSSLSocketFactory(ctx.getSocketFactory());
     HttpsURLConnection.setDefaultHostnameVerifier(new TestHostnameVerifier());

--- a/test/src/main/java/org/apache/accumulo/test/functional/MonitorSslIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MonitorSslIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.test.functional;
 
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -63,7 +64,7 @@ public class MonitorSslIT extends ConfigurableMacBase {
   public static void initHttps() throws NoSuchAlgorithmException, KeyManagementException {
     SSLContext ctx = SSLContext.getInstance("TLSv1.2");
     TrustManager[] tm = {new TestTrustManager()};
-    ctx.init(new KeyManager[0], tm, random);
+    ctx.init(new KeyManager[0], tm, SECURE_RANDOM.get());
     SSLContext.setDefault(ctx);
     HttpsURLConnection.setDefaultSSLSocketFactory(ctx.getSocketFactory());
     HttpsURLConnection.setDefaultHostnameVerifier(new TestHostnameVerifier());

--- a/test/src/main/java/org/apache/accumulo/test/functional/NativeMapIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/NativeMapIT.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.test.functional;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.apache.accumulo.harness.AccumuloITBase.SUNNY_DAY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -411,10 +411,10 @@ public class NativeMapIT {
 
   // random length random field
   private static byte[] getRandomBytes(int maxLen) {
-    int len = SECURE_RANDOM.get().nextInt(maxLen);
+    int len = RANDOM.get().nextInt(maxLen);
 
     byte[] f = new byte[len];
-    SECURE_RANDOM.get().nextBytes(f);
+    RANDOM.get().nextBytes(f);
 
     return f;
   }
@@ -431,7 +431,7 @@ public class NativeMapIT {
     for (int i = 0; i < 100000; i++) {
 
       Key k = new Key(getRandomBytes(97), getRandomBytes(13), getRandomBytes(31),
-          getRandomBytes(11), (SECURE_RANDOM.get().nextLong() & 0x7fffffffffffffffL), false, false);
+          getRandomBytes(11), (RANDOM.get().nextLong() & 0x7fffffffffffffffL), false, false);
       Value v = new Value(getRandomBytes(511));
 
       testData.add(new Pair<>(k, v));
@@ -475,7 +475,7 @@ public class NativeMapIT {
       System.out.println("test 11 nm mem " + nm.getMemoryUsed());
 
       // insert data again w/ different value
-      Collections.shuffle(testData, SECURE_RANDOM.get());
+      Collections.shuffle(testData, RANDOM.get());
       // insert unsorted data
       for (Pair<Key,Value> pair : testData) {
         pair.getSecond().set(getRandomBytes(511));

--- a/test/src/main/java/org/apache/accumulo/test/functional/NativeMapIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/NativeMapIT.java
@@ -19,8 +19,8 @@
 package org.apache.accumulo.test.functional;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.apache.accumulo.harness.AccumuloITBase.SUNNY_DAY;
-import static org.apache.accumulo.harness.AccumuloITBase.random;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -411,10 +411,10 @@ public class NativeMapIT {
 
   // random length random field
   private static byte[] getRandomBytes(int maxLen) {
-    int len = random.nextInt(maxLen);
+    int len = SECURE_RANDOM.get().nextInt(maxLen);
 
     byte[] f = new byte[len];
-    random.nextBytes(f);
+    SECURE_RANDOM.get().nextBytes(f);
 
     return f;
   }
@@ -431,7 +431,7 @@ public class NativeMapIT {
     for (int i = 0; i < 100000; i++) {
 
       Key k = new Key(getRandomBytes(97), getRandomBytes(13), getRandomBytes(31),
-          getRandomBytes(11), (random.nextLong() & 0x7fffffffffffffffL), false, false);
+          getRandomBytes(11), (SECURE_RANDOM.get().nextLong() & 0x7fffffffffffffffL), false, false);
       Value v = new Value(getRandomBytes(511));
 
       testData.add(new Pair<>(k, v));
@@ -475,7 +475,7 @@ public class NativeMapIT {
       System.out.println("test 11 nm mem " + nm.getMemoryUsed());
 
       // insert data again w/ different value
-      Collections.shuffle(testData, random);
+      Collections.shuffle(testData, SECURE_RANDOM.get());
       // insert unsorted data
       for (Pair<Key,Value> pair : testData) {
         pair.getSecond().set(getRandomBytes(511));

--- a/test/src/main/java/org/apache/accumulo/test/functional/ReadWriteIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ReadWriteIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.test.functional;
 
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.apache.accumulo.harness.AccumuloITBase.STANDALONE_CAPABLE_CLUSTER;
 import static org.apache.accumulo.harness.AccumuloITBase.SUNNY_DAY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -154,7 +155,7 @@ public class ReadWriteIT extends AccumuloClusterHarness {
               "Using HTTPS since monitor ssl keystore configuration was observed in accumulo configuration");
           SSLContext ctx = SSLContext.getInstance("TLSv1.2");
           TrustManager[] tm = {new TestTrustManager()};
-          ctx.init(new KeyManager[0], tm, random);
+          ctx.init(new KeyManager[0], tm, SECURE_RANDOM.get());
           SSLContext.setDefault(ctx);
           HttpsURLConnection.setDefaultSSLSocketFactory(ctx.getSocketFactory());
           HttpsURLConnection.setDefaultHostnameVerifier(new TestHostnameVerifier());

--- a/test/src/main/java/org/apache/accumulo/test/functional/ReadWriteIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ReadWriteIT.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.apache.accumulo.harness.AccumuloITBase.STANDALONE_CAPABLE_CLUSTER;
 import static org.apache.accumulo.harness.AccumuloITBase.SUNNY_DAY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -155,7 +155,7 @@ public class ReadWriteIT extends AccumuloClusterHarness {
               "Using HTTPS since monitor ssl keystore configuration was observed in accumulo configuration");
           SSLContext ctx = SSLContext.getInstance("TLSv1.2");
           TrustManager[] tm = {new TestTrustManager()};
-          ctx.init(new KeyManager[0], tm, SECURE_RANDOM.get());
+          ctx.init(new KeyManager[0], tm, RANDOM.get());
           SSLContext.setDefault(ctx);
           HttpsURLConnection.setDefaultSSLSocketFactory(ctx.getSocketFactory());
           HttpsURLConnection.setDefaultHostnameVerifier(new TestHostnameVerifier());

--- a/test/src/main/java/org/apache/accumulo/test/functional/ScanIdIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ScanIdIT.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.test.functional;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -365,7 +365,7 @@ public class ScanIdIT extends AccumuloClusterHarness {
 
       for (int i = 0; i < NUM_DATA_ROWS; i++) {
 
-        Text rowId = new Text(String.format("%d", ((SECURE_RANDOM.get().nextInt(10) * 100) + i)));
+        Text rowId = new Text(String.format("%d", ((RANDOM.get().nextInt(10) * 100) + i)));
 
         Mutation m = new Mutation(rowId);
         m.put("fam1", "count", Integer.toString(i));

--- a/test/src/main/java/org/apache/accumulo/test/functional/ScanIdIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ScanIdIT.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.test.functional;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -364,7 +365,7 @@ public class ScanIdIT extends AccumuloClusterHarness {
 
       for (int i = 0; i < NUM_DATA_ROWS; i++) {
 
-        Text rowId = new Text(String.format("%d", ((random.nextInt(10) * 100) + i)));
+        Text rowId = new Text(String.format("%d", ((SECURE_RANDOM.get().nextInt(10) * 100) + i)));
 
         Mutation m = new Mutation(rowId);
         m.put("fam1", "count", Integer.toString(i));

--- a/test/src/main/java/org/apache/accumulo/test/functional/SummaryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SummaryIT.java
@@ -26,7 +26,7 @@ import static org.apache.accumulo.core.client.summary.CountingSummarizer.EMITTED
 import static org.apache.accumulo.core.client.summary.CountingSummarizer.SEEN_STAT;
 import static org.apache.accumulo.core.client.summary.CountingSummarizer.TOO_LONG_STAT;
 import static org.apache.accumulo.core.client.summary.CountingSummarizer.TOO_MANY_STAT;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.apache.accumulo.test.functional.BasicSummarizer.DELETES_STAT;
 import static org.apache.accumulo.test.functional.BasicSummarizer.MAX_TIMESTAMP_STAT;
 import static org.apache.accumulo.test.functional.BasicSummarizer.MIN_TIMESTAMP_STAT;
@@ -832,8 +832,8 @@ public class SummaryIT extends SharedMiniClusterBase {
         // this loop should cause a varying number of files and compactions
         try (BatchWriter bw = c.createBatchWriter(table)) {
           for (int i = 0; i < 10000; i++) {
-            String row = String.format("%06d", SECURE_RANDOM.get().nextInt(1_000_000));
-            String fam = String.format("%03d", SECURE_RANDOM.get().nextInt(100));
+            String row = String.format("%06d", RANDOM.get().nextInt(1_000_000));
+            String fam = String.format("%03d", RANDOM.get().nextInt(100));
             String qual = String.format("%06d", q++);
             write(bw, row, fam, qual, "val");
             famCounts.merge(fam, 1L, Long::sum);

--- a/test/src/main/java/org/apache/accumulo/test/functional/SummaryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SummaryIT.java
@@ -26,6 +26,7 @@ import static org.apache.accumulo.core.client.summary.CountingSummarizer.EMITTED
 import static org.apache.accumulo.core.client.summary.CountingSummarizer.SEEN_STAT;
 import static org.apache.accumulo.core.client.summary.CountingSummarizer.TOO_LONG_STAT;
 import static org.apache.accumulo.core.client.summary.CountingSummarizer.TOO_MANY_STAT;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.apache.accumulo.test.functional.BasicSummarizer.DELETES_STAT;
 import static org.apache.accumulo.test.functional.BasicSummarizer.MAX_TIMESTAMP_STAT;
 import static org.apache.accumulo.test.functional.BasicSummarizer.MIN_TIMESTAMP_STAT;
@@ -831,8 +832,8 @@ public class SummaryIT extends SharedMiniClusterBase {
         // this loop should cause a varying number of files and compactions
         try (BatchWriter bw = c.createBatchWriter(table)) {
           for (int i = 0; i < 10000; i++) {
-            String row = String.format("%06d", random.nextInt(1_000_000));
-            String fam = String.format("%03d", random.nextInt(100));
+            String row = String.format("%06d", SECURE_RANDOM.get().nextInt(1_000_000));
+            String fam = String.format("%03d", SECURE_RANDOM.get().nextInt(100));
             String qual = String.format("%06d", q++);
             write(bw, row, fam, qual, "val");
             famCounts.merge(fam, 1L, Long::sum);

--- a/test/src/main/java/org/apache/accumulo/test/functional/WALSunnyDayIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/WALSunnyDayIT.java
@@ -25,7 +25,7 @@ import static org.apache.accumulo.core.conf.Property.INSTANCE_ZK_TIMEOUT;
 import static org.apache.accumulo.core.conf.Property.TSERV_WAL_MAX_SIZE;
 import static org.apache.accumulo.core.conf.Property.TSERV_WAL_REPLICATION;
 import static org.apache.accumulo.core.security.Authorizations.EMPTY;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.apache.accumulo.harness.AccumuloITBase.SUNNY_DAY;
 import static org.apache.accumulo.minicluster.ServerType.GARBAGE_COLLECTOR;
 import static org.apache.accumulo.minicluster.ServerType.TABLET_SERVER;
@@ -181,11 +181,11 @@ public class WALSunnyDayIT extends ConfigurableMacBase {
       byte[] value = new byte[10];
 
       for (int r = 0; r < row; r++) {
-        SECURE_RANDOM.get().nextBytes(rowData);
+        RANDOM.get().nextBytes(rowData);
         Mutation m = new Mutation(rowData);
         for (int c = 0; c < col; c++) {
-          SECURE_RANDOM.get().nextBytes(cq);
-          SECURE_RANDOM.get().nextBytes(value);
+          RANDOM.get().nextBytes(cq);
+          RANDOM.get().nextBytes(value);
           m.put(CF, new Text(cq), new Value(value));
         }
         bw.addMutation(m);

--- a/test/src/main/java/org/apache/accumulo/test/functional/WALSunnyDayIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/WALSunnyDayIT.java
@@ -25,6 +25,7 @@ import static org.apache.accumulo.core.conf.Property.INSTANCE_ZK_TIMEOUT;
 import static org.apache.accumulo.core.conf.Property.TSERV_WAL_MAX_SIZE;
 import static org.apache.accumulo.core.conf.Property.TSERV_WAL_REPLICATION;
 import static org.apache.accumulo.core.security.Authorizations.EMPTY;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.apache.accumulo.harness.AccumuloITBase.SUNNY_DAY;
 import static org.apache.accumulo.minicluster.ServerType.GARBAGE_COLLECTOR;
 import static org.apache.accumulo.minicluster.ServerType.TABLET_SERVER;
@@ -180,11 +181,11 @@ public class WALSunnyDayIT extends ConfigurableMacBase {
       byte[] value = new byte[10];
 
       for (int r = 0; r < row; r++) {
-        random.nextBytes(rowData);
+        SECURE_RANDOM.get().nextBytes(rowData);
         Mutation m = new Mutation(rowData);
         for (int c = 0; c < col; c++) {
-          random.nextBytes(cq);
-          random.nextBytes(value);
+          SECURE_RANDOM.get().nextBytes(cq);
+          SECURE_RANDOM.get().nextBytes(value);
           m.put(CF, new Text(cq), new Value(value));
         }
         bw.addMutation(m);

--- a/test/src/main/java/org/apache/accumulo/test/functional/ZombieTServer.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ZombieTServer.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.test.functional;
 
 import static java.util.concurrent.TimeUnit.DAYS;
-import static org.apache.accumulo.harness.AccumuloITBase.random;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 
 import java.util.HashMap;
 import java.util.UUID;
@@ -106,7 +106,7 @@ public class ZombieTServer {
   private static final Logger log = LoggerFactory.getLogger(ZombieTServer.class);
 
   public static void main(String[] args) throws Exception {
-    int port = random.nextInt(30000) + 2000;
+    int port = SECURE_RANDOM.get().nextInt(30000) + 2000;
     var context = new ServerContext(SiteConfiguration.auto());
     final ClientServiceHandler csh =
         new ClientServiceHandler(context, new TransactionWatcher(context));

--- a/test/src/main/java/org/apache/accumulo/test/functional/ZombieTServer.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ZombieTServer.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.test.functional;
 
 import static java.util.concurrent.TimeUnit.DAYS;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.util.HashMap;
 import java.util.UUID;
@@ -106,7 +106,7 @@ public class ZombieTServer {
   private static final Logger log = LoggerFactory.getLogger(ZombieTServer.class);
 
   public static void main(String[] args) throws Exception {
-    int port = SECURE_RANDOM.get().nextInt(30000) + 2000;
+    int port = RANDOM.get().nextInt(30000) + 2000;
     var context = new ServerContext(SiteConfiguration.auto());
     final ClientServiceHandler csh =
         new ClientServiceHandler(context, new TransactionWatcher(context));

--- a/test/src/main/java/org/apache/accumulo/test/manager/SuspendedTabletsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/manager/SuspendedTabletsIT.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.test.manager;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -158,7 +159,7 @@ public class SuspendedTabletsIT extends ConfigurableMacBase {
       // kill tablet servers that are not hosting the metadata table.
       List<ProcessReference> procs = getCluster().getProcesses().get(ServerType.TABLET_SERVER)
           .stream().filter(p -> !metadataTserverProcess.equals(p)).collect(Collectors.toList());
-      Collections.shuffle(procs, random);
+      Collections.shuffle(procs, SECURE_RANDOM.get());
       assertEquals(TSERVERS - 1, procs.size(), "Not enough tservers exist");
       assertTrue(procs.size() >= count, "Attempting to kill more tservers (" + count
           + ") than exist in the cluster (" + procs.size() + ")");
@@ -202,7 +203,7 @@ public class SuspendedTabletsIT extends ConfigurableMacBase {
           "Expecting " + (TSERVERS - 1) + " tServers in shutdown-list");
 
       List<TServerInstance> tserversList = new ArrayList<>(tserverSet);
-      Collections.shuffle(tserversList, random);
+      Collections.shuffle(tserversList, SECURE_RANDOM.get());
 
       for (int i1 = 0; i1 < count; ++i1) {
         final String tserverName = tserversList.get(i1).getHostPortSession();

--- a/test/src/main/java/org/apache/accumulo/test/manager/SuspendedTabletsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/manager/SuspendedTabletsIT.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.test.manager;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -159,7 +159,7 @@ public class SuspendedTabletsIT extends ConfigurableMacBase {
       // kill tablet servers that are not hosting the metadata table.
       List<ProcessReference> procs = getCluster().getProcesses().get(ServerType.TABLET_SERVER)
           .stream().filter(p -> !metadataTserverProcess.equals(p)).collect(Collectors.toList());
-      Collections.shuffle(procs, SECURE_RANDOM.get());
+      Collections.shuffle(procs, RANDOM.get());
       assertEquals(TSERVERS - 1, procs.size(), "Not enough tservers exist");
       assertTrue(procs.size() >= count, "Attempting to kill more tservers (" + count
           + ") than exist in the cluster (" + procs.size() + ")");
@@ -203,7 +203,7 @@ public class SuspendedTabletsIT extends ConfigurableMacBase {
           "Expecting " + (TSERVERS - 1) + " tServers in shutdown-list");
 
       List<TServerInstance> tserversList = new ArrayList<>(tserverSet);
-      Collections.shuffle(tserversList, SECURE_RANDOM.get());
+      Collections.shuffle(tserversList, RANDOM.get());
 
       for (int i1 = 0; i1 < count; ++i1) {
         final String tserverName = tserversList.get(i1).getHostPortSession();

--- a/test/src/main/java/org/apache/accumulo/test/performance/scan/CollectTabletStats.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/scan/CollectTabletStats.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test.performance.scan;
 
-import static org.apache.accumulo.harness.AccumuloITBase.random;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -382,7 +382,7 @@ public class CollectTabletStats {
     List<KeyExtent> tabletsToTest = new ArrayList<>();
 
     for (int i = 0; i < numThreads; i++) {
-      int rindex = random.nextInt(candidates.size());
+      int rindex = SECURE_RANDOM.get().nextInt(candidates.size());
       tabletsToTest.add(candidates.get(rindex));
       Collections.swap(candidates, rindex, candidates.size() - 1);
       candidates = candidates.subList(0, candidates.size() - 1);

--- a/test/src/main/java/org/apache/accumulo/test/performance/scan/CollectTabletStats.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/scan/CollectTabletStats.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test.performance.scan;
 
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -382,7 +382,7 @@ public class CollectTabletStats {
     List<KeyExtent> tabletsToTest = new ArrayList<>();
 
     for (int i = 0; i < numThreads; i++) {
-      int rindex = SECURE_RANDOM.get().nextInt(candidates.size());
+      int rindex = RANDOM.get().nextInt(candidates.size());
       tabletsToTest.add(candidates.get(rindex));
       Collections.swap(candidates, rindex, candidates.size() - 1);
       candidates = candidates.subList(0, candidates.size() - 1);

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellCreateTableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellCreateTableIT.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.test.shell;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.newBufferedReader;
 import static java.util.Objects.requireNonNull;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.apache.accumulo.harness.AccumuloITBase.MINI_CLUSTER_ONLY;
 import static org.apache.accumulo.harness.AccumuloITBase.SUNNY_DAY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -694,7 +695,7 @@ public class ShellCreateTableIT extends SharedMiniClusterBase {
     Set<Text> splits = new HashSet<>();
     for (int i = 0; i < numItems; i++) {
       byte[] split = new byte[len];
-      random.nextBytes(split);
+      SECURE_RANDOM.get().nextBytes(split);
       splits.add(new Text(split));
     }
     return splits;

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellCreateTableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellCreateTableIT.java
@@ -21,7 +21,7 @@ package org.apache.accumulo.test.shell;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.newBufferedReader;
 import static java.util.Objects.requireNonNull;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.apache.accumulo.harness.AccumuloITBase.MINI_CLUSTER_ONLY;
 import static org.apache.accumulo.harness.AccumuloITBase.SUNNY_DAY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -695,7 +695,7 @@ public class ShellCreateTableIT extends SharedMiniClusterBase {
     Set<Text> splits = new HashSet<>();
     for (int i = 0; i < numItems; i++) {
       byte[] split = new byte[len];
-      SECURE_RANDOM.get().nextBytes(split);
+      RANDOM.get().nextBytes(split);
       splits.add(new Text(split));
     }
     return splits;

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
@@ -20,7 +20,7 @@ package org.apache.accumulo.test.shell;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.apache.accumulo.harness.AccumuloITBase.MINI_CLUSTER_ONLY;
 import static org.apache.accumulo.harness.AccumuloITBase.SUNNY_DAY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -794,7 +794,7 @@ public class ShellServerIT extends SharedMiniClusterBase {
 
     // create two large files
     StringBuilder sb = new StringBuilder("insert b v q ");
-    SECURE_RANDOM.get().ints(10_000, 0, 26).forEach(i -> sb.append('a' + i));
+    RANDOM.get().ints(10_000, 0, 26).forEach(i -> sb.append('a' + i));
 
     ts.exec(sb.toString());
     ts.exec("flush -w");

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.test.shell;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.accumulo.core.util.LazySingletons.SECURE_RANDOM;
 import static org.apache.accumulo.harness.AccumuloITBase.MINI_CLUSTER_ONLY;
 import static org.apache.accumulo.harness.AccumuloITBase.SUNNY_DAY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -793,7 +794,7 @@ public class ShellServerIT extends SharedMiniClusterBase {
 
     // create two large files
     StringBuilder sb = new StringBuilder("insert b v q ");
-    random.ints(10_000, 0, 26).forEach(i -> sb.append('a' + i));
+    SECURE_RANDOM.get().ints(10_000, 0, 26).forEach(i -> sb.append('a' + i));
 
     ts.exec(sb.toString());
     ts.exec("flush -w");


### PR DESCRIPTION
A new class, `LazySingletons` was added in #3531 which hosts singleton suppliers. This PR adds a supplier to that class for a `SecureRandom` object and replaces the creation of new `SecureRandom` objects with that supplier.