### PR TITLE
WIP: Separate file deletions from standard GC logs.

### DIFF
--- a/assemble/conf/log4j2-service.properties
+++ b/assemble/conf/log4j2-service.properties
@@ -84,8 +84,20 @@ logger.accumulo.level = debug
 #logger.audit.additivity = false
 #logger.audit.appenderRef.audit.ref = AuditLogFiles
 
+appender.files.type = File
+appender.files.name = FileActionsLogFiles
+appender.files.fileName = ${filename}-file-actions.log
+appender.files.layout.type = PatternLayout
+appender.files.layout.pattern = %d{ISO8601} [%-8c{2}] %-5p: %m%n
+
+logger.gcFiles = DEBUG, files
+logger.gcFiles.level = debug
+logger.gcFiles.name = org.apache.accumulo.gc.files
+logger.gcFiles.app.appenderRef.files.ref = FileActionsLogFiles
+
 rootLogger.level = info
 rootLogger.appenderRef.console.ref = STDERR
 rootLogger.appenderRef.rolling.ref = LogFiles
 rootLogger.appenderRef.monitor.ref = MonitorLog
+rootLogger.appenderRef.gcFiles.ref = FileActionsLogFiles
 

--- a/assemble/conf/log4j2.properties
+++ b/assemble/conf/log4j2.properties
@@ -30,6 +30,17 @@ appender.console.target = SYSTEM_ERR
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %style{%d{ISO8601}}{dim,cyan} %style{[}{red}%style{%-8c{2}}{dim,blue}%style{]}{red} %highlight{%-5p}%style{:}{red} %m%n
 
+appender.files.type = File
+appender.files.name = FileActionsLogFiles
+appender.files.fileName = gc-file-actions.log
+appender.files.layout.type = PatternLayout
+appender.files.layout.pattern = %d{ISO8601} [%-8c{2}] %-5p: %m%n
+
+logger.gcFiles = DEBUG, files
+logger.gcFiles.level = debug
+logger.gcFiles.name = org.apache.accumulo.gc.files
+logger.gcFiles.app.appenderRef.files.ref = FileActionsLogFiles
+
 logger.shellaudit.name = org.apache.accumulo.shell.Shell.audit
 logger.shellaudit.level = warn
 

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
@@ -51,6 +51,7 @@ import org.apache.accumulo.core.fate.zookeeper.ZooReader;
 import org.apache.accumulo.core.gc.Reference;
 import org.apache.accumulo.core.gc.ReferenceDirectory;
 import org.apache.accumulo.core.gc.ReferenceFile;
+import org.apache.accumulo.core.logging.Logging;
 import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
