### PR TITLE
add check to gc to validate metadata scan is complete

### DIFF
--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
@@ -29,7 +29,6 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import com.google.common.base.Preconditions;
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
@@ -49,6 +48,7 @@ import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.PeekingIterator;
 
@@ -374,16 +374,18 @@ public class GarbageCollectionAlgorithm {
       this.row = null;
     }
 
-    private void checkRow(){
-      Preconditions.checkState(hasDir && hasPrevRow, "May not have fully read metadata for row, aborting this run. Validation results: %s", this);
+    private void checkRow() {
+      Preconditions.checkState(hasDir && hasPrevRow,
+          "May not have fully read metadata for row, aborting this run. Validation results: %s",
+          this);
     }
 
     public void sawRow(final Text candidate) {
       Preconditions.checkState(!closed);
       Objects.requireNonNull(candidate);
-      if(row == null) {
+      if (row == null) {
         row = candidate;
-      } else if(!row.equals(candidate)) {
+      } else if (!row.equals(candidate)) {
         checkRow();
         hasPrevRow = false;
         hasDir = false;
@@ -401,9 +403,9 @@ public class GarbageCollectionAlgorithm {
       hasPrevRow = true;
     }
 
-    public void sawLastRow(){
+    public void sawLastRow() {
       Preconditions.checkState(!closed);
-      if(row != null){
+      if (row != null) {
         checkRow();
       }
       closed = true;

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
@@ -368,6 +368,8 @@ public class GarbageCollectionAlgorithm {
     private Text row;
 
     private boolean closed = false;
+    // guard against processing only delete markers
+    private boolean sawAtLeastOneRow;
 
     public MetadataReadTracker() {
       this.row = null;
@@ -392,6 +394,7 @@ public class GarbageCollectionAlgorithm {
       Objects.requireNonNull(candidate);
       if (row == null) {
         row = candidate;
+        sawAtLeastOneRow = true;
       } else if (!row.equals(candidate)) {
         validate();
         hasPrevRow = false;
@@ -422,6 +425,7 @@ public class GarbageCollectionAlgorithm {
      */
     @Override
     public void close() {
+      Preconditions.checkState(sawAtLeastOneRow);
       Preconditions.checkState(!closed);
       if (row != null) {
         validate();

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
@@ -393,7 +393,9 @@ public class GarbageCollectionAlgorithm {
       if (row == null) {
         row = candidate; // first row seen
       } else if (!row.equals(candidate)) {
+        // row changed, validate previous
         validate();
+        // start tracking the next row
         hasPrevRow = false;
         hasDir = false;
         row = candidate;

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
@@ -422,8 +422,7 @@ public class GarbageCollectionAlgorithm {
      */
     @Override
     public void close() {
-      Preconditions.checkState(!closed);
-      if (row != null) {
+      if (!closed && row != null) {
         validate();
       }
       closed = true;

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
@@ -176,7 +176,7 @@ public class GarbageCollectionAlgorithm {
 
     // it is important that the tracker is closed before performing deletes so that last row is
     // checked
-    try (MetadataReadTracker readTracker = new MetadataReadTracker()) {
+    try (MetadataRowReadTracker readTracker = new MetadataRowReadTracker()) {
       Iterator<Entry<Key,Value>> iter = gce.getReferenceIterator();
       while (iter.hasNext()) {
         Entry<Key,Value> entry = iter.next();
@@ -364,14 +364,14 @@ public class GarbageCollectionAlgorithm {
    * Track metadata rows read to help validate that gc scan has complete information to make a
    * decision on deleting files
    */
-  private static class MetadataReadTracker implements AutoCloseable {
+  private static class MetadataRowReadTracker implements AutoCloseable {
     private boolean hasDir = false;
     private boolean hasPrevRow = false;
     private Text row;
 
     private boolean closed = false;
 
-    public MetadataReadTracker() {
+    public MetadataRowReadTracker() {
       this.row = null;
     }
 

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
@@ -231,7 +231,9 @@ public class GarbageCollectionAlgorithm {
           throw new RuntimeException(
               "Scanner over metadata table returned unexpected column : " + entry.getKey());
       }
-    } // closed tracker - checks last row.
+      // the tracker is closed at the end of this block; it will check the last row
+      // in its close method as its final action
+    }
     confirmDeletesFromReplication(gce.getReplicationNeededIterator(),
         candidateMap.entrySet().iterator());
   }

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
@@ -391,7 +391,7 @@ public class GarbageCollectionAlgorithm {
       Preconditions.checkState(!closed);
       Objects.requireNonNull(candidate);
       if (row == null) {
-        row = candidate;
+        row = candidate; // first row seen
       } else if (!row.equals(candidate)) {
         validate();
         hasPrevRow = false;

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
@@ -368,8 +368,6 @@ public class GarbageCollectionAlgorithm {
     private Text row;
 
     private boolean closed = false;
-    // guard against processing only delete markers
-    private boolean sawAtLeastOneRow;
 
     public MetadataReadTracker() {
       this.row = null;
@@ -394,7 +392,6 @@ public class GarbageCollectionAlgorithm {
       Objects.requireNonNull(candidate);
       if (row == null) {
         row = candidate;
-        sawAtLeastOneRow = true;
       } else if (!row.equals(candidate)) {
         validate();
         hasPrevRow = false;
@@ -425,7 +422,6 @@ public class GarbageCollectionAlgorithm {
      */
     @Override
     public void close() {
-      Preconditions.checkState(sawAtLeastOneRow);
       Preconditions.checkState(!closed);
       if (row != null) {
         validate();

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -328,7 +328,7 @@ public class SimpleGarbageCollector extends AccumuloServerContext implements Ifa
       scanner.fetchColumnFamily(ScanFileColumnFamily.NAME);
       TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.fetch(scanner);
       TabletIterator tabletIterator =
-          new TabletIterator(scanner, MetadataSchema.TabletsSection.getRange(), false, true);
+          new TabletIterator(scanner, MetadataSchema.TabletsSection.getRange(), true, true);
 
       return Iterators
           .concat(Iterators.transform(tabletIterator, input -> input.entrySet().iterator()));

--- a/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
@@ -58,11 +58,7 @@ public class GarbageCollectionTest {
     ArrayList<String> tablesDirsToDelete = new ArrayList<>();
     TreeMap<String,Status> filesToReplicate = new TreeMap<>();
 
-    public TestGCE() {
-      // add dummy reference so at lest one tablet to be "scanned" is always present.
-      addPrevRowReference("1", null);
-      addDirReference("1", null, "/default_tablet");
-    }
+    public TestGCE() {}
 
     @Override
     public boolean getCandidates(String continuePoint, List<String> ret) {
@@ -787,6 +783,7 @@ public class GarbageCollectionTest {
     gce.addDirReference("1636", null, "/default_tablet");
     gce.addPrevRowReference("1636", null);
     gca.collect(gce);
+    assertEquals(0, gce.deletes.size());
   }
 
   /**
@@ -800,6 +797,7 @@ public class GarbageCollectionTest {
     gce.candidates.add("/1636/default_tablet");
     gce.addPrevRowReference("1636", null);
     assertThrows(IllegalStateException.class, () -> gca.collect(gce));
+    assertEquals(1, gce.candidates.size());
   }
 
   /**
@@ -818,6 +816,7 @@ public class GarbageCollectionTest {
     gce.addPrevRowReference("1636", null);
 
     assertThrows(IllegalStateException.class, () -> gca.collect(gce));
+    assertEquals(2, gce.candidates.size());
   }
 
   /**
@@ -831,6 +830,7 @@ public class GarbageCollectionTest {
     gce.candidates.add("/1636/default_tablet");
     gce.addDirReference("1636", null, "/default_tablet");
     assertThrows(IllegalStateException.class, () -> gca.collect(gce));
+    assertEquals(1, gce.candidates.size());
   }
 
   /**
@@ -849,25 +849,25 @@ public class GarbageCollectionTest {
     gce.addPrevRowReference("1636", null);
 
     assertThrows(IllegalStateException.class, () -> gca.collect(gce));
+    assertEquals(2, gce.candidates.size());
   }
 
   /**
    * Show that IllegalState is thrown when no prevRow entry present in metadata scan.
    */
   @Test
-  public void testFilesOnly() {
+  public void testPrevRowOnly() {
     TestGCE gce = new TestGCE();
 
     gce.candidates.add("hdfs://foo:6000/accumulo/tables/4/t0/F000.rf");
     gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/4/t0/F001.rf");
     gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/5/t0/F005.rf");
 
-    GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
-    // removed dummy reference so that no tablets scanned"
-    gce.removePrevRowReference("1", null);
-    gce.removeDirReference("1", null);
+    gce.addPrevRowReference("1636", null);
 
+    GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
     assertThrows(IllegalStateException.class, () -> gca.collect(gce));
+    assertEquals(3, gce.candidates.size());
   }
 
 }

--- a/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
@@ -770,11 +770,10 @@ public class GarbageCollectionTest {
   }
 
   /**
-   * Minimal test to show that dir and prevRow are required for valid scan
+   * Minimal test to show that dir and prevRow are required for valid scan (go path)
    */
   @Test
   public void testDirAndPrevRow() throws Exception {
-
     GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
 
     TestGCE gce = new TestGCE();
@@ -785,11 +784,10 @@ public class GarbageCollectionTest {
   }
 
   /**
-   * Show that IllegalState is thrown when no dir entry present in metadata scan.
+   * Show that IllegalState is thrown when no dir entry present in metadata scan in last row seen.
    */
   @Test
-  public void testNoDir() {
-
+  public void testNoDirAsLastRow() {
     GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
 
     TestGCE gce = new TestGCE();
@@ -799,16 +797,51 @@ public class GarbageCollectionTest {
   }
 
   /**
-   * Show that IllegalState is thrown when no prev row present in metadata scan.
+   * Show that IllegalState is thrown when no dir entry present in metadata scan.
    */
   @Test
-  public void testNoPrevRow() {
+  public void testNoDir() {
+    GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
 
+    TestGCE gce = new TestGCE();
+    gce.candidates.add("/1636/default_tablet/f1");
+    gce.addPrevRowReference("1636", "a");
+
+    gce.candidates.add("/1636/t1/f2");
+    gce.addDirReference("1636", null, "/t1");
+    gce.addPrevRowReference("1636", null);
+
+    assertThrows(IllegalStateException.class, () -> gca.collect(gce));
+  }
+
+  /**
+   * Show that IllegalState is thrown when no prev row present in metadata scan in last row seen.
+   */
+  @Test
+  public void testNoPrevRowAsLastRow() {
     GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
 
     TestGCE gce = new TestGCE();
     gce.candidates.add("/1636/default_tablet");
     gce.addDirReference("1636", null, "/default_tablet");
+    assertThrows(IllegalStateException.class, () -> gca.collect(gce));
+  }
+
+  /**
+   * Show that IllegalState is thrown when no prevRow entry present in metadata scan.
+   */
+  @Test
+  public void testPrevRow() {
+    GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
+
+    TestGCE gce = new TestGCE();
+    gce.candidates.add("/1636/default_tablet/f1");
+    gce.addDirReference("1636", "a", "/default_tablet");
+
+    gce.candidates.add("/1636/t1/f2");
+    gce.addDirReference("1636", null, "/t1");
+    gce.addPrevRowReference("1636", null);
+
     assertThrows(IllegalStateException.class, () -> gca.collect(gce));
   }
 }

--- a/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
@@ -58,6 +58,12 @@ public class GarbageCollectionTest {
     ArrayList<String> tablesDirsToDelete = new ArrayList<>();
     TreeMap<String,Status> filesToReplicate = new TreeMap<>();
 
+    public TestGCE() {
+      // add dummy reference so at lest one tablet to be "scanned" is always present.
+      addPrevRowReference("1", null);
+      addDirReference("1", null, "/default_tablet");
+    }
+
     @Override
     public boolean getCandidates(String continuePoint, List<String> ret) {
       Iterator<String> iter = candidates.tailSet(continuePoint, false).iterator();
@@ -591,8 +597,8 @@ public class GarbageCollectionTest {
   @Test
   public void testBadDeletes() throws Exception {
     GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
-
     TestGCE gce = new TestGCE();
+
     gce.candidates.add("");
     gce.candidates.add("A");
     gce.candidates.add("/");
@@ -613,10 +619,10 @@ public class GarbageCollectionTest {
 
   @Test
   public void test() throws Exception {
-
     GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
 
     TestGCE gce = new TestGCE();
+
     gce.candidates.add("/1636/default_tablet");
     gce.addDirReference("1636", null, "/default_tablet");
     gce.addPrevRowReference("1636", null);
@@ -849,25 +855,6 @@ public class GarbageCollectionTest {
    * Show that IllegalState is thrown when no prevRow entry present in metadata scan.
    */
   @Test
-  public void testFilesOnly2() {
-    TestGCE gce = new TestGCE();
-
-    gce.candidates.add("hdfs://foo:6000/accumulo/tables/4/t0/F000.rf");
-    gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/4/t0/F001.rf");
-
-    gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/5/t0/F005.rf");
-    gce.addFileReference("5", null, "hdfs://foo.com:6000/accumulo/tables/4/t0/F000.rf");
-    gce.addDirReference("5", null, "/4");
-
-    GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
-
-    assertThrows(IllegalStateException.class, () -> gca.collect(gce));
-  }
-
-  /**
-   * Show that IllegalState is thrown when no prevRow entry present in metadata scan.
-   */
-  @Test
   public void testFilesOnly() {
     TestGCE gce = new TestGCE();
 
@@ -876,6 +863,9 @@ public class GarbageCollectionTest {
     gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/5/t0/F005.rf");
 
     GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
+    // removed dummy reference so that no tablets scanned"
+    gce.removePrevRowReference("1", null);
+    gce.removeDirReference("1", null);
 
     assertThrows(IllegalStateException.class, () -> gca.collect(gce));
   }

--- a/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
@@ -844,4 +844,42 @@ public class GarbageCollectionTest {
 
     assertThrows(IllegalStateException.class, () -> gca.collect(gce));
   }
+
+  /**
+   * Show that IllegalState is thrown when no prevRow entry present in metadata scan.
+   */
+  @Test
+  public void testFilesOnly2() {
+    TestGCE gce = new TestGCE();
+
+    gce.candidates.add("hdfs://foo:6000/accumulo/tables/4/t0/F000.rf");
+    gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/4/t0/F001.rf");
+    gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/5/t0/F005.rf");
+
+    gce.addFileReference("4", null, "hdfs://foo.com:6000/accumulo/tables/4/t0/F000.rf");
+    gce.addFileReference("5", null, "hdfs://foo.com:6000/accumulo/tables/4/t0/F000.rf");
+
+    GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
+
+    assertThrows(IllegalStateException.class, () -> gca.collect(gce));
+  }
+
+  /**
+   * Show that IllegalState is thrown when no prevRow entry present in metadata scan.
+   */
+  @Test
+  public void testFilesOnly() {
+    TestGCE gce = new TestGCE();
+
+    gce.candidates.add("hdfs://foo:6000/accumulo/tables/4/t0/F000.rf");
+    gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/4/t0/F001.rf");
+    gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/5/t0/F005.rf");
+
+    gce.addFileReference("4", null, "hdfs://foo.com:6000/accumulo/tables/4/t0/F000.rf");
+
+    GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
+
+    assertThrows(IllegalStateException.class, () -> gca.collect(gce));
+  }
+
 }

--- a/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
@@ -870,4 +870,14 @@ public class GarbageCollectionTest {
     assertEquals(3, gce.candidates.size());
   }
 
+  @Test
+  public void testNoPrevRowNoDir() throws Exception {
+
+    GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
+
+    TestGCE gce = new TestGCE();
+    gce.candidates.add("/1636/default_tablet");
+    gce.addFileReference("b", "m", "hdfs://foo.com:6000/user/foo/tables/b/t-0/F00.rf");
+    assertThrows(IllegalStateException.class, () -> gca.collect(gce));
+  }
 }

--- a/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
@@ -854,10 +854,10 @@ public class GarbageCollectionTest {
 
     gce.candidates.add("hdfs://foo:6000/accumulo/tables/4/t0/F000.rf");
     gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/4/t0/F001.rf");
-    gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/5/t0/F005.rf");
 
-    gce.addFileReference("4", null, "hdfs://foo.com:6000/accumulo/tables/4/t0/F000.rf");
+    gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/5/t0/F005.rf");
     gce.addFileReference("5", null, "hdfs://foo.com:6000/accumulo/tables/4/t0/F000.rf");
+    gce.addDirReference("5", null, "/4");
 
     GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
 
@@ -874,8 +874,6 @@ public class GarbageCollectionTest {
     gce.candidates.add("hdfs://foo:6000/accumulo/tables/4/t0/F000.rf");
     gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/4/t0/F001.rf");
     gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/5/t0/F005.rf");
-
-    gce.addFileReference("4", null, "hdfs://foo.com:6000/accumulo/tables/4/t0/F000.rf");
 
     GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
 


### PR DESCRIPTION
Add validation that dir and prevRow are present when the gc is scanning for in-use file references.  If a row is processed and the dir and prevRow entries are not present, an IllegalStateException is throw to abort the current gc cycle.

This is to help detect / prevent partial metadata scans from missing file references that are in use.

Fixes #3696 for 1.10