### PR TITLE
Create getTabletInformation API method

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
@@ -1034,4 +1034,9 @@ public interface TableOperations {
     throw new UnsupportedOperationException();
   }
 
+  default Stream<TabletInformation> getTabletInformation(final String tableName, final Range range)
+      throws TableNotFoundException {
+    throw new UnsupportedOperationException();
+  }
+
 }

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/TabletInformation.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/TabletInformation.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.client.admin;
+
+import java.util.Objects;
+
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.core.util.NumUtil;
+import org.apache.hadoop.io.Text;
+
+public class TabletInformation {
+
+  private final String tableName;
+  private final int numFiles;
+  private final int numWalLogs;
+  private final long numEntries;
+  private final long size;
+  private final String status;
+  private final String location;
+  private final String dir;
+  private final TableId tableId;
+  private final KeyExtent tablet;
+  private final TabletHostingGoal goal;
+
+  public TabletInformation(String tableName, KeyExtent tablet, int numFiles, int numWalLogs,
+      long numEntries, long size, String status, String location, String dir,
+      TabletHostingGoal goal) {
+    this.tableName = tableName;
+    this.tableId = tablet.tableId();
+    this.tablet = tablet;
+    this.numFiles = numFiles;
+    this.numWalLogs = numWalLogs;
+    this.numEntries = numEntries;
+    this.size = size;
+    this.status = status;
+    this.location = location;
+    this.dir = dir;
+    this.goal = goal;
+  }
+
+  public String getEndRow() {
+    Text t = this.tablet.endRow();
+    if (t == null) {
+      return "+INF";
+    } else {
+      return t.toString();
+    }
+  }
+
+  public String getStartRow() {
+    Text t = tablet.prevEndRow();
+    if (t == null) {
+      return "-INF";
+    } else {
+      return t.toString();
+    }
+  }
+
+  public String getTableId() {
+    return this.tablet.tableId().canonical();
+  }
+
+  public KeyExtent getExtent() {
+    return this.tablet;
+  }
+
+  public String getTablet() {
+    return getStartRow() + " " + getEndRow();
+  }
+
+  public String getTableName() {
+    return this.tableName;
+  }
+
+  public int getNumFiles() {
+    return this.numFiles;
+  }
+
+  public int getNumWalLogs() {
+    return this.numWalLogs;
+  }
+
+  public long getNumEntries() {
+    return this.numEntries;
+  }
+
+  public String getNumEntries(final boolean humanReadable) {
+    if (humanReadable) {
+      return NumUtil.bigNumberForQuantity(numEntries);
+    }
+    return String.format("%,d", numEntries);
+  }
+
+  public long getSize() {
+    return this.size;
+  }
+
+  public String getSize(final boolean humanReadable) {
+    if (humanReadable) {
+      return NumUtil.bigNumberForSize(size);
+    }
+    return String.format("%,d", size);
+  }
+
+  public String getStatus() {
+    return this.status;
+  }
+
+  public String getLocation() {
+    return this.location;
+  }
+
+  public String getTabletDir() {
+    return this.dir;
+  }
+
+  public TabletHostingGoal getHostingGoal() {
+    return this.goal;
+  }
+
+  @Override
+  public String toString() {
+    return "TabletInformation{tableName='" + tableName + '\'' + ", numFiles=" + numFiles
+        + ", numWalLogs=" + numWalLogs + ", numEntries=" + numEntries + ", size=" + size
+        + ", status='" + status + '\'' + ", location='" + location + '\'' + ", dir='" + dir + '\''
+        + ", tableId=" + tableId + ", tablet=" + tablet + ", goal=" + goal + '}';
+  }
+
+  public static final String header =
+      String.format("%-4s %-15s %-5s %-5s %-9s %-9s %-10s %-30s %-5s %-20s %-20s %-10s", "NUM",
+          "TABLET_DIR", "FILES", "WALS", "ENTRIES", "SIZE", "STATUS", "LOCATION", "ID",
+          "START (Exclusive)", "END", "GOAL");
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TabletInformation that = (TabletInformation) o;
+    return numFiles == that.numFiles && numWalLogs == that.numWalLogs
+        && numEntries == that.numEntries && size == that.size
+        && Objects.equals(tableName, that.tableName) && Objects.equals(status, that.status)
+        && Objects.equals(location, that.location) && Objects.equals(dir, that.dir)
+        && Objects.equals(tableId, that.tableId) && Objects.equals(tablet, that.tablet)
+        && goal == that.goal;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(tableName, numFiles, numWalLogs, numEntries, size, status, location, dir,
+        tableId, tablet, goal);
+  }
+}

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -26,10 +26,16 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toSet;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.DIR;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.FILES;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.HOSTING_GOAL;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.HOSTING_REQUESTED;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LAST;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LOCATION;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LOGS;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.PREV_ROW;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.SUSPEND;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.TIME;
 import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.apache.accumulo.core.util.Validators.EXISTING_TABLE_NAME;
 import static org.apache.accumulo.core.util.Validators.NEW_TABLE_NAME;
