### PR TITLE
Add Message Prefix for File deletion actions in GCRun

### DIFF
--- a/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
@@ -97,7 +97,7 @@ public class GCRun implements GarbageCollectionEnvironment {
   private long errors = 0;
 
   public GCRun(Ample.DataLevel level, ServerContext context) {
-    this.log = LoggerFactory.getLogger(level.name() + GCRun.class);
+    this.log = LoggerFactory.getLogger(GCRun.class.getName() + level.name());
     this.level = level;
     this.context = context;
     this.config = context.getConfiguration();

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
@@ -321,7 +321,7 @@ public class GCRun implements GarbageCollectionEnvironment {
             processedDeletes.add(delete);
           }
         } catch (Exception e) {
-          log.error("{} {}", fileActionPrefix, e.getMessage(), e);
+          log.error("{} Exception while deleting files ", fileActionPrefix, e);
         }
 
       };

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
@@ -99,7 +99,7 @@ public class GCRun implements GarbageCollectionEnvironment {
   private long errors = 0;
 
   public GCRun(Ample.DataLevel level, ServerContext context) {
-    this.log = LoggerFactory.getLogger(GCRun.class.getName() + level.name());
+    this.log = LoggerFactory.getLogger(GCRun.class.getName() + "." + level.name());
     this.level = level;
     this.context = context;
     this.config = context.getConfiguration();

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
@@ -89,7 +89,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 public class GCRun implements GarbageCollectionEnvironment {
   // loggers are not static to support unique naming by level
   private final Logger log;
-  private static String fileActionPrefix = "FILE-ACTION:";
+  private static final String fileActionPrefix = "FILE-ACTION:";
   private final Ample.DataLevel level;
   private final ServerContext context;
   private final AccumuloConfiguration config;

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
@@ -310,7 +310,7 @@ public class GCRun implements GarbageCollectionEnvironment {
                   }
                 }
               } else {
-                log.warn("{} Very strange path name: {}", fileActionPrefix, delete);
+                log.warn("{} Invalid file path format: {}", fileActionPrefix, delete);
               }
             }
           }

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
@@ -87,6 +87,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
  * A single garbage collection performed on a table (Root, MD) or all User tables.
  */
 public class GCRun implements GarbageCollectionEnvironment {
+  // loggers are not static to support unique naming by level
   private final Logger log;
   private final Logger fileLog;
   private final Ample.DataLevel level;


### PR DESCRIPTION
<details>
  <summary>Original Ticket Contents</summary>

This change allows easy logging targeting by putting all file deletion actions into a separate logger.

* Adds a separate file logger to GCRun to allow for easy filtering of file deletion log messages.
* Fixes #3744 by changing how the standard logger is created.
* Moves datalevel to the end of the logger name. 

This approach was chosen because log4j2 regexFilters only work against the message body.
That solution would work as long as log messages were written in a specific format with no validation.
By using a completely separate logger, the contents of the log message don't matter.
Instead, as long as the correct logger is used, the contents can be targeted fairly easily.

This logger is created under the existing GCRun prefix, so any logging targeting the GCRun class should still work.
</details>


This change allows easy logging targeting by grouping all file deletion actions under a common prefix.
Adding a message prefix is a much smaller scoped change that is better suited to a 2.1.x release. 

* Adds a message prefix to specific log messages in GCRun to allow for easy targeting.
* Fixes #3744 by changing how the standard logger is created.
* Moves datalevel to the end of the logger name. 

**How to Test** 

I added the following changes to the `test/src/main/resources/log4j2-test.properties` file. 

<details>
  <summary>Original Test Contents</summary>

These changes setup a separate appender, then create 3 specific loggers to pull those file deletion messages together.

```
appender.files.type = RollingFile
appender.files.name = FileActionsLogFiles
appender.files.fileName = ./target/test-gc-file-actions.log
appender.files.filePattern = ${filesFilename}-%d{MM-dd-yy-HH}-%i.log.gz
appender.files.layout.type = PatternLayout
appender.files.layout.pattern = %d{ISO8601} [%c{2}] %-5p: %m%n
appender.files.policies.type = Policies
appender.files.policies.time.type = TimeBasedTriggeringPolicy
appender.files.policies.time.interval = 1
appender.files.policies.time.modulate = true
appender.files.policies.size.type = SizeBasedTriggeringPolicy
appender.files.policies.size.size=100MB
appender.files.strategy.type = DefaultRolloverStrategy
appender.files.strategy.max = 10


logger.gcFiles1.name = org.apache.accumulo.gc.GCRunROOT.files
logger.gcFiles1.level = debug
logger.gcFiles1.additivity = false
logger.gcFiles1.appenderRef.files.ref = FileActionsLogFiles

logger.gcFiles2.name = org.apache.accumulo.gc.GCRunMETADATA.files
logger.gcFiles2.level = debug
logger.gcFiles2.additivity = false
logger.gcFiles2.appenderRef.files.ref = FileActionsLogFiles

logger.gcFiles3.name = org.apache.accumulo.gc.GCRunUSER.files
logger.gcFiles3.level = debug
logger.gcFiles3.additivity = false
logger.gcFiles3.appenderRef.files.ref = FileActionsLogFiles
```
</details> 

These changes create a new appender with a regex filter set to deny message that don't match "FILE-ACTIONS:" 

```
appender.files.type = RollingFile
appender.files.name = FileActionsLogFiles
appender.files.fileName = ./target/test-gc-file-actions.log
appender.files.filePattern = ${filesFilename}-%d{MM-dd-yy-HH}-%i.log.gz
appender.files.layout.type = PatternLayout
appender.files.layout.pattern = %d{ISO8601} [%c{2}] %-5p: %m%n
appender.files.policies.type = Policies
appender.files.policies.time.type = TimeBasedTriggeringPolicy
appender.files.policies.time.interval = 1
appender.files.policies.time.modulate = true
appender.files.policies.size.type = SizeBasedTriggeringPolicy
appender.files.policies.size.size=100MB
appender.files.filter.1.type = RegexFilter
appender.files.filter.1.regex = .*(FILE-ACTION:).*
appender.files.filter.1.onMatch = ACCEPT
appender.files.filter.1.onMismatch = DENY
appender.files.strategy.type = DefaultRolloverStrategy
appender.files.strategy.max = 10
```

Then the appender is added to the rootLogger

```
rootLogger.level = debug
rootLogger.appenderRef.console.ref = STDOUT
rootLogger.appenderRef.files.ref = FileActionsLogFiles
```


When running the `org.apache.accumulo.test.functional.GarbageCollectorIT`, from the root of the repo directory, the file `test/target/test-gc-actions.log` is created and contains the file deletion messages from the GC. 

```
:2023-09-07T20:51:42,841 [gc.GCRunROOT] DEBUG: FILE-ACTION: Deleting file:/data/workspace/accumulo/test/target/mini-tests/org.apache.accumulo.test.functional.GarbageCollectorIT_gcTest/accumulo/tables/+r/root_tablet/F000005y.rf
15:2023-09-07T20:51:42,913 [gc.GCRunMETADATA] DEBUG: FILE-ACTION: Deleting file:/data/workspace/accumulo/test/target/mini-tests/org.apache.accumulo.test.functional.GarbageCollectorIT_gcTest/accumulo/tables/!0/table_info/0_1.rf
16:2023-09-07T20:51:42,915 [gc.GCRunMETADATA] DEBUG: FILE-ACTION: Deleting file:/data/workspace/accumulo/test/target/mini-tests/org.apache.accumulo.test.functional.GarbageCollectorIT_gcTest/accumulo/tables/!0/table_info/A000000e.rf
```

The file deletions are also still present in the main `SimpleGarbageCollector_<id>.out` logs