### PR TITLE
Attempt to prevent half-closed Tablet due to failing minc

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/ConfigurationTypeHelper.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ConfigurationTypeHelper.java
@@ -174,7 +174,7 @@ public class ConfigurationTypeHelper {
     try {
       instance = getClassInstance(context, clazzName, base);
     } catch (RuntimeException | IOException | ReflectiveOperationException e) {
-      log.warn("Failed to load class {} in classloader context {}", clazzName, context, e);
+      log.error("Failed to load class {} in classloader context {}", clazzName, context, e);
     }
 
     if (instance == null && defaultInstance != null) {

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfiguration.java
@@ -183,7 +183,7 @@ public class TableConfiguration extends ZooBasedConfiguration {
       log.error(
           "Null returned for compaction dispatcher for table: {}. Did not return default value, check server log.",
           tableId);
-      return newDispatcher;
+      return null;
     }
 
     Map<String,String> opts =

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfiguration.java
@@ -178,6 +178,14 @@ public class TableConfiguration extends ZooBasedConfiguration {
     CompactionDispatcher newDispatcher = Property.createTableInstanceFromPropertyName(conf,
         Property.TABLE_COMPACTION_DISPATCHER, CompactionDispatcher.class, null);
 
+    if (newDispatcher == null) {
+      // return early to prevent NPE
+      log.error(
+          "Null returned for compaction dispatcher for table: {}. Did not return default value, check server log.",
+          tableId);
+      return newDispatcher;
+    }
+
     Map<String,String> opts =
         conf.getAllPropertiesWithPrefixStripped(Property.TABLE_COMPACTION_DISPATCHER_OPTS);
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
@@ -1009,6 +1009,9 @@ public class TabletClientHandler implements TabletClientService.Iface {
       } catch (IOException e) {
         log.warn("Failed to split " + keyExtent, e);
         throw new RuntimeException(e);
+      } catch (RuntimeException re) {
+        log.warn("Failed to split " + keyExtent, re);
+        throw re;
       }
     }
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
@@ -1473,6 +1473,13 @@ public class CompactableImpl implements Compactable {
     try {
       var dispatcher = tablet.getTableConfiguration().getCompactionDispatcher();
 
+      if (dispatcher == null) {
+        log.error(
+            "Failed to dispatch compaction {} kind:{} hints:{}, falling back to {} service. Check server log.",
+            getExtent(), kind, debugHints, CompactionServicesConfig.DEFAULT_SERVICE);
+        return CompactionServicesConfig.DEFAULT_SERVICE;
+      }
+
       Map<String,String> tmpHints = Map.of();
 
       if (kind == CompactionKind.USER) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
@@ -1475,7 +1475,7 @@ public class CompactableImpl implements Compactable {
 
       if (dispatcher == null) {
         log.error(
-            "Failed to dispatch compaction {} kind:{} hints:{}, falling back to {} service. Check server log.",
+            "Failed to dispatch compaction {} kind:{} hints:{}, falling back to {} service. Unable to instantiate dispatcher plugin. Check server log.",
             getExtent(), kind, debugHints, CompactionServicesConfig.DEFAULT_SERVICE);
         return CompactionServicesConfig.DEFAULT_SERVICE;
       }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactionTask.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactionTask.java
@@ -18,8 +18,6 @@
  */
 package org.apache.accumulo.tserver.tablet;
 
-import java.io.IOException;
-
 import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.trace.TraceUtil;
@@ -90,8 +88,11 @@ class MinorCompactionTask implements Runnable {
               tablet.getTabletServer().minorCompactionStarted(commitSession,
                   commitSession.getWALogSeq() + 1, newFile.getMetaInsert());
               break;
-            } catch (IOException e) {
-              // An IOException could have occurred while creating the new file
+            } catch (Exception e) {
+              // Catching Exception here rather than something more specific as we can't allow the
+              // MinorCompactionTask to exit and the thread to die. Tablet.minorCompact *must* be
+              // called and *must* complete else no future minor compactions can be performed on
+              // this Tablet.
               if (newFile == null) {
                 log.warn("Failed to create new file for minor compaction {}", e.getMessage(), e);
               } else {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactionTask.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactionTask.java
@@ -131,11 +131,11 @@ class MinorCompactionTask implements Runnable {
       if (tablet.needsSplit(tablet.getSplitComputations())) {
         tablet.getTabletServer().executeSplit(tablet);
       }
-      tablet.minorCompactionComplete(true);
     } catch (Exception e) {
       log.error("Unknown error during minor compaction for extent: {}", tablet.getExtent(), e);
-      tablet.minorCompactionComplete(false);
       throw e;
+    } finally {
+      tablet.minorCompactionComplete();
     }
   }
 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactionTask.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactionTask.java
@@ -130,11 +130,11 @@ class MinorCompactionTask implements Runnable {
       if (tablet.needsSplit(tablet.getSplitComputations())) {
         tablet.getTabletServer().executeSplit(tablet);
       }
+      tablet.minorCompactionComplete(true);
     } catch (Exception e) {
       log.error("Unknown error during minor compaction for extent: {}", tablet.getExtent(), e);
+      tablet.minorCompactionComplete(false);
       throw e;
-    } finally {
-      tablet.minorCompactionComplete();
     }
   }
 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
@@ -50,6 +50,7 @@ public class MinorCompactor extends FileCompactor {
   private static final SecureRandom random = new SecureRandom();
   private static final Logger log = LoggerFactory.getLogger(MinorCompactor.class);
 
+  private final Tablet tablet;
   private final TabletServer tabletServer;
   private final MinorCompactionReason mincReason;
 
@@ -58,6 +59,7 @@ public class MinorCompactor extends FileCompactor {
     super(tabletServer.getContext(), tablet.getExtent(), Collections.emptyMap(), outputFile, true,
         new MinCEnv(mincReason, imm.compactionIterator()), Collections.emptyList(), tableConfig,
         tableConfig.getCryptoService());
+    this.tablet = tablet;
     this.tabletServer = tabletServer;
     this.mincReason = mincReason;
   }
@@ -131,6 +133,7 @@ public class MinorCompactor extends FileCompactor {
           throw new IllegalStateException(e);
         }
 
+        this.tablet.minorCompactionFailure();
         int sleep = sleepTime + random.nextInt(sleepTime);
         log.debug("MinC failed sleeping {} ms before retrying", sleep);
         sleepUninterruptibly(sleep, TimeUnit.MILLISECONDS);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
@@ -50,7 +50,6 @@ public class MinorCompactor extends FileCompactor {
   private static final SecureRandom random = new SecureRandom();
   private static final Logger log = LoggerFactory.getLogger(MinorCompactor.class);
 
-  private final Tablet tablet;
   private final TabletServer tabletServer;
   private final MinorCompactionReason mincReason;
 
@@ -59,7 +58,6 @@ public class MinorCompactor extends FileCompactor {
     super(tabletServer.getContext(), tablet.getExtent(), Collections.emptyMap(), outputFile, true,
         new MinCEnv(mincReason, imm.compactionIterator()), Collections.emptyList(), tableConfig,
         tableConfig.getCryptoService());
-    this.tablet = tablet;
     this.tabletServer = tabletServer;
     this.mincReason = mincReason;
   }
@@ -133,7 +131,6 @@ public class MinorCompactor extends FileCompactor {
           throw new IllegalStateException(e);
         }
 
-        this.tablet.minorCompactionFailure();
         int sleep = sleepTime + random.nextInt(sleepTime);
         log.debug("MinC failed sleeping {} ms before retrying", sleep);
         sleepUninterruptibly(sleep, TimeUnit.MILLISECONDS);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -919,13 +919,6 @@ public class Tablet extends TabletBase {
           // We don't know when the last minc occurred. Kick one off now. It's possible
           // that a minc will not be initiated (if there is no data in the table for example)
           if (initiateMinorCompaction(MinorCompactionReason.CLOSE)) {
-            // Not calling getTabletMemory().waitForMinC(); as it will wait
-            // indefinitely for a successful minor compaction. It's possible
-            // that won't happen. We just want to know if the current minc
-            // fails.
-            // while (isMinorCompactionQueued() || isMinorCompactionRunning()) {
-            // UtilWaitThread.sleepUninterruptibly(50, TimeUnit.MILLISECONDS);
-            // }
             getTabletMemory().waitForMinC();
           }
         }

--- a/test/src/main/java/org/apache/accumulo/test/functional/HalfClosedTablet2IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/HalfClosedTablet2IT.java
@@ -37,6 +37,13 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+//This IT tests the cases seen in https://github.com/apache/accumulo/issues/3674
+//where a failing minor compaction causes a Tablet.initiateClose to leave the
+//Tablet in a half-closed state. The half-closed Tablet cannot be unloaded and
+//the TabletServer cannot be shutdown normally. Because the minor compaction has
+//been failing the Tablet needs to be recovered when it's ultimately re-assigned.
+//The test in this class sets up a VolumeChooser configuration on MiniAccumuloCluster
+//to test a specific code path that caused the minor compaction thread to die.
 public class HalfClosedTablet2IT extends SharedMiniClusterBase {
 
   public static class HalfClosedTablet2ITConfiguration implements MiniClusterConfigurationCallback {

--- a/test/src/main/java/org/apache/accumulo/test/functional/HalfClosedTablet2IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/HalfClosedTablet2IT.java
@@ -93,6 +93,9 @@ public class HalfClosedTablet2IT extends SharedMiniClusterBase {
       HalfClosedTabletIT.setInvalidClassLoaderContextPropertyWithoutValidation(
           getCluster().getServerContext(), tableId);
 
+      // Need to wait for TabletServer to pickup configuration change
+      Thread.sleep(3000);
+
       tops.flush(tableName);
 
       // minc should fail until invalid context is removed, so there should be no files

--- a/test/src/main/java/org/apache/accumulo/test/functional/HalfClosedTablet2IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/HalfClosedTablet2IT.java
@@ -105,8 +105,7 @@ public class HalfClosedTablet2IT extends SharedMiniClusterBase {
       // unloaded
       tops.offline(tableName);
 
-      Wait.waitFor(() -> HalfClosedTabletIT.countHostedTablets(client, tableId).count() == 0L,
-          340_000);
+      Wait.waitFor(() -> HalfClosedTabletIT.countHostedTablets(client, tableId) == 0L, 340_000);
 
     }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/HalfClosedTablet2IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/HalfClosedTablet2IT.java
@@ -37,13 +37,11 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-//This IT tests the cases seen in https://github.com/apache/accumulo/issues/3674
-//where a failing minor compaction causes a Tablet.initiateClose to leave the
-//Tablet in a half-closed state. The half-closed Tablet cannot be unloaded and
-//the TabletServer cannot be shutdown normally. Because the minor compaction has
-//been failing the Tablet needs to be recovered when it's ultimately re-assigned.
-//The test in this class sets up a VolumeChooser configuration on MiniAccumuloCluster
-//to test a specific code path that caused the minor compaction thread to die.
+// This covers issues like that reported in https://github.com/apache/accumulo/issues/3674
+// where a failing minor compaction leaves the Tablet in a half-closed state that prevents it
+// from unloading and the TServer from shutting down normally.
+// This test recreates that scenario by setting an invalid context and verifies that the
+// tablet can recover and unload after the context is set correctly.
 public class HalfClosedTablet2IT extends SharedMiniClusterBase {
 
   public static class HalfClosedTablet2ITConfiguration implements MiniClusterConfigurationCallback {

--- a/test/src/main/java/org/apache/accumulo/test/functional/HalfClosedTablet2IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/HalfClosedTablet2IT.java
@@ -101,8 +101,7 @@ public class HalfClosedTablet2IT extends SharedMiniClusterBase {
       // minc should fail until invalid context is removed, so there should be no files
       FunctionalTestUtils.checkRFiles(client, tableName, 1, 1, 0, 0);
 
-      HalfClosedTabletIT.removeInvalidClassLoaderContextPropertyWithoutValidation(
-          getCluster().getServerContext(), tableId);
+      HalfClosedTabletIT.removeInvalidClassLoaderContextProperty(client, tableName);
 
       // Minc should have completed successfully
       Wait.waitFor(() -> HalfClosedTabletIT.tabletHasExpectedRFiles(client, tableName, 1, 1, 1, 1),

--- a/test/src/main/java/org/apache/accumulo/test/functional/HalfClosedTablet2IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/HalfClosedTablet2IT.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test.functional;
+
+import java.io.File;
+
+import org.apache.accumulo.core.client.Accumulo;
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.spi.fs.DelegatingChooser;
+import org.apache.accumulo.core.spi.fs.PreferredVolumeChooser;
+import org.apache.accumulo.harness.MiniClusterConfigurationCallback;
+import org.apache.accumulo.harness.SharedMiniClusterBase;
+import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
+import org.apache.accumulo.test.util.Wait;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.Text;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class HalfClosedTablet2IT extends SharedMiniClusterBase {
+
+  public static class HalfClosedTablet2ITConfiguration implements MiniClusterConfigurationCallback {
+
+    @Override
+    public void configureMiniCluster(MiniAccumuloConfigImpl cfg, Configuration coreSite) {
+      cfg.setNumTservers(1);
+      cfg.setProperty(Property.GENERAL_VOLUME_CHOOSER, DelegatingChooser.class.getName());
+      cfg.setProperty("general.custom.volume.chooser.default",
+          PreferredVolumeChooser.class.getName());
+      cfg.setProperty("general.custom.volume.preferred.default",
+          new File(cfg.getDir().getAbsolutePath(), "/accumulo").toURI().toString());
+    }
+  }
+
+  @BeforeAll
+  public static void startup() throws Exception {
+    SharedMiniClusterBase.startMiniClusterWithConfig(new HalfClosedTablet2ITConfiguration());
+  }
+
+  @AfterAll
+  public static void shutdown() throws Exception {
+    SharedMiniClusterBase.stopMiniCluster();
+  }
+
+  @Test
+  public void testInvalidContextCausesVolumeChooserFailure() throws Exception {
+
+    // In this scenario an invalid context causes the VolumeChooser impl to not
+    // be loaded, which causes the MinorCompactionTask to fail to create an
+    // output file. This failure causes the minor compaction thread to die.
+
+    String tableName = getUniqueNames(1)[0];
+    try (final var client = Accumulo.newClient().from(getClientProps()).build()) {
+
+      final var tops = client.tableOperations();
+      tops.create(tableName);
+      TableId tableId = TableId.of(tops.tableIdMap().get(tableName));
+
+      try (final var bw = client.createBatchWriter(tableName)) {
+        final var m1 = new Mutation("a");
+        final var m2 = new Mutation("b");
+        m1.put(new Text("cf"), new Text(), new Value());
+        m2.put(new Text("cf"), new Text(), new Value());
+        bw.addMutation(m1);
+        bw.addMutation(m2);
+      }
+
+      tops.setProperty(tableName, Property.TABLE_CLASSLOADER_CONTEXT.getKey(), "invalid");
+
+      tops.flush(tableName);
+
+      // minc should fail until invalid context is removed, so there should be no files
+      FunctionalTestUtils.checkRFiles(client, tableName, 1, 1, 0, 0);
+
+      tops.removeProperty(tableName, Property.TABLE_CLASSLOADER_CONTEXT.getKey());
+
+      // Minc should have completed successfully
+      Wait.waitFor(() -> HalfClosedTabletIT.tabletHasExpectedRFiles(client, tableName, 1, 1, 1, 1),
+          340_000);
+
+      // offline the table which will unload the tablets. If the context property is not
+      // removed above, then this test will fail because the tablets will not be able to be
+      // unloaded
+      tops.offline(tableName);
+
+      Wait.waitFor(() -> HalfClosedTabletIT.countHostedTablets(client, tableId).count() == 0L,
+          340_000);
+
+    }
+
+  }
+
+}

--- a/test/src/main/java/org/apache/accumulo/test/functional/HalfClosedTabletIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/HalfClosedTabletIT.java
@@ -238,8 +238,7 @@ public class HalfClosedTabletIT extends SharedMiniClusterBase {
       // Minc should have completed successfully
       Wait.waitFor(() -> tabletHasExpectedRFiles(c, tableName, 1, 1, 1, 1), 340_000);
 
-      // Taking the table offline should succeed normally
-      tops.offline(tableName);
+      // The previous operation to offline the table should be able to succeed after the minor compaction completed
       Wait.waitFor(() -> countHostedTablets(c, tid) == 0L, 340_000);
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/HalfClosedTabletIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/HalfClosedTabletIT.java
@@ -214,7 +214,7 @@ public class HalfClosedTabletIT extends SharedMiniClusterBase {
 
       c.tableOperations().flush(tableName, null, null, false);
 
-      UtilWaitThread.sleepUninterruptibly(30, TimeUnit.SECONDS);
+      UtilWaitThread.sleepUninterruptibly(5, TimeUnit.SECONDS);
 
       // minc should fail, so there should be no files
       FunctionalTestUtils.checkRFiles(c, tableName, 1, 1, 0, 0);

--- a/test/src/main/java/org/apache/accumulo/test/functional/HalfClosedTabletIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/HalfClosedTabletIT.java
@@ -253,11 +253,13 @@ public class HalfClosedTabletIT extends SharedMiniClusterBase {
         Map.of(Property.TABLE_CLASSLOADER_CONTEXT.getKey(), "invalid"));
   }
 
-  public static void removeInvalidClassLoaderContextPropertyWithoutValidation(ServerContext context,
-      TableId tableId) {
-    TablePropKey key = TablePropKey.of(context, tableId);
-    context.getPropStore().removeProperties(key,
-        List.of(Property.TABLE_CLASSLOADER_CONTEXT.getKey()));
+  public static void removeInvalidClassLoaderContextProperty(AccumuloClient client,
+      String tableName) {
+    try {
+      client.tableOperations().removeProperty(tableName, Property.TABLE_CLASSLOADER_CONTEXT.getKey());
+    } catch (AccumuloException | AccumuloSecurityException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   public static boolean tabletHasExpectedRFiles(AccumuloClient c, String tableName, int minTablets,

--- a/test/src/main/java/org/apache/accumulo/test/functional/HalfClosedTabletIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/HalfClosedTabletIT.java
@@ -161,7 +161,7 @@ public class HalfClosedTabletIT extends SharedMiniClusterBase {
       try {
         // We are expecting this to fail, the table should not be taken offline
         // because the bad iterator will prevent the minc from completing.
-        Wait.waitFor(() -> countHostedTablets(c, tid).count() == 0L, 340_000);
+        Wait.waitFor(() -> countHostedTablets(c, tid).count() == 0L, 120_000);
         fail("Zero hosted tablets for table.");
       } catch (IllegalStateException e) {}
 
@@ -182,7 +182,7 @@ public class HalfClosedTabletIT extends SharedMiniClusterBase {
     }
   }
 
-  private boolean tabletHasExpectedRFiles(AccumuloClient c, String tableName, int minTablets,
+  public static boolean tabletHasExpectedRFiles(AccumuloClient c, String tableName, int minTablets,
       int maxTablets, int minRFiles, int maxRFiles) {
     try {
       FunctionalTestUtils.checkRFiles(c, tableName, minTablets, maxTablets, minRFiles, maxRFiles);
@@ -192,7 +192,7 @@ public class HalfClosedTabletIT extends SharedMiniClusterBase {
     }
   }
 
-  private Stream<TabletMetadata> countHostedTablets(AccumuloClient c, TableId tid) {
+  public static Stream<TabletMetadata> countHostedTablets(AccumuloClient c, TableId tid) {
     return ((ClientContext) c).getAmple().readTablets().forTable(tid).fetch(ColumnType.LOCATION)
         .build().stream();
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/HalfClosedTabletIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/HalfClosedTabletIT.java
@@ -164,7 +164,7 @@ public class HalfClosedTabletIT extends SharedMiniClusterBase {
       IteratorSetting setting = new IteratorSetting(50, "error", ErrorThrowingIterator.class);
       setting.addOption(ErrorThrowingIterator.TIMES, "3");
       c.tableOperations().attachIterator(tableName, setting, EnumSet.of(IteratorScope.minc));
-      c.tableOperations().compact(tableName, new CompactionConfig().setWait(true));
+      c.tableOperations().compact(tableName, new CompactionConfig().setWait(true).setFlush(true));
 
       // Taking the table offline should succeed normally
       tops.offline(tableName);

--- a/test/src/main/java/org/apache/accumulo/test/functional/HalfClosedTabletIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/HalfClosedTabletIT.java
@@ -222,12 +222,10 @@ public class HalfClosedTabletIT extends SharedMiniClusterBase {
       // tell the server to take the table offline
       tops.offline(tableName);
 
-      try {
-        // We are expecting this to fail, the table should not be taken offline
-        // because the bad iterator will prevent the minc from completing.
-        Wait.waitFor(() -> countHostedTablets(c, tid) == 0L, 120_000);
-        fail("Zero hosted tablets for table.");
-      } catch (IllegalStateException e) {}
+      // The offine operation should not be able to complete because the tablet can not minor compact, give the offline operation a bit of time to attempt to complete even though it should never be able to complete.
+      UtilWaitThread.sleepUninterruptibly(5, TimeUnit.SECONDS);
+
+      assertTrue(countHostedTablets(c, tid) > 0);
 
       // minc should fail, so there should be no files
       FunctionalTestUtils.checkRFiles(c, tableName, 1, 1, 0, 0);


### PR DESCRIPTION
Prior to this change Tablet.initiateClose would close the compactable, wait for the current minor compaction to finish, and then kick off another minor compaction. In the case where minor compactions are failing, the compactable will get closed and the call to wait for the current minor compaction to finish will hang indefinitely leaving the Tablet in a half-closed state. Tablet.initiateClose is called when either the TabletServer is closing the Tablet (due to migration or shutdown) or on a Tablet split. Therefore, a failing minor compaction will prevent Tablet migration and split or normal TabletServer shutdown.

This change adds some logic at the start of Tablet.initiateClose to try and detect a currently or previously failing minor compaction. In these cases an exception is thrown before the compactable is closed to prevent the Tablet from being in a half-closed state. This prevents the Tablet from being closed until the cause for the failing minor compaction is corrected. Causes could be a bad iterator applied at minor compaction or a bad table configuration option (like classloader context). When the cause of the failing minor compaction is corrected, then the Tablet should be able to be closed normally allowing normal migration, split, and TabletServer shutdown.

Fixes #3674