### PR TITLE
reverts changes from #3747 that caused tablet split to fail

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
@@ -341,9 +341,8 @@ class DatafileManager {
     metadataUpdateCount.updateAndGet(MetadataUpdateCount::incrementStart);
     // do not place any code here between above stmt and following try{}finally
     try {
-      // Can not hold tablet lock while acquiring the log lock. The following check is there to
-      // prevent deadlock.
-      Preconditions.checkState(!Thread.holdsLock(this));
+      // Should not hold the tablet lock while trying to acquire the log lock because this could
+      // lead to deadlock. However there is a path in the code that does this. See #3759
       tablet.getLogLock().lock();
       // do not place any code here between lock and try
       try {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -1957,9 +1957,8 @@ public class Tablet extends TabletBase {
 
     boolean releaseLock = true;
 
-    // Can not hold tablet lock while acquiring the log lock. The following check is there to
-    // prevent deadlock.
-    Preconditions.checkState(!Thread.holdsLock(this));
+    // Should not hold the tablet lock while trying to acquire the log lock because this could lead
+    // to deadlock. However there is a path in the code that does this. See #3759
     logLock.lock();
 
     try {


### PR DESCRIPTION
Reverts a validation to prevent deadlock that was being covered by the code path to close a tablet.  #3759 was opened to investigate this. This commit removes the new check as the code path that could cause deadlock has existed for a long time and may never actually cause deadlock.

fixes #3757