@@ -88,6 +89,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
  */
 public class GCRun implements GarbageCollectionEnvironment {
   private final Logger log;
+  private final Logger fileLog;
   private final Ample.DataLevel level;
   private final ServerContext context;
   private final AccumuloConfiguration config;
@@ -98,6 +100,9 @@ public class GCRun implements GarbageCollectionEnvironment {
 
   public GCRun(Ample.DataLevel level, ServerContext context) {
     this.log = LoggerFactory.getLogger(level.name() + GCRun.class);
+    // Create a new file logger for only the file actions
+    // prefix: org.apache.accumulo.gc.files
+    this.fileLog = LoggerFactory.getLogger(Logging.PREFIX + "gc.files");
     this.level = level;
     this.context = context;
     this.config = context.getConfiguration();
@@ -236,17 +241,17 @@ public class GCRun implements GarbageCollectionEnvironment {
       System.out.println("SAFEMODE: There are " + confirmedDeletes.size()
           + " data file candidates marked for deletion in " + metadataLocation + ".\n"
           + "          Examine the log files to identify them.\n");
-      log.info("SAFEMODE: Listing all data file candidates for deletion");
+      fileLog.info("SAFEMODE: Listing all data file candidates for deletion");
       for (String s : confirmedDeletes.values()) {
-        log.info("SAFEMODE: {}", s);
+        fileLog.info("SAFEMODE: {}", s);
       }
-      log.info("SAFEMODE: End candidates for deletion");
+      fileLog.info("SAFEMODE: End candidates for deletion");
       return;
     }
 
     List<String> processedDeletes = Collections.synchronizedList(new ArrayList<>());
 
-    minimizeDeletes(confirmedDeletes, processedDeletes, fs, log);
+    minimizeDeletes(confirmedDeletes, processedDeletes, fs, fileLog);
 
     ExecutorService deleteThreadPool = ThreadPools.getServerThreadPools()
         .createExecutorService(config, Property.GC_DELETE_THREADS, false);
@@ -271,14 +276,15 @@ public class GCRun implements GarbageCollectionEnvironment {
             // uses suffixes to compare delete entries, there is no danger
             // of deleting something that should not be deleted. Must not change value of delete
             // variable because that's what's stored in metadata table.
-            log.debug("Volume replaced {} -> {}", delete, switchedDelete);
+            fileLog.debug("Volume replaced {} -> {}", delete, switchedDelete);
             fullPath = ValidationUtil.validate(switchedDelete);
           } else {
             fullPath = new Path(ValidationUtil.validate(delete));
           }
 
           for (Path pathToDel : GcVolumeUtil.expandAllVolumesUri(fs, fullPath)) {
-            log.debug("Deleting {}", pathToDel);
+
+            fileLog.debug("Deleting {}", pathToDel);
 
             if (moveToTrash(pathToDel) || fs.deleteRecursively(pathToDel)) {
               // delete succeeded, still want to delete
@@ -288,7 +294,7 @@ public class GCRun implements GarbageCollectionEnvironment {
               // leave the entry in the metadata; we'll try again later
               removeFlag = false;
               errors++;
-              log.warn("File exists, but was not deleted for an unknown reason: {}", pathToDel);
+              fileLog.warn("File exists, but was not deleted for an unknown reason: {}", pathToDel);
               break;
             } else {
               // this failure, we still want to remove the metadata entry
@@ -303,11 +309,11 @@ public class GCRun implements GarbageCollectionEnvironment {
                 if (tableState != null && tableState != TableState.DELETING) {
                   // clone directories don't always exist
                   if (!tabletDir.startsWith(Constants.CLONE_PREFIX)) {
-                    log.debug("File doesn't exist: {}", pathToDel);
+                    fileLog.debug("File doesn't exist: {}", pathToDel);
                   }
                 }
               } else {
-                log.warn("Very strange path name: {}", delete);
+                fileLog.warn("Very strange path name: {}", delete);
               }
             }
           }
@@ -318,7 +324,7 @@ public class GCRun implements GarbageCollectionEnvironment {
             processedDeletes.add(delete);
           }
         } catch (Exception e) {
-          log.error("{}", e.getMessage(), e);
+          fileLog.error("{}", e.getMessage(), e);
         }
 
       };
@@ -332,7 +338,7 @@ public class GCRun implements GarbageCollectionEnvironment {
       while (!deleteThreadPool.awaitTermination(1000, TimeUnit.MILLISECONDS)) { // empty
       }
     } catch (InterruptedException e1) {
-      log.error("{}", e1.getMessage(), e1);
+      fileLog.error("{}", e1.getMessage(), e1);
     }
 
     context.getAmple().deleteGcCandidates(level, processedDeletes);
@@ -353,7 +359,7 @@ public class GCRun implements GarbageCollectionEnvironment {
 
       if (tabletDirs.length == 0) {
         Path p = new Path(dir + "/" + tableID);
-        log.debug("Removing table dir {}", p);
+        fileLog.debug("Removing table dir {}", p);
         if (!moveToTrash(p)) {
           fs.delete(p);
         }

--- a/server/gc/src/test/resources/log4j2-test.properties
+++ b/server/gc/src/test/resources/log4j2-test.properties
@@ -27,6 +27,16 @@ appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{ISO8601} [%-8c{2}] %-5p: %m%n
 
+appender.files.type = File
+appender.files.name = FileActionsLogFiles
+appender.files.fileName = ${filename}-file-actions.log
+appender.files.layout.type = PatternLayout
+appender.files.layout.pattern = %d{ISO8601} [%-8c{2}] %-5p: %m%n
+
+logger.gcFiles = DEBUG, files
+logger.gcFiles.name = org.apache.accumulo.gc.files
+logger.gcFiles.app.appenderRef.files.ref = FileActionsLogFiles
+
 logger.01.name = org.apache.hadoop.util.NativeCodeLoader
 logger.01.level = error
 

--- a/server/gc/src/test/resources/log4j2-test.properties
+++ b/server/gc/src/test/resources/log4j2-test.properties
@@ -29,11 +29,12 @@ appender.console.layout.pattern = %d{ISO8601} [%-8c{2}] %-5p: %m%n
 
 appender.files.type = File
 appender.files.name = FileActionsLogFiles
-appender.files.fileName = ${filename}-file-actions.log
+appender.files.fileName = ./target/gc-file-actions.log
 appender.files.layout.type = PatternLayout
 appender.files.layout.pattern = %d{ISO8601} [%-8c{2}] %-5p: %m%n
 
 logger.gcFiles = DEBUG, files
+logger.gcFiles.level = debug
 logger.gcFiles.name = org.apache.accumulo.gc.files
 logger.gcFiles.app.appenderRef.files.ref = FileActionsLogFiles
 


### PR DESCRIPTION
Adds separate file logger for the GC to group file actions for troubleshooting.
Adds appender to log4j-test properties to try filtering the log messages to a separate file log.

Goal is to generate a new log file when running the IT `org.apache.accumulo.test.functional.GarbageCollectorIT` that only contains messages related to file deletions.
