### PR TITLE
lowers number of files in compaction IT test

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
@@ -311,12 +311,12 @@ public class CompactionIT extends AccumuloClusterHarness {
       client.tableOperations().setProperty(table1, Property.TABLE_MAJC_RATIO.getKey(), "1001");
       TableId tid = TableId.of(client.tableOperations().tableIdMap().get(table1));
 
-      ReadWriteIT.ingest(client, MAX_DATA, 1, 1, 0, "colf", table1, 1);
+      ReadWriteIT.ingest(client, MAX_DATA, 1, 1, 0, "colf", table1, 10);
 
       Ample ample = ((ClientContext) client).getAmple();
       TabletsMetadata tms = ample.readTablets().forTable(tid).fetch(ColumnType.FILES).build();
       TabletMetadata tm = tms.iterator().next();
-      assertEquals(1000, tm.getFiles().size());
+      assertEquals(100, tm.getFiles().size());
 
       IteratorSetting setting = new IteratorSetting(50, "error", ErrorThrowingIterator.class);
       setting.addOption(ErrorThrowingIterator.TIMES, "3");


### PR DESCRIPTION
The test CompactionIT.testErrorDuringUserCompaction() was timing out. The test would create a tablet with 1000 files.  These would compact in batches of 10 files at a time with a 4 or 5 seconds between each compaction.  So this could take 400 to 500 seconds.  The few second delay between compactions comes from waiting for the manager to scan the metadata table again. When compactions ran in the tablet server it would immediately start another compaction when one finished.

This commit changes the test to create 100 files in the tablet instead of 1000.