### PR TITLE
Fix bad assert statements in tests

### DIFF
--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/AccumuloInputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/AccumuloInputFormatIT.java
@@ -205,7 +205,7 @@ public class AccumuloInputFormatIT extends AccumuloClusterHarness {
     // Check we are getting back correct type pf split
     splits = inputFormat.getSplits(job);
     for (InputSplit split : splits) {
-      assert (split instanceof BatchInputSplit);
+      assertTrue(split instanceof BatchInputSplit);
     }
 
     // We should split along the tablet lines

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletIT.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.test.functional;
 
 import static java.util.Collections.singletonMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.util.Map;
@@ -96,7 +97,7 @@ public class TabletIT extends AccumuloClusterHarness {
       int count = 0;
       for (Entry<Key,Value> elt : scanner) {
         String expected = String.format("%05d", count);
-        assert elt.getKey().getRow().toString().equals(expected);
+        assertTrue(elt.getKey().getRow().toString().equals(expected));
         count++;
       }
       assertEquals(N, count);

--- a/test/src/main/java/org/apache/accumulo/test/mapreduce/AccumuloInputFormatIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapreduce/AccumuloInputFormatIT.java
@@ -23,6 +23,7 @@ import static org.apache.accumulo.core.util.UtilWaitThread.sleepUninterruptibly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -190,7 +191,7 @@ public class AccumuloInputFormatIT extends AccumuloClusterHarness {
       client.tableOperations().online(table);
       splits = inputFormat.getSplits(job);
       for (InputSplit split : splits) {
-        assert (split instanceof org.apache.accumulo.core.clientImpl.mapreduce.BatchInputSplit);
+        assertTrue(split instanceof org.apache.accumulo.core.clientImpl.mapreduce.BatchInputSplit);
       }
 
       // We should divide along the tablet lines similar to when using `setAutoAdjustRanges(job,


### PR DESCRIPTION
Fix the incorrect use of assert statements in test code when a JUnit assertTrue is the appropriate solution to resolve the error caught by the errorprone compiler.


This issue was only seen on the 2.1 branch after bumping the version of errorprone to the same version as in the main branch. The issue still exists on the main branch, but for some reason, erorrprone doesn't flag on it in that branch. It was seen after creating 2.1.2-rc1, but is not important enough to warrant creating an rc2. If rc1 fails the vote, this can be included in rc2.

This PR does not replace all assert statements, only those that were obviously incorrect, which was enough to make the errorprone check pass locally. This does not change assert statements in non-test code, and does not change them in the test-adjacent utility code, such as SlowOps and BatchWriterIterator.