### PR TITLE
Remove unneeded handling of exceptions not thrown

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/metrics/CompactionExecutorsMetrics.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/metrics/CompactionExecutorsMetrics.java
@@ -49,12 +49,21 @@ public class CompactionExecutorsMetrics implements MetricsProducer {
   private final Map<CompactionExecutorId,ExMetrics> exCeMetricsMap = new HashMap<>();
   private MeterRegistry registry = null;
 
-  private static class CeMetrics {
-    AtomicInteger queued;
-    AtomicInteger running;
+  // public so it can be closed by outside callers
+  public static class CeMetrics implements AutoCloseable {
+    private AtomicInteger queued;
+    private AtomicInteger running;
 
-    IntSupplier runningSupplier;
-    IntSupplier queuedSupplier;
+    private IntSupplier runningSupplier;
+    private IntSupplier queuedSupplier;
+
+    @Override
+    public void close() {
+      runningSupplier = () -> 0;
+      queuedSupplier = () -> 0;
+      running.set(0);
+      queued.set(0);
+    }
   }
 
   private static class ExMetrics {
@@ -75,8 +84,8 @@ public class CompactionExecutorsMetrics implements MetricsProducer {
         minimumRefreshDelay, minimumRefreshDelay, TimeUnit.MILLISECONDS));
   }
 
-  public synchronized AutoCloseable addExecutor(CompactionExecutorId ceid,
-      IntSupplier runningSupplier, IntSupplier queuedSupplier) {
+  public synchronized CeMetrics addExecutor(CompactionExecutorId ceid, IntSupplier runningSupplier,
+      IntSupplier queuedSupplier) {
 
     synchronized (ceMetricsMap) {
 
@@ -96,14 +105,7 @@ public class CompactionExecutorsMetrics implements MetricsProducer {
 
       ceMetricsList = List.copyOf(ceMetricsMap.values());
 
-      return () -> {
-
-        cem.runningSupplier = () -> 0;
-        cem.queuedSupplier = () -> 0;
-
-        cem.running.set(0);
-        cem.queued.set(0);
-      };
+      return cem;
     }
 
   }


### PR DESCRIPTION
* Use more specific AutoCloseable type for metrics closer, since it doesn't thrown exceptions, and there's no point in forcing the caller to handle them because the super-class has `throws Exception` that this one doesn't use
* Narrow the catch block on compaction failures to handle only RuntimeExceptions, since it can't throw any checked exceptions

I noticed the opportunity to make these tiny improvements after seeing the wide net `catch (Exception e)` statements while reviewing #3555 