### PR TITLE
Deduplicate compaction tests

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionTestUtils.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionTestUtils.java
@@ -20,6 +20,8 @@ package org.apache.accumulo.test.compaction;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -31,6 +33,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -54,6 +57,7 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.core.rpc.ThriftUtil;
@@ -281,6 +285,14 @@ public class ExternalCompactionTestUtils {
     return ecids;
   }
 
+  public static long countTablets(ServerContext ctx, String tableName,
+      Predicate<TabletMetadata> tabletTest) {
+    var tableId = TableId.of(ctx.tableOperations().tableIdMap().get(tableName));
+    try (var tabletsMetadata = ctx.getAmple().readTablets().forTable(tableId).build()) {
+      return tabletsMetadata.stream().filter(tabletTest).count();
+    }
+  }
+
   public static void waitForRunningCompactions(ServerContext ctx, TableId tid,
       Set<ExternalCompactionId> idsToWaitFor) throws Exception {
 
@@ -349,5 +361,21 @@ public class ExternalCompactionTestUtils {
       assertEquals(expectedState, ExternalCompactionTestUtils.getLastState(tec));
     }
 
+  }
+
+  public static void assertNoCompactionMetadata(ServerContext ctx, String tableName) {
+    var tableId = TableId.of(ctx.tableOperations().tableIdMap().get(tableName));
+    var tabletsMetadata = ctx.getAmple().readTablets().forTable(tableId).build();
+
+    int count = 0;
+
+    for (var tabletMetadata : tabletsMetadata) {
+      assertEquals(Set.of(), tabletMetadata.getCompacted());
+      assertNull(tabletMetadata.getSelectedFiles());
+      assertEquals(Set.of(), tabletMetadata.getExternalCompactions().keySet());
+      count++;
+    }
+
+    assertTrue(count > 0);
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_1_IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_1_IT.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.test.compaction;
 
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.GROUP1;
 import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.GROUP2;
 import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.GROUP3;
@@ -25,6 +27,7 @@ import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.GR
 import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.GROUP6;
 import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.GROUP8;
 import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.MAX_DATA;
+import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.assertNoCompactionMetadata;
 import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.compact;
 import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.createTable;
 import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.row;
@@ -32,14 +35,17 @@ import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.ve
 import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.writeData;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -47,6 +53,7 @@ import java.util.stream.Collectors;
 import org.apache.accumulo.compactor.ExtCEnv.CompactorIterEnv;
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.Scanner;
@@ -66,20 +73,28 @@ import org.apache.accumulo.core.iterators.Filter;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.accumulo.core.metadata.MetadataTable;
+import org.apache.accumulo.core.metadata.RootTable;
+import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.spi.compaction.SimpleCompactionDispatcher;
 import org.apache.accumulo.harness.MiniClusterConfigurationCallback;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
+import org.apache.accumulo.test.functional.CompactionIT.ErrorThrowingSelector;
+import org.apache.accumulo.test.util.Wait;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 
-// ELASTICITY_TODO now that there are only external compactions, could merge some of these ITs that are redundant w/ CompactionIT
 public class ExternalCompaction_1_IT extends SharedMiniClusterBase {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ExternalCompaction_1_IT.class);
 
   public static class ExternalCompaction1Config implements MiniClusterConfigurationCallback {
     @Override
@@ -133,6 +148,103 @@ public class ExternalCompaction_1_IT extends SharedMiniClusterBase {
       return Integer.parseInt(v.toString()) % modulus == 0;
     }
 
+  }
+
+  @Test
+  public void testBadSelector() throws Exception {
+    try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
+      final String tableName = getUniqueNames(1)[0];
+      NewTableConfiguration tc = new NewTableConfiguration();
+      // Ensure compactions don't kick off
+      tc.setProperties(Map.of(Property.TABLE_MAJC_RATIO.getKey(), "10.0"));
+      c.tableOperations().create(tableName, tc);
+      // Create multiple RFiles
+      try (BatchWriter bw = c.createBatchWriter(tableName)) {
+        for (int i = 1; i <= 4; i++) {
+          Mutation m = new Mutation(Integer.toString(i));
+          m.put("cf", "cq", new Value());
+          bw.addMutation(m);
+          bw.flush();
+          // flush often to create multiple files to compact
+          c.tableOperations().flush(tableName, null, null, true);
+        }
+      }
+
+      CompactionConfig config = new CompactionConfig()
+          .setSelector(new PluginConfig(ErrorThrowingSelector.class.getName(), Map.of()))
+          .setWait(true);
+      assertThrows(AccumuloException.class, () -> c.tableOperations().compact(tableName, config));
+
+      List<String> rows = new ArrayList<>();
+      c.createScanner(tableName).forEach((k, v) -> rows.add(k.getRow().toString()));
+      assertEquals(List.of("1", "2", "3", "4"), rows);
+
+      assertNoCompactionMetadata(getCluster().getServerContext(), tableName);
+    }
+  }
+
+  @Test
+  public void testMetadataCompactions() throws Exception {
+    // The metadata and root table have default config that causes them to compact down to one
+    // tablet. This test verifies that both tables compact to one file after a flush.
+    try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
+      String[] tableNames = getUniqueNames(2);
+
+      // creating a user table should cause a write to the metadata table
+      c.tableOperations().create(tableNames[0]);
+
+      var mfiles1 = getCluster().getServerContext().getAmple().readTablets()
+          .forTable(MetadataTable.ID).build().iterator().next().getFiles();
+      var rootFiles1 =
+          getCluster().getServerContext().getAmple().readTablet(RootTable.EXTENT).getFiles();
+
+      LOG.debug("mfiles1 {}",
+          mfiles1.stream().map(StoredTabletFile::getFileName).collect(toList()));
+      LOG.debug("rootFiles1 {}",
+          rootFiles1.stream().map(StoredTabletFile::getFileName).collect(toList()));
+
+      c.tableOperations().flush(MetadataTable.NAME, null, null, true);
+      c.tableOperations().flush(RootTable.NAME, null, null, true);
+
+      // create another table to cause more metadata writes
+      c.tableOperations().create(tableNames[1]);
+      try (var writer = c.createBatchWriter(tableNames[1])) {
+        var m = new Mutation("r1");
+        m.put("f1", "q1", "v1");
+        writer.addMutation(m);
+      }
+      c.tableOperations().flush(tableNames[1], null, null, true);
+
+      // create another metadata file
+      c.tableOperations().flush(MetadataTable.NAME, null, null, true);
+      c.tableOperations().flush(RootTable.NAME, null, null, true);
+
+      // The multiple flushes should create multiple files. We expect the file sets to changes and
+      // eventually equal one.
+
+      Wait.waitFor(() -> {
+        var mfiles2 = getCluster().getServerContext().getAmple().readTablets()
+            .forTable(MetadataTable.ID).build().iterator().next().getFiles();
+        LOG.debug("mfiles2 {}",
+            mfiles2.stream().map(StoredTabletFile::getFileName).collect(toList()));
+        return mfiles2.size() == 1 && !mfiles2.equals(mfiles1);
+      });
+
+      Wait.waitFor(() -> {
+        var rootFiles2 =
+            getCluster().getServerContext().getAmple().readTablet(RootTable.EXTENT).getFiles();
+        LOG.debug("rootFiles2 {}",
+            rootFiles2.stream().map(StoredTabletFile::getFileName).collect(toList()));
+        return rootFiles2.size() == 1 && !rootFiles2.equals(rootFiles1);
+      });
+
+      var entries = c.createScanner(tableNames[1]).stream()
+          .map(e -> e.getKey().getRow() + ":" + e.getKey().getColumnFamily() + ":"
+              + e.getKey().getColumnQualifier() + ":" + e.getValue())
+          .collect(toSet());
+
+      assertEquals(Set.of("r1:f1:q1:v1"), entries);
+    }
   }
 
   @Test
