### PR TITLE
Improve the UniqueNameAllocator configurability

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -226,15 +226,14 @@ public enum Property {
       "Name of classloader factory to be used to create classloaders for named contexts,"
           + " such as per-table contexts set by `table.class.loader.context`.",
       "2.1.0"),
+  GENERAL_FILE_NAME_ALLOCATION_BATCH_SIZE_MIN("general.file.name.allocation.batch.size.min", "100",
+      PropertyType.COUNT,
+      "The minimum number of filenames that will be allocated from ZooKeeper at a time.", "2.1.3"),
+  GENERAL_FILE_NAME_ALLOCATION_BATCH_SIZE_MAX("general.file.name.allocation.batch.size.max", "200",
+      PropertyType.COUNT,
+      "The maximum number of filenames that will be allocated from ZooKeeper at a time.", "2.1.3"),
   GENERAL_RPC_TIMEOUT("general.rpc.timeout", "120s", PropertyType.TIMEDURATION,
       "Time to wait on I/O for simple, short RPC calls", "1.3.5"),
-  GENERAL_FILENAME_BASE_ALLOCATION("general.filename.base.allocation", "100", PropertyType.COUNT,
-      "The minimum number of filenames that will be allocated from Zookeeper at a time.", "2.1.3"),
-  GENERAL_FILENAME_JITTER_ALLOCATION("general.filename.jitter.allocation", "100",
-      PropertyType.COUNT,
-      "The size of the jitter that will be applied to the `general.filename.base.allocation` when allocating "
-          + "filenames from Zookeeper. This will result in an allocation between base and (base + jitter).  This property is ignored when its <= 0 and only base is used.",
-      "2.1.3"),
   @Experimental
   GENERAL_RPC_SERVER_TYPE("general.rpc.server.type", "", PropertyType.STRING,
       "Type of Thrift server to instantiate, see "
@@ -1837,8 +1836,8 @@ public enum Property {
         || key.startsWith(Property.MASTER_PREFIX.getKey())
         || key.startsWith(Property.GC_PREFIX.getKey())
         || key.startsWith(Property.GENERAL_ARBITRARY_PROP_PREFIX.getKey())
-        || key.equals(Property.GENERAL_FILENAME_BASE_ALLOCATION.getKey())
-        || key.equals(Property.GENERAL_FILENAME_JITTER_ALLOCATION.getKey())
+        || key.equals(Property.GENERAL_FILE_NAME_ALLOCATION_BATCH_SIZE_MIN.getKey())
+        || key.equals(Property.GENERAL_FILE_NAME_ALLOCATION_BATCH_SIZE_MAX.getKey())
         || key.startsWith(VFS_CONTEXT_CLASSPATH_PROPERTY.getKey())
         || key.startsWith(REPLICATION_PREFIX.getKey());
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/tablets/UniqueNameAllocator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tablets/UniqueNameAllocator.java
@@ -68,7 +68,7 @@ public class UniqueNameAllocator {
         next = maxAllocated - allocate;
 
       } catch (Exception e) {
-        throw new RuntimeException(e);
+        throw new IllegalStateException(e);
       }
     }
     return new String(FastFormat.toZeroPaddedString(next++, 7, Character.MAX_RADIX, new byte[0]),

--- a/server/base/src/main/java/org/apache/accumulo/server/tablets/UniqueNameAllocator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tablets/UniqueNameAllocator.java
@@ -42,6 +42,7 @@ public class UniqueNameAllocator {
   private static final SecureRandom random = new SecureRandom();
   private static final Property MIN_PROP = Property.GENERAL_FILE_NAME_ALLOCATION_BATCH_SIZE_MIN;
   private static final Property MAX_PROP = Property.GENERAL_FILE_NAME_ALLOCATION_BATCH_SIZE_MAX;
+  private static final int DEFAULT_MIN = DefaultConfiguration.getInstance().getCount(MIN_PROP);
 
   private final ServerContext context;
   private final String nextNamePath;
@@ -79,10 +80,9 @@ public class UniqueNameAllocator {
     int maxAllocation = context.getConfiguration().getCount(MAX_PROP);
 
     if (minAllocation <= 0) {
-      int defaultMin = DefaultConfiguration.getInstance().getCount(MIN_PROP);
       log.warn("{} was set to {}, but must be greater than 0. Using the default ({}).",
-          MIN_PROP.getKey(), minAllocation, defaultMin);
-      minAllocation = defaultMin;
+          MIN_PROP.getKey(), minAllocation, DEFAULT_MIN);
+      minAllocation = DEFAULT_MIN;
     }
 
     if (maxAllocation < minAllocation) {

--- a/server/base/src/main/java/org/apache/accumulo/server/tablets/UniqueNameAllocator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tablets/UniqueNameAllocator.java
@@ -23,6 +23,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import java.security.SecureRandom;
 
 import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.util.FastFormat;
 import org.apache.accumulo.server.ServerContext;
@@ -37,16 +38,16 @@ import org.slf4j.LoggerFactory;
  */
 public class UniqueNameAllocator {
 
-  private static Logger log = LoggerFactory.getLogger(UniqueNameAllocator.class);
+  private static final Logger log = LoggerFactory.getLogger(UniqueNameAllocator.class);
+  private static final SecureRandom random = new SecureRandom();
+  private static final Property MIN_PROP = Property.GENERAL_FILE_NAME_ALLOCATION_BATCH_SIZE_MIN;
+  private static final Property MAX_PROP = Property.GENERAL_FILE_NAME_ALLOCATION_BATCH_SIZE_MAX;
 
-  private static final int DEFAULT_BASE_ALLOCATION =
-      Integer.parseInt(Property.GENERAL_FILENAME_BASE_ALLOCATION.getDefaultValue());
+  private final ServerContext context;
+  private final String nextNamePath;
 
-  private ServerContext context;
   private long next = 0;
   private long maxAllocated = 0;
-  private String nextNamePath;
-  private static final SecureRandom random = new SecureRandom();
 
   public UniqueNameAllocator(ServerContext context) {
     this.context = context;
@@ -54,10 +55,8 @@ public class UniqueNameAllocator {
   }
 
   public synchronized String getNextName() {
-
     while (next >= maxAllocated) {
       final int allocate = getAllocation();
-
       try {
         byte[] max = context.getZooReaderWriter().mutateExisting(nextNamePath, currentValue -> {
           long l = Long.parseLong(new String(currentValue, UTF_8), Character.MAX_RADIX);
@@ -71,31 +70,29 @@ public class UniqueNameAllocator {
         throw new RuntimeException(e);
       }
     }
-
     return new String(FastFormat.toZeroPaddedString(next++, 7, Character.MAX_RADIX, new byte[0]),
         UTF_8);
   }
 
   private int getAllocation() {
-    int baseAllocation =
-        context.getConfiguration().getCount(Property.GENERAL_FILENAME_BASE_ALLOCATION);
-    int jitterAllocation =
-        context.getConfiguration().getCount(Property.GENERAL_FILENAME_JITTER_ALLOCATION);
+    int minAllocation = context.getConfiguration().getCount(MIN_PROP);
+    int maxAllocation = context.getConfiguration().getCount(MAX_PROP);
 
-    if (baseAllocation <= 0) {
-      log.warn("{} was set to {}, must be greater than 0. Using the default {}.",
-          Property.GENERAL_FILENAME_BASE_ALLOCATION.getKey(), baseAllocation,
-          DEFAULT_BASE_ALLOCATION);
-      baseAllocation = DEFAULT_BASE_ALLOCATION;
+    if (minAllocation <= 0) {
+      int defaultMin = DefaultConfiguration.getInstance().getCount(MIN_PROP);
+      log.warn("{} was set to {}, but must be greater than 0. Using the default ({}).",
+          MIN_PROP.getKey(), minAllocation, defaultMin);
+      minAllocation = defaultMin;
     }
 
-    int totalAllocation = baseAllocation;
-    if (jitterAllocation > 0) {
-      totalAllocation += random.nextInt(jitterAllocation);
+    if (maxAllocation < minAllocation) {
+      log.warn("{} was set to {}, must be greater than or equal to {} ({}). Using {}.",
+          MAX_PROP.getKey(), maxAllocation, MIN_PROP.getKey(), minAllocation, minAllocation);
+      maxAllocation = minAllocation;
     }
 
-    log.debug("Allocating {} filenames", totalAllocation);
-
-    return totalAllocation;
+    int actualBatchSize = minAllocation + random.nextInt((maxAllocation - minAllocation) + 1);
+    log.debug("Allocating {} filenames", actualBatchSize);
+    return actualBatchSize;
   }
 }


### PR DESCRIPTION
* Replace "base" and "jitter" concepts, which are confusing and require defining, with explicit "min" and "max" values for the configuration options for UniqueNameAllocator.
* Adjust formatting of Property descriptions so they don't excessively exceed our line length style.
* Reorder property names so RPC props aren't split up and stay together instead.

This fixes #3722 