### PR TITLE
Move range validation to AbstractTabletFile

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/ReferencedTabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/ReferencedTabletFile.java
@@ -19,7 +19,6 @@
 package org.apache.accumulo.core.metadata;
 
 import static org.apache.accumulo.core.Constants.HDFS_TABLES_DIR;
-import static org.apache.accumulo.core.metadata.StoredTabletFile.requireRowRange;
 
 import java.net.URI;
 import java.util.Comparator;
@@ -166,7 +165,7 @@ public class ReferencedTabletFile extends AbstractTabletFile<ReferencedTabletFil
    * qualify an absolute path or create a new file.
    */
   public ReferencedTabletFile(Path metaPath, Range range) {
-    super(Objects.requireNonNull(metaPath), requireRowRange(range));
+    super(Objects.requireNonNull(metaPath), range);
     log.trace("Parsing TabletFile from {}", metaPath);
     parts = parsePath(metaPath);
   }


### PR DESCRIPTION
Also add validation to StoredTabletFile validation method and on serialization.

This makes 3 changes to the validation added in 883d3d8b32faf839b98b6f3a604bc0d3f8813302

1. Validation has been moved to the constructor of `AbstractTabletFile` from ReferencedTabletFile/StoredTabletFile as all TabletFiles should have the range validated to be a row range.
2. Validation was added in the serialization method inside of StoredTabletFile so we can make sure that we validate before serialization as this method is public/static and can be called outside of the constructor.
3. I also added row range validation to the validate() method inside of MetadataConstraints but this may not be needed because when metadata is read and deserialized the code that processes the json will only [construct](https://github.com/cshannon/accumulo/blob/3e764c50512298631c00ccd9056e4ef738674c60/core/src/main/java/org/apache/accumulo/core/metadata/StoredTabletFile.java#L209) the Range correctly with just the rows and correct inclusive/exclusive for start/end keys.

I looked at adding a test to MetadataConstraintsTest but I couldn't figure out a good way because essentially all the validation checks and serialization code now prevent being able to screw things up because even if I manually modified metadata to store a bad Range it won't be read (such as adding a CF) because the format for storing in the table only stores the row portion of the ranges and re-constructs correctly.