### PR TITLE
Fixes 3233. Add copy-properties option for createnamespace and createtable shell commands

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellCreateNamespaceIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellCreateNamespaceIT.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test.shell;
+
+import static org.apache.accumulo.harness.AccumuloITBase.MINI_CLUSTER_ONLY;
+import static org.apache.accumulo.harness.AccumuloITBase.SUNNY_DAY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.apache.accumulo.core.client.Accumulo;
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.harness.MiniClusterConfigurationCallback;
+import org.apache.accumulo.harness.SharedMiniClusterBase;
+import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(MINI_CLUSTER_ONLY)
+@Tag(SUNNY_DAY)
+public class ShellCreateNamespaceIT extends SharedMiniClusterBase {
+
+  private MockShell ts;
+
+  private static class SSCTITCallback implements MiniClusterConfigurationCallback {
+    @Override
+    public void configureMiniCluster(MiniAccumuloConfigImpl cfg, Configuration coreSite) {
+      // Only one tserver to avoid race conditions on ZK propagation (auths and configuration)
+      cfg.setNumTservers(1);
+      // Set the min span to 0 so we will definitely get all the traces back. See ACCUMULO-4365
+      Map<String,String> siteConf = cfg.getSiteConfig();
+      cfg.setSiteConfig(siteConf);
+    }
+  }
+
+  @BeforeAll
+  public static void setupMiniCluster() throws Exception {
+    SharedMiniClusterBase.startMiniClusterWithConfig(new SSCTITCallback());
+  }
+
+  @BeforeEach
+  public void setupShell() throws Exception {
+    ts = new MockShell(getPrincipal(), getRootPassword(),
+        getCluster().getConfig().getInstanceName(), getCluster().getConfig().getZooKeepers(),
+        getCluster().getConfig().getClientPropsFile());
+  }
+
+  @AfterAll
+  public static void tearDownAfterAll() {
+    SharedMiniClusterBase.stopMiniCluster();
+  }
+
+  @AfterEach
+  public void tearDownShell() {
+    ts.shell.shutdown();
+  }
+
+  @Test
+  public void createSimpleTest() throws Exception {
+    final String namespace = getUniqueNames(1)[0];
+    ts.exec("createnamespace " + namespace, true);
+    try (AccumuloClient accumuloClient = Accumulo.newClient().from(getClientProps()).build()) {
+      assertTrue(accumuloClient.namespaceOperations().exists(namespace));
+      ts.exec("deletenamespace -f " + namespace);
+    }
+  }
+
+  @Test
+  public void copyConfigTest() throws Exception {
+
+    final String sysPropName = "table.custom.my_sys_prop";
+    final String sysPropVal1 = "sys_v1";
+    final String sysPropVal2 = "sys_v2";
+
+    final String nsPropName = "table.custom.my_ns_prop";
+    final String nsPropVal1 = "ns_v1";
+
+    final String[] names = getUniqueNames(2);
+    final String ns1 = names[0];
+    final String ns2 = names[1];
+
+    ts.exec("createnamespace " + ns1, true);
+    ts.exec("config -s " + sysPropName + "=" + sysPropVal1);
+    ts.exec("config -s " + nsPropName + "=" + nsPropVal1 + " -ns " + ns1);
+
+    ts.exec("createnamespace -cc " + ns1 + " " + ns2, true);
+
+    ts.exec("config -s " + sysPropName + "=" + sysPropVal2);
+
+    try (AccumuloClient accumuloClient = Accumulo.newClient().from(getClientProps()).build()) {
+      assertTrue(accumuloClient.namespaceOperations().exists(ns1));
+      assertTrue(accumuloClient.namespaceOperations().exists(ns2));
+
+      // prop not set on namespace
+      Map<String,String> p1 = accumuloClient.namespaceOperations().getNamespaceProperties(ns1);
+      assertNull(p1.get(sysPropName));
+      assertEquals(nsPropVal1, p1.get(nsPropName));
+      // copied config will have copied the property and will override
+      Map<String,String> p2 = accumuloClient.namespaceOperations().getNamespaceProperties(ns2);
+      assertEquals(sysPropVal1, p2.get(sysPropName));
+
+      // p2 will have configuration props in addition to custom prop
+      assertTrue(p2.size() > p1.size());
+
+      ts.exec("deletenamespace -f " + ns1);
+      ts.exec("deletenamespace -f " + ns2);
+    }
+  }
+
+  @Test
+  public void copyPropertiesTest() throws Exception {
+
+    final String sysPropName = "table.custom.my_sys_prop";
+    final String sysPropVal1 = "sys_v1";
+    final String sysPropVal2 = "sys_v2";
+
+    final String nsPropName = "table.custom.my_ns_prop";
+    final String nsPropVal1 = "ns_v1";
+
+    final String[] names = getUniqueNames(2);
+    final String srcNs = names[0];
+    final String destNs = names[1];
+
+    ts.exec("createnamespace " + srcNs, true);
+    ts.exec("config -s " + sysPropName + "=" + sysPropVal1);
+    ts.exec("config -s " + nsPropName + "=" + nsPropVal1 + " -ns " + srcNs);
+
+    ts.exec("createnamespace -cp " + srcNs + " " + destNs, true);
+
+    ts.exec("config -s " + sysPropName + "=" + sysPropVal2);
+
+    try (AccumuloClient accumuloClient = Accumulo.newClient().from(getClientProps()).build()) {
+      assertTrue(accumuloClient.namespaceOperations().exists(srcNs));
+      assertTrue(accumuloClient.namespaceOperations().exists(destNs));
+
+      // props not set on source namespace
+      Map<String,String> srcProps =
+          accumuloClient.namespaceOperations().getNamespaceProperties(srcNs);
+      assertNull(srcProps.get(sysPropName));
+      assertEquals(nsPropVal1, srcProps.get(nsPropName));
+
+      // copied props will not have copied the configuration properties
+      Map<String,String> copiedProps =
+          accumuloClient.namespaceOperations().getNamespaceProperties(destNs);
+      assertNull(copiedProps.get(sysPropName));
+      assertEquals(nsPropVal1, copiedProps.get(nsPropName));
+      // p2 will have same namespace props
+      assertEquals(copiedProps, srcProps);
+
+      Map<String,String> config = accumuloClient.namespaceOperations().getConfiguration(destNs);
+      // because not copied, dest ns sees system change
+      assertEquals(sysPropVal2, config.get(sysPropName));
+
+      ts.exec("deletenamespace -f " + srcNs);
+      ts.exec("deletenamespace -f " + destNs);
+    }
+  }
+
+  @Test
+  public void copyTablePropsInvalidOptsTest() throws Exception {
+    String[] names = getUniqueNames(2);
+
+    ts.exec("createnamespace " + names[0]);
+    ts.exec("createnamespace " + names[1]);
+
+    // expect this to throw IllegalArgumentException
+    ts.exec("createnamespace -cp " + names[0] + " -cc " + names[1] + " dest", false);
+  }
+
+}

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellCreateNamespaceIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellCreateNamespaceIT.java
@@ -148,7 +148,7 @@ public class ShellCreateNamespaceIT extends SharedMiniClusterBase {
     ts.exec("config -s " + sysPropName + "=" + sysPropVal1);
     ts.exec("config -s " + nsPropName + "=" + nsPropVal1 + " -ns " + srcNs);
 
-    ts.exec("createnamespace -cp " + srcNs + " " + destNs, true);
+    ts.exec("createnamespace --exclude-parent -cc " + srcNs + " " + destNs, true);
 
     ts.exec("config -s " + sysPropName + "=" + sysPropVal2);
 
@@ -181,13 +181,13 @@ public class ShellCreateNamespaceIT extends SharedMiniClusterBase {
 
   @Test
   public void copyTablePropsInvalidOptsTest() throws Exception {
-    String[] names = getUniqueNames(3);
+    String[] names = getUniqueNames(2);
 
     ts.exec("createnamespace " + names[0]);
     ts.exec("createnamespace " + names[1]);
 
-    // test -cc and -cp are mutually exclusive - expect this fail
-    ts.exec("createnamespace -cp " + names[0] + " -cc " + names[1] + " " + names[2], false);
+    // test --exclude-parent requires -cc option - expect this fail
+    ts.exec("createnamespace --exlcude-parent " + names[0] + " " + names[1], false);
   }
 
   @Test

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellCreateNamespaceIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellCreateNamespaceIT.java
@@ -181,13 +181,46 @@ public class ShellCreateNamespaceIT extends SharedMiniClusterBase {
 
   @Test
   public void copyTablePropsInvalidOptsTest() throws Exception {
-    String[] names = getUniqueNames(2);
+    String[] names = getUniqueNames(3);
 
     ts.exec("createnamespace " + names[0]);
     ts.exec("createnamespace " + names[1]);
 
-    // expect this to throw IllegalArgumentException
-    ts.exec("createnamespace -cp " + names[0] + " -cc " + names[1] + " dest", false);
+    // test -cc and -cp are mutually exclusive - expect this fail
+    ts.exec("createnamespace -cp " + names[0] + " -cc " + names[1] + " " + names[2], false);
+  }
+
+  @Test
+  public void missingSrcCopyPropsTest() throws Exception {
+    String[] names = getUniqueNames(2);
+    // test -cc and -cp are mutually exclusive expect this fail
+    ts.exec("createnamespace -cp " + names[0] + " " + names[1], false);
+  }
+
+  @Test
+  public void missingSrcCopyConfigTest() throws Exception {
+    String[] names = getUniqueNames(2);
+    // test command fail if src is not available
+    ts.exec("createnamespace -cc " + names[0] + " " + names[1], false);
+  }
+
+  @Test
+  public void destExistsTest() throws Exception {
+    String[] names = getUniqueNames(2);
+
+    ts.exec("createnamespace " + names[0]);
+    ts.exec("createnamespace " + names[1]);
+    // expect to fail because target already exists
+    ts.exec("createnamespace -cp " + names[0] + " " + names[1], false);
+  }
+
+  @Test
+  public void duplicateNamespaceTest() throws Exception {
+    String[] names = getUniqueNames(2);
+
+    ts.exec("createnamespace " + names[0]);
+    // expect to fail because target already exists
+    ts.exec("createnamespace " + names[0], false);
   }
 
 }

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellCreateTableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellCreateTableIT.java
@@ -25,6 +25,7 @@ import static org.apache.accumulo.harness.AccumuloITBase.MINI_CLUSTER_ONLY;
 import static org.apache.accumulo.harness.AccumuloITBase.SUNNY_DAY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -49,10 +50,13 @@ import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.util.TextUtil;
 import org.apache.accumulo.harness.MiniClusterConfigurationCallback;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
+import org.apache.accumulo.server.conf.store.PropStore;
+import org.apache.accumulo.server.conf.store.TablePropKey;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.AfterAll;
@@ -279,7 +283,7 @@ public class ShellCreateTableIT extends SharedMiniClusterBase {
 
   /**
    * Use shell to create a table with a supplied file containing splits.
-   *
+   * <p>
    * The splits will be contained in a file, sorted and un-encoded with no repeats or blank lines.
    */
   @Test
@@ -300,7 +304,7 @@ public class ShellCreateTableIT extends SharedMiniClusterBase {
 
   /**
    * Use shell to create a table with a supplied file containing splits.
-   *
+   * <p>
    * The splits will be contained in a file, unsorted and un-encoded with no repeats or blank lines.
    */
   @Test
@@ -321,7 +325,7 @@ public class ShellCreateTableIT extends SharedMiniClusterBase {
 
   /**
    * Use shell to create a table with a supplied file containing splits.
-   *
+   * <p>
    * The splits will be contained in a file, sorted and encoded with no repeats or blank lines.
    */
   @Test
@@ -342,7 +346,7 @@ public class ShellCreateTableIT extends SharedMiniClusterBase {
 
   /**
    * Use shell to create a table with a supplied file containing splits.
-   *
+   * <p>
    * The splits will be contained in a file, sorted and un-encoded with a blank line and no repeats.
    */
   @Test
@@ -363,7 +367,7 @@ public class ShellCreateTableIT extends SharedMiniClusterBase {
 
   /**
    * Use shell to create a table with a supplied file containing splits.
-   *
+   * <p>
    * The splits will be contained in a file, sorted and un-encoded with a blank line and no repeats.
    */
   @Test
@@ -384,7 +388,7 @@ public class ShellCreateTableIT extends SharedMiniClusterBase {
 
   /**
    * Use shell to create a table with a supplied file containing splits.
-   *
+   * <p>
    * The splits will be contained in a file, unsorted and un-encoded with a blank line and repeats.
    */
   @Test
@@ -405,7 +409,7 @@ public class ShellCreateTableIT extends SharedMiniClusterBase {
 
   /**
    * Use shell to create a table with a supplied file containing splits.
-   *
+   * <p>
    * The splits will be contained in a file, sorted and encoded with a blank line and repeats.
    */
   @Test
@@ -426,12 +430,11 @@ public class ShellCreateTableIT extends SharedMiniClusterBase {
 
   /**
    * Use shell to create a table with a supplied file containing splits.
-   *
+   * <p>
    * The splits file will be empty.
    */
   @Test
-  public void testCreateTableWithEmptySplitFile()
-      throws IOException, AccumuloSecurityException, TableNotFoundException, AccumuloException {
+  public void testCreateTableWithEmptySplitFile() throws IOException {
     String splitsFile = System.getProperty("user.dir") + "/target/splitFile";
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
       generateSplitsFile(splitsFile, 0, 0, false, false, false, false, false);
@@ -483,7 +486,7 @@ public class ShellCreateTableIT extends SharedMiniClusterBase {
 
   /**
    * Use shell to create a table with a supplied file containing splits.
-   *
+   * <p>
    * The splits will be contained in a file, sorted and encoded with no repeats or blank lines.
    */
   @Test
@@ -504,7 +507,7 @@ public class ShellCreateTableIT extends SharedMiniClusterBase {
 
   /**
    * Use shell to create a table with a supplied file containing splits.
-   *
+   * <p>
    * The splits will be contained in a file, unsorted and encoded with no repeats or blank lines.
    */
   @Test
@@ -525,7 +528,7 @@ public class ShellCreateTableIT extends SharedMiniClusterBase {
 
   /**
    * Use shell to create a table with a supplied file containing splits.
-   *
+   * <p>
    * The splits will be contained in a file, sorted and encoded with no repeats or blank lines.
    */
   @Test
@@ -546,7 +549,7 @@ public class ShellCreateTableIT extends SharedMiniClusterBase {
 
   /**
    * Use shell to create a table with a supplied file containing splits.
-   *
+   * <p>
    * The splits will be contained in a file, sorted and encoded with a blank line and no repeats.
    */
   @Test
@@ -567,7 +570,7 @@ public class ShellCreateTableIT extends SharedMiniClusterBase {
 
   /**
    * Use shell to create a table with a supplied file containing splits.
-   *
+   * <p>
    * The splits will be contained in a file, sorted and encoded with a blank line and no repeats.
    */
   @Test
@@ -588,7 +591,7 @@ public class ShellCreateTableIT extends SharedMiniClusterBase {
 
   /**
    * Use shell to create a table with a supplied file containing splits.
-   *
+   * <p>
    * The splits will be contained in a file, unsorted and encoded with a blank line and repeats.
    */
   @Test
@@ -609,7 +612,7 @@ public class ShellCreateTableIT extends SharedMiniClusterBase {
 
   /**
    * Use shell to create a table with a supplied file containing splits.
-   *
+   * <p>
    * The splits will be contained in a file, sorted and encoded with a blank line and repeats.
    */
   @Test
@@ -680,6 +683,156 @@ public class ShellCreateTableIT extends SharedMiniClusterBase {
         }
       }
     }
+  }
+
+  /**
+   * This test confirms the behaviour that when a table is created with the copy-configuration
+   * option that the properties that get set on the new table are the effective properties - that is
+   * the table properties include the system and namespace are copied into the table properties.
+   */
+  @Test
+  public void copyConfigOptionsTest() throws Exception {
+    String[] names = getUniqueNames(2);
+    String srcNS = "src_ns_" + names[0];
+
+    String srcTable = srcNS + ".src_table_" + names[1];
+    String destTable = srcNS + ".dest_table_" + names[1];
+
+    // define constants
+    final String sysPropName = "table.custom.my_sys_prop";
+    final String sysPropValue1 = "sys_value1";
+    final String sysPropValue2 = "sys_value2";
+    final String nsPropName = "table.custom.my_ns_prop";
+    final String nsPropValue1 = "ns_value1";
+    final String nsPropValue2 = "ns_value2";
+
+    ts.exec("config -s " + sysPropName + "=" + sysPropValue1);
+
+    ts.exec("createnamespace " + srcNS);
+    ts.exec("config -s " + nsPropName + "=" + nsPropValue1 + " -ns " + srcNS);
+
+    ts.exec("createtable " + srcTable);
+    ts.exec("createtable -cc " + srcTable + " " + destTable);
+
+    try (AccumuloClient accumuloClient = Accumulo.newClient().from(getClientProps()).build()) {
+      Map<String,String> tids = accumuloClient.tableOperations().tableIdMap();
+
+      // used to grab values directly from ZooKeeper to bypass hierarchy
+      PropStore propStore = getCluster().getServerContext().getPropStore();
+
+      // the Zk node should have all effective properties copied from configuration
+      var vp1 = propStore
+          .get(TablePropKey.of(getCluster().getServerContext(), TableId.of(tids.get(destTable))));
+      assertEquals(sysPropValue1, vp1.asMap().get(sysPropName));
+      assertEquals(nsPropValue1, vp1.asMap().get(nsPropName));
+
+      // check getTableProperties also inherits the effective config
+      Map<String,String> tableEffective =
+          accumuloClient.tableOperations().getTableProperties(destTable);
+      assertEquals(sysPropValue1, tableEffective.get(sysPropName));
+      assertEquals(nsPropValue1, tableEffective.get(nsPropName));
+
+      // changing the system and namespace props should leave the copied effective props unchanged
+      ts.exec("config -s " + sysPropName + "=" + sysPropValue2);
+      ts.exec("config -s " + nsPropName + "=" + nsPropValue2 + " -ns " + srcNS);
+
+      // source will still inherit from sys and namespace (no prop values)
+      var vp2 = propStore
+          .get(TablePropKey.of(getCluster().getServerContext(), TableId.of(tids.get(srcTable))));
+      assertNull(vp2.asMap().get(sysPropName));
+      assertNull(vp2.asMap().get(nsPropName));
+
+      // dest (copied props) should remain local to the table, overriding sys and namespace
+      var vp3 = propStore
+          .get(TablePropKey.of(getCluster().getServerContext(), TableId.of(tids.get(destTable))));
+      assertEquals(sysPropValue1, vp3.asMap().get(sysPropName));
+      assertEquals(nsPropValue1, vp3.asMap().get(nsPropName));
+
+      // show change propagated in source table effective hierarchy
+      tableEffective = accumuloClient.tableOperations().getConfiguration(srcTable);
+
+      assertEquals(sysPropValue2, tableEffective.get(sysPropName));
+      assertEquals(nsPropValue2, tableEffective.get(nsPropName));
+
+      // because effective config was copied, the change should not propagate to effective hierarchy
+      tableEffective = accumuloClient.tableOperations().getConfiguration(destTable);
+      assertEquals(sysPropValue1, tableEffective.get(sysPropName));
+      assertEquals(nsPropValue1, tableEffective.get(nsPropName));
+    }
+  }
+
+  @Test
+  public void copyTablePropsOnlyOptionsTest() throws Exception {
+    String[] names = getUniqueNames(2);
+    String srcNS = "src_ns_" + names[0];
+
+    String srcTable = srcNS + ".src_table_" + names[1];
+    String destTable = srcNS + ".dest_table_" + names[1];
+
+    // define constants
+    final String sysPropName = "table.custom.my_sys_prop";
+    final String sysPropValue1 = "sys_value1";
+    final String sysPropValue2 = "sys_value2";
+    final String nsPropName = "table.custom.my_ns_prop";
+    final String nsPropValue1 = "ns_value1";
+    final String nsPropValue2 = "ns_value2";
+
+    ts.exec("config -s " + sysPropName + "=" + sysPropValue1);
+
+    ts.exec("createnamespace " + srcNS);
+    ts.exec("config -s " + nsPropName + "=" + nsPropValue1 + " -ns " + srcNS);
+
+    ts.exec("createtable " + srcTable);
+    ts.exec("createtable -cp " + srcTable + " " + destTable);
+
+    try (AccumuloClient accumuloClient = Accumulo.newClient().from(getClientProps()).build()) {
+      Map<String,String> tids = accumuloClient.tableOperations().tableIdMap();
+
+      // only table unique values should be stored in Zk node for the table.
+      var vp1 = getCluster().getServerContext().getPropStore()
+          .get(TablePropKey.of(getCluster().getServerContext(), TableId.of(tids.get(destTable))));
+      assertNull(vp1.asMap().get(sysPropName));
+      assertNull(vp1.asMap().get(nsPropName));
+
+      // check props were inherited in effective props
+      Map<String,String> tableEffective =
+          accumuloClient.tableOperations().getConfiguration(destTable);
+      assertEquals(sysPropValue1, tableEffective.get(sysPropName));
+      assertEquals(nsPropValue1, tableEffective.get(nsPropName));
+
+      // changing the system and namespace props should leave the effective props copied unchanged
+      ts.exec("config -s " + sysPropName + "=" + sysPropValue2);
+      ts.exec("config -s " + nsPropName + "=" + nsPropValue2 + " -ns " + srcNS);
+
+      // source will still inherit from sys and namespace (no prop values)
+      var vp2 = getCluster().getServerContext().getPropStore()
+          .get(TablePropKey.of(getCluster().getServerContext(), TableId.of(tids.get(srcTable))));
+      assertNull(vp2.asMap().get(sysPropName));
+      assertNull(vp2.asMap().get(nsPropName));
+
+      // dest (copied props) should remain local to the table, overriding sys and namespace
+      var vp3 = getCluster().getServerContext().getPropStore()
+          .get(TablePropKey.of(getCluster().getServerContext(), TableId.of(tids.get(destTable))));
+      assertNull(vp3.asMap().get(sysPropName));
+      assertNull(vp3.asMap().get(nsPropName));
+
+      // because effective config was not copied, the changes should propagate to effective
+      // hierarchy
+      tableEffective = accumuloClient.tableOperations().getConfiguration(destTable);
+      assertEquals(sysPropValue2, tableEffective.get(sysPropName));
+      assertEquals(nsPropValue2, tableEffective.get(nsPropName));
+    }
+  }
+
+  @Test
+  public void copyTablePropsInvalidOptsTest() throws Exception {
+    String[] names = getUniqueNames(2);
+
+    ts.exec("createtable " + names[0]);
+    ts.exec("createtable " + names[1]);
+
+    // expect this to throw IllegalArgumentException
+    ts.exec("createtable -cp " + names[0] + " -cc " + names[1] + " dest", false);
   }
 
   private Collection<Text> generateNonBinarySplits(final int numItems, final int len) {

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
@@ -1051,7 +1051,7 @@ public class ShellServerIT extends SharedMiniClusterBase {
     final String table = getUniqueNames(1)[0];
 
     // constraint
-    ts.exec("constraint -l -t " + MetadataTable.NAME + "", true, "MetadataConstraints=1", true);
+    ts.exec("constraint -l -t " + MetadataTable.NAME, true, "MetadataConstraints=1", true);
     ts.exec("createtable " + table + " -evc");
 
     // Make sure the table is fully propagated through zoocache
@@ -1478,12 +1478,12 @@ public class ShellServerIT extends SharedMiniClusterBase {
     ts.exec("merge --all", true);
     ts.exec("getsplits", true, "z", false);
     ts.exec("deletetable -f " + table);
-    ts.exec("getsplits -t " + MetadataTable.NAME + "", true);
+    ts.exec("getsplits -t " + MetadataTable.NAME, true);
     assertEquals(2, ts.output.get().split("\n").length);
     ts.exec("getsplits -t accumulo.root", true);
     assertEquals(1, ts.output.get().split("\n").length);
-    ts.exec("merge --all -t " + MetadataTable.NAME + "");
-    ts.exec("getsplits -t " + MetadataTable.NAME + "", true);
+    ts.exec("merge --all -t " + MetadataTable.NAME);
+    ts.exec("getsplits -t " + MetadataTable.NAME, true);
     assertEquals(1, ts.output.get().split("\n").length);
   }
 
@@ -2257,5 +2257,4 @@ public class ShellServerIT extends SharedMiniClusterBase {
       System.setProperty("accumulo.properties", orgProps);
     }
   }
-
 }


### PR DESCRIPTION
Currently the copy-configuration option in createnamespace and createtable commands copy the entire effective configuration into the target.  This PR adds a flag to ignore the parent configuration.  This prevents the copied properties from masking properties higher in the hierarchy (see issue #3233)

- adds --exclude-parent as an option to --copy-config in createnamespace and createtable shell commands.
- adds IT tests
- uses NewTableConfiguration in create table command
- minor checkstyle fixes
