### PR TITLE
logs info when a tablet consistency check goes from bad to good

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -1114,6 +1114,8 @@ public class Tablet extends TabletBase {
     }
   }
 
+  private boolean loggedErrorForTabletComparison = false;
+
   /**
    * Checks that tablet metadata from the metadata table matches what this tablet has in memory. The
    * caller of this method must acquire the updateCounter parameter before acquiring the
@@ -1162,10 +1164,17 @@ public class Tablet extends TabletBase {
       } else {
         log.error("Data files in {} differ from in-memory data {} {} {} {}", extent,
             tabletMetadata.getFilesMap(), dataFileSizes, updateCounter, latestCount);
+        loggedErrorForTabletComparison = true;
       }
     } else {
-      log.trace("AMCC Tablet {} files in memory are same as in metadata table {}",
-          tabletMetadata.getExtent(), updateCounter);
+      if (loggedErrorForTabletComparison) {
+        log.info("AMCC Tablet {} files in memory are now same as in metadata table {}",
+            tabletMetadata.getExtent(), updateCounter);
+        loggedErrorForTabletComparison = false;
+      } else {
+        log.trace("AMCC Tablet {} files in memory are same as in metadata table {}",
+            tabletMetadata.getExtent(), updateCounter);
+      }
     }
   }
 


### PR DESCRIPTION
When the tablet server does a periodic consistency check on a tablet it logs an error when there is a mismatch.  Later if there is no longer a mismatch, then this commit changes the code to log an info.

related to #3537 but does not fix that issue