### PR TITLE
Prevent setting deprecated properties in the shell unless forced

### DIFF
--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ConfigCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ConfigCommand.java
@@ -128,7 +128,7 @@ public class ConfigCommand extends Command {
 
       // check for deprecation
       var theProp = Property.getPropertyByKey(property);
-      if (theProp.isDeprecated()) {
+      if (theProp != null && theProp.isDeprecated()) {
         if (!forceSet(shellState, cl,
             "Trying to set deprecated property `" + property + "` continue")) {
           throw new BadArgumentException(

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ConfigCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ConfigCommand.java
@@ -52,8 +52,8 @@ import org.jline.reader.LineReader;
 import com.google.common.collect.ImmutableSortedMap;
 
 public class ConfigCommand extends Command {
-  private Option tableOpt, deleteOpt, setOpt, filterOpt, filterWithValuesOpt, disablePaginationOpt,
-      outputFileOpt, namespaceOpt;
+  private Option tableOpt, deleteOpt, setOpt, forceOpt, filterOpt, filterWithValuesOpt,
+      disablePaginationOpt, outputFileOpt, namespaceOpt;
 
   private int COL1 = 10, COL2 = 7;
   private LineReader reader;
@@ -126,6 +126,16 @@ public class ConfigCommand extends Command {
       property = pair[0];
       value = pair[1];
 
+      // check for deprecation
+      var theProp = Property.getPropertyByKey(property);
+      if (theProp.isDeprecated()) {
+        if (!forceSet(shellState, cl,
+            "Trying to set deprecated property `" + property + "` continue")) {
+          throw new BadArgumentException(
+              "Tried to set deprecated property and force not specified.", fullCommand,
+              fullCommand.indexOf(property));
+        }
+      }
       if (tableName != null) {
         if (!Property.isValidTablePropertyKey(property)) {
           throw new BadArgumentException("Invalid per-table property.", fullCommand,
@@ -398,6 +408,8 @@ public class ConfigCommand extends Command {
         "table to display/set/delete properties for");
     deleteOpt = new Option("d", "delete", true, "delete a per-table property");
     setOpt = new Option("s", "set", true, "set a per-table property");
+    forceOpt = new Option("force", "force", false,
+        "used with set to set a deprecated property without asking");
     filterOpt = new Option("f", "filter", true,
         "show only properties that contain this string in their name.");
     filterWithValuesOpt = new Option("fv", "filter-with-values", true,
@@ -428,6 +440,7 @@ public class ConfigCommand extends Command {
     o.addOptionGroup(og);
     o.addOption(disablePaginationOpt);
     o.addOption(outputFileOpt);
+    o.addOption(forceOpt);
 
     return o;
   }
@@ -435,5 +448,19 @@ public class ConfigCommand extends Command {
   @Override
   public int numArgs() {
     return 0;
+  }
+
+  /**
+   * Determine is force is set as an option or user enters (y | yes) on the shell prompt.
+   *
+   * @return true if force is set as opt or y | yes entered at command line.
+   */
+  private boolean forceSet(final Shell shellState, final CommandLine cl, final String prompt) {
+    if (cl.hasOption(forceOpt)) {
+      return true;
+    }
+    shellState.getWriter().flush();
+    String line = shellState.getReader().readLine(prompt + " (yes|no)? ");
+    return line != null && (line.equalsIgnoreCase("y") || line.equalsIgnoreCase("yes"));
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellIT.java
@@ -543,10 +543,22 @@ public class ShellIT extends SharedMiniClusterBase {
           Shell.log.debug("Property Type: " + propertyType + " has no defined test case");
           invalidValue = "foo";
       }
-      String setCommand = "config -s ";
-      if (Property.isValidTablePropertyKey(property.getKey())) {
-        setCommand = "config -t " + testTable + " -s ";
+      
+      String setCommand;
+      if(property.isDeprecated()){
+        setCommand = "config --force -s ";
+      } else {
+        setCommand = "config -s ";
       }
+
+      if (Property.isValidTablePropertyKey(property.getKey())) {
+        if (property.isDeprecated()) {
+          setCommand = "config --force -t " + testTable + " -s ";
+        } else {
+          setCommand = "config -t " + testTable + " -s ";
+        }
+      }
+
       Shell.log.debug("Testing Property {} with Type {}", property.getKey(), propertyType);
       Shell.log.debug("Invalid property value of \"{}\"", invalidValue);
       exec(setCommand + property.getKey() + "=" + invalidValue, false,

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellIT.java
@@ -543,9 +543,9 @@ public class ShellIT extends SharedMiniClusterBase {
           Shell.log.debug("Property Type: " + propertyType + " has no defined test case");
           invalidValue = "foo";
       }
-      
+
       String setCommand;
-      if(property.isDeprecated()){
+      if (property.isDeprecated()) {
         setCommand = "config --force -s ";
       } else {
         setCommand = "config -s ";


### PR DESCRIPTION
Adds a prompt y/n when setting a deprecated property with the shell.  Also adds --force as an option to bypass the prompt.

Working with a user, we set a deprecated property - the consequence was that the tserver logs started to be spammed with warning that a deprecated property was set. If we had not been actively monitoring the monitor logs it likely would have gone unnoticed for quite a while.  The noisy log behavior has been stated as desirable. With this change, shell users need to consciously set the deprecated property by answering a y/n prompt, or using the --force option.

 The prompt looks like 
```
Trying to set deprecated property `tserver.compaction.major.concurrent.max` continue (yes|no)? no
2023-08-08T17:56:11,361 [shell.Shell] ERROR: org.apache.accumulo.core.util.BadArgumentException: Tried to set deprecated property and force not specified. near index 10
```
