### PR TITLE
Add text icon to monitor navbar to indicate manager state

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/css/screen.css
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/css/screen.css
@@ -325,6 +325,7 @@ pre.logevent {
 }
 
 .icon-dot {
+  position: relative;
   display: inline-block;
   min-width: 1em;
   height: 1em;
@@ -335,6 +336,15 @@ pre.logevent {
   border-radius: 1em;
 }
 
+.icon-dot.special::before {
+  content: "\26A0"; /* Unicode character for warning symbol: ⚠ */
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 1;
+  color: #000000;
+}
 
 
 .smalltext {

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/css/screen.css
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/css/screen.css
@@ -337,7 +337,7 @@ pre.logevent {
 }
 
 .icon-dot.special::before {
-  content: "\26A0"; /* Unicode character for warning symbol: ⚠ */
+  content: "\26A0"; /* Unicode character for warning symbol */
   position: absolute;
   top: 50%;
   left: 50%;

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
@@ -41,8 +41,14 @@ const CLASS = {
  * @param {string} elementId the element id to update
  * @param {string} status the status of that element. used to set the associated color
  */
-function updateElementStatus(elementId, status) {
+function updateElementStatus(elementId, status, specialIcon = false) {
   const $element = $(`#${elementId}`);
+
+  if (specialIcon) {
+    $element.addClass('special');
+  } else {
+    $element.removeClass('special');
+  }
 
   switch (status) {
   case STATUS.ERROR:
@@ -73,12 +79,13 @@ function updateServerNotifications(statusData) {
 
     const isSafeMode = managerState === 'SAFE_MODE' || managerGoalState === 'SAFE_MODE';
     const isCleanStop = managerState === 'CLEAN_STOP' || managerGoalState === 'CLEAN_STOP';
+    const isManagerNotNormal = isSafeMode || isCleanStop;
 
     // setting manager status notification
     if (statusData.managerStatus === STATUS.ERROR || isCleanStop) {
-      updateElementStatus('managerStatusNotification', STATUS.ERROR);
+      updateElementStatus('managerStatusNotification', STATUS.ERROR, true);
     } else if (statusData.managerStatus === STATUS.WARN || isSafeMode) {
-      updateElementStatus('managerStatusNotification', STATUS.WARN);
+      updateElementStatus('managerStatusNotification', STATUS.WARN, true);
     } else if (statusData.managerStatus === STATUS.OK) {
       updateElementStatus('managerStatusNotification', STATUS.OK);
     } else {
@@ -102,18 +109,18 @@ function updateServerNotifications(statusData) {
     }
 
     // Setting overall servers status notification
-    if ((statusData.managerStatus === STATUS.OK && !isSafeMode && !isCleanStop) &&
+    if ((statusData.managerStatus === STATUS.OK && !isManagerNotNormal) &&
       statusData.tServerStatus === STATUS.OK &&
       statusData.gcStatus === STATUS.OK) {
       updateElementStatus('statusNotification', STATUS.OK);
     } else if (statusData.managerStatus === STATUS.ERROR || isCleanStop ||
       statusData.tServerStatus === STATUS.ERROR ||
       statusData.gcStatus === STATUS.ERROR) {
-      updateElementStatus('statusNotification', STATUS.ERROR);
+      updateElementStatus('statusNotification', STATUS.ERROR, isManagerNotNormal);
     } else if (statusData.managerStatus === STATUS.WARN || isSafeMode ||
       statusData.tServerStatus === STATUS.WARN ||
       statusData.gcStatus === STATUS.WARN) {
-      updateElementStatus('statusNotification', STATUS.WARN);
+      updateElementStatus('statusNotification', STATUS.WARN, isManagerNotNormal);
     }
 
   });


### PR DESCRIPTION
Alternative approach to #3711. The difference here is the icon added is simply a unicode character that is displayed over the existing dot icon when the manager state is not normal. With this approach, the changes are a lot more minimal compared to #3711 which had to introduce an svg and change the code to accomodate.

Here are some screenshots with these changes:

![Screenshot from 2023-08-24 11-47-26](https://github.com/apache/accumulo/assets/47725857/d46bf059-4179-48d6-8edc-43623922f3cb)

![Screenshot from 2023-08-24 11-48-04](https://github.com/apache/accumulo/assets/47725857/9ad50be4-40e4-4a6c-9d44-4a27434fdc53)

Manager in `SAFE_MODE` state
![Screenshot from 2023-08-24 11-50-13](https://github.com/apache/accumulo/assets/47725857/d873d599-46e1-4ce6-9a75-1f1bf905c06a)

Manager in `CLEAN_STOP` state
![Screenshot from 2023-08-24 11-51-55](https://github.com/apache/accumulo/assets/47725857/3eba7843-0a11-4542-98b8-e937437be3d1)

![Screenshot from 2023-08-24 12-01-47](https://github.com/apache/accumulo/assets/47725857/fda9d200-e341-4c3c-bcf8-6414a0a0a60f)

It is very easy to change which icon is displayed. Here are some alternative icons that have been suggested:
![Screenshot from 2023-08-24 12-03-29](https://github.com/apache/accumulo/assets/47725857/68c42f09-f8cd-49e6-b952-317a0a3e4d21)

![Screenshot from 2023-08-24 12-04-22](https://github.com/apache/accumulo/assets/47725857/cb5a5934-29f9-48ff-af31-df5e4ae89aa3)

Any other suggestions for which icons to try out are welcome.