@@ -95,6 +101,7 @@ import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.client.admin.SummaryRetriever;
 import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.core.client.admin.TabletHostingGoal;
+import org.apache.accumulo.core.client.admin.TabletInformation;
 import org.apache.accumulo.core.client.admin.TimeType;
 import org.apache.accumulo.core.client.admin.compaction.CompactionConfigurer;
 import org.apache.accumulo.core.client.admin.compaction.CompactionSelector;
@@ -134,6 +141,8 @@ import org.apache.accumulo.core.manager.thrift.FateService;
 import org.apache.accumulo.core.manager.thrift.ManagerClientService;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
+import org.apache.accumulo.core.metadata.TServerInstance;
+import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.TabletDeletedException;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
@@ -696,7 +705,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
       throws AccumuloException, AccumuloSecurityException, TableNotFoundException {
     EXISTING_TABLE_NAME.validate(tableName);
 
-    List<ByteBuffer> args = Arrays.asList(ByteBuffer.wrap(tableName.getBytes(UTF_8)));
+    List<ByteBuffer> args = List.of(ByteBuffer.wrap(tableName.getBytes(UTF_8)));
     Map<String,String> opts = new HashMap<>();
     try {
       doTableFateOperation(tableName, TableNotFoundException.class, FateOperation.TABLE_DELETE,
@@ -846,7 +855,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
     EXISTING_TABLE_NAME.validate(tableName);
 
     TableId tableId = context.getTableId(tableName);
-    List<ByteBuffer> args = Arrays.asList(ByteBuffer.wrap(tableId.canonical().getBytes(UTF_8)));
+    List<ByteBuffer> args = List.of(ByteBuffer.wrap(tableId.canonical().getBytes(UTF_8)));
     Map<String,String> opts = new HashMap<>();
 
     try {
@@ -1176,7 +1185,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
 
     TableId tableId = context.getTableId(tableName);
     ClientTabletCache tl = ClientTabletCache.getInstance(context, tableId);
-    // its possible that the cache could contain complete, but old information about a tables
+    // it's possible that the cache could contain complete, but old information about a tables
     // tablets... so clear it
     tl.invalidateCache();
 
@@ -1420,7 +1429,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
       return;
     }
 
-    List<ByteBuffer> args = Arrays.asList(ByteBuffer.wrap(tableId.canonical().getBytes(UTF_8)));
+    List<ByteBuffer> args = List.of(ByteBuffer.wrap(tableId.canonical().getBytes(UTF_8)));
     Map<String,String> opts = new HashMap<>();
 
     try {
@@ -1477,7 +1486,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
     while (diskUsages == null) {
       Pair<String,Client> pair = null;
       try {
-        // this operation may us a lot of memory... its likely that connections to tabletservers
+        // this operation may us a lot of memory... it's likely that connections to tabletservers
         // hosting metadata tablets will be cached, so do not use cached
         // connections
         pair = ThriftClientTypes.CLIENT.getTabletServerConnection(context, false);
@@ -2086,7 +2095,8 @@ public class TableOperationsImpl extends TableOperationsHelper {
   public TimeType getTimeType(final String tableName) throws TableNotFoundException {
     TableId tableId = context.getTableId(tableName);
     Optional<TabletMetadata> tabletMetadata = context.getAmple().readTablets().forTable(tableId)
-        .fetch(TabletMetadata.ColumnType.TIME).checkConsistency().build().stream().findFirst();
+        .fetch(TIME).checkConsistency().build().stream().findFirst();
+
     TabletMetadata timeData =
         tabletMetadata.orElseThrow(() -> new IllegalStateException("Failed to retrieve TimeType"));
     return timeData.getTime().getType();
@@ -2162,7 +2172,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
     return tabletsMetadata.stream().peek(tm -> {
       if (scanRangeStart != null && tm.getEndRow() != null
           && tm.getEndRow().compareTo(scanRangeStart) < 0) {
-        log.debug(">>>> tablet {} is before scan start range: {}", tm.getExtent(), scanRangeStart);
+        log.debug("tablet {} is before scan start range: {}", tm.getExtent(), scanRangeStart);
         throw new RuntimeException("Bug in ample or this code.");
       }
     }).takeWhile(tm -> tm.getPrevEndRow() == null
@@ -2170,4 +2180,44 @@ public class TableOperationsImpl extends TableOperationsHelper {
         .map(tm -> new HostingGoalForTablet(new TabletIdImpl(tm.getExtent()), tm.getHostingGoal()))
         .onClose(tabletsMetadata::close);
   }
+
+  @Override
+  public Stream<TabletInformation> getTabletInformation(final String tableName, final Range range)
+      throws TableNotFoundException {
+    EXISTING_TABLE_NAME.validate(tableName);
+
+    final Text scanRangeStart = (range.getStartKey() == null) ? null : range.getStartKey().getRow();
+    TableId tableId = context.getTableId(tableName);
+
+    TabletsMetadata tabletsMetadata =
+        context.getAmple().readTablets().forTable(tableId).overlapping(scanRangeStart, true, null)
+            .fetch(HOSTING_GOAL, LOCATION, DIR, PREV_ROW, FILES, LAST, LOGS, SUSPEND)
+            .checkConsistency().build();
+
+    Set<TServerInstance> liveTserverSet = TabletMetadata.getLiveTServers(context);
+    long[] numEntries = new long[1];
+    long[] size = new long[1];
+    return tabletsMetadata.stream().peek(tm -> {
+      if (scanRangeStart != null && tm.getEndRow() != null
+          && tm.getEndRow().compareTo(scanRangeStart) < 0) {
+        log.debug("tablet {} is before scan start range: {}", tm.getExtent(), scanRangeStart);
+        throw new RuntimeException("Bug in ample or this code.");
+      }
+      numEntries[0] = 0;
+      size[0] = 0;
+      for (DataFileValue dfv : tm.getFilesMap().values()) {
+        numEntries[0] = dfv.getNumEntries();
+        size[0] += dfv.getSize();
+      }
+    }).takeWhile(tm -> tm.getPrevEndRow() == null
+        || !range.afterEndKey(new Key(tm.getPrevEndRow()).followingKey(PartialKey.ROW)))
+        .map(tm -> new TabletInformation(tableName, tm.getExtent(), tm.getFilesMap().size(),
+            tm.getLogs().size(), numEntries[0], size[0],
+            tm.getTabletState(liveTserverSet).toString(),
+            tm.getLocation() == null ? "None"
+                : tm.getLocation().getType() + ":" + tm.getLocation().getHostPort(),
+            tm.getDirName(), tm.getHostingGoal()))
+        .onClose(tabletsMetadata::close);
+  }
+
 }

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ListTabletsCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ListTabletsCommand.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.shell.commands;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -26,27 +25,21 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.client.NamespaceNotFoundException;
 import org.apache.accumulo.core.client.admin.TableOperations;
-import org.apache.accumulo.core.clientImpl.ClientContext;
+import org.apache.accumulo.core.client.admin.TabletInformation;
 import org.apache.accumulo.core.clientImpl.Namespaces;
 import org.apache.accumulo.core.data.NamespaceId;
+import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
-import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.metadata.TServerInstance;
-import org.apache.accumulo.core.metadata.schema.DataFileValue;
-import org.apache.accumulo.core.metadata.schema.TabletMetadata;
-import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
-import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
-import org.apache.accumulo.core.util.NumUtil;
 import org.apache.accumulo.shell.Shell;
 import org.apache.accumulo.shell.Shell.Command;
 import org.apache.accumulo.shell.ShellOptions;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
-import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,7 +47,7 @@ import com.google.common.annotations.VisibleForTesting;
 
 /**
  * Utility that generates single line tablet info. The output of this could be fed to sort, awk,
- * grep, etc inorder to answer questions like which tablets have the most files.
+ * grep, etc. in order to answer questions like which tablets have the most files.
  */
 public class ListTabletsCommand extends Command {
 
@@ -76,15 +69,20 @@ public class ListTabletsCommand extends Command {
     boolean humanReadable = cl.hasOption(optHumanReadable.getOpt());
 
     List<String> lines = new LinkedList<>();
-    lines.add(TabletRowInfo.header);
+    lines.add(TabletInformation.header);
     for (TableInfo tableInfo : tableInfoSet) {
       String name = tableInfo.name;
       lines.add("TABLE: " + name);
 
-      List<TabletRowInfo> rows = getTabletRowInfo(shellState, tableInfo);
-      for (int i = 0; i < rows.size(); i++) {
-        TabletRowInfo row = rows.get(i);
-        lines.add(row.format(i + 1, humanReadable));
+      List<TabletInformation> tabletsList = shellState.getContext().tableOperations()
+          .getTabletInformation(name, new Range()).collect(Collectors.toList());
+      for (int i = 0; i < tabletsList.size(); i++) {
+        TabletInformation tabletInfo = tabletsList.get(i);
+        lines.add(String.format("%-4d %-15s %-5d %-5s %-9s %-9s %-10s %-30s %-5s %-20s %-20s %-10s",
+            i + 1, tabletInfo.getTabletDir(), tabletInfo.getNumFiles(), tabletInfo.getNumWalLogs(),
+            tabletInfo.getNumEntries(humanReadable), tabletInfo.getSize(humanReadable),
+            tabletInfo.getStatus(), tabletInfo.getLocation(), tabletInfo.getTableId(),
+            tabletInfo.getStartRow(), tabletInfo.getEndRow(), tabletInfo.getHostingGoal()));
       }
     }
 
@@ -179,7 +177,7 @@ public class ListTabletsCommand extends Command {
   }
 
   /**
-   * Wrapper for tablename and id. Comparisons, equals and hash code use tablename (id is ignored)
+   * Wrapper for tableName and id. Comparisons, equals and hash code use tableName (id is ignored)
    */
   static class TableInfo implements Comparable<TableInfo> {
 
@@ -212,52 +210,6 @@ public class ListTabletsCommand extends Command {
     public int hashCode() {
       return Objects.hash(name);
     }
-  }
-
-  private List<TabletRowInfo> getTabletRowInfo(Shell shellState, TableInfo tableInfo)
-      throws Exception {
-    log.trace("scan metadata for tablet info table name: \'{}\', tableId: \'{}\' ", tableInfo.name,
-        tableInfo.id);
-
-    List<TabletRowInfo> tResults = getMetadataInfo(shellState, tableInfo);
-
-    if (log.isTraceEnabled()) {
-      for (TabletRowInfo tabletRowInfo : tResults) {
-        log.trace("Tablet info: {}", tabletRowInfo);
-      }
-    }
-
-    return tResults;
-  }
-
-  protected List<TabletRowInfo> getMetadataInfo(Shell shellState, TableInfo tableInfo)
-      throws Exception {
-    List<TabletRowInfo> results = new ArrayList<>();
-    final ClientContext context = shellState.getContext();
-    Set<TServerInstance> liveTserverSet = TabletMetadata.getLiveTServers(context);
-
-    try (var tabletsMetadata = TabletsMetadata.builder(context).forTable(tableInfo.id).build()) {
-      for (var md : tabletsMetadata) {
-        TabletRowInfo.Factory factory = new TabletRowInfo.Factory(tableInfo.name, md.getExtent());
-        var fileMap = md.getFilesMap();
-        factory.numFiles(fileMap.size());
-        long entries = 0L;
-        long size = 0L;
-        for (DataFileValue dfv : fileMap.values()) {
-          entries += dfv.getNumEntries();
-          size += dfv.getSize();
-        }
-        factory.numEntries(entries);
-        factory.size(size);
-        factory.numWalLogs(md.getLogs().size());
-        factory.dir(md.getDirName());
-        factory.location(md.getLocation());
-        factory.status(md.getTabletState(liveTserverSet).toString());
-        results.add(factory.build());
-      }
-    }
-
-    return results;
   }
 
   @Override
@@ -299,155 +251,6 @@ public class ListTabletsCommand extends Command {
     opts.addOption(outputFileOpt);
 
     return opts;
-  }
-
-  static class TabletRowInfo {
-
-    public final String tableName;
-    public final int numFiles;
-    public final int numWalLogs;
-    public final long numEntries;
-    public final long size;
-    public final String status;
-    public final String location;
-    public final String dir;
-    public final TableId tableId;
-    public final KeyExtent tablet;
-    public final boolean tableExists;
-
-    private TabletRowInfo(String tableName, KeyExtent tablet, int numFiles, int numWalLogs,
-        long numEntries, long size, String status, String location, String dir,
-        boolean tableExists) {
-      this.tableName = tableName;
-      this.tableId = tablet.tableId();
-      this.tablet = tablet;
-      this.numFiles = numFiles;
-      this.numWalLogs = numWalLogs;
-      this.numEntries = numEntries;
-      this.size = size;
-      this.status = status;
-      this.location = location;
-      this.dir = dir;
-      this.tableExists = tableExists;
-    }
-
-    String getNumEntries(final boolean humanReadable) {
-      if (humanReadable) {
-        return String.format("%9s", NumUtil.bigNumberForQuantity(numEntries));
-      }
-      // return String.format("%,24d", numEntries);
-      return Long.toString(numEntries);
-    }
-
-    String getSize(final boolean humanReadable) {
-      if (humanReadable) {
-        return String.format("%9s", NumUtil.bigNumberForSize(size));
-      }
-      // return String.format("%,24d", size);
-      return Long.toString(size);
-    }
-
-    public String getEndRow() {
-      Text t = tablet.endRow();
-      if (t == null) {
-        return "+INF";
-      } else {
-        return t.toString();
-      }
-    }
-
-    public String getStartRow() {
-      Text t = tablet.prevEndRow();
-      if (t == null) {
-        return "-INF";
-      } else {
-        return t.toString();
-      }
-    }
-
-    public static final String header = String.format(
-        "%-4s %-15s %-5s %-5s %-9s %-9s %-10s %-30s %-5s %-20s %-20s", "NUM", "TABLET_DIR", "FILES",
-        "WALS", "ENTRIES", "SIZE", "STATUS", "LOCATION", "ID", "START (Exclusive)", "END");
-
-    String format(int number, boolean prettyPrint) {
-      return String.format("%-4d %-15s %-5d %-5s %-9s %-9s %-10s %-30s %-5s %-20s %-20s", number,
-          dir, numFiles, numWalLogs, getNumEntries(prettyPrint), getSize(prettyPrint), status,
-          location, tableId, getStartRow(), getEndRow());
-    }
-
-    public String getTablet() {
-      return getStartRow() + " " + getEndRow();
-    }
-
-    public static class Factory {
-      final String tableName;
-      final KeyExtent tablet;
-      final TableId tableId;
-      int numFiles = 0;
-      int numWalLogs = 0;
-      long numEntries = 0;
-      long size = 0;
-      String status = "";
-      String location = "";
-      String dir = "";
-      boolean tableExists = false;
-
-      Factory(final String tableName, KeyExtent tablet) {
-        this.tableName = tableName;
-        this.tablet = tablet;
-        this.tableId = tablet.tableId();
-      }
-
-      Factory numFiles(int numFiles) {
-        this.numFiles = numFiles;
-        return this;
-      }
-
-      Factory numWalLogs(int numWalLogs) {
-        this.numWalLogs = numWalLogs;
-        return this;
-      }
-
-      public Factory numEntries(long numEntries) {
-        this.numEntries = numEntries;
-        return this;
-      }
-
-      public Factory size(long size) {
-        this.size = size;
-        return this;
-      }
-
-      public Factory status(String status) {
-        this.status = status;
-        return this;
-      }
-
-      public Factory location(Location location) {
-        if (location == null) {
-          this.location = "None";
-        } else {
-          String server = location.getHostPort();
-          this.location = location.getType() + ":" + server;
-        }
-        return this;
-      }
-
-      public Factory dir(String dirName) {
-        this.dir = dirName;
-        return this;
-      }
-
-      public Factory tableExists(boolean tableExists) {
-        this.tableExists = tableExists;
-        return this;
-      }
-
-      public TabletRowInfo build() {
-        return new TabletRowInfo(tableName, tablet, numFiles, numWalLogs, numEntries, size, status,
-            location, dir, tableExists);
-      }
-    }
   }
 
 }


### PR DESCRIPTION
This PR creates a new public API method, `getTabletInformation`, which returns a stream of `TabletInformation` objects containing information for each tablet within a provided table. The method can be accessed from the code or `JShell` via the `TableOperations` object.

A new `TabletInformation` class is used to hold information for an individual tablet.

The `listtablets` command has been modified to use this new method rather than using non-public API. The `ListTabletsCommandTest` was updated to reflect the new method. A new IT test has been added to `ShellServerIT` which tests `listtablets` and effectively tests the new API since the method is used to obtain the information for `listtablets`.