### PR TITLE
syncs ZK before reading root tablet metadata

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
@@ -537,7 +537,11 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
       case IMMEDIATE:
         ZooReader zooReader = ctx.getZooReader();
         try {
-          byte[] bytes = zooReader.getData(zkRoot + RootTable.ZROOT_TABLET);
+          var path = zkRoot + RootTable.ZROOT_TABLET;
+          // attempt (see ZOOKEEPER-1675) to ensure the latest root table metadata is read from
+          // zookeeper
+          zooReader.sync(path);
+          byte[] bytes = zooReader.getData(path);
           return new RootTabletMetadata(new String(bytes, UTF_8)).toTabletMetadata();
         } catch (InterruptedException | KeeperException e) {
           throw new RuntimeException(e);


### PR DESCRIPTION
While working on metadata code in the elasticity branch, I realized it would be good to sync ZK before reading the root tablet metadata.  Did not want to make that change only in the elasticity branch and it seemed like a good change for 2.1.2.