### PR TITLE
Fix TabletServer shutdown

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
@@ -1214,16 +1214,16 @@ public class TabletClientHandler implements TabletServerClientService.Iface,
 
     checkPermission(security, context, server, credentials, lock, "halt");
 
-    Halt.halt(0, () -> {
+    //Halt.halt(0, () -> {
       log.info("Manager requested tablet server halt");
       context.getLowMemoryDetector().logGCInfo(server.getConfiguration());
       server.requestStop();
       try {
         server.getLock().unlock();
       } catch (Exception e) {
-        log.error("Caught exception unlocking TabletServer lock", e);
+        log.trace("Caught exception unlocking TabletServer lock", e);
       }
-    });
+    //});
   }
 
   @Override

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
@@ -1214,16 +1214,14 @@ public class TabletClientHandler implements TabletServerClientService.Iface,
 
     checkPermission(security, context, server, credentials, lock, "halt");
 
-    //Halt.halt(0, () -> {
-      log.info("Manager requested tablet server halt");
-      context.getLowMemoryDetector().logGCInfo(server.getConfiguration());
-      server.requestStop();
-      try {
-        server.getLock().unlock();
-      } catch (Exception e) {
-        log.trace("Caught exception unlocking TabletServer lock", e);
-      }
-    //});
+    log.info("Manager requested tablet server halt");
+    context.getLowMemoryDetector().logGCInfo(server.getConfiguration());
+    server.requestStop();
+    try {
+      server.getLock().unlock();
+    } catch (Exception e) {
+      log.trace("Caught exception unlocking TabletServer lock", e);
+    }
   }
 
   @Override


### PR DESCRIPTION
Fixes #3282 

My attempt to fix the Tabletserver shutdown code.
* Basically I stripped out the `shutdownComplete` code from `TabletServer` because  the `shutdownComplete` variable was never set.
* Further the `halt` method in `TabletClientHandler` seemed to cause unwanted behaviour because it prematurely exits the JVM before shutdown was handled. I enterily removed the `Halt.halt()` from that method.
* In `TabletServer` I think that the Halt.halt call in `LockWactcher`'s lostLock method is placed incorrecly. I guess it makes more sense putting it inside the `!serverStopRequested` if statement.
* After making these changes, the shutdown code is executed correctly but that also caused the `tabletServerLock.unlock()` was called twice, causing a NullPointerException when trying to unlock for the second time. I am not entirely sure weather one of these `unlock` calls can be 'dropped'.
