### PR TITLE
System-wide alert on all monitor pages

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/css/screen.css
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/css/screen.css
@@ -325,6 +325,7 @@ pre.logevent {
 }
 
 .icon-dot {
+  position: relative;
   display: inline-block;
   min-width: 1em;
   height: 1em;
@@ -335,6 +336,15 @@ pre.logevent {
   border-radius: 1em;
 }
 
+.icon-dot.special::before {
+  content: "\26A0"; /* Unicode character for warning symbol */
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 1;
+  color: #000000;
+}
 
 
 .smalltext {

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
@@ -191,6 +191,7 @@ function refreshSidebar() {
  */
 function refreshNavBar() {
   refreshSidebar();
+  updateSystemAlerts();
 }
 
 /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/systemAlert.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/systemAlert.js
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+"use strict";
+
+/**
+ * Add new system-wide messages to this object
+ * 
+ * message: the message to display within the alert banner
+ * id: short string used to identify the message
+ * alertClass: the bootstrap class for which alert style to apply
+ * notificationClass: the color class to apply to the status notification in the navbar
+ */
+const alertMap = {
+  CLEAN_STOP: {
+    message: "The manager state is in CLEAN_STOP.",
+    id: "cleanStop",
+    alertClass: "alert-danger",
+    notifcationClass: "error"
+  },
+  SAFE_MODE: {
+    message: "The manager is in SAFE_MODE.",
+    id: "safeMode",
+    alertClass: "alert-warning",
+    notifcationClass: "warning"
+  }
+};
+
+/**
+ * Idempotently append an alert message
+ */
+function appendAlertMessage(alertInfo) {
+  if (alertInfo && $('#' + alertInfo.id).length === 0) {
+    const li = $('<li></li>').text(alertInfo.message).attr('id', alertInfo.id);
+    $("#alertMessages").append(li);
+  }
+}
+
+function removeAlertMessage(alertInfo) {
+  if (alertInfo) {
+    $('#' + alertInfo.id).remove();
+  }
+}
+
+function setAlertClass(alertClass) {
+  $("#systemAlert").removeClass("alert-warning alert-danger").addClass(alertClass);
+}
+
+function setNotificationClass(notifcationClass) {
+  $("#alertStatus").removeClass("warning error").addClass(notifcationClass);
+}
+
+function showAlert() {
+  $("#systemAlert").show();
+  $("#alertStatus").show();
+}
+
+function hideAlert() {
+  $("#systemAlert").hide();
+  $("#alertStatus").hide();
+}
+
+/**
+ * Appends or removes an alert message based on the provided parameters.
+ *
+ * @param {string} alertType - Specifies the type of alert. Should match keys in the alertMap object (e.g., 'CLEAN_STOP', 'SAFE_MODE').
+ * @param {string} operation - Specifies the operation to perform on the alert. Accepted values are 'apply' to apply the alert or 'remove' to remove it.
+ */
+function handleAlert(alertType, operation) {
+  const alertInfo = alertMap[alertType];
+  if (operation === 'apply') {
+    appendAlertMessage(alertInfo);
+    setAlertClass(alertInfo.alertClass);
+    setNotificationClass(alertInfo.notifcationClass);
+    showAlert();
+  } else if (operation === 'remove') {
+    removeAlertMessage(alertInfo);
+    // Check if there are any more list items left. If none, hide the alert.
+    if ($("#alertMessages").children().length === 0) {
+      hideAlert();
+    }
+  } else {
+    console.error('Alert operation not recognized')
+  }
+}
+
+function updateManagerAlerts() {
+  getManager().then(function () {
+
+    // gather information about the manager
+    const managerData = JSON.parse(sessionStorage.manager);
+    const managerState = managerData.managerState;
+    const managerGoalState = managerData.managerGoalState;
+
+    const isSafeMode = managerState === 'SAFE_MODE' || managerGoalState === 'SAFE_MODE';
+    const isCleanStop = managerState === 'CLEAN_STOP' || managerGoalState === 'CLEAN_STOP';
+
+    handleAlert('SAFE_MODE', 'remove');
+    handleAlert('CLEAN_STOP', 'remove');
+
+    if (isCleanStop) {
+      handleAlert('CLEAN_STOP', 'apply');
+    } else if (isSafeMode) {
+      handleAlert('SAFE_MODE', 'apply');
+    }
+  })
+}
+
+/**
+ * Pulls the neccesarry data then refreshes the system wide alert banner and status notification
+ */
+function updateSystemAlerts() {
+  updateManagerAlerts();
+}
+
+$(document).ready(function () {
+  updateSystemAlerts();
+});

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/default.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/default.ftl
@@ -66,12 +66,14 @@
       <script src="/resources/js/${js}"></script>
     </#if>
     <script src="/resources/js/navbar.js"></script>
+    <script src="/resources/js/systemAlert.js"></script>
   </head>
 
   <body>
     <#include "navbar.ftl">
 
     <div id="main" class="container-fluid">
+      <#include "systemAlert.ftl">
       <#include "${template}">
     </div>
 

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/navbar.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/navbar.ftl
@@ -31,6 +31,9 @@
         </div>
         <div class="collapse navbar-collapse" id="nav-items">
           <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
+            <li class="navbar-text px-2">
+              <span id="alertStatus" class="icon-dot special" title="System-wide alert. See top of page." style="display: none;"></span>
+            </li>
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                 <span id="statusNotification" class="icon-dot normal"></span>&nbspServers

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/systemAlert.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/systemAlert.ftl
@@ -1,0 +1,27 @@
+<#--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<div id="systemAlert" class="alert" style="display: none;" role="alert">
+    <h4>System-wide Notifications</h4>
+    <hr>
+    <ul id="alertMessages">
+        <!-- Messages will be appended here -->
+    </ul>
+</div>


### PR DESCRIPTION
This PR adds an alert that appears on the top of every page in the monitor when there is a system-wide message. The only cases where this alert appears right now is when the manager is in a non-normal state. The code is extensible and if other cases are added in the future they can be added to the code. The alert allows for multiple messages at a time and will append them to a list in the alert. Along with the alert banner, a new status notification was added to the navbar which on hover will say that an alert is present and to see the top of the page.

Here is a screen recording where the system was in a normal state, then I switched the manager to `SAFE_MODE` and then to `CLEAN_STOP`. Its not shown in the recording but once the manager shuts down, the alert disapears.
![full](https://github.com/apache/accumulo/assets/47725857/e30819bd-6c15-4447-b3f9-925243ff50bf)
