### PR TITLE
Close Reader when IOException thrown in LocalityGroupReader

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/CachableBlockFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/CachableBlockFile.java
@@ -475,7 +475,7 @@ public class CachableBlockFile {
 
       closed = true;
 
-      BCFile.Reader reader = bcfr.get();
+      BCFile.Reader reader = bcfr.getAndSet(null);
       if (reader != null) {
         reader.close();
       }

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/RFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/RFile.java
@@ -830,7 +830,7 @@ public class RFile {
     public void next() throws IOException {
       try {
         _next();
-      } catch (IOException ioe) {
+      } catch (IOException | RuntimeException ioe) {
         reset(true);
         throw ioe;
       }
@@ -913,7 +913,7 @@ public class RFile {
 
       try {
         _seek(range);
-      } catch (IOException ioe) {
+      } catch (IOException | RuntimeException ioe) {
         reset(true);
         throw ioe;
       }

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/RFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/RFile.java
@@ -831,7 +831,7 @@ public class RFile {
       try {
         _next();
       } catch (IOException ioe) {
-        reset();
+        reset(true);
         throw ioe;
       }
     }
@@ -914,18 +914,21 @@ public class RFile {
       try {
         _seek(range);
       } catch (IOException ioe) {
-        reset();
+        reset(true);
         throw ioe;
       }
     }
 
-    private void reset() {
+    private void reset(boolean exceptionThrown) {
       rk = null;
       hasTop = false;
       if (currBlock != null) {
         try {
           try {
             currBlock.close();
+            if (exceptionThrown) {
+              reader.close();
+            }
           } catch (IOException e) {
             log.warn("Failed to close block reader", e);
           }
@@ -955,7 +958,7 @@ public class RFile {
 
       if (range.afterEndKey(firstKey)) {
         // range is before first key in rfile, so there is nothing to do
-        reset();
+        reset(false);
         reseek = false;
       }
 
@@ -1017,7 +1020,7 @@ public class RFile {
       if (reseek) {
         iiter = index.lookup(startKey);
 
-        reset();
+        reset(false);
 
         if (iiter.hasNext()) {
 


### PR DESCRIPTION
Added parameter to LocalityGroupReader.reset to indicate if method was being called due to an exception. When true, reset then calls CachableBlockFile.Reader.close(). Also modified that close method to set an AtomicReference to null.

Closes #3617