### PR TITLE
Fix FencedReader getLastKey() and splits

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/RFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/RFile.java
@@ -1578,10 +1578,14 @@ public class RFile {
 
     private final FileSKVIterator reader;
     protected final Range fence;
+    private final Key fencedStartKey;
+    private final Key fencedEndKey;
 
     public FencedFileSKVIterator(FileSKVIterator reader, Range fence) {
       this.reader = Objects.requireNonNull(reader);
-      this.fence = fence;
+      this.fence = Objects.requireNonNull(fence);
+      this.fencedStartKey = fence.getStartKey();
+      this.fencedEndKey = getEndKey(fence.getEndKey());
     }
 
     @Override
@@ -1614,7 +1618,7 @@ public class RFile {
     public Key getFirstKey() throws IOException {
       var rfk = reader.getFirstKey();
       if (fence.beforeStartKey(rfk)) {
-        return fence.getStartKey();
+        return fencedStartKey;
       } else {
         return rfk;
       }
@@ -1624,7 +1628,7 @@ public class RFile {
     public Key getLastKey() throws IOException {
       var rlk = reader.getLastKey();
       if (fence.afterEndKey(rlk)) {
-        return fence.getEndKey();
+        return fencedEndKey;
       } else {
         return rlk;
       }
@@ -1659,6 +1663,20 @@ public class RFile {
     public void close() throws IOException {
       reader.close();
     }
+
+    private Key getEndKey(Key key) {
+      if (fence.isEndKeyInclusive() || key == null) {
+        return key;
+      }
+
+      final byte[] ba = key.getRow().getBytes();
+      Preconditions.checkArgument(ba.length > 0 && ba[ba.length - 1] == (byte) 0x00);
+      byte[] fba = new byte[ba.length - 1];
+      System.arraycopy(ba, 0, fba, 0, ba.length - 1);
+
+      return new Key(fba);
+    }
+
   }
 
   static class FencedIndex extends FencedFileSKVIterator {

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/RFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/RFile.java
@@ -1665,10 +1665,14 @@ public class RFile {
     }
 
     private Key getEndKey(Key key) {
-      if (fence.isEndKeyInclusive() || key == null) {
+      // If they key is infinite it will be null or if inclusive we can just use it as is
+      // as it would be the correct value for getLastKey()
+      if (fence.isInfiniteStopKey() || fence.isEndKeyInclusive()) {
         return key;
       }
 
+      // If exclusive we need to strip the last byte to get the last key that is part of the
+      // actual range to return
       final byte[] ba = key.getRow().getBytes();
       Preconditions.checkArgument(ba.length > 0 && ba[ba.length - 1] == (byte) 0x00);
       byte[] fba = new byte[ba.length - 1];

--- a/core/src/main/java/org/apache/accumulo/core/metadata/AbstractTabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/AbstractTabletFile.java
@@ -23,7 +23,6 @@ import java.util.Objects;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.Text;
 
 import com.google.common.base.Preconditions;
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/AbstractTabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/AbstractTabletFile.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.Text;
 
 import com.google.common.base.Preconditions;
 
@@ -65,8 +66,8 @@ public abstract class AbstractTabletFile<T extends AbstractTabletFile<T>>
     }
 
     if (!range.isInfiniteStopKey()) {
-      Preconditions.checkArgument(!range.isEndKeyInclusive() && isOnlyRowSet(range.getEndKey()),
-          "Range is not a row range %s", range);
+      Preconditions.checkArgument(!range.isEndKeyInclusive() && isOnlyRowSet(range.getEndKey())
+          && isExclusiveKey(range.getEndKey()), "Range is not a row range %s", range);
     }
 
     return range;
@@ -75,6 +76,11 @@ public abstract class AbstractTabletFile<T extends AbstractTabletFile<T>>
   private static boolean isOnlyRowSet(Key key) {
     return key.getColumnFamilyData().length() == 0 && key.getColumnQualifierData().length() == 0
         && key.getColumnVisibilityData().length() == 0 && key.getTimestamp() == Long.MAX_VALUE;
+  }
+
+  private static boolean isExclusiveKey(Key key) {
+    Text row = key.getRow();
+    return row.getLength() > 0 && row.getBytes()[row.getLength() - 1] == (byte) 0x00;
   }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/AbstractTabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/AbstractTabletFile.java
@@ -79,8 +79,8 @@ public abstract class AbstractTabletFile<T extends AbstractTabletFile<T>>
   }
 
   private static boolean isExclusiveKey(Key key) {
-    Text row = key.getRow();
-    return row.getLength() > 0 && row.getBytes()[row.getLength() - 1] == (byte) 0x00;
+    var row = key.getRowData();
+    return row.length() > 0 && row.byteAt(row.length() - 1) == (byte) 0x00;
   }
 
 }


### PR DESCRIPTION
This update fixes getLastKey() to correctly return the last included key of the Range for a TabletFile, and not the end key of the range which will always fall outside the valid range.

Because the endKey is always required to be exclusive, the actual end key of the range can't be returned from getLastKey() as that key is not part of the range. Certain constructors for the Range() object already append a 0x00 byte to the end of the key when converting from inclusive to exclusive so we can require that this exists and then we can strip that byte and get the last included key in the range to return.