### PR TITLE
Remove GC candidates found to still be referenced

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -886,6 +886,11 @@ public enum Property {
       "The listening port for the garbage collector's monitor service", "1.3.5"),
   GC_DELETE_THREADS("gc.threads.delete", "16", PropertyType.COUNT,
       "The number of threads used to delete RFiles and write-ahead logs", "1.3.5"),
+  @Experimental
+  GC_REMOVE_IN_USE_CANDIDATES("gc.remove.in.use.candidates", "false", PropertyType.BOOLEAN,
+      "GC will remove deletion candidates that are in-use from the metadata location. "
+          + "This is expected to increase the speed of subsequent GC runs",
+      "2.1.3"),
   @Deprecated(since = "2.1.1", forRemoval = true)
   GC_TRASH_IGNORE("gc.trash.ignore", "false", PropertyType.BOOLEAN,
       "Do not use the Trash, even if it is configured.", "1.5.0"),

--- a/core/src/main/java/org/apache/accumulo/core/gc/GcCandidate.java
+++ b/core/src/main/java/org/apache/accumulo/core/gc/GcCandidate.java
@@ -21,13 +21,11 @@ package org.apache.accumulo.core.gc;
 import java.lang.Object;
 import java.util.Objects;
 
-import org.apache.accumulo.core.metadata.StoredTabletFile;
-
 public class GcCandidate implements Comparable<GcCandidate> {
-  private final Long uid;
+  private final long uid;
   private final String path;
 
-  public GcCandidate(String path, Long uid) {
+  public GcCandidate(String path, long uid) {
     this.path = path;
     this.uid = uid;
   }
@@ -36,16 +34,8 @@ public class GcCandidate implements Comparable<GcCandidate> {
     return path;
   }
 
-  public Long getUid() {
+  public long getUid() {
     return uid;
-  }
-
-  public String getFileName() {
-    return new StoredTabletFile(path).getFileName();
-  }
-
-  public String getParent() {
-    return new StoredTabletFile(path).getPath().getParent().toString();
   }
 
   @Override
@@ -60,7 +50,7 @@ public class GcCandidate implements Comparable<GcCandidate> {
     }
     if (obj instanceof GcCandidate) {
       GcCandidate candidate = (GcCandidate) obj;
-      return this.uid.equals(candidate.getUid()) && this.path.equals(candidate.getPath());
+      return this.uid == candidate.getUid() && this.path.equals(candidate.getPath());
     }
     return false;
   }
@@ -69,7 +59,7 @@ public class GcCandidate implements Comparable<GcCandidate> {
   public int compareTo(GcCandidate candidate) {
     var cmp = this.path.compareTo(candidate.getPath());
     if (cmp == 0) {
-      return this.uid.compareTo(candidate.getUid());
+      return Long.compare(this.uid, candidate.getUid());
     } else {
       return cmp;
     }

--- a/core/src/main/java/org/apache/accumulo/core/gc/GcCandidate.java
+++ b/core/src/main/java/org/apache/accumulo/core/gc/GcCandidate.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.gc;
+
+import java.lang.Object;
+import java.util.Objects;
+
+import org.apache.accumulo.core.metadata.StoredTabletFile;
+
+public class GcCandidate implements Comparable<GcCandidate> {
+  private final Long uid;
+  private final String path;
+
+  public GcCandidate(String path, Long uid) {
+    this.path = path;
+    this.uid = uid;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public Long getUid() {
+    return uid;
+  }
+
+  public String getFileName() {
+    return new StoredTabletFile(path).getFileName();
+  }
+
+  public String getParent() {
+    return new StoredTabletFile(path).getPath().getParent().toString();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(path, uid);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj instanceof GcCandidate) {
+      GcCandidate candidate = (GcCandidate) obj;
+      return this.uid.equals(candidate.getUid()) && this.path.equals(candidate.getPath());
+    }
+    return false;
+  }
+
+  @Override
+  public int compareTo(GcCandidate candidate) {
+    var cmp = this.path.compareTo(candidate.getPath());
+    if (cmp == 0) {
+      return this.uid.compareTo(candidate.getUid());
+    } else {
+      return cmp;
+    }
+  }
+
+  @Override
+  public String toString() {
+    return path + ", UUID: " + uid;
+  }
+}

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
@@ -27,6 +27,7 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.fate.zookeeper.ServiceLock;
+import org.apache.accumulo.core.gc.GcCandidate;
 import org.apache.accumulo.core.gc.ReferenceFile;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
@@ -134,6 +135,24 @@ public interface Ample {
   }
 
   /**
+   * Enables status based processing of GcCandidates.
+   */
+  public enum GcCandidateType {
+    /**
+     * Candidates which have corresponding file references still present in tablet metadata.
+     */
+    INUSE,
+    /**
+     * Candidates that have no matching file references and can be removed from the system.
+     */
+    VALID,
+    /**
+     * Candidates that are malformed.
+     */
+    INVALID
+  }
+
+  /**
    * Read a single tablets metadata. No checking is done for prev row, so it could differ. The
    * method will read the data using {@link ReadConsistency#IMMEDIATE}.
    *
@@ -193,11 +212,15 @@ public interface Ample {
     throw new UnsupportedOperationException();
   }
 
-  default void deleteGcCandidates(DataLevel level, Collection<String> paths) {
+  /**
+   * Enum added to support unique candidate deletions in 2.1
+   */
+  default void deleteGcCandidates(DataLevel level, Collection<GcCandidate> candidates,
+      GcCandidateType type) {
     throw new UnsupportedOperationException();
   }
 
-  default Iterator<String> getGcCandidates(DataLevel level) {
+  default Iterator<GcCandidate> getGcCandidates(DataLevel level) {
     throw new UnsupportedOperationException();
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/RootGcCandidates.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/RootGcCandidates.java
@@ -20,12 +20,14 @@ package org.apache.accumulo.server.metadata;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import java.security.SecureRandom;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Stream;
 
+import org.apache.accumulo.core.gc.GcCandidate;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.hadoop.fs.Path;
 
@@ -64,6 +66,7 @@ public class RootGcCandidates {
 
   public RootGcCandidates(String jsonString) {
     this.data = gson.fromJson(jsonString, Data.class);
+
     checkArgument(data.version == VERSION, "Invalid Root Table GC Candidates JSON version %s",
         data.version);
     data.candidates.forEach((parent, files) -> {
@@ -78,20 +81,23 @@ public class RootGcCandidates {
         .add(ref.getFileName()));
   }
 
-  public void remove(Stream<String> refs) {
-    refs.map(Path::new).forEach(
-        path -> data.candidates.computeIfPresent(path.getParent().toString(), (key, values) -> {
-          values.remove(path.getName());
-          return values.isEmpty() ? null : values;
-        }));
+  public void remove(Stream<GcCandidate> refs) {
+    refs.map(GcCandidate::getPath).map(Path::new).forEach(path -> {
+      data.candidates.computeIfPresent(path.getParent().toString(), (key, values) -> {
+        values.remove(path.getName());
+        return values.isEmpty() ? null : values;
+      });
+    });
   }
 
-  public Stream<String> sortedStream() {
+  public Stream<GcCandidate> sortedStream() {
+    var uidGen = new SecureRandom();
     return data.candidates.entrySet().stream().flatMap(entry -> {
       String parent = entry.getKey();
       SortedSet<String> names = entry.getValue();
-      return names.stream().map(name -> new Path(parent, name));
-    }).map(Path::toString).sorted();
+      return names.stream()
+          .map(name -> new GcCandidate(parent + Path.SEPARATOR + name, uidGen.nextLong()));
+    }).sorted();
   }
 
   public String toJson() {

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/RootGcCandidates.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/RootGcCandidates.java
@@ -66,7 +66,6 @@ public class RootGcCandidates {
 
   public RootGcCandidates(String jsonString) {
     this.data = gson.fromJson(jsonString, Data.class);
-
     checkArgument(data.version == VERSION, "Invalid Root Table GC Candidates JSON version %s",
         data.version);
     data.candidates.forEach((parent, files) -> {

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
@@ -45,6 +45,7 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.fate.FateTxId;
+import org.apache.accumulo.core.gc.GcCandidate;
 import org.apache.accumulo.core.gc.ReferenceFile;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
@@ -210,17 +211,22 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
   }
 
   @Override
-  public void deleteGcCandidates(DataLevel level, Collection<String> paths) {
+  public void deleteGcCandidates(DataLevel level, Collection<GcCandidate> candidates,
+      GcCandidateType type) {
 
     if (level == DataLevel.ROOT) {
-      mutateRootGcCandidates(rgcc -> rgcc.remove(paths.stream()));
+      if (type == GcCandidateType.INUSE) {
+        // Deletion of INUSE candidates is not supported in 2.1.x.
+        return;
+      }
+      mutateRootGcCandidates(rgcc -> rgcc.remove(candidates.stream()));
       return;
     }
 
     try (BatchWriter writer = context.createBatchWriter(level.metaTable())) {
-      for (String path : paths) {
-        Mutation m = new Mutation(DeletesSection.encodeRow(path));
-        m.putDelete(EMPTY_TEXT, EMPTY_TEXT);
+      for (GcCandidate candidate : candidates) {
+        Mutation m = new Mutation(DeletesSection.encodeRow(candidate.getPath()));
+        m.putDelete(EMPTY_TEXT, EMPTY_TEXT, candidate.getUid());
         writer.addMutation(m);
       }
     } catch (MutationsRejectedException | TableNotFoundException e) {
@@ -229,7 +235,7 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
   }
 
   @Override
-  public Iterator<String> getGcCandidates(DataLevel level) {
+  public Iterator<GcCandidate> getGcCandidates(DataLevel level) {
     if (level == DataLevel.ROOT) {
       var zooReader = context.getZooReader();
       byte[] jsonBytes;
@@ -251,7 +257,10 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
       }
       scanner.setRange(range);
       return scanner.stream().filter(entry -> entry.getValue().equals(SkewedKeyValue.NAME))
-          .map(entry -> DeletesSection.decodeRow(entry.getKey().getRow().toString())).iterator();
+          .map(
+              entry -> new GcCandidate(DeletesSection.decodeRow(entry.getKey().getRow().toString()),
+                  entry.getKey().getTimestamp()))
+          .iterator();
     } else {
       throw new IllegalArgumentException();
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ListVolumesUsed.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ListVolumesUsed.java
@@ -22,6 +22,7 @@ import java.util.Iterator;
 import java.util.TreeSet;
 
 import org.apache.accumulo.core.conf.SiteConfiguration;
+import org.apache.accumulo.core.gc.GcCandidate;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
@@ -78,9 +79,9 @@ public class ListVolumesUsed {
         + " deletes section (volume replacement occurs at deletion time)");
     volumes.clear();
 
-    Iterator<String> delPaths = context.getAmple().getGcCandidates(level);
+    Iterator<GcCandidate> delPaths = context.getAmple().getGcCandidates(level);
     while (delPaths.hasNext()) {
-      volumes.add(getTableURI(delPaths.next()));
+      volumes.add(getTableURI(delPaths.next().getPath()));
     }
     for (String volume : volumes) {
       System.out.println("\tVolume : " + volume);

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
@@ -336,7 +336,7 @@ public class GCRun implements GarbageCollectionEnvironment {
                   }
                 }
               } else {
-                log.warn("Very strange path name: {}", delete.getPath());
+                log.warn("Delete Failed: Path name format cannot be parsed: {}", delete.getPath());
               }
             }
           }

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
@@ -121,19 +121,17 @@ public class GCRun implements GarbageCollectionEnvironment {
   public void deleteGcCandidates(Collection<GcCandidate> gcCandidates, GcCandidateType type) {
     if (inSafeMode()) {
       System.out.println("SAFEMODE: There are " + gcCandidates.size()
-          + " reference file gcCandidates entries marked for deletion from " + level + ".\n"
-          + "          Examine the log files to identify them.\n");
+          + " reference file gcCandidates entries marked for deletion from " + level + " of type: "
+          + type + ".\n          Examine the log files to identify them.\n");
       log.info("SAFEMODE: Listing all ref file gcCandidates for deletion");
       for (GcCandidate gcCandidate : gcCandidates) {
         log.info("SAFEMODE: {}", gcCandidate);
       }
       log.info("SAFEMODE: End reference candidates for deletion");
-    }
-
-    if (!config.getBoolean(Property.GC_REMOVE_IN_USE_CANDIDATES)
-        && type.equals(GcCandidateType.INUSE)) {
       return;
     }
+
+    log.info("Attempting to delete gcCandidates of type {} from metadata", type);
     context.getAmple().deleteGcCandidates(level, gcCandidates, type);
   }
 
@@ -481,10 +479,20 @@ public class GCRun implements GarbageCollectionEnvironment {
   /**
    * Checks if safemode is set - files will not be deleted.
    *
-   * @return number of delete threads
+   * @return value of {@link Property#GC_SAFEMODE}
    */
   boolean inSafeMode() {
     return context.getConfiguration().getBoolean(Property.GC_SAFEMODE);
+  }
+
+  /**
+   * Checks if InUse Candidates can be removed.
+   *
+   * @return value of {@link Property#GC_REMOVE_IN_USE_CANDIDATES}
+   */
+  @Override
+  public boolean canRemoveInUseCandidates() {
+    return context.getConfiguration().getBoolean(Property.GC_REMOVE_IN_USE_CANDIDATES);
   }
 
   /**

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
@@ -26,6 +26,7 @@ import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -48,6 +49,7 @@ import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.zookeeper.ZooReader;
+import org.apache.accumulo.core.gc.GcCandidate;
 import org.apache.accumulo.core.gc.Reference;
 import org.apache.accumulo.core.gc.ReferenceDirectory;
 import org.apache.accumulo.core.gc.ReferenceFile;
@@ -58,6 +60,7 @@ import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.ValidationUtil;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
+import org.apache.accumulo.core.metadata.schema.Ample.GcCandidateType;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
@@ -104,21 +107,47 @@ public class GCRun implements GarbageCollectionEnvironment {
   }
 
   @Override
-  public Iterator<String> getCandidates() {
+  public Iterator<GcCandidate> getCandidates() {
     return context.getAmple().getGcCandidates(level);
   }
 
+  /**
+   * Removes gcCandidates from the metadata location depending on type.
+   *
+   * @param gcCandidates Collection of deletion reference candidates to remove.
+   * @param type type of deletion reference candidates.
+   */
   @Override
-  public List<String> readCandidatesThatFitInMemory(Iterator<String> candidates) {
+  public void deleteGcCandidates(Collection<GcCandidate> gcCandidates, GcCandidateType type) {
+    if (inSafeMode()) {
+      System.out.println("SAFEMODE: There are " + gcCandidates.size()
+          + " reference file gcCandidates entries marked for deletion from " + level + ".\n"
+          + "          Examine the log files to identify them.\n");
+      log.info("SAFEMODE: Listing all ref file gcCandidates for deletion");
+      for (GcCandidate gcCandidate : gcCandidates) {
+        log.info("SAFEMODE: {}", gcCandidate);
+      }
+      log.info("SAFEMODE: End reference candidates for deletion");
+    }
+
+    if (!config.getBoolean(Property.GC_REMOVE_IN_USE_CANDIDATES)
+        && type.equals(GcCandidateType.INUSE)) {
+      return;
+    }
+    context.getAmple().deleteGcCandidates(level, gcCandidates, type);
+  }
+
+  @Override
+  public List<GcCandidate> readCandidatesThatFitInMemory(Iterator<GcCandidate> candidates) {
     long candidateLength = 0;
     // Converting the bytes to approximate number of characters for batch size.
     long candidateBatchSize = getCandidateBatchSize() / 2;
 
-    List<String> candidatesBatch = new ArrayList<>();
+    List<GcCandidate> candidatesBatch = new ArrayList<>();
 
     while (candidates.hasNext()) {
-      String candidate = candidates.next();
-      candidateLength += candidate.length();
+      GcCandidate candidate = candidates.next();
+      candidateLength += candidate.getPath().length();
       candidatesBatch.add(candidate);
       if (candidateLength > candidateBatchSize) {
         log.info("Candidate batch of size {} has exceeded the threshold. Attempting to delete "
@@ -226,7 +255,7 @@ public class GCRun implements GarbageCollectionEnvironment {
   }
 
   @Override
-  public void deleteConfirmedCandidates(SortedMap<String,String> confirmedDeletes)
+  public void deleteConfirmedCandidates(SortedMap<String,GcCandidate> confirmedDeletes)
       throws TableNotFoundException {
     final VolumeManager fs = context.getVolumeManager();
     var metadataLocation = level == Ample.DataLevel.ROOT
@@ -237,14 +266,14 @@ public class GCRun implements GarbageCollectionEnvironment {
           + " data file candidates marked for deletion in " + metadataLocation + ".\n"
           + "          Examine the log files to identify them.\n");
       log.info("SAFEMODE: Listing all data file candidates for deletion");
-      for (String s : confirmedDeletes.values()) {
-        log.info("SAFEMODE: {}", s);
+      for (GcCandidate candidate : confirmedDeletes.values()) {
+        log.info("SAFEMODE: {}", candidate);
       }
       log.info("SAFEMODE: End candidates for deletion");
       return;
     }
 
-    List<String> processedDeletes = Collections.synchronizedList(new ArrayList<>());
+    List<GcCandidate> processedDeletes = Collections.synchronizedList(new ArrayList<>());
 
     minimizeDeletes(confirmedDeletes, processedDeletes, fs, log);
 
@@ -253,7 +282,7 @@ public class GCRun implements GarbageCollectionEnvironment {
 
     final List<Pair<Path,Path>> replacements = context.getVolumeReplacements();
 
-    for (final String delete : confirmedDeletes.values()) {
+    for (final GcCandidate delete : confirmedDeletes.values()) {
 
       Runnable deleteTask = () -> {
         boolean removeFlag = false;
@@ -261,7 +290,7 @@ public class GCRun implements GarbageCollectionEnvironment {
         try {
           Path fullPath;
           Path switchedDelete =
-              VolumeUtil.switchVolume(delete, VolumeManager.FileType.TABLE, replacements);
+              VolumeUtil.switchVolume(delete.getPath(), VolumeManager.FileType.TABLE, replacements);
           if (switchedDelete != null) {
             // actually replacing the volumes in the metadata table would be tricky because the
             // entries would be different rows. So it could not be
@@ -271,10 +300,10 @@ public class GCRun implements GarbageCollectionEnvironment {
             // uses suffixes to compare delete entries, there is no danger
             // of deleting something that should not be deleted. Must not change value of delete
             // variable because that's what's stored in metadata table.
-            log.debug("Volume replaced {} -> {}", delete, switchedDelete);
+            log.debug("Volume replaced {} -> {}", delete.getPath(), switchedDelete);
             fullPath = ValidationUtil.validate(switchedDelete);
           } else {
-            fullPath = new Path(ValidationUtil.validate(delete));
+            fullPath = new Path(ValidationUtil.validate(delete.getPath()));
           }
 
           for (Path pathToDel : GcVolumeUtil.expandAllVolumesUri(fs, fullPath)) {
@@ -307,7 +336,7 @@ public class GCRun implements GarbageCollectionEnvironment {
                   }
                 }
               } else {
-                log.warn("Very strange path name: {}", delete);
+                log.warn("Very strange path name: {}", delete.getPath());
               }
             }
           }
@@ -335,7 +364,7 @@ public class GCRun implements GarbageCollectionEnvironment {
       log.error("{}", e1.getMessage(), e1);
     }
 
-    context.getAmple().deleteGcCandidates(level, processedDeletes);
+    deleteGcCandidates(processedDeletes, GcCandidateType.VALID);
   }
 
   @Override
@@ -396,21 +425,21 @@ public class GCRun implements GarbageCollectionEnvironment {
   }
 
   @VisibleForTesting
-  static void minimizeDeletes(SortedMap<String,String> confirmedDeletes,
-      List<String> processedDeletes, VolumeManager fs, Logger logger) {
+  static void minimizeDeletes(SortedMap<String,GcCandidate> confirmedDeletes,
+      List<GcCandidate> processedDeletes, VolumeManager fs, Logger logger) {
     Set<Path> seenVolumes = new HashSet<>();
 
     // when deleting a dir and all files in that dir, only need to delete the dir.
     // The dir will sort right before the files... so remove the files in this case
     // to minimize namenode ops
-    Iterator<Map.Entry<String,String>> cdIter = confirmedDeletes.entrySet().iterator();
+    Iterator<Map.Entry<String,GcCandidate>> cdIter = confirmedDeletes.entrySet().iterator();
 
     String lastDirRel = null;
     Path lastDirAbs = null;
     while (cdIter.hasNext()) {
-      Map.Entry<String,String> entry = cdIter.next();
+      Map.Entry<String,GcCandidate> entry = cdIter.next();
       String relPath = entry.getKey();
-      Path absPath = new Path(entry.getValue());
+      Path absPath = new Path(entry.getValue().getPath());
 
       if (SimpleGarbageCollector.isDir(relPath)) {
         lastDirRel = relPath;
@@ -437,7 +466,7 @@ public class GCRun implements GarbageCollectionEnvironment {
           }
 
           if (sameVol) {
-            logger.info("Ignoring {} because {} exist", entry.getValue(), lastDirAbs);
+            logger.info("Ignoring {} because {} exist", entry.getValue().getPath(), lastDirAbs);
             processedDeletes.add(entry.getValue());
             cdIter.remove();
           }

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
@@ -161,8 +161,7 @@ public class GarbageCollectionAlgorithm {
 
         GcCandidate gcTemp = candidateMap.remove(dir);
         if (gcTemp != null) {
-          log.debug("Candidate was still in use: {}", dir);
-          inUseCandidates.add(gcTemp);
+          log.debug("Directory Candidate was still in use by dir ref: {}", dir);
         }
       } else {
         String reference = ref.getMetadataEntry();
@@ -180,15 +179,14 @@ public class GarbageCollectionAlgorithm {
         // You MUST REMOVE candidates that are still in use
         GcCandidate gcTemp = candidateMap.remove(relativePath);
         if (gcTemp != null) {
-          log.debug("Candidate was still in use: {}", relativePath);
+          log.debug("File Candidate was still in use: {}", relativePath);
           inUseCandidates.add(gcTemp);
         }
 
         String dir = relativePath.substring(0, relativePath.lastIndexOf('/'));
         GcCandidate gcT = candidateMap.remove(dir);
         if (gcT != null) {
-          log.debug("Candidate was still in use: {}", relativePath);
-          inUseCandidates.add(gcT);
+          log.debug("Directory Candidate was still in use by file ref: {}", relativePath);
         }
       }
     }

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionEnvironment.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionEnvironment.java
@@ -29,6 +29,7 @@ import java.util.SortedMap;
 import java.util.stream.Stream;
 
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.gc.GcCandidate;
 import org.apache.accumulo.core.gc.Reference;
@@ -49,6 +50,13 @@ public interface GarbageCollectionEnvironment {
    * @return an iterator referencing a List containing deletion candidates
    */
   Iterator<GcCandidate> getCandidates() throws TableNotFoundException;
+
+  /**
+   * Used for determining if deletion of InUse candidates is enabled.
+   *
+   * @return value of {@link Property#GC_REMOVE_IN_USE_CANDIDATES}
+   */
+  boolean canRemoveInUseCandidates();
 
   /**
    * Given an iterator to a deletion candidate list, return a sub-list of candidates which fit

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionEnvironment.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionEnvironment.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.gc;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -29,10 +30,12 @@ import java.util.stream.Stream;
 
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.gc.GcCandidate;
 import org.apache.accumulo.core.gc.Reference;
 import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
+import org.apache.accumulo.core.metadata.schema.Ample.GcCandidateType;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ScanFileColumnFamily;
 import org.apache.accumulo.server.replication.proto.Replication.Status;
@@ -45,7 +48,7 @@ public interface GarbageCollectionEnvironment {
    *
    * @return an iterator referencing a List containing deletion candidates
    */
-  Iterator<String> getCandidates() throws TableNotFoundException;
+  Iterator<GcCandidate> getCandidates() throws TableNotFoundException;
 
   /**
    * Given an iterator to a deletion candidate list, return a sub-list of candidates which fit
@@ -54,7 +57,7 @@ public interface GarbageCollectionEnvironment {
    * @param candidatesIter iterator referencing a List of possible deletion candidates
    * @return a List of possible deletion candidates
    */
-  List<String> readCandidatesThatFitInMemory(Iterator<String> candidatesIter);
+  List<GcCandidate> readCandidatesThatFitInMemory(Iterator<GcCandidate> candidatesIter);
 
   /**
    * Fetch a list of paths for all bulk loads in progress (blip) from a given table,
@@ -98,8 +101,15 @@ public interface GarbageCollectionEnvironment {
    *
    * @param candidateMap A Map from relative path to absolute path for files to be deleted.
    */
-  void deleteConfirmedCandidates(SortedMap<String,String> candidateMap)
+  void deleteConfirmedCandidates(SortedMap<String,GcCandidate> candidateMap)
       throws TableNotFoundException;
+
+  /**
+   * Delete in-use reference candidates based on property settings
+   *
+   * @param GcCandidates Collection of deletion reference candidates to remove.
+   */
+  void deleteGcCandidates(Collection<GcCandidate> GcCandidates, GcCandidateType type);
 
   /**
    * Delete a table's directory if it is empty.

--- a/server/gc/src/test/java/org/apache/accumulo/gc/SimpleGarbageCollectorTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/SimpleGarbageCollectorTest.java
@@ -45,6 +45,7 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.gc.GcCandidate;
 import org.apache.accumulo.core.volume.Volume;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.fs.VolumeManager;
@@ -168,38 +169,49 @@ public class SimpleGarbageCollectorTest {
 
     replay(vol1, vol2, volMgr2);
 
-    TreeMap<String,String> confirmed = new TreeMap<>();
-    confirmed.put("5a/t-0001", "hdfs://nn1/accumulo/tables/5a/t-0001");
-    confirmed.put("5a/t-0001/F0001.rf", "hdfs://nn1/accumulo/tables/5a/t-0001/F0001.rf");
-    confirmed.put("5a/t-0001/F0002.rf", "hdfs://nn1/accumulo/tables/5a/t-0001/F0002.rf");
-    confirmed.put("5a/t-0002/F0001.rf", "hdfs://nn1/accumulo/tables/5a/t-0002/F0001.rf");
+    TreeMap<String,GcCandidate> confirmed = new TreeMap<>();
+    confirmed.put("5a/t-0001", new GcCandidate("hdfs://nn1/accumulo/tables/5a/t-0001", 0L));
+    confirmed.put("5a/t-0001/F0001.rf",
+        new GcCandidate("hdfs://nn1/accumulo/tables/5a/t-0001/F0001.rf", 1L));
+    confirmed.put("5a/t-0001/F0002.rf",
+        new GcCandidate("hdfs://nn1/accumulo/tables/5a/t-0001/F0002.rf", 2L));
+    confirmed.put("5a/t-0002/F0001.rf",
+        new GcCandidate("hdfs://nn1/accumulo/tables/5a/t-0002/F0001.rf", 3L));
     var allVolumesDirectory = new AllVolumesDirectory(TableId.of("5b"), "t-0003");
-    confirmed.put("5b/t-0003", allVolumesDirectory.getMetadataEntry());
-    confirmed.put("5b/t-0003/F0001.rf", "hdfs://nn1/accumulo/tables/5b/t-0003/F0001.rf");
-    confirmed.put("5b/t-0003/F0002.rf", "hdfs://nn2/accumulo/tables/5b/t-0003/F0002.rf");
-    confirmed.put("5b/t-0003/F0003.rf", "hdfs://nn3/accumulo/tables/5b/t-0003/F0003.rf");
+    confirmed.put("5b/t-0003", new GcCandidate(allVolumesDirectory.getMetadataEntry(), 4L));
+    confirmed.put("5b/t-0003/F0001.rf",
+        new GcCandidate("hdfs://nn1/accumulo/tables/5b/t-0003/F0001.rf", 5L));
+    confirmed.put("5b/t-0003/F0002.rf",
+        new GcCandidate("hdfs://nn2/accumulo/tables/5b/t-0003/F0002.rf", 6L));
+    confirmed.put("5b/t-0003/F0003.rf",
+        new GcCandidate("hdfs://nn3/accumulo/tables/5b/t-0003/F0003.rf", 7L));
     allVolumesDirectory = new AllVolumesDirectory(TableId.of("5b"), "t-0004");
-    confirmed.put("5b/t-0004", allVolumesDirectory.getMetadataEntry());
-    confirmed.put("5b/t-0004/F0001.rf", "hdfs://nn1/accumulo/tables/5b/t-0004/F0001.rf");
+    confirmed.put("5b/t-0004", new GcCandidate(allVolumesDirectory.getMetadataEntry(), 8L));
+    confirmed.put("5b/t-0004/F0001.rf",
+        new GcCandidate("hdfs://nn1/accumulo/tables/5b/t-0004/F0001.rf", 9L));
 
-    List<String> processedDeletes = new ArrayList<>();
+    List<GcCandidate> processedDeletes = new ArrayList<>();
 
     GCRun.minimizeDeletes(confirmed, processedDeletes, volMgr2, log);
 
-    TreeMap<String,String> expected = new TreeMap<>();
-    expected.put("5a/t-0001", "hdfs://nn1/accumulo/tables/5a/t-0001");
-    expected.put("5a/t-0002/F0001.rf", "hdfs://nn1/accumulo/tables/5a/t-0002/F0001.rf");
+    TreeMap<String,GcCandidate> expected = new TreeMap<>();
+    expected.put("5a/t-0001", new GcCandidate("hdfs://nn1/accumulo/tables/5a/t-0001", 0L));
+    expected.put("5a/t-0002/F0001.rf",
+        new GcCandidate("hdfs://nn1/accumulo/tables/5a/t-0002/F0001.rf", 3L));
     allVolumesDirectory = new AllVolumesDirectory(TableId.of("5b"), "t-0003");
-    expected.put("5b/t-0003", allVolumesDirectory.getMetadataEntry());
-    expected.put("5b/t-0003/F0003.rf", "hdfs://nn3/accumulo/tables/5b/t-0003/F0003.rf");
+    expected.put("5b/t-0003", new GcCandidate(allVolumesDirectory.getMetadataEntry(), 4L));
+    expected.put("5b/t-0003/F0003.rf",
+        new GcCandidate("hdfs://nn3/accumulo/tables/5b/t-0003/F0003.rf", 7L));
     allVolumesDirectory = new AllVolumesDirectory(TableId.of("5b"), "t-0004");
-    expected.put("5b/t-0004", allVolumesDirectory.getMetadataEntry());
+    expected.put("5b/t-0004", new GcCandidate(allVolumesDirectory.getMetadataEntry(), 8L));
 
     assertEquals(expected, confirmed);
-    assertEquals(Arrays.asList("hdfs://nn1/accumulo/tables/5a/t-0001/F0001.rf",
-        "hdfs://nn1/accumulo/tables/5a/t-0001/F0002.rf",
-        "hdfs://nn1/accumulo/tables/5b/t-0003/F0001.rf",
-        "hdfs://nn2/accumulo/tables/5b/t-0003/F0002.rf",
-        "hdfs://nn1/accumulo/tables/5b/t-0004/F0001.rf"), processedDeletes);
+    assertEquals(
+        Arrays.asList(new GcCandidate("hdfs://nn1/accumulo/tables/5a/t-0001/F0001.rf", 1L),
+            new GcCandidate("hdfs://nn1/accumulo/tables/5a/t-0001/F0002.rf", 2L),
+            new GcCandidate("hdfs://nn1/accumulo/tables/5b/t-0003/F0001.rf", 5L),
+            new GcCandidate("hdfs://nn2/accumulo/tables/5b/t-0003/F0002.rf", 6L),
+            new GcCandidate("hdfs://nn1/accumulo/tables/5b/t-0004/F0001.rf", 9L)),
+        processedDeletes);
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorIT.java
@@ -21,16 +21,22 @@ package org.apache.accumulo.test.functional;
 import static org.apache.accumulo.core.util.UtilWaitThread.sleepUninterruptibly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.UncheckedIOException;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.Accumulo;
@@ -45,9 +51,12 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.fate.zookeeper.ServiceLock;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
+import org.apache.accumulo.core.gc.GcCandidate;
 import org.apache.accumulo.core.gc.ReferenceFile;
 import org.apache.accumulo.core.metadata.MetadataTable;
+import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.Ample;
+import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.DeletesSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.DeletesSection.SkewedKeyValue;
 import org.apache.accumulo.core.security.Authorizations;
@@ -71,11 +80,14 @@ import org.apache.hadoop.io.Text;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.NoNodeException;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Iterators;
 
 public class GarbageCollectorIT extends ConfigurableMacBase {
   private static final String OUR_SECRET = "itsreallysecret";
+  public static final Logger log = LoggerFactory.getLogger(GarbageCollectorIT.class);
 
   @Override
   protected Duration defaultTimeout() {
@@ -265,6 +277,37 @@ public class GarbageCollectorIT extends ConfigurableMacBase {
   }
 
   @Test
+  public void testUserUniqueMutationDelete() throws Exception {
+    killMacGc();
+    try (AccumuloClient c = Accumulo.newClient().from(getClientProperties()).build()) {
+      String table = getUniqueNames(1)[0];
+      c.tableOperations().create(table);
+      log.info("User GcCandidate Deletion test of table {}", table);
+      log.info("GcCandidates will be added/removed from table {}", DataLevel.USER.metaTable());
+      createAndDeleteUniqueMutation(TableId.of(table), Ample.GcCandidateType.INUSE);
+    }
+  }
+
+  @Test
+  public void testMetadataUniqueMutationDelete() throws Exception {
+    killMacGc();
+    TableId tableId = DataLevel.USER.tableId();
+    log.info("Metadata GcCandidate Deletion test of table {}", DataLevel.USER.metaTable());
+    log.info("GcCandidates will be added/removed from table {}", DataLevel.METADATA.metaTable());
+    createAndDeleteUniqueMutation(tableId, Ample.GcCandidateType.INUSE);
+  }
+
+  @Test
+  public void testRootUniqueMutationDelete() throws Exception {
+    killMacGc();
+    TableId tableId = DataLevel.METADATA.tableId();
+    log.info(
+        "Root GcCandidate Deletion test of table {}\n GcCandidates will be added/removed from Zookeeper",
+        DataLevel.METADATA.metaTable());
+    createAndDeleteUniqueMutation(tableId, Ample.GcCandidateType.INUSE);
+  }
+
+  @Test
   public void testProperPortAdvertisement() throws Exception {
 
     try (AccumuloClient client = Accumulo.newClient().from(getClientProperties()).build()) {
@@ -328,5 +371,62 @@ public class GarbageCollectorIT extends ConfigurableMacBase {
         bw.addMutation(delFlag);
       }
     }
+  }
+
+  private void createAndDeleteUniqueMutation(TableId tableId, Ample.GcCandidateType type) {
+    Ample ample = cluster.getServerContext().getAmple();
+    DataLevel datalevel = Ample.DataLevel.of(tableId);
+
+    // Ensure that no other candidates exist before starting test.
+    List<GcCandidate> candidates = new ArrayList<>();
+    Iterator<GcCandidate> candidate = ample.getGcCandidates(datalevel);
+
+    while (candidate.hasNext()) {
+      GcCandidate cTemp = candidate.next();
+      log.debug("PreExisting Candidate Found: {}", cTemp);
+      candidates.add(cTemp);
+    }
+    assertTrue(candidates.size() == 0);
+
+    // Create multiple candidate entries
+    List<StoredTabletFile> stfs = Stream
+        .of(new StoredTabletFile("hdfs://foo.com:6000/user/foo/tables/a/t-0/F00.rf"),
+            new StoredTabletFile("hdfs://foo.com:6000/user/foo/tables/b/t-0/F00.rf"))
+        .collect(Collectors.toList());
+
+    log.debug("Adding candidates to table {}", tableId);
+    ample.putGcCandidates(tableId, stfs);
+    // Retrieve new entries.
+    candidate = ample.getGcCandidates(datalevel);
+
+    while (candidate.hasNext()) {
+      GcCandidate cTemp = candidate.next();
+      log.debug("Candidate Found: {}", cTemp);
+      candidates.add(cTemp);
+    }
+    assertTrue(candidates.size() == 2);
+
+    GcCandidate deleteCandidate = candidates.get(0);
+    assertNotNull(deleteCandidate);
+    ample.putGcCandidates(tableId, List.of(new StoredTabletFile(deleteCandidate.getPath())));
+
+    log.debug("Deleting Candidate {}", deleteCandidate);
+    ample.deleteGcCandidates(datalevel, List.of(deleteCandidate), Ample.GcCandidateType.INUSE);
+
+    candidate = ample.getGcCandidates(datalevel);
+
+    int counter = 0;
+    boolean foundNewCandidate = false;
+    while (candidate.hasNext()) {
+      GcCandidate gcC = candidate.next();
+      log.debug("Candidate Found: {}", gcC);
+      if (gcC.getPath().equals(deleteCandidate.getPath())) {
+        assertTrue(!Objects.equals(gcC.getUid(), deleteCandidate.getUid()));
+        foundNewCandidate = true;
+      }
+      counter++;
+    }
+    assertTrue(counter == 2);
+    assertTrue(foundNewCandidate);
   }
 }


### PR DESCRIPTION
The current GC behavior does not remove InUse candidates and would spend subsequent runs processing and discarding the same InUse Candidates in each batch size.

This is inefficient and can lead to unnecessarily long GC run times in high-load system environments.

This change adds the ability to remove Garbage Collection Candidates that still have matching tablet references.

A new class called GcCandidate and a GcCandidateType Enum have been added. The new GcCandidate type values are "VALID, INUSE, and INVALID". 

A new property has been added called `GC_REMOVE_IN_USE_CANDIDATES` which controls if the garbage collector deletes the InUse candidates.

This property is disabled by default to ensure that existing behavior is not changed. 

Additional tests have been added to the GarbageCollectorIT and GarbageCollectionTest classes.

This PR contains the relevant changes for the 2.1.x branch . 
Supporting removal of InUse candidates for the Root table breaks version compatibility for 2.1.x, so that work has been targeted for a 3.1.x release. 

Once the 3.1.x work is completed #3693 can be closed. 