### PR TITLE
Allow ACCUMULO_JAVA_PREFIX to be an array

### DIFF
--- a/assemble/bin/accumulo
+++ b/assemble/bin/accumulo
@@ -83,7 +83,7 @@ function main() {
     exit 1
   fi
   if [[ -n $ACCUMULO_JAVA_PREFIX ]]; then
-    JAVA=("${ACCUMULO_JAVA_PREFIX[*]}" "$JAVA")
+    JAVA=("${ACCUMULO_JAVA_PREFIX[@]}" "$JAVA")
   fi
 
   exec "${JAVA[@]}" "${JAVA_OPTS[@]}" org.apache.accumulo.start.Main "$@"

--- a/assemble/conf/accumulo-env.sh
+++ b/assemble/conf/accumulo-env.sh
@@ -142,5 +142,10 @@ esac
 # Variables that are optional. Uncomment to set
 ###############################################
 
-## Specifies command that will be placed before calls to Java in accumulo script
-# export ACCUMULO_JAVA_PREFIX=""
+## ACCUMULO_JAVA_PREFIX can be used to specify commands to prepend to the "java"
+## command when it is executed. This can be declared as either a scalar or an
+## array variable. The following use of declare to check if it's already set is
+## not strictly necessary, but ensures that if you set it in the calling
+## environment, that will override what is set here, rather than some mangled
+## merged result. You can set the variable any way you like.
+#declare -p 'ACCUMULO_JAVA_PREFIX' &>/dev/null || ACCUMULO_JAVA_PREFIX=''

--- a/server/base/src/main/scripts/generate-protobuf.sh
+++ b/server/base/src/main/scripts/generate-protobuf.sh
@@ -46,15 +46,14 @@ if ! protoc --version 2>/dev/null | grep -qF "${REQUIRED_PROTOC_VERSION}"; then
 fi
 
 # Ensure output directories are created
-PROTOC_ARGS="--java_out=$BUILD_DIR"
-rm -rf $BUILD_DIR
-mkdir -p $BUILD_DIR
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR"
 
-protoc ${PROTOC_ARGS} src/main/protobuf/*.proto || fail unable to generate Java protocol buffer classes
+protoc --java_out="$BUILD_DIR" src/main/protobuf/*.proto || fail unable to generate Java protocol buffer classes
 
 # For all generated protobuf code, suppress all warnings and add the LICENSE header
 s='@SuppressWarnings("unused")'
-find $BUILD_DIR -name '*.java' -print0 | xargs -0 sed -i.orig -e 's/\(public final class \)/'"$s"' \1/'
+find "$BUILD_DIR" -name '*.java' -print0 | xargs -0 sed -i.orig -e 's/\(public final class \)/'"$s"' \1/'
 
 PREFIX="/*
 "


### PR DESCRIPTION
* Update the interpretation of the `ACCUMULO_JAVA_PREFIX` option in `accumulo-env.sh` so it can be passed as an array
* Add a check to help the user use the variable correctly, and add comments to explain
* Also fix shellcheck errors in generate-protobuf.sh

This fixes #3697