@@ -264,6 +376,7 @@ public class ExternalCompaction_1_IT extends SharedMiniClusterBase {
               .setConfigurer(new PluginConfig(CompressionConfigurer.class.getName(),
                   Map.of(CompressionConfigurer.LARGE_FILE_COMPRESSION_TYPE, "gz",
                       CompressionConfigurer.LARGE_FILE_COMPRESSION_THRESHOLD, data.length + ""))));
+      assertNoCompactionMetadata(getCluster().getServerContext(), tableName);
 
       // after compacting with compression, expect small file
       sizes = CompactionExecutorIT.getFileSizes(client, tableName);
@@ -271,11 +384,65 @@ public class ExternalCompaction_1_IT extends SharedMiniClusterBase {
           "Unexpected files sizes: data: " + data.length + ", file:" + sizes);
 
       client.tableOperations().compact(tableName, new CompactionConfig().setWait(true));
+      assertNoCompactionMetadata(getCluster().getServerContext(), tableName);
 
       // after compacting without compression, expect big files again
       sizes = CompactionExecutorIT.getFileSizes(client, tableName);
       assertTrue(sizes > data.length * 10 && sizes < data.length * 11,
           "Unexpected files sizes : " + sizes);
+
+      // We need to cancel the compaction or delete the table here because we initiate a user
+      // compaction above in the test. Even though the external compaction was cancelled
+      // because we split the table, FaTE will continue to queue up a compaction
+      client.tableOperations().cancelCompaction(tableName);
+    }
+  }
+
+  @Test
+  public void testConfigurerSetOnTable() throws Exception {
+    String tableName = this.getUniqueNames(1)[0];
+
+    try (AccumuloClient client =
+        Accumulo.newClient().from(getCluster().getClientProperties()).build()) {
+
+      byte[] data = new byte[100000];
+
+      Map<String,String> props = Map.of("table.compaction.dispatcher",
+          SimpleCompactionDispatcher.class.getName(), "table.compaction.dispatcher.opts.service",
+          "cs5", Property.TABLE_FILE_COMPRESSION_TYPE.getKey(), "none",
+          Property.TABLE_COMPACTION_CONFIGURER.getKey(), CompressionConfigurer.class.getName(),
+          Property.TABLE_COMPACTION_CONFIGURER_OPTS.getKey()
+              + CompressionConfigurer.LARGE_FILE_COMPRESSION_TYPE,
+          "gz", Property.TABLE_COMPACTION_CONFIGURER_OPTS.getKey()
+              + CompressionConfigurer.LARGE_FILE_COMPRESSION_THRESHOLD,
+          "" + data.length);
+      NewTableConfiguration ntc = new NewTableConfiguration().setProperties(props);
+      client.tableOperations().create(tableName, ntc);
+
+      Arrays.fill(data, (byte) 65);
+      try (var writer = client.createBatchWriter(tableName)) {
+        for (int row = 0; row < 10; row++) {
+          Mutation m = new Mutation(row + "");
+          m.at().family("big").qualifier("stuff").put(data);
+          writer.addMutation(m);
+        }
+      }
+      client.tableOperations().flush(tableName, null, null, true);
+
+      // without compression, expect file to be large
+      long sizes = CompactionExecutorIT.getFileSizes(client, tableName);
+      assertTrue(sizes > data.length * 10 && sizes < data.length * 11,
+          "Unexpected files sizes : " + sizes);
+
+      client.tableOperations().compact(tableName, new CompactionConfig().setWait(true));
+      assertNoCompactionMetadata(getCluster().getServerContext(), tableName);
+
+      // after compacting with compression, expect small file
+      sizes = CompactionExecutorIT.getFileSizes(client, tableName);
+      assertTrue(sizes < data.length,
+          "Unexpected files sizes: data: " + data.length + ", file:" + sizes);
+
+      assertNoCompactionMetadata(getCluster().getServerContext(), tableName);
 
       // We need to cancel the compaction or delete the table here because we initiate a user
       // compaction above in the test. Even though the external compaction was cancelled
@@ -317,6 +484,8 @@ public class ExternalCompaction_1_IT extends SharedMiniClusterBase {
       try (Scanner s = client.createScanner(table1)) {
         assertFalse(s.iterator().hasNext());
       }
+
+      assertNoCompactionMetadata(getCluster().getServerContext(), table1);
 
       // We need to cancel the compaction or delete the table here because we initiate a user
       // compaction above in the test. Even though the external compaction was cancelled
@@ -372,6 +541,7 @@ public class ExternalCompaction_1_IT extends SharedMiniClusterBase {
       CompactionConfig config = new CompactionConfig().setIterators(List.of(iterSetting))
           .setWait(true).setSelector(new PluginConfig(FSelector.class.getName()));
       client.tableOperations().compact(tableName, config);
+      assertNoCompactionMetadata(getCluster().getServerContext(), tableName);
 
       try (Scanner scanner = client.createScanner(tableName)) {
         int count = 0;

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_2_IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_2_IT.java
@@ -25,6 +25,7 @@ import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.MA
 import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.compact;
 import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.confirmCompactionCompleted;
 import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.confirmCompactionRunning;
+import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.countTablets;
 import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.createTable;
 import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.row;
 import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.waitForCompactionStartAndReturnEcids;
@@ -49,7 +50,9 @@ import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.compaction.thrift.TCompactionState;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.harness.MiniClusterConfigurationCallback;
@@ -149,15 +152,28 @@ public class ExternalCompaction_2_IT extends SharedMiniClusterBase {
           .confirmCompactionRunning(getCluster().getServerContext(), ecids);
       assertTrue(matches > 0);
 
+      // when the compaction starts it will create a selected files column in the tablet, wait for
+      // that to happen
+      while (countTablets(getCluster().getServerContext(), table1,
+          tm -> tm.getSelectedFiles() != null) == 0) {
+        Thread.sleep(1000);
+      }
+
       client.tableOperations().cancelCompaction(table1);
 
       confirmCompactionCompleted(getCluster().getServerContext(), ecids,
           TCompactionState.CANCELLED);
 
-      // We need to cancel the compaction or delete the table here because we initiate a user
-      // compaction above in the test. Even though the external compaction was cancelled
-      // because we split the table, FaTE will continue to queue up a compaction
-      client.tableOperations().cancelCompaction(table1);
+      // ensure the canceled compaction deletes any tablet metadata related to the compaction
+      while (countTablets(getCluster().getServerContext(), table1,
+          tm -> tm.getSelectedFiles() != null || !tm.getCompacted().isEmpty()) > 0) {
+        Thread.sleep(1000);
+      }
+      //
+      // // We need to cancel the compaction or delete the table here because we initiate a user
+      // // compaction above in the test. Even though the external compaction was cancelled
+      // // because we split the table, FaTE will continue to queue up a compaction
+      // client.tableOperations().cancelCompaction(table1);
     }
   }
 
@@ -181,10 +197,25 @@ public class ExternalCompaction_2_IT extends SharedMiniClusterBase {
       int matches = confirmCompactionRunning(getCluster().getServerContext(), ecids);
       assertTrue(matches > 0);
 
+      // when the compaction starts it will create a selected files column in the tablet, wait for
+      // that to happen
+      while (countTablets(getCluster().getServerContext(), table1,
+          tm -> tm.getSelectedFiles() != null) == 0) {
+        Thread.sleep(1000);
+      }
+
       client.tableOperations().delete(table1);
 
       confirmCompactionCompleted(getCluster().getServerContext(), ecids,
           TCompactionState.CANCELLED);
+
+      // ELASTICITY_TODO make delete table fate op get operation ids before deleting
+      // there should be no metadata for the table, check to see if the compaction wrote anything
+      // after table delete
+      try (var scanner = client.createScanner(MetadataTable.NAME)) {
+        scanner.setRange(MetadataSchema.TabletsSection.getRange(tid));
+        assertEquals(0, scanner.stream().count());
+      }
 
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
@@ -21,37 +21,27 @@ package org.apache.accumulo.test.functional;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
-import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.stream.IntStream;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
-import org.apache.accumulo.core.client.AccumuloException;
-import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.Scanner;
@@ -60,39 +50,29 @@ import org.apache.accumulo.core.client.admin.CompactionConfig;
 import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.client.admin.PluginConfig;
 import org.apache.accumulo.core.client.admin.compaction.CompactionSelector;
-import org.apache.accumulo.core.client.admin.compaction.CompressionConfigurer;
 import org.apache.accumulo.core.clientImpl.ClientContext;
-import org.apache.accumulo.core.clientImpl.TableOperationsImpl;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.iterators.DevNull;
 import org.apache.accumulo.core.iterators.Filter;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
-import org.apache.accumulo.core.iterators.user.AgeOffFilter;
 import org.apache.accumulo.core.iterators.user.GrepIterator;
 import org.apache.accumulo.core.metadata.MetadataTable;
-import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
-import org.apache.accumulo.core.metadata.schema.Ample;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
-import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
-import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.test.VerifyIngest;
 import org.apache.accumulo.test.VerifyIngest.VerifyParams;
-import org.apache.accumulo.test.compaction.CompactionExecutorIT;
-import org.apache.accumulo.test.compaction.ExternalCompaction_1_IT.FSelector;
+import org.apache.accumulo.test.compaction.ExternalCompactionTestUtils;
 import org.apache.accumulo.test.util.Wait;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -188,402 +168,12 @@ public class CompactionIT extends AccumuloClusterHarness {
     hadoopCoreSite.set("fs.file.impl", RawLocalFileSystem.class.getName());
   }
 
-  @Test
-  public void testBadSelector() throws Exception {
-    try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
-      final String tableName = getUniqueNames(1)[0];
-      NewTableConfiguration tc = new NewTableConfiguration();
-      // Ensure compactions don't kick off
-      tc.setProperties(Map.of(Property.TABLE_MAJC_RATIO.getKey(), "10.0"));
-      c.tableOperations().create(tableName, tc);
-      // Create multiple RFiles
-      try (BatchWriter bw = c.createBatchWriter(tableName)) {
-        for (int i = 1; i <= 4; i++) {
-          Mutation m = new Mutation(Integer.toString(i));
-          m.put("cf", "cq", new Value());
-          bw.addMutation(m);
-          bw.flush();
-          // flush often to create multiple files to compact
-          c.tableOperations().flush(tableName, null, null, true);
-        }
-      }
-
-      CompactionConfig config = new CompactionConfig()
-          .setSelector(new PluginConfig(ErrorThrowingSelector.class.getName(), Map.of()))
-          .setWait(true);
-      assertThrows(AccumuloException.class, () -> c.tableOperations().compact(tableName, config));
-
-      List<String> rows = new ArrayList<>();
-      c.createScanner(tableName).forEach((k, v) -> rows.add(k.getRow().toString()));
-      assertEquals(List.of("1", "2", "3", "4"), rows);
-
-      assertNoCompactionMetadata(tableName);
-    }
-  }
-
-  @Test
-  public void testCompactionWithTableIterator() throws Exception {
-    String table1 = this.getUniqueNames(1)[0];
-    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-      client.tableOperations().create(table1);
-      try (BatchWriter bw = client.createBatchWriter(table1)) {
-        for (int i = 1; i <= 4; i++) {
-          Mutation m = new Mutation(Integer.toString(i));
-          m.put("cf", "cq", new Value());
-          bw.addMutation(m);
-          bw.flush();
-          // flush often to create multiple files to compact
-          client.tableOperations().flush(table1, null, null, true);
-        }
-      }
-
-      IteratorSetting setting = new IteratorSetting(50, "delete", DevNull.class);
-      client.tableOperations().attachIterator(table1, setting, EnumSet.of(IteratorScope.majc));
-      client.tableOperations().compact(table1, new CompactionConfig().setWait(true));
-
-      try (Scanner s = client.createScanner(table1)) {
-        assertFalse(s.iterator().hasNext());
-      }
-
-      assertNoCompactionMetadata(table1);
-    }
-  }
-
-  @Test
-  public void testUserCompactionCancellation() throws Exception {
-    final String table1 = this.getUniqueNames(1)[0];
-    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-      client.tableOperations().create(table1);
-      try (BatchWriter bw = client.createBatchWriter(table1)) {
-        for (int i = 1; i <= MAX_DATA; i++) {
-          Mutation m = new Mutation(Integer.toString(i));
-          m.put("cf", "cq", new Value());
-          bw.addMutation(m);
-          bw.flush();
-          // flush often to create multiple files to compact
-          client.tableOperations().flush(table1, null, null, true);
-        }
-      }
-
-      final AtomicReference<Exception> error = new AtomicReference<>();
-      Thread t = new Thread(() -> {
-        try {
-          IteratorSetting setting = new IteratorSetting(50, "sleepy", SlowIterator.class);
-          setting.addOption("sleepTime", "3000");
-          setting.addOption("seekSleepTime", "3000");
-          var cconf = new CompactionConfig().setWait(true).setIterators(List.of(setting));
-          client.tableOperations().compact(table1, cconf);
-        } catch (AccumuloSecurityException | TableNotFoundException | AccumuloException e) {
-          error.set(e);
-        }
-      });
-      t.start();
-      // when the compaction starts it will create a selected files column in the tablet, wait for
-      // that to happen
-      while (countTablets(table1, tm -> tm.getSelectedFiles() != null) == 0) {
-        Thread.sleep(1000);
-      }
-      client.tableOperations().cancelCompaction(table1);
-      t.join();
-      Exception e = error.get();
-      assertNotNull(e);
-      assertEquals(TableOperationsImpl.COMPACTION_CANCELED_MSG, e.getMessage());
-      // ensure the canceled compaction deletes any tablet metadata related to the compaction
-      while (countTablets(table1,
-          tm -> tm.getSelectedFiles() != null || !tm.getCompacted().isEmpty()) > 0) {
-        Thread.sleep(1000);
-      }
-    }
-  }
-
   private long countTablets(String tableName, Predicate<TabletMetadata> tabletTest) {
     var tableId = TableId.of(getServerContext().tableOperations().tableIdMap().get(tableName));
     try (var tabletsMetadata =
         getServerContext().getAmple().readTablets().forTable(tableId).build()) {
       return tabletsMetadata.stream().filter(tabletTest).count();
     }
-  }
-
-  @Test
-  public void testErrorDuringUserCompaction() throws Exception {
-    final String table1 = this.getUniqueNames(1)[0];
-    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-      client.tableOperations().create(table1);
-      client.tableOperations().setProperty(table1, Property.TABLE_FILE_MAX.getKey(), "1001");
-      client.tableOperations().setProperty(table1, Property.TABLE_MAJC_RATIO.getKey(), "1001");
-      TableId tid = TableId.of(client.tableOperations().tableIdMap().get(table1));
-
-      ReadWriteIT.ingest(client, MAX_DATA, 1, 1, 0, "colf", table1, 1);
-
-      Ample ample = ((ClientContext) client).getAmple();
-      TabletsMetadata tms = ample.readTablets().forTable(tid).fetch(ColumnType.FILES).build();
-      TabletMetadata tm = tms.iterator().next();
-      assertEquals(1000, tm.getFiles().size());
-
-      IteratorSetting setting = new IteratorSetting(50, "error", ErrorThrowingIterator.class);
-      setting.addOption(ErrorThrowingIterator.TIMES, "3");
-      client.tableOperations().attachIterator(table1, setting, EnumSet.of(IteratorScope.majc));
-      client.tableOperations().compact(table1, new CompactionConfig().setWait(true));
-
-      tms = ample.readTablets().forTable(tid).fetch(ColumnType.FILES).build();
-      tm = tms.iterator().next();
-      assertEquals(1, tm.getFiles().size());
-
-      ReadWriteIT.verify(client, MAX_DATA, 1, 1, 0, table1);
-
-    }
-  }
-
-  @Test
-  public void testErrorDuringCompactionNoOutput() throws Exception {
-    final String table1 = this.getUniqueNames(1)[0];
-    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-      client.tableOperations().create(table1);
-      client.tableOperations().setProperty(table1, Property.TABLE_MAJC_RATIO.getKey(), "51");
-      TableId tid = TableId.of(client.tableOperations().tableIdMap().get(table1));
-
-      ReadWriteIT.ingest(client, 50, 1, 1, 0, "colf", table1, 1);
-      ReadWriteIT.verify(client, 50, 1, 1, 0, table1);
-
-      Ample ample = ((ClientContext) client).getAmple();
-      TabletsMetadata tms = ample.readTablets().forTable(tid).fetch(ColumnType.FILES).build();
-      TabletMetadata tm = tms.iterator().next();
-      assertEquals(50, tm.getFiles().size());
-
-      IteratorSetting setting = new IteratorSetting(50, "ageoff", AgeOffFilter.class);
-      setting.addOption("ttl", "0");
-      setting.addOption("currentTime", Long.toString(System.currentTimeMillis() + 86400));
-      client.tableOperations().attachIterator(table1, setting, EnumSet.of(IteratorScope.majc));
-
-      // Since this iterator is on the top, it will throw an error 3 times, then allow the
-      // ageoff iterator to do its work.
-      IteratorSetting setting2 = new IteratorSetting(51, "error", ErrorThrowingIterator.class);
-      setting2.addOption(ErrorThrowingIterator.TIMES, "3");
-      client.tableOperations().attachIterator(table1, setting2, EnumSet.of(IteratorScope.majc));
-      client.tableOperations().compact(table1, new CompactionConfig().setWait(true));
-
-      assertThrows(NoSuchElementException.class, () -> ample.readTablets().forTable(tid)
-          .fetch(ColumnType.FILES).build().iterator().next());
-      assertEquals(0, client.createScanner(table1).stream().count());
-    }
-  }
-
-  @Test
-  public void testTableDeletedDuringUserCompaction() throws Exception {
-    final String table1 = this.getUniqueNames(1)[0];
-    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-      client.tableOperations().create(table1);
-      try (BatchWriter bw = client.createBatchWriter(table1)) {
-        for (int i = 1; i <= MAX_DATA; i++) {
-          Mutation m = new Mutation(Integer.toString(i));
-          m.put("cf", "cq", new Value());
-          bw.addMutation(m);
-          bw.flush();
-          // flush often to create multiple files to compact
-          client.tableOperations().flush(table1, null, null, true);
-        }
-      }
-
-      final AtomicReference<Exception> error = new AtomicReference<>();
-      Thread t = new Thread(() -> {
-        try {
-          IteratorSetting setting = new IteratorSetting(50, "sleepy", SlowIterator.class);
-          setting.addOption("sleepTime", "3000");
-          setting.addOption("seekSleepTime", "3000");
-          var cconf = new CompactionConfig().setWait(true).setIterators(List.of(setting));
-          client.tableOperations().compact(table1, cconf);
-        } catch (AccumuloSecurityException | TableNotFoundException | AccumuloException e) {
-          error.set(e);
-        }
-      });
-      t.start();
-      // when the compaction starts it will create a selected files column in the tablet, wait for
-      // that to happen
-      while (countTablets(table1, tm -> tm.getSelectedFiles() != null) == 0) {
-        Thread.sleep(1000);
-      }
-
-      // grab the table id before deleting the table as its needed for a check later and can not get
-      // it after delete
-      var tableId = TableId.of(getServerContext().tableOperations().tableIdMap().get(table1));
-
-      client.tableOperations().delete(table1);
-      t.join();
-      Exception e = error.get();
-      assertNotNull(e);
-      assertEquals(TableOperationsImpl.COMPACTION_CANCELED_MSG, e.getMessage());
-
-      // ELASTICITY_TODO make delete table fate op get operation ids before deleting
-      // there should be no metadata for the table, check to see if the compaction wrote anything
-      // after table delete
-      try (var scanner = client.createScanner(MetadataTable.NAME)) {
-        scanner.setRange(MetadataSchema.TabletsSection.getRange(tableId));
-        assertEquals(0, scanner.stream().count());
-      }
-    }
-  }
-
-  @Test
-  public void testPartialCompaction() throws Exception {
-    String tableName = getUniqueNames(1)[0];
-    try (final AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-
-      client.tableOperations().create(tableName);
-
-      // Insert MAX_DATA rows
-      try (BatchWriter bw = client.createBatchWriter(tableName)) {
-        for (int i = 0; i < MAX_DATA; i++) {
-          Mutation m = new Mutation(String.format("r:%04d", i));
-          m.put("", "", "" + i);
-          bw.addMutation(m);
-        }
-      }
-      client.tableOperations().flush(tableName, null, null, true);
-      IteratorSetting iterSetting = new IteratorSetting(100, TestFilter.class);
-      // make sure iterator options make it to compactor process
-      iterSetting.addOption("modulus", 17 + "");
-      CompactionConfig config =
-          new CompactionConfig().setIterators(List.of(iterSetting)).setWait(true);
-      client.tableOperations().compact(tableName, config);
-
-      // Insert 2 * MAX_DATA rows
-      try (BatchWriter bw = client.createBatchWriter(tableName)) {
-        for (int i = MAX_DATA; i < MAX_DATA * 2; i++) {
-          Mutation m = new Mutation(String.format("r:%04d", i));
-          m.put("", "", "" + i);
-          bw.addMutation(m);
-        }
-      }
-      // this should create an F file
-      client.tableOperations().flush(tableName, null, null, true);
-
-      // ELASTICITY_TODO compactions flush tablets, needs to evaluate this behavior
-
-      // run a compaction that only compacts F files
-      iterSetting = new IteratorSetting(100, TestFilter.class);
-      // compact F file w/ different modulus and user pmodulus option for partial compaction
-      iterSetting.addOption("pmodulus", 19 + "");
-      config = new CompactionConfig().setIterators(List.of(iterSetting)).setWait(true)
-          .setSelector(new PluginConfig(FSelector.class.getName()));
-      client.tableOperations().compact(tableName, config);
-      assertNoCompactionMetadata(tableName);
-
-      try (Scanner scanner = client.createScanner(tableName)) {
-        int count = 0;
-        for (Entry<Key,Value> entry : scanner) {
-
-          int v = Integer.parseInt(entry.getValue().toString());
-          int modulus = v < MAX_DATA ? 17 : 19;
-
-          assertEquals(0, Integer.parseInt(entry.getValue().toString()) % modulus,
-              String.format("%s %s %d != 0", entry.getValue(), "%", modulus));
-          count++;
-        }
-
-        // Verify
-        int expectedCount = 0;
-        for (int i = 0; i < MAX_DATA * 2; i++) {
-          int modulus = i < MAX_DATA ? 17 : 19;
-          if (i % modulus == 0) {
-            expectedCount++;
-          }
-        }
-        assertEquals(expectedCount, count);
-      }
-
-    }
-  }
-
-  @Test
-  public void testConfigurer() throws Exception {
-    String tableName = this.getUniqueNames(1)[0];
-
-    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-
-      Map<String,String> props = Map.of(Property.TABLE_FILE_COMPRESSION_TYPE.getKey(), "none");
-      NewTableConfiguration ntc = new NewTableConfiguration().setProperties(props);
-      client.tableOperations().create(tableName, ntc);
-
-      byte[] data = new byte[100000];
-      generateConfigurerTestData(tableName, client, data);
-
-      // without compression, expect file to be large
-      long sizes = CompactionExecutorIT.getFileSizes(client, tableName);
-      assertTrue(sizes > data.length * 10 && sizes < data.length * 11,
-          "Unexpected files sizes : " + sizes);
-
-      client.tableOperations().compact(tableName,
-          new CompactionConfig().setWait(true)
-              .setConfigurer(new PluginConfig(CompressionConfigurer.class.getName(),
-                  Map.of(CompressionConfigurer.LARGE_FILE_COMPRESSION_TYPE, "gz",
-                      CompressionConfigurer.LARGE_FILE_COMPRESSION_THRESHOLD, data.length + ""))));
-      assertNoCompactionMetadata(tableName);
-
-      // after compacting with compression, expect small file
-      sizes = CompactionExecutorIT.getFileSizes(client, tableName);
-      assertTrue(sizes < data.length,
-          "Unexpected files sizes: data: " + data.length + ", file:" + sizes);
-
-      client.tableOperations().compact(tableName, new CompactionConfig().setWait(true));
-      assertNoCompactionMetadata(tableName);
-
-      // after compacting without compression, expect big files again
-      sizes = CompactionExecutorIT.getFileSizes(client, tableName);
-      assertTrue(sizes > data.length * 10 && sizes < data.length * 11,
-          "Unexpected files sizes : " + sizes);
-
-    }
-  }
-
-  @Test
-  public void testConfigurerSetOnTable() throws Exception {
-    String tableName = this.getUniqueNames(1)[0];
-
-    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-
-      byte[] data = new byte[100000];
-
-      Map<String,
-          String> props = Map.of(Property.TABLE_FILE_COMPRESSION_TYPE.getKey(), "none",
-              Property.TABLE_COMPACTION_CONFIGURER.getKey(), CompressionConfigurer.class.getName(),
-              Property.TABLE_COMPACTION_CONFIGURER_OPTS.getKey()
-                  + CompressionConfigurer.LARGE_FILE_COMPRESSION_TYPE,
-              "gz", Property.TABLE_COMPACTION_CONFIGURER_OPTS.getKey()
-                  + CompressionConfigurer.LARGE_FILE_COMPRESSION_THRESHOLD,
-              "" + data.length);
-      NewTableConfiguration ntc = new NewTableConfiguration().setProperties(props);
-      client.tableOperations().create(tableName, ntc);
-
-      generateConfigurerTestData(tableName, client, data);
-
-      // without compression, expect file to be large
-      long sizes = CompactionExecutorIT.getFileSizes(client, tableName);
-      assertTrue(sizes > data.length * 10 && sizes < data.length * 11,
-          "Unexpected files sizes : " + sizes);
-
-      client.tableOperations().compact(tableName, new CompactionConfig().setWait(true));
-
-      // after compacting with compression, expect small file
-      sizes = CompactionExecutorIT.getFileSizes(client, tableName);
-      assertTrue(sizes < data.length,
-          "Unexpected files sizes: data: " + data.length + ", file:" + sizes);
-
-      assertNoCompactionMetadata(tableName);
-
-    }
-  }
-
-  private static void generateConfigurerTestData(String tableName, AccumuloClient client,
-      byte[] data) throws AccumuloException, AccumuloSecurityException, TableNotFoundException {
-    Arrays.fill(data, (byte) 65);
-    try (var writer = client.createBatchWriter(tableName)) {
-      for (int row = 0; row < 10; row++) {
-        Mutation m = new Mutation(row + "");
-        m.at().family("big").qualifier("stuff").put(data);
-        writer.addMutation(m);
-      }
-    }
-    client.tableOperations().flush(tableName, null, null, true);
   }
 
   @Test
@@ -694,7 +284,7 @@ public class CompactionIT extends AccumuloClusterHarness {
       var finalCount = countFiles(c);
       assertTrue(finalCount <= beforeCount);
 
-      assertNoCompactionMetadata(tableName);
+      ExternalCompactionTestUtils.assertNoCompactionMetadata(getServerContext(), tableName);
     }
   }
 
@@ -718,7 +308,7 @@ public class CompactionIT extends AccumuloClusterHarness {
 
       assertEquals(Set.of("a", "b"), getRows(c, tableName));
 
-      assertNoCompactionMetadata(tableName);
+      ExternalCompactionTestUtils.assertNoCompactionMetadata(getServerContext(), tableName);
     }
 
   }
@@ -877,84 +467,6 @@ public class CompactionIT extends AccumuloClusterHarness {
     }
   }
 
-  private void assertNoCompactionMetadata(String tableName) {
-    var tableId = TableId.of(getServerContext().tableOperations().tableIdMap().get(tableName));
-    var tabletsMetadata = getServerContext().getAmple().readTablets().forTable(tableId).build();
-
-    int count = 0;
-
-    for (var tabletMetadata : tabletsMetadata) {
-      assertEquals(Set.of(), tabletMetadata.getCompacted());
-      assertNull(tabletMetadata.getSelectedFiles());
-      assertEquals(Set.of(), tabletMetadata.getExternalCompactions().keySet());
-      count++;
-    }
-
-    assertTrue(count > 0);
-  }
-
-  @Test
-  public void testMetadataCompactions() throws Exception {
-    // The metadata and root table have default config that causes them to compact down to one
-    // tablet. This test verifies that both tables compact to one file after a flush.
-    try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
-      String[] tableNames = getUniqueNames(2);
-
-      // creating a user table should cause a write to the metadata table
-      c.tableOperations().create(tableNames[0]);
-
-      var mfiles1 = getServerContext().getAmple().readTablets().forTable(MetadataTable.ID).build()
-          .iterator().next().getFiles();
-      var rootFiles1 = getServerContext().getAmple().readTablet(RootTable.EXTENT).getFiles();
-
-      log.debug("mfiles1 {}",
-          mfiles1.stream().map(StoredTabletFile::getFileName).collect(toList()));
-      log.debug("rootFiles1 {}",
-          rootFiles1.stream().map(StoredTabletFile::getFileName).collect(toList()));
-
-      c.tableOperations().flush(MetadataTable.NAME, null, null, true);
-      c.tableOperations().flush(RootTable.NAME, null, null, true);
-
-      // create another table to cause more metadata writes
-      c.tableOperations().create(tableNames[1]);
-      try (var writer = c.createBatchWriter(tableNames[1])) {
-        var m = new Mutation("r1");
-        m.put("f1", "q1", "v1");
-        writer.addMutation(m);
-      }
-      c.tableOperations().flush(tableNames[1], null, null, true);
-
-      // create another metadata file
-      c.tableOperations().flush(MetadataTable.NAME, null, null, true);
-      c.tableOperations().flush(RootTable.NAME, null, null, true);
-
-      // The multiple flushes should create multiple files. We expect the file sets to changes and
-      // eventually equal one.
-
-      Wait.waitFor(() -> {
-        var mfiles2 = getServerContext().getAmple().readTablets().forTable(MetadataTable.ID).build()
-            .iterator().next().getFiles();
-        log.debug("mfiles2 {}",
-            mfiles2.stream().map(StoredTabletFile::getFileName).collect(toList()));
-        return mfiles2.size() == 1 && !mfiles2.equals(mfiles1);
-      });
-
-      Wait.waitFor(() -> {
-        var rootFiles2 = getServerContext().getAmple().readTablet(RootTable.EXTENT).getFiles();
-        log.debug("rootFiles2 {}",
-            rootFiles2.stream().map(StoredTabletFile::getFileName).collect(toList()));
-        return rootFiles2.size() == 1 && !rootFiles2.equals(rootFiles1);
-      });
-
-      var entries = c.createScanner(tableNames[1]).stream()
-          .map(e -> e.getKey().getRow() + ":" + e.getKey().getColumnFamily() + ":"
-              + e.getKey().getColumnQualifier() + ":" + e.getValue())
-          .collect(toSet());
-
-      assertEquals(Set.of("r1:f1:q1:v1"), entries);
-    }
-  }
-
   @Test
   public void testSystemCompactionsRefresh() throws Exception {
     // This test ensures that after a system compaction occurs that a tablet will refresh its files.
@@ -1037,18 +549,6 @@ public class CompactionIT extends AccumuloClusterHarness {
       s.fetchColumnFamily(new Text(DataFileColumnFamily.NAME));
       return Iterators.size(s.iterator());
     }
-  }
-
-  private void writeRandomValue(AccumuloClient c, String tableName, int size) throws Exception {
-    byte[] data1 = new byte[size];
-    RANDOM.get().nextBytes(data1);
-
-    try (BatchWriter bw = c.createBatchWriter(tableName)) {
-      Mutation m1 = new Mutation("r" + RANDOM.get().nextInt(909090));
-      m1.put("data", "bl0b", new Value(data1));
-      bw.addMutation(m1);
-    }
-    c.tableOperations().flush(tableName, null, null, true);
   }
 
   private Set<String> getRows(AccumuloClient c, String tableName) throws TableNotFoundException {

--- a/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
@@ -63,6 +63,7 @@ import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iterators.user.GrepIterator;
 import org.apache.accumulo.core.metadata.MetadataTable;
+import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
@@ -465,6 +466,68 @@ public class CompactionIT extends AccumuloClusterHarness {
           > 0) {
         Thread.sleep(250);
       }
+    }
+  }
+
+  @Test
+  public void testMetadataCompactions() throws Exception {
+    // The metadata and root table have default config that causes them to compact down to one
+    // tablet. This test verifies that both tables compact to one file after a flush.
+    try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
+      String[] tableNames = getUniqueNames(2);
+
+      // creating a user table should cause a write to the metadata table
+      c.tableOperations().create(tableNames[0]);
+
+      var mfiles1 = getServerContext().getAmple().readTablets().forTable(MetadataTable.ID).build()
+          .iterator().next().getFiles();
+      var rootFiles1 = getServerContext().getAmple().readTablet(RootTable.EXTENT).getFiles();
+
+      log.debug("mfiles1 {}",
+          mfiles1.stream().map(StoredTabletFile::getFileName).collect(toList()));
+      log.debug("rootFiles1 {}",
+          rootFiles1.stream().map(StoredTabletFile::getFileName).collect(toList()));
+
+      c.tableOperations().flush(MetadataTable.NAME, null, null, true);
+      c.tableOperations().flush(RootTable.NAME, null, null, true);
+
+      // create another table to cause more metadata writes
+      c.tableOperations().create(tableNames[1]);
+      try (var writer = c.createBatchWriter(tableNames[1])) {
+        var m = new Mutation("r1");
+        m.put("f1", "q1", "v1");
+        writer.addMutation(m);
+      }
+      c.tableOperations().flush(tableNames[1], null, null, true);
+
+      // create another metadata file
+      c.tableOperations().flush(MetadataTable.NAME, null, null, true);
+      c.tableOperations().flush(RootTable.NAME, null, null, true);
+
+      // The multiple flushes should create multiple files. We expect the file sets to changes and
+      // eventually equal one.
+
+      Wait.waitFor(() -> {
+        var mfiles2 = getServerContext().getAmple().readTablets().forTable(MetadataTable.ID).build()
+            .iterator().next().getFiles();
+        log.debug("mfiles2 {}",
+            mfiles2.stream().map(StoredTabletFile::getFileName).collect(toList()));
+        return mfiles2.size() == 1 && !mfiles2.equals(mfiles1);
+      });
+
+      Wait.waitFor(() -> {
+        var rootFiles2 = getServerContext().getAmple().readTablet(RootTable.EXTENT).getFiles();
+        log.debug("rootFiles2 {}",
+            rootFiles2.stream().map(StoredTabletFile::getFileName).collect(toList()));
+        return rootFiles2.size() == 1 && !rootFiles2.equals(rootFiles1);
+      });
+
+      var entries = c.createScanner(tableNames[1]).stream()
+          .map(e -> e.getKey().getRow() + ":" + e.getKey().getColumnFamily() + ":"
+              + e.getKey().getColumnQualifier() + ":" + e.getValue())
+          .collect(toSet());
+
+      assertEquals(Set.of("r1:f1:q1:v1"), entries);
     }
   }
 


### PR DESCRIPTION
Removed tests from CompactionIT that had a matching test in `ExternalCompaction*IT`. Updated tests in `ExternalCompaction*IT` that were missing some recent updates in CompactionIT.