### PR TITLE
ensures sessions are always cleaned up

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/ScanSession.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/ScanSession.java
@@ -189,4 +189,8 @@ public abstract class ScanSession extends Session implements ScanInfo {
     return true;
   }
 
+  @Override
+  public String toString() {
+    return super.toString() + " tableId:" + getTableId();
+  }
 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/Session.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/Session.java
@@ -50,6 +50,7 @@ public class Session {
     return true;
   }
 
+  @Override
   public String toString() {
     return getClass().getSimpleName() + " " + state + " startTime:" + startTime + " lastAccessTime:"
         + lastAccessTime + " client:" + client;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/Session.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/Session.java
@@ -49,4 +49,9 @@ public class Session {
   public boolean cleanup() {
     return true;
   }
+
+  public String toString() {
+    return getClass().getSimpleName() + " " + state + " startTime:" + startTime + " lastAccessTime:"
+        + lastAccessTime + " client:" + client;
+  }
 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SessionManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SessionManager.java
@@ -236,15 +236,15 @@ public class SessionManager {
         }
 
         try {
-          retry.waitForNextAttempt(log, "Cleanup session " + session);
+          retry.waitForNextAttempt(log, "Unable to cleanup session or defer cleanup " + session);
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
           throw new RuntimeException(e);
         }
-        retry.logRetry(log, "Cleanup session " + session);
+        retry.logRetry(log, "Unable to cleanup session or defer cleanup " + session);
       }
 
-      retry.logCompletion(log, "Cleanup session " + session);
+      retry.logCompletion(log, "Cleaned up session or deferred cleanup " + session);
     }
   }
 


### PR DESCRIPTION
This is a potential fix for #3512.  It ensures that when a sesssions cleanup method returns false that cleanup will be attempted again later.