### PR TITLE
avoids calling toString on Text for isEmpty

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/mapred/AccumuloOutputFormat.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapred/AccumuloOutputFormat.java
@@ -425,7 +425,7 @@ public class AccumuloOutputFormat implements OutputFormat<Text,Mutation> {
      */
     @Override
     public void write(Text table, Mutation mutation) throws IOException {
-      if (table == null || table.toString().isEmpty()) {
+      if (table == null || table.getLength() == 0) {
         table = this.defaultTableName;
       }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/mapreduce/AccumuloOutputFormat.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapreduce/AccumuloOutputFormat.java
@@ -426,7 +426,7 @@ public class AccumuloOutputFormat extends OutputFormat<Text,Mutation> {
      */
     @Override
     public void write(Text table, Mutation mutation) throws IOException {
-      if (table == null || table.toString().isEmpty()) {
+      if (table == null || table.getLength() == 0) {
         table = this.defaultTableName;
       }
 

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapred/AccumuloRecordWriter.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapred/AccumuloRecordWriter.java
@@ -89,7 +89,7 @@ public class AccumuloRecordWriter implements RecordWriter<Text,Mutation> {
    */
   @Override
   public void write(Text table, Mutation mutation) throws IOException {
-    if (table == null || table.toString().isEmpty()) {
+    if (table == null || table.getLength() == 0) {
       table = this.defaultTableName;
     }
 

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/AccumuloRecordWriter.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/AccumuloRecordWriter.java
@@ -90,7 +90,7 @@ public class AccumuloRecordWriter extends RecordWriter<Text,Mutation> {
    */
   @Override
   public void write(Text table, Mutation mutation) throws IOException {
-    if (table == null || table.toString().isEmpty()) {
+    if (table == null || table.getLength() == 0) {
       table = this.defaultTableName;
     }
 


### PR DESCRIPTION
In profiling of an Accumulo map reduce job it was noticed that a good bit of time was spent calling toString on a Text object to check if it was empty. This commit avoids the toString() call and instead checks the text length.