### PR TITLE
Remove getTabletHostingGoal method from TableOperations

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
@@ -1012,6 +1012,8 @@ public interface TableOperations {
    * start and end Keys and the inclusivity parameters are used when determining the range of
    * affected tablets. The other portions of the start and end Keys are not used.
    *
+   * To retrieve the TabletHostingGoal use the {@Link #getTabletInformation(String, Range)} method.
+   *
    * @param tableName table name
    * @param range tablet range
    * @param goal hosting goal
@@ -1023,20 +1025,8 @@ public interface TableOperations {
   }
 
   /**
-   * Retrieve the hosting goal for a range of tablets in the specified table.
-   *
-   * @param tableName table name
-   * @param range tablet range
-   * @since 4.0.0
-   */
-  default Stream<HostingGoalForTablet> getTabletHostingGoal(final String tableName,
-      final Range range) throws TableNotFoundException {
-    throw new UnsupportedOperationException();
-  }
-
-  /**
-   * @return a stream of tablets information for tablets that fall in the specified range. The
-   *         stream may be backed by a scanner, so its best to close the stream.
+   * @return a stream of tablet information for tablets that fall in the specified range. The stream
+   *         may be backed by a scanner, so it's best to close the stream.
    * @since 4.0.0
    */
   default Stream<TabletInformation> getTabletInformation(final String tableName, final Range range)

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
@@ -1012,8 +1012,6 @@ public interface TableOperations {
    * start and end Keys and the inclusivity parameters are used when determining the range of
    * affected tablets. The other portions of the start and end Keys are not used.
    *
-   * To retrieve the TabletHostingGoal use the {@Link #getTabletInformation(String, Range)} method.
-   *
    * @param tableName table name
    * @param range tablet range
    * @param goal hosting goal

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/GetTabletHostingGoalCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/GetTabletHostingGoalCommand.java
@@ -21,7 +21,7 @@ package org.apache.accumulo.shell.commands;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.apache.accumulo.core.client.admin.HostingGoalForTablet;
+import org.apache.accumulo.core.client.admin.TabletInformation;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.shell.Shell;
 import org.apache.commons.cli.CommandLine;
@@ -48,11 +48,11 @@ public class GetTabletHostingGoalCommand extends TableOperation {
 
   @Override
   protected void doTableOp(Shell shellState, String tableName) throws Exception {
-    List<HostingGoalForTablet> tabletHostingGoal = shellState.getAccumuloClient().tableOperations()
-        .getTabletHostingGoal(tableName, range).collect(Collectors.toList());
+    List<TabletInformation> tabletInformationList = shellState.getAccumuloClient().tableOperations()
+        .getTabletInformation(tableName, range).collect(Collectors.toList());
     shellState.getWriter().println("TABLE: " + tableName);
     shellState.getWriter().println("TABLET ID    HOSTING GOAL");
-    tabletHostingGoal.forEach(p -> shellState.getWriter()
+    tabletInformationList.forEach(p -> shellState.getWriter()
         .println(String.format("%-10s   %s", p.getTabletId(), p.getHostingGoal())));
   }
 

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/GetTabletHostingGoalCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/GetTabletHostingGoalCommand.java
@@ -18,10 +18,6 @@
  */
 package org.apache.accumulo.shell.commands;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.apache.accumulo.core.client.admin.TabletInformation;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.shell.Shell;
 import org.apache.commons.cli.CommandLine;
@@ -48,12 +44,11 @@ public class GetTabletHostingGoalCommand extends TableOperation {
 
   @Override
   protected void doTableOp(Shell shellState, String tableName) throws Exception {
-    List<TabletInformation> tabletInformationList = shellState.getAccumuloClient().tableOperations()
-        .getTabletInformation(tableName, range).collect(Collectors.toList());
     shellState.getWriter().println("TABLE: " + tableName);
     shellState.getWriter().println("TABLET ID    HOSTING GOAL");
-    tabletInformationList.forEach(p -> shellState.getWriter()
-        .println(String.format("%-10s   %s", p.getTabletId(), p.getHostingGoal())));
+    shellState.getAccumuloClient().tableOperations().getTabletInformation(tableName, range)
+        .forEach(p -> shellState.getWriter()
+            .println(String.format("%-10s   %s", p.getTabletId(), p.getHostingGoal())));
   }
 
   @Override


### PR DESCRIPTION
Remove the `getTabletHostingGoal` method from `TableOperations` as the information can now be retrieved with the more robust `getTabletInformation` method.

The shell command, `getgoals`, still works as before, but the `GetTabletHostingGoalCommand` was updated to use the new `getTabletInformation` method to retrieve the necessary information rather than the removed `getTabletHostingGoal` method.