### PR TITLE
make option exclude-parent-properties, other minor clean-up

### DIFF
--- a/shell/src/main/java/org/apache/accumulo/shell/commands/CreateNamespaceCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/CreateNamespaceCommand.java
@@ -44,7 +44,7 @@ public class CreateNamespaceCommand extends Command {
       TableNotFoundException, IOException, ClassNotFoundException, NamespaceExistsException,
       NamespaceNotFoundException {
 
-    // exclude parent properties only valid with copy config
+    // exclude parent properties; only valid with copy config
     if (cl.hasOption(createNamesapceOptExcludeParentProps.getLongOpt())
         && !cl.hasOption(createNamespaceOptCopyConfig.getOpt())) {
       throw new IllegalArgumentException(createNamesapceOptExcludeParentProps.getLongOpt()

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/CreateNamespaceCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/CreateNamespaceCommand.java
@@ -44,7 +44,7 @@ public class CreateNamespaceCommand extends Command {
       TableNotFoundException, IOException, ClassNotFoundException, NamespaceExistsException,
       NamespaceNotFoundException {
 
-    // validate that copy config and copy properties options are mutually exclusive.
+    // exclude parent properties only valid with copy config
     if (cl.hasOption(createNamesapceOptExcludeParentProps.getLongOpt())
         && !cl.hasOption(createNamespaceOptCopyConfig.getOpt())) {
       throw new IllegalArgumentException(createNamesapceOptExcludeParentProps.getLongOpt()
@@ -102,8 +102,8 @@ public class CreateNamespaceCommand extends Command {
         new Option("cc", "copy-config", true, "namespace to copy configuration from");
     createNamespaceOptCopyConfig.setArgName("namespace");
 
-    createNamesapceOptExcludeParentProps = new Option(null, "exclude-parent", false,
-        "exclude parent(s) properties when copying configuration");
+    createNamesapceOptExcludeParentProps = new Option(null, "exclude-parent-properties", false,
+        "exclude properties from its parent(s) when copying configuration");
 
     o.addOption(createNamespaceOptCopyConfig);
     o.addOption(createNamesapceOptExcludeParentProps);

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/CreateTableCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/CreateTableCommand.java
@@ -101,7 +101,7 @@ public class CreateTableCommand extends Command {
           new TreeSet<>(shellState.getAccumuloClient().tableOperations().listSplits(oldTable)));
     }
 
-    // allow only copy config or copy properties,
+    // exclude parent properties only valid with copy config
     if (cl.hasOption(createTableOptExcludeParentProps.getLongOpt())
         && !cl.hasOption(createTableOptCopyConfig.getOpt())) {
       throw new IllegalArgumentException(createTableOptExcludeParentProps.getLongOpt()
@@ -311,8 +311,8 @@ public class CreateTableCommand extends Command {
 
     createTableOptCopyConfig =
         new Option("cc", "copy-config", true, "table to copy effective configuration from");
-    createTableOptExcludeParentProps = new Option(null, "exclude-parent", false,
-        "exclude parent(s) properties when copying configuration");
+    createTableOptExcludeParentProps = new Option(null, "exclude-parent-properties", false,
+        "exclude properties from its parent(s) when copying configuration");
     createTableOptCopySplits =
         new Option("cs", "copy-splits", true, "table to copy current splits from");
     createTableOptSplit = new Option("sf", "splits-file", true,

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/CreateTableCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/CreateTableCommand.java
@@ -101,7 +101,7 @@ public class CreateTableCommand extends Command {
           new TreeSet<>(shellState.getAccumuloClient().tableOperations().listSplits(oldTable)));
     }
 
-    // exclude parent properties only valid with copy config
+    // exclude parent properties; only valid with copy config
     if (cl.hasOption(createTableOptExcludeParentProps.getLongOpt())
         && !cl.hasOption(createTableOptCopyConfig.getOpt())) {
       throw new IllegalArgumentException(createTableOptExcludeParentProps.getLongOpt()

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellCreateNamespaceIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellCreateNamespaceIT.java
@@ -148,7 +148,7 @@ public class ShellCreateNamespaceIT extends SharedMiniClusterBase {
     ts.exec("config -s " + sysPropName + "=" + sysPropVal1);
     ts.exec("config -s " + nsPropName + "=" + nsPropVal1 + " -ns " + srcNs);
 
-    ts.exec("createnamespace --exclude-parent -cc " + srcNs + " " + destNs, true);
+    ts.exec("createnamespace --exclude-parent-properties -cc " + srcNs + " " + destNs, true);
 
     ts.exec("config -s " + sysPropName + "=" + sysPropVal2);
 
@@ -187,7 +187,7 @@ public class ShellCreateNamespaceIT extends SharedMiniClusterBase {
     ts.exec("createnamespace " + names[1]);
 
     // test --exclude-parent requires -cc option - expect this fail
-    ts.exec("createnamespace --exlcude-parent " + names[0] + " " + names[1], false);
+    ts.exec("createnamespace --exclude-parent-properties " + names[0] + " " + names[1], false);
   }
 
   @Test

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellCreateTableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellCreateTableIT.java
@@ -784,7 +784,8 @@ public class ShellCreateTableIT extends SharedMiniClusterBase {
     ts.exec("config -s " + nsPropName + "=" + nsPropValue1 + " -ns " + srcNS);
 
     ts.exec("createtable " + srcTable);
-    ts.exec("createtable --exclude-parent --copy-config " + srcTable + " " + destTable, true);
+    ts.exec("createtable --exclude-parent-properties --copy-config " + srcTable + " " + destTable,
+        true);
 
     try (AccumuloClient accumuloClient = Accumulo.newClient().from(getClientProps()).build()) {
       Map<String,String> tids = accumuloClient.tableOperations().tableIdMap();


### PR DESCRIPTION
- Change command option from `exclude-parent` to `exclude-parent-properties` for clarity.
- clarify command description present to uses
- comment clean-up

From additional comment in PR #3562 made after merge.