### PR TITLE
Refactor assertTrue(!=) with assertNotEquals & Add explanatory messages

### DIFF
--- a/server/base/src/test/java/org/apache/accumulo/server/util/fateCommand/SummaryReportTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/fateCommand/SummaryReportTest.java
@@ -23,6 +23,7 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -45,15 +46,17 @@ class SummaryReportTest {
   public void blankReport() {
     Map<String,String> idMap = Map.of("1", "ns1", "2", "tbl1");
     FateSummaryReport report = new FateSummaryReport(idMap, null);
-    assertNotNull(report);
-    assertTrue(report.getReportTime() != 0);
-    assertEquals(Map.of(), report.getStatusCounts());
-    assertEquals(Map.of(), report.getCmdCounts());
-    assertEquals(Map.of(), report.getStepCounts());
-    assertEquals(Set.of(), report.getFateDetails());
-    assertEquals(Set.of(), report.getStatusFilterNames());
-    assertNotNull(report.toJson());
-    assertNotNull(report.formatLines());
+
+    assertNotNull(report, "The report should not be null");
+    assertNotEquals(0, report.getReportTime(), "Report time should not be 0");
+    assertEquals(Map.of(), report.getStatusCounts(), "Status counts should be empty");
+    assertEquals(Map.of(), report.getCmdCounts(), "Command counts should be empty");
+    assertEquals(Map.of(), report.getStepCounts(), "Step counts should be empty");
+    assertEquals(Set.of(), report.getFateDetails(), "Fate details should be empty");
+    assertEquals(Set.of(), report.getStatusFilterNames(), "Status filter names should be empty");
+    assertNotNull(report.toJson(), "JSON representation should not be null");
+    assertNotNull(report.formatLines(), "Formatted lines should not be null");
+
     log.info("json: {}", report.toJson());
     log.info("formatted: {}", report.formatLines());
   }
@@ -77,16 +80,16 @@ class SummaryReportTest {
     FateSummaryReport report = new FateSummaryReport(idMap, null);
     report.gatherTxnStatus(status1);
 
-    assertNotNull(report);
-    assertTrue(report.getReportTime() != 0);
-    assertEquals(Map.of("IN_PROGRESS", 1), report.getStatusCounts());
-    assertEquals(Map.of("?", 1), report.getCmdCounts());
-    assertEquals(Map.of("?", 1), report.getStepCounts());
-    assertEquals(Set.of(), report.getStatusFilterNames());
-    assertNotNull(report.toJson());
-    assertNotNull(report.formatLines());
+    assertNotNull(report, "The report should not be null");
+    assertNotEquals(0, report.getReportTime(), "Report time should not be 0");
+    assertEquals(Map.of("IN_PROGRESS", 1), report.getStatusCounts(), "Status counts should match");
+    assertEquals(Map.of("?", 1), report.getCmdCounts(), "Command counts should match");
+    assertEquals(Map.of("?", 1), report.getStepCounts(), "Step counts should match");
+    assertEquals(Set.of(), report.getStatusFilterNames(), "Status filter names should be empty");
+    assertNotNull(report.toJson(), "JSON representation should not be null");
+    assertNotNull(report.formatLines(), "Formatted lines should not be null");
 
-    assertNotNull(report.getFateDetails());
+    assertNotNull(report.getFateDetails(), "Fate details should not be null");
 
     log.debug("json: {}", report.toJson());
     log.debug("formatted: {}", report.formatLines());

--- a/server/base/src/test/java/org/apache/accumulo/server/util/fateCommand/SummaryReportTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/fateCommand/SummaryReportTest.java
@@ -46,15 +46,15 @@ class SummaryReportTest {
     Map<String,String> idMap = Map.of("1", "ns1", "2", "tbl1");
     FateSummaryReport report = new FateSummaryReport(idMap, null);
 
-    assertNotNull(report, "The report should not be null");
-    assertNotEquals(0, report.getReportTime(), "Report time should not be 0");
-    assertEquals(Map.of(), report.getStatusCounts(), "Status counts should be empty");
-    assertEquals(Map.of(), report.getCmdCounts(), "Command counts should be empty");
-    assertEquals(Map.of(), report.getStepCounts(), "Step counts should be empty");
-    assertEquals(Set.of(), report.getFateDetails(), "Fate details should be empty");
-    assertEquals(Set.of(), report.getStatusFilterNames(), "Status filter names should be empty");
-    assertNotNull(report.toJson(), "JSON representation should not be null");
-    assertNotNull(report.formatLines(), "Formatted lines should not be null");
+    assertNotNull(report);
+    assertNotEquals(0, report.getReportTime());
+    assertEquals(Map.of(), report.getStatusCounts());
+    assertEquals(Map.of(), report.getCmdCounts());
+    assertEquals(Map.of(), report.getStepCounts());
+    assertEquals(Set.of(), report.getFateDetails());
+    assertEquals(Set.of(), report.getStatusFilterNames());
+    assertNotNull(report.toJson());
+    assertNotNull(report.formatLines());
 
     log.info("json: {}", report.toJson());
     log.info("formatted: {}", report.formatLines());
@@ -79,16 +79,16 @@ class SummaryReportTest {
     FateSummaryReport report = new FateSummaryReport(idMap, null);
     report.gatherTxnStatus(status1);
 
-    assertNotNull(report, "The report should not be null");
-    assertNotEquals(0, report.getReportTime(), "Report time should not be 0");
-    assertEquals(Map.of("IN_PROGRESS", 1), report.getStatusCounts(), "Status counts should match");
-    assertEquals(Map.of("?", 1), report.getCmdCounts(), "Command counts should match");
-    assertEquals(Map.of("?", 1), report.getStepCounts(), "Step counts should match");
-    assertEquals(Set.of(), report.getStatusFilterNames(), "Status filter names should be empty");
-    assertNotNull(report.toJson(), "JSON representation should not be null");
-    assertNotNull(report.formatLines(), "Formatted lines should not be null");
+    assertNotNull(report);
+    assertNotEquals(0, report.getReportTime());
+    assertEquals(Map.of("IN_PROGRESS", 1), report.getStatusCounts());
+    assertEquals(Map.of("?", 1), report.getCmdCounts());
+    assertEquals(Map.of("?", 1), report.getStepCounts());
+    assertEquals(Set.of(), report.getStatusFilterNames());
+    assertNotNull(report.toJson());
+    assertNotNull(report.formatLines());
 
-    assertNotNull(report.getFateDetails(), "Fate details should not be null");
+    assertNotNull(report.getFateDetails());
 
     log.debug("json: {}", report.toJson());
     log.debug("formatted: {}", report.formatLines());

--- a/server/base/src/test/java/org/apache/accumulo/server/util/fateCommand/SummaryReportTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/fateCommand/SummaryReportTest.java
@@ -25,7 +25,6 @@ import static org.easymock.EasyMock.verify;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
I am working on research that investigates test smell refactoring in which we identify alternative implementations of test cases, study how commonly used these refactorings are, and assess how acceptable they are in practice.

The first smell is when inappropriate assertions are used, while there exist better alternatives. For example, in [SummaryReportTest.java](https://github.com/apache/accumulo/commit/a657b6ee75d7c6a0556d0059dc3bc1317594d34b#diff-d0c6de0d5f496d76d1c71a7b39cb5ddc4060d8c68ddcf9893fd1f7fd5395d626), I refactored `assertTrue(report.getReportTime() != 0);` using `assertNotEquals` instead.

The second smell is known as _Assertion Roulette_, where a test method has multiple asserts without explanatory messages, which can sometimes make it difficult to identify which assert has failed. Therefore, I added exploratory messages to the asserts in the two test methods in [SummaryReportTest.java](https://github.com/apache/accumulo/commit/a657b6ee75d7c6a0556d0059dc3bc1317594d34b#diff-d0c6de0d5f496d76d1c71a7b39cb5ddc4060d8c68ddcf9893fd1f7fd5395d626).

I would like to get your feedback on these particular test smells and their refactorings. Thanks in advance for your input.