### PR TITLE
fixes bug where lock is not unlocked on exception

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
@@ -341,6 +341,8 @@ class DatafileManager {
     metadataUpdateCount.updateAndGet(MetadataUpdateCount::incrementStart);
     // do not place any code here between above stmt and following try{}finally
     try {
+      tablet.getLogLock().lock();
+      // do not place any code here between lock and try
       try {
         // The following call pairs with tablet.finishClearingUnusedLogs() in the finally block. If
         // moving where the following method is called, examine it and finishClearingUnusedLogs()
@@ -391,8 +393,10 @@ class DatafileManager {
                 status);
           }
         }
-      } finally {
+
         tablet.finishClearingUnusedLogs();
+      } finally {
+        tablet.getLogLock().unlock();
       }
 
       do {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
@@ -341,9 +341,12 @@ class DatafileManager {
     metadataUpdateCount.updateAndGet(MetadataUpdateCount::incrementStart);
     // do not place any code here between above stmt and following try{}finally
     try {
-      Set<String> unusedWalLogs = tablet.beginClearingUnusedLogs();
-      // do not place any code here between above stmt and following try{}finally
       try {
+        // The following call pairs with tablet.finishClearingUnusedLogs() in the finally block. If
+        // moving where the following method is called, examine it and finishClearingUnusedLogs()
+        // before moving.
+        Set<String> unusedWalLogs = tablet.beginClearingUnusedLogs();
+
         // the order of writing to metadata and walog is important in the face of machine/process
         // failures need to write to metadata before writing to walog, when things are done in the
         // reverse order data could be lost... the minor compaction start even should be written

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
@@ -344,7 +344,7 @@ class DatafileManager {
       tablet.getLogLock().lock();
       // do not place any code here between lock and try
       try {
-        // The following call pairs with tablet.finishClearingUnusedLogs() in the finally block. If
+        // The following call pairs with tablet.finishClearingUnusedLogs() later in this block. If
         // moving where the following method is called, examine it and finishClearingUnusedLogs()
         // before moving.
         Set<String> unusedWalLogs = tablet.beginClearingUnusedLogs();


### PR DESCRIPTION
The tablet code was structured in such a way that an exception could leave a lock related to write ahead logs locked forever.  This change does two things to fix this.

 * In Tablet.beginClearingUnusedLogs() the lock is released on exception.
 * In DatafileManager.bringMinorCompactionOnline() the call to Tablet.beginClearingUnusedLogs() is moved to be immediately before the try{}finally{} that releases the lock.