### PR TITLE
Makes DefaultCompactionPlanner emit multiple jobs

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
@@ -30,6 +30,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.client.admin.compaction.CompactableFile;
 import org.apache.accumulo.core.conf.ConfigurationTypeHelper;
@@ -180,6 +181,21 @@ public class DefaultCompactionPlanner implements CompactionPlanner {
     }
   }
 
+  private static class FakeFileGenerator {
+
+    private int count = 0;
+
+    public CompactableFile create(long size) {
+      try {
+        return CompactableFile.create(
+            new URI("hdfs://fake/accumulo/tables/adef/t-zzFAKEzz/FAKE-0000" + count + ".rf"), size,
+            0);
+      } catch (URISyntaxException e) {
+        throw new IllegalStateException(e);
+      }
+    }
+  }
+
   private List<Executor> executors;
   private int maxFilesToCompact;
 
@@ -258,76 +274,92 @@ public class DefaultCompactionPlanner implements CompactionPlanner {
 
     Set<CompactableFile> filesCopy = new HashSet<>(params.getCandidates());
 
+    FakeFileGenerator fakeFileGenerator = new FakeFileGenerator();
+
     long maxSizeToCompact = getMaxSizeToCompact(params.getKind());
 
-    Collection<CompactableFile> group;
-    if (params.getRunningCompactions().isEmpty()) {
-      group =
+    // This set represents future files that will be produced by running compactions. If the optimal
+    // set of files to compact is computed and contains one of these files, then its optimal to wait
+    // for this compaction to finish.
+    Set<CompactableFile> expectedFiles =
+        params.getRunningCompactions().stream().filter(job -> job.getKind() == params.getKind())
+            .map(job -> getExpected(job.getFiles(), fakeFileGenerator)).collect(Collectors.toSet());
+    // TODO test that user compaction does not wait on system compaction
+    filesCopy.addAll(expectedFiles);
+
+    List<Collection<CompactableFile>> compactionJobs = new ArrayList<>();
+
+    while (true) {
+      var filesToCompact =
           findDataFilesToCompact(filesCopy, params.getRatio(), maxFilesToCompact, maxSizeToCompact);
-
-      if (!group.isEmpty() && group.size() < params.getCandidates().size()
-          && params.getCandidates().size() <= maxFilesToCompact
-          && (params.getKind() == CompactionKind.USER
-              || params.getKind() == CompactionKind.SELECTOR)) {
-        // USER and SELECTOR compactions must eventually compact all files. When a subset of files
-        // that meets the compaction ratio is selected, look ahead and see if the next compaction
-        // would also meet the compaction ratio. If not then compact everything to avoid doing
-        // more than logarithmic work across multiple comapctions.
-
-        filesCopy.removeAll(group);
-        filesCopy.add(getExpected(group, 0));
-
-        if (findDataFilesToCompact(filesCopy, params.getRatio(), maxFilesToCompact,
-            maxSizeToCompact).isEmpty()) {
-          // The next possible compaction does not meet the compaction ratio, so compact
-          // everything.
-          group = Set.copyOf(params.getCandidates());
-        }
-
+      if (!Collections.disjoint(filesToCompact, expectedFiles)) {
+        // the optimal set of files to compact includes the output of a running compaction, so lets
+        // wait for that running compaction to finish.
+        break;
       }
 
-    } else if (params.getKind() == CompactionKind.SYSTEM) {
-      // This code determines if once the files compacting finish would they be included in a
-      // compaction with the files smaller than them? If so, then wait for the running compaction
-      // to complete.
-
-      // The set of files running compactions may produce
-      var expectedFiles = getExpected(params.getRunningCompactions());
-
-      if (!Collections.disjoint(filesCopy, expectedFiles)) {
-        throw new AssertionError();
+      if (filesToCompact.isEmpty()) {
+        break;
       }
 
-      filesCopy.addAll(expectedFiles);
+      filesCopy.removeAll(filesToCompact);
 
-      group =
-          findDataFilesToCompact(filesCopy, params.getRatio(), maxFilesToCompact, maxSizeToCompact);
+      // A compaction job will be created for these files, so lets add an expected file for that
+      // planned compaction job. Then if future iterations of this loop will include that file then
+      // they will not compact.
+      var expectedFile = getExpected(filesToCompact, fakeFileGenerator);
+      expectedFiles.add(expectedFile);
+      filesCopy.add(expectedFile);
 
-      if (!Collections.disjoint(group, expectedFiles)) {
-        // file produced by running compaction will eventually compact with existing files, so
-        // wait.
-        group = Set.of();
+      compactionJobs.add(filesToCompact);
+
+      if (filesToCompact.size() < maxFilesToCompact) {
+        // Only continue looking for more compaction jobs when a set of files is found equals
+        // maxFilesToCompact in size. When the files found is less than the max size its an
+        // indication that the compaction ratio was no longer met and therefore it would be
+        // suboptimal to look for more jobs because the smallest optimal set was found.
+        break;
       }
-    } else {
-      group = Set.of();
     }
 
-    if (group.isEmpty()
+    if (compactionJobs.size() == 1
+        && (params.getKind() == CompactionKind.USER || params.getKind() == CompactionKind.SELECTOR)
+        && compactionJobs.get(0).size() < params.getCandidates().size()
+        && compactionJobs.get(0).size() <= maxFilesToCompact) {
+      // USER and SELECTOR compactions must eventually compact all files. When a subset of files
+      // that meets the compaction ratio is selected, look ahead and see if the next compaction
+      // would also meet the compaction ratio. If not then compact everything to avoid doing
+      // more than logarithmic work across multiple comapctions.
+
+      var group = compactionJobs.get(0);
+      var candidatesCopy = new HashSet<>(params.getCandidates());
+
+      candidatesCopy.removeAll(group);
+      candidatesCopy.add(getExpected(group, fakeFileGenerator));
+
+      if (findDataFilesToCompact(candidatesCopy, params.getRatio(), maxFilesToCompact,
+          maxSizeToCompact).isEmpty()) {
+        // The next possible compaction does not meet the compaction ratio, so compact
+        // everything.
+        compactionJobs.set(0, Set.copyOf(params.getCandidates()));
+      }
+    }
+
+    if (compactionJobs.isEmpty()
         && (params.getKind() == CompactionKind.USER || params.getKind() == CompactionKind.SELECTOR
             || params.getKind() == CompactionKind.CHOP)
         && params.getRunningCompactions().stream()
             .noneMatch(job -> job.getKind() == params.getKind())) {
-      group = findMaximalRequiredSetToCompact(params.getCandidates(), maxFilesToCompact);
+      // These kinds of compaction require files to compact even if none of the files meet the
+      // compaction ratio. No files were found using the compaction ratio and no compactions are
+      // running, so force a compaction.
+      compactionJobs = findMaximalRequiredSetToCompact(params.getCandidates(), maxFilesToCompact);
     }
 
-    if (group.isEmpty()) {
-      return params.createPlanBuilder().build();
-    } else {
-      // determine which executor to use based on the size of the files
-      var ceid = getExecutor(group);
-
-      return params.createPlanBuilder().addJob(createPriority(params, group), ceid, group).build();
-    }
+    var builder = params.createPlanBuilder();
+    compactionJobs.forEach(jobFiles -> builder.addJob(createPriority(params, jobFiles),
+        getExecutor(jobFiles), jobFiles));
+    return builder.build();
   }
 
   private static short createPriority(PlanningParameters params,
@@ -346,51 +378,42 @@ public class DefaultCompactionPlanner implements CompactionPlanner {
     return Long.MAX_VALUE;
   }
 
-  private CompactableFile getExpected(Collection<CompactableFile> files, int count) {
+  private CompactableFile getExpected(Collection<CompactableFile> files,
+      FakeFileGenerator fakeFileGenerator) {
     long size = files.stream().mapToLong(CompactableFile::getEstimatedSize).sum();
-    try {
-      return CompactableFile.create(
-          new URI("hdfs://fake/accumulo/tables/adef/t-zzFAKEzz/FAKE-0000" + count + ".rf"), size,
-          0);
-    } catch (URISyntaxException e) {
-      throw new IllegalStateException(e);
-    }
+    return fakeFileGenerator.create(size);
   }
 
-  /**
-   * @return the expected files sizes for sets of compacting files.
-   */
-  private Set<CompactableFile> getExpected(Collection<CompactionJob> compacting) {
-
-    Set<CompactableFile> expected = new HashSet<>();
-
-    int count = 0;
-
-    for (CompactionJob job : compacting) {
-      count++;
-      expected.add(getExpected(job.getFiles(), count));
-    }
-
-    return expected;
-  }
-
-  private static Collection<CompactableFile>
+  private static List<Collection<CompactableFile>>
       findMaximalRequiredSetToCompact(Collection<CompactableFile> files, int maxFilesToCompact) {
 
     if (files.size() <= maxFilesToCompact) {
-      return files;
+      return List.of(files);
     }
 
     List<CompactableFile> sortedFiles = sortByFileSize(files);
 
-    int numToCompact = maxFilesToCompact;
+    // compute the number of full compaction jobs with full files that could run and then subtract
+    // 1. The 1 is subtracted because the last job is a special case.
+    int batches = sortedFiles.size() / maxFilesToCompact - 1;
 
-    if (sortedFiles.size() > maxFilesToCompact && sortedFiles.size() < 2 * maxFilesToCompact) {
-      // on the second to last compaction pass, compact the minimum amount of files possible
-      numToCompact = sortedFiles.size() - maxFilesToCompact + 1;
+    if (batches > 0) {
+      ArrayList<Collection<CompactableFile>> jobs = new ArrayList<>();
+      for (int i = 0; i < batches; i++) {
+        jobs.add(sortedFiles.subList(i * maxFilesToCompact, (i + 1) * maxFilesToCompact));
+      }
+      return jobs;
+    } else {
+      int numToCompact = maxFilesToCompact;
+
+      if (sortedFiles.size() > maxFilesToCompact && sortedFiles.size() < 2 * maxFilesToCompact) {
+        // On the second to last compaction pass, compact the minimum amount of files possible. This
+        // is done to avoid unnecessarily compacting the largest files more than once.
+        numToCompact = sortedFiles.size() - maxFilesToCompact + 1;
+      }
+
+      return List.of(sortedFiles.subList(0, numToCompact));
     }
-
-    return sortedFiles.subList(0, numToCompact);
   }
 
   static Collection<CompactableFile> findDataFilesToCompact(Set<CompactableFile> files,

--- a/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
@@ -391,7 +391,7 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
           if (actions.contains(ManagementAction.NEEDS_COMPACTING)) {
             var jobs = compactionGenerator.generateJobs(tm,
                 TabletManagementIterator.determineCompactionKinds(actions));
-            LOG.debug("{} may need compacting.", tm.getExtent());
+            LOG.debug("{} may need compacting adding {} jobs", tm.getExtent(), jobs.size());
             manager.getCompactionQueues().add(tm, jobs);
           }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
@@ -89,7 +89,6 @@ import org.apache.accumulo.core.metadata.schema.ExternalCompactionMetadata;
 import org.apache.accumulo.core.metadata.schema.SelectedFiles;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.rpc.ThriftUtil;
-import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
 import org.apache.accumulo.core.securityImpl.thrift.TCredentials;
 import org.apache.accumulo.core.spi.compaction.CompactionJob;
 import org.apache.accumulo.core.spi.compaction.CompactionKind;
@@ -118,8 +117,6 @@ import org.apache.accumulo.server.tablets.TabletNameGenerator;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.thrift.TException;
-import org.apache.thrift.transport.TTransport;
-import org.apache.thrift.transport.TTransportException;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -431,21 +428,6 @@ public class CompactionCoordinator implements CompactionCoordinatorService.Iface
 
     return result;
 
-  }
-
-  /**
-   * Return the Thrift client for the TServer
-   *
-   * @param tserver tserver instance
-   * @return thrift client
-   * @throws TTransportException thrift error
-   */
-  protected TabletServerClientService.Client getTabletServerConnection(TServerInstance tserver)
-      throws TTransportException {
-    LiveTServerSet.TServerConnection connection = tserverSet.getConnection(tserver);
-    TTransport transport =
-        this.ctx.getTransportPool().getTransport(connection.getAddress(), 0, this.ctx);
-    return ThriftUtil.createClient(ThriftClientTypes.TABLET_SERVER, transport);
   }
 
   // ELASTICITY_TODO unit test this code

--- a/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
@@ -314,6 +314,9 @@ public class CompactionIT extends AccumuloClusterHarness {
       client.tableOperations().setProperty(table1, Property.TABLE_MAJC_RATIO.getKey(), "1001");
       TableId tid = TableId.of(client.tableOperations().tableIdMap().get(table1));
 
+      // In addition to testing errors in compactions, this test also exercises creating lots of
+      // files to compact. The following will create 1000 files to compact. When changing this test
+      // try to keep both or create a new test for lots of files to compact.
       ReadWriteIT.ingest(client, MAX_DATA, 1, 1, 0, "colf", table1, 1);
 
       Ample ample = ((ClientContext) client).getAmple();

--- a/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
@@ -182,8 +182,9 @@ public class CompactionIT extends AccumuloClusterHarness {
   public void configureMiniCluster(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
     cfg.setProperty(Property.INSTANCE_ZK_TIMEOUT, "15s");
     cfg.setProperty(Property.TSERV_MAJC_DELAY, "1");
-    cfg.setProperty(Property.MANAGER_TABLET_GROUP_WATCHER_INTERVAL, "5ms");
-    cfg.setProperty(Property.COMPACTOR_MIN_JOB_WAIT_TIME, "10ms");
+    cfg.setProperty(Property.MANAGER_TABLET_GROUP_WATCHER_INTERVAL, "1s");
+    cfg.setProperty(Property.COMPACTOR_MIN_JOB_WAIT_TIME, "100ms");
+    cfg.setProperty(Property.COMPACTOR_MAX_JOB_WAIT_TIME, "1s");
     // use raw local file system so walogs sync and flush will work
     hadoopCoreSite.set("fs.file.impl", RawLocalFileSystem.class.getName());
   }
@@ -325,12 +326,13 @@ public class CompactionIT extends AccumuloClusterHarness {
       client.tableOperations().attachIterator(table1, setting, EnumSet.of(IteratorScope.majc));
       client.tableOperations().compact(table1, new CompactionConfig().setWait(true));
 
-      tms = ample.readTablets().forTable(tid).fetch(ColumnType.FILES).build();
+      tms = ample.readTablets().forTable(tid).fetch(ColumnType.FILES, ColumnType.ECOMP).build();
       tm = tms.iterator().next();
       assertEquals(1, tm.getFiles().size());
+      // ensure the failed compactions did not leave anything in the metadata table
+      assertEquals(0, tm.getExternalCompactions().size());
 
       ReadWriteIT.verify(client, MAX_DATA, 1, 1, 0, table1);
-
     }
   }
 


### PR DESCRIPTION
The DefaultCompactionPlanner would only emit one compaction job per tablet.  This commit changes it to be able to emit multiple compactions for a single tablet as long as doing so is optimal w.r.t. to the compaction ratio.