### PR TITLE
Adjust shell to indicate how re-authtication occurs

### DIFF
--- a/shell/src/main/java/org/apache/accumulo/shell/Shell.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/Shell.java
@@ -233,6 +233,8 @@ public class Shell extends ShellOptions implements KeywordExecutable {
   private long authTimeout;
   private long lastUserActivity = System.nanoTime();
   private boolean logErrorsToConsole = false;
+  private boolean askAgain = false;
+  private boolean usedClientProps = false;
 
   static {
     // set the JLine output encoding to some reasonable default if it isn't already set
@@ -250,7 +252,7 @@ public class Shell extends ShellOptions implements KeywordExecutable {
     }
   }
 
-  // no arg constructor should do minimal work since its used in Main ServiceLoader
+  // no arg constructor should do minimal work since it's used in Main ServiceLoader
   public Shell() {}
 
   public Shell(LineReader reader) {
@@ -272,8 +274,10 @@ public class Shell extends ShellOptions implements KeywordExecutable {
         && clientProperties.containsKey(ClientProperty.AUTH_TOKEN.getKey())
         && principal.equals(ClientProperty.AUTH_PRINCIPAL.getValue(clientProperties))) {
       token = ClientProperty.getAuthenticationToken(clientProperties);
+      usedClientProps = true;
     }
-    if (token == null) {
+    if (token == null || askAgain) {
+      usedClientProps = false;
       // Read password if the user explicitly asked for it, or didn't specify anything at all
       if (PasswordConverter.STDIN.equals(authenticationString) || authenticationString == null) {
         authenticationString = reader.readLine(passwordPrompt, '*');
@@ -618,7 +622,7 @@ public class Shell extends ShellOptions implements KeywordExecutable {
         writer.println();
 
         String partialLine = uie.getPartialLine();
-        if (partialLine == null || "".equals(uie.getPartialLine().trim())) {
+        if (partialLine == null || uie.getPartialLine().trim().isEmpty()) {
           // No content, actually exit
           return exitCode;
         }
@@ -760,6 +764,12 @@ public class Shell extends ShellOptions implements KeywordExecutable {
 
             if (authFailed) {
               writer.print("Invalid password. ");
+              askAgain = true;
+            } else {
+              if (usedClientProps) {
+                writer.println(
+                    "User re-authenticated using value from accumulo-client.properties file");
+              }
             }
           } while (authFailed);
           lastUserActivity = System.nanoTime();

--- a/shell/src/main/java/org/apache/accumulo/shell/Shell.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/Shell.java
@@ -622,7 +622,7 @@ public class Shell extends ShellOptions implements KeywordExecutable {
         writer.println();
 
         String partialLine = uie.getPartialLine();
-        if (partialLine == null || uie.getPartialLine().trim().isEmpty()) {
+        if (partialLine == null || partialLine.trim().isEmpty()) {
           // No content, actually exit
           return exitCode;
         }


### PR DESCRIPTION
This PR adds presents additional information to the shell when the re-authentication is automatically performed using the value from accumulo-client.properties.

Once merged, the update will be applied to 3.x where it corrects an situation where an endless loop can be triggered when attempting re-authentication if the accumulo-client.properties file password is altered after initial setup.

See #3495 for more detail.