### PR TITLE
Removed table configuration cache from ServiceEnvironmentImpl

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/ServiceEnvironmentImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServiceEnvironmentImpl.java
@@ -19,8 +19,6 @@
 package org.apache.accumulo.server;
 
 import java.io.IOException;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.accumulo.core.classloader.ClassLoaderUtil;
 import org.apache.accumulo.core.client.TableNotFoundException;
@@ -33,7 +31,6 @@ public class ServiceEnvironmentImpl implements ServiceEnvironment {
 
   private final ServerContext context;
   private final Configuration conf;
-  private final Map<TableId,Configuration> tableConfigs = new ConcurrentHashMap<>();
 
   public ServiceEnvironmentImpl(ServerContext context) {
     this.context = context;
@@ -47,8 +44,7 @@ public class ServiceEnvironmentImpl implements ServiceEnvironment {
 
   @Override
   public Configuration getConfiguration(TableId tableId) {
-    return tableConfigs.computeIfAbsent(tableId,
-        tid -> new ConfigurationImpl(context.getTableConfiguration(tid)));
+    return new ConfigurationImpl(context.getTableConfiguration(tableId));
   }
 
   @Override


### PR DESCRIPTION
ServiceEnvironmentImpl cached table configurations for the lifetime of the instance. For long-lived objects that use them, like a TabletBalancer, this would prevent new or updated properties being available.

Fixes #3585