### PR TITLE
Avoids reusing rfile objects when runtime exception happens

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -452,16 +452,17 @@ public class Tablet extends TabletBase {
 
     ScanDataSource dataSource = createDataSource(scanParams, false, iFlag);
 
+    boolean sawException = false;
     try {
       SortedKeyValueIterator<Key,Value> iter = new SourceSwitchingIterator(dataSource);
       checker.check(iter);
-    } catch (IOException ioe) {
-      dataSource.close(true);
-      throw ioe;
+    } catch (IOException | RuntimeException e) {
+      sawException = true;
+      throw e;
     } finally {
       // code in finally block because always want
       // to return mapfiles, even when exception is thrown
-      dataSource.close(false);
+      dataSource.close(sawException);
     }
   }
 


### PR DESCRIPTION
Rfiles were not reused when IOException happened, but were reused when a runtime exception happened.  This changes the code to not reuse when a runtime exception happens.

See #3617