### PR TITLE
Modified ClassLoaderUtil.getClassLoader(String) to not swallow exception

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/classloader/ClassLoaderUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/classloader/ClassLoaderUtil.java
@@ -75,13 +75,9 @@ public class ClassLoaderUtil {
 
   @SuppressWarnings("deprecation")
   public static ClassLoader getClassLoader(String context) {
-    try {
-      if (FACTORY.isValid(context)) {
-        return FACTORY.getClassLoader(context);
-      } else {
-        return org.apache.accumulo.start.classloader.vfs.AccumuloVFSClassLoader.getClassLoader();
-      }
-    } catch (RuntimeException e) {
+    if (FACTORY != null && FACTORY.isValid(context)) {
+      return FACTORY.getClassLoader(context);
+    } else {
       return org.apache.accumulo.start.classloader.vfs.AccumuloVFSClassLoader.getClassLoader();
     }
   }


### PR DESCRIPTION
A change was made in #3678 that returned AccumuloVFSClassLoader.getClassLoader() in the event that a RuntimeException was thrown. This was a behavior change from the code prior to #3678. This change removes the try-catch block that was added in that commit.