### PR TITLE
Always use retry backoff in ZooReader(Writer)

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooReader.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooReader.java
@@ -184,7 +184,11 @@ public class ZooReader {
       try {
         return zkf.apply(getZooKeeper());
       } catch (KeeperException e) {
-        if (alwaysRetryCondition.test(e) || useRetryForTransient(retries, e)) {
+        if (alwaysRetryCondition.test(e)) {
+          retries.waitForNextAttempt(log,
+              "attempting to communicate with zookeeper after exception that requires retry");
+          continue;
+        } else if (useRetryForTransient(retries, e)) {
           continue;
         }
         throw e;

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooReader.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooReader.java
@@ -186,7 +186,8 @@ public class ZooReader {
       } catch (KeeperException e) {
         if (alwaysRetryCondition.test(e)) {
           retries.waitForNextAttempt(log,
-              "attempting to communicate with zookeeper after exception that requires retry");
+              "attempting to communicate with zookeeper after exception that always requires retry: "
+                  + e.getMessage());
           continue;
         } else if (useRetryForTransient(retries, e)) {
           continue;
@@ -205,7 +206,8 @@ public class ZooReader {
       log.warn("Saw (possibly) transient exception communicating with ZooKeeper", e);
       if (retries.canRetry()) {
         retries.useRetry();
-        retries.waitForNextAttempt(log, "attempting to communicate with zookeeper after exception");
+        retries.waitForNextAttempt(log,
+            "attempting to communicate with zookeeper after exception: " + e.getMessage());
         return true;
       }
       log.error("Retry attempts ({}) exceeded trying to communicate with ZooKeeper",

--- a/core/src/test/java/org/apache/accumulo/core/fate/zookeeper/ZooReaderWriterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/fate/zookeeper/ZooReaderWriterTest.java
@@ -134,6 +134,9 @@ public class ZooReaderWriterTest {
     // Let 2nd setData succeed
     expect(zk.setData(path, mutatedBytes, 0)).andReturn(null);
 
+    retry.waitForNextAttempt(anyObject(), anyObject());
+    expectLastCall().once();
+
     replay(zk, zrw, retryFactory, retry);
 
     assertArrayEquals(new byte[] {1}, zrw.mutateOrCreate(path, value, mutator));


### PR DESCRIPTION
Always use the retry backoff when always retrying. This fixes an issue where an "always retry" condition is triggered, it will not barrage ZooKeeper with repeated immediate retries.

This fixes #3718