### PR TITLE
Allow configurable name allocations

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -235,7 +235,7 @@ public enum Property {
   GENERAL_FILENAME_JITTER_ALLOCATION("general.filename.jitter.allocation", "100",
       PropertyType.COUNT,
       "The size of the jitter that will be applied to the `general.filename.base.allocation` when allocating "
-          + "filenames from Zookeeper. This will result in an allocation between base and (base + jitter).",
+          + "filenames from Zookeeper. This will result in an allocation between base and (base + jitter).  This property is ignored when its <= 0 and only base is used.",
       "2.1.3"),
   @Experimental
   GENERAL_RPC_SERVER_TYPE("general.rpc.server.type", "", PropertyType.STRING,

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -228,6 +228,15 @@ public enum Property {
       "2.1.0"),
   GENERAL_RPC_TIMEOUT("general.rpc.timeout", "120s", PropertyType.TIMEDURATION,
       "Time to wait on I/O for simple, short RPC calls", "1.3.5"),
+  GENERAL_FILENAME_PREFIX("general.filename.", null, PropertyType.PREFIX,
+      "Properties related to filename allocations.", "2.1.3"),
+  GENERAL_FILENAME_BASE_ALLOCATION("general.filename.base.allocation", "100", PropertyType.COUNT,
+      "The minimum number of filenames that will be allocated from Zookeeper at a time.", "2.1.3"),
+  GENERAL_FILENAME_JITTER_ALLOCATION("general.filename.jitter.allocation", "100",
+      PropertyType.COUNT,
+      "The size of the jitter that will be applied to the `general.filename.base.allocation` when allocating "
+          + "filenames from Zookeeper. This will result in an allocation between base and (base + jitter).",
+      "2.1.3"),
   @Experimental
   GENERAL_RPC_SERVER_TYPE("general.rpc.server.type", "", PropertyType.STRING,
       "Type of Thrift server to instantiate, see "
@@ -1830,6 +1839,7 @@ public enum Property {
         || key.startsWith(Property.MASTER_PREFIX.getKey())
         || key.startsWith(Property.GC_PREFIX.getKey())
         || key.startsWith(Property.GENERAL_ARBITRARY_PROP_PREFIX.getKey())
+        || key.startsWith(Property.GENERAL_FILENAME_PREFIX.getKey())
         || key.startsWith(VFS_CONTEXT_CLASSPATH_PROPERTY.getKey())
         || key.startsWith(REPLICATION_PREFIX.getKey());
   }

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -228,8 +228,6 @@ public enum Property {
       "2.1.0"),
   GENERAL_RPC_TIMEOUT("general.rpc.timeout", "120s", PropertyType.TIMEDURATION,
       "Time to wait on I/O for simple, short RPC calls", "1.3.5"),
-  GENERAL_FILENAME_PREFIX("general.filename.", null, PropertyType.PREFIX,
-      "Properties related to filename allocations.", "2.1.3"),
   GENERAL_FILENAME_BASE_ALLOCATION("general.filename.base.allocation", "100", PropertyType.COUNT,
       "The minimum number of filenames that will be allocated from Zookeeper at a time.", "2.1.3"),
   GENERAL_FILENAME_JITTER_ALLOCATION("general.filename.jitter.allocation", "100",
@@ -1839,7 +1837,8 @@ public enum Property {
         || key.startsWith(Property.MASTER_PREFIX.getKey())
         || key.startsWith(Property.GC_PREFIX.getKey())
         || key.startsWith(Property.GENERAL_ARBITRARY_PROP_PREFIX.getKey())
-        || key.startsWith(Property.GENERAL_FILENAME_PREFIX.getKey())
+        || key.equals(Property.GENERAL_FILENAME_BASE_ALLOCATION.getKey())
+        || key.equals(Property.GENERAL_FILENAME_JITTER_ALLOCATION.getKey())
         || key.startsWith(VFS_CONTEXT_CLASSPATH_PROPERTY.getKey())
         || key.startsWith(REPLICATION_PREFIX.getKey());
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/tablets/UniqueNameAllocator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tablets/UniqueNameAllocator.java
@@ -83,8 +83,7 @@ public class UniqueNameAllocator {
         context.getConfiguration().getCount(Property.GENERAL_FILENAME_JITTER_ALLOCATION);
 
     if (baseAllocation <= 0) {
-      log.warn(Property.GENERAL_FILENAME_BASE_ALLOCATION.getKey()
-          + " must be greater than 0. Using the default.");
+      log.warn("{} was set to {}, must be greater than 0. Using the default {}.", Property.GENERAL_FILENAME_BASE_ALLOCATION.getKey(), baseAllocation, DEFAULT_BASE_ALLOCATION);
       baseAllocation = DEFAULT_BASE_ALLOCATION;
     }
 
@@ -93,7 +92,7 @@ public class UniqueNameAllocator {
       totalAllocation += random.nextInt(jitterAllocation);
     }
 
-    log.debug("Allocated {} filenames", totalAllocation);
+    log.debug("Allocating {} filenames", totalAllocation);
 
     return totalAllocation;
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/tablets/UniqueNameAllocator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tablets/UniqueNameAllocator.java
@@ -83,7 +83,9 @@ public class UniqueNameAllocator {
         context.getConfiguration().getCount(Property.GENERAL_FILENAME_JITTER_ALLOCATION);
 
     if (baseAllocation <= 0) {
-      log.warn("{} was set to {}, must be greater than 0. Using the default {}.", Property.GENERAL_FILENAME_BASE_ALLOCATION.getKey(), baseAllocation, DEFAULT_BASE_ALLOCATION);
+      log.warn("{} was set to {}, must be greater than 0. Using the default {}.",
+          Property.GENERAL_FILENAME_BASE_ALLOCATION.getKey(), baseAllocation,
+          DEFAULT_BASE_ALLOCATION);
       baseAllocation = DEFAULT_BASE_ALLOCATION;
     }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/tablets/UniqueNameAllocator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tablets/UniqueNameAllocator.java
@@ -23,8 +23,11 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import java.security.SecureRandom;
 
 import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.util.FastFormat;
 import org.apache.accumulo.server.ServerContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Allocates unique names for an accumulo instance. The names are unique for the lifetime of the
@@ -33,6 +36,11 @@ import org.apache.accumulo.server.ServerContext;
  * This is useful for filenames because it makes caching easy.
  */
 public class UniqueNameAllocator {
+
+  private static Logger log = LoggerFactory.getLogger(UniqueNameAllocator.class);
+
+  private static final int DEFAULT_BASE_ALLOCATION =
+      Integer.parseInt(Property.GENERAL_FILENAME_BASE_ALLOCATION.getDefaultValue());
 
   private ServerContext context;
   private long next = 0;
@@ -48,7 +56,7 @@ public class UniqueNameAllocator {
   public synchronized String getNextName() {
 
     while (next >= maxAllocated) {
-      final int allocate = 100 + random.nextInt(100);
+      final int allocate = getAllocation();
 
       try {
         byte[] max = context.getZooReaderWriter().mutateExisting(nextNamePath, currentValue -> {
@@ -66,5 +74,27 @@ public class UniqueNameAllocator {
 
     return new String(FastFormat.toZeroPaddedString(next++, 7, Character.MAX_RADIX, new byte[0]),
         UTF_8);
+  }
+
+  private int getAllocation() {
+    int baseAllocation =
+        context.getConfiguration().getCount(Property.GENERAL_FILENAME_BASE_ALLOCATION);
+    int jitterAllocation =
+        context.getConfiguration().getCount(Property.GENERAL_FILENAME_JITTER_ALLOCATION);
+
+    if (baseAllocation <= 0) {
+      log.warn(Property.GENERAL_FILENAME_BASE_ALLOCATION.getKey()
+          + " must be greater than 0. Using the default.");
+      baseAllocation = DEFAULT_BASE_ALLOCATION;
+    }
+
+    int totalAllocation = baseAllocation;
+    if (jitterAllocation > 0) {
+      totalAllocation += random.nextInt(jitterAllocation);
+    }
+
+    log.debug("Allocated {} filenames", totalAllocation);
+
+    return totalAllocation;
   }
 }


### PR DESCRIPTION
Update the UniqueNameAllocator to support a configurable filename range size. The default values match what was previously there so there is no behavior change unless you override the properties.