### PR TITLE
tests custom prop changes are seen

### DIFF
--- a/core/src/test/java/org/apache/accumulo/core/util/ConfigurationImplTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/ConfigurationImplTest.java
@@ -45,5 +45,21 @@ public class ConfigurationImplTest {
 
     assertNull(confImp.getCustom("p1"));
     assertNull(confImp.getTableCustom("p3"));
+
+    // ensure changes to custom props are seen
+    conf.set("general.custom.p4", "v5");
+    conf.set("table.custom.p2", "v6");
+    conf.set("table.custom.p5", "v7");
+
+    assertEquals(Map.of("p3", "v3", "p4", "v5"), confImp.getCustom());
+    assertEquals(Map.of("p1", "v1", "p2", "v6", "p5", "v7"), confImp.getTableCustom());
+
+    assertEquals("v3", confImp.getCustom("p3"));
+    assertEquals("v5", confImp.getCustom("p4"));
+    assertEquals("v1", confImp.getTableCustom("p1"));
+    assertEquals("v6", confImp.getTableCustom("p2"));
+
+    assertNull(confImp.getCustom("p5"));
+    assertNull(confImp.getTableCustom("p4"));
   }
 }


### PR DESCRIPTION
This is a follow up to #3588.  Realized that ConfigurationCopy supported the Deriver that ConfigrationImpl uses to detect changes, so added unit test that leverage this.