### PR TITLE
update test to handle connect error when tserver killed

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -1020,6 +1020,9 @@ public class Manager extends AbstractServer
             }
             badServers.remove(server);
           }
+          log.debug("communication error count: {} of {} attempts for server {}",
+              badServers.getOrDefault(server, new AtomicInteger(-1)).get(), MAX_BAD_STATUS_COUNT,
+              server);
         }
       });
     }


### PR DESCRIPTION
Adds a check in the test when trying to read the from `TabletStateStore` iterator.  

Upfront, this seems to fix the test.  An alternative would be to handle the connection failure on the `TabletStateStore` implementations side of things.  Changing the test seems like fixing it "on the client side" and I am unsure if it may be preferable to handle it "on the server side".   The situation in the test is triggering a server failure to force table reassignments.  If the connection error is seen when reading values so the test knows when to proceed and specific to the test, then modifying the test seems the best approach.  However, if this is a more generic exception handling situation for a server that dies, then it may be better to strengthen the TabletStateStore implementations.  Currently only this test seems to be triggering the connection error / failure.  (This also may be a timing issue with the dead server check and the way the test is using it)

The change tries to get the TabletStateStore iterator, catching any Exception and retrying until the store is available.  The issue is caused when trying to talk with a recently kill server. When the tserver is killed, by design as part of the test, occasionally the TabletStateStore iterator will see an exception that the socket is closed.  The exception thrown is an EOFException, wrapped in a RuntimeException.

With the test code changes:

```
2023-09-22T17:20:09,789 [functional.ConfigurableMacBase] DEBUG: Failed to get TabletStateStore iterator - will retry
java.lang.RuntimeException: java.io.EOFException: Socket is closed by peer.
        at org.apache.accumulo.core.clientImpl.TabletServerBatchReaderIterator.hasNext(TabletServerBatchReaderIterator.java:198) ~[accumulo-core-2.1.3-SNAPSHOT.jar:2.1.3-SNAPSHOT]
        at org.apache.accumulo.server.manager.state.MetaDataTableScanner.hasNext(MetaDataTableScanner.java:125) ~[accumulo-server-base-2.1.3-SNAPSHOT.jar:2.1.3-SNAPSHOT]
        at org.apache.accumulo.test.ManagerRepairsDualAssignmentIT.test(ManagerRepairsDualAssignmentIT.java:120) ~[classes/:?]

```

Catching the exception allows the test to continue.  There is a background thread that results in 

```
2023-09-22T17:20:10,800 [rpc.ThriftUtil] WARN : Failed to open transport to ip-xx-xx-xx-xx:45665
2023-09-22T17:20:10,905 [rpc.ThriftUtil] WARN : Failed to open transport to ip-xx-xx-xx-xx:45665
2023-09-22T17:20:10,909 [rpc.ThriftUtil] WARN : Failed to open transport to ip-xx-xx-xx-xx:45665
```

Once that clears (I'm assuming that it eventually finds the remaining running server) the test seems to pass reliably. I have not seen a case where the retry is attempted more than once.

If this is the correct way to fix the test, this fixes #3762  
