### PR TITLE
Count dead tservers to continue in ManagerRepairsDualAssignmentIT

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/ManagerRepairsDualAssignmentIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ManagerRepairsDualAssignmentIT.java
@@ -105,6 +105,7 @@ public class ManagerRepairsDualAssignmentIT extends ConfigurableMacBase {
       assertEquals(2, states.size());
       int deadCount = getZkDeadCount(cluster.getServerContext().getZooReader(),
           cluster.getServerContext().getInstanceID());
+      assertEquals(0, deadCount, "expect no dead servers at start");
       // Kill a tablet server... we don't care which one... wait for everything to be reassigned
       cluster.killProcess(ServerType.TABLET_SERVER,
           cluster.getProcesses().get(ServerType.TABLET_SERVER).iterator().next());

--- a/test/src/main/java/org/apache/accumulo/test/ManagerRepairsDualAssignmentIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ManagerRepairsDualAssignmentIT.java
@@ -132,7 +132,7 @@ public class ManagerRepairsDualAssignmentIT extends ConfigurableMacBase {
             allAssigned = false;
           }
         }
-        log.info(states + "{} size {} allAssigned {}", states, states.size(), allAssigned);
+        log.info("{} size {} allAssigned {}", states, states.size(), allAssigned);
         if (states.size() != 2 && allAssigned) {
           break;
         }


### PR DESCRIPTION
Adds a check that requires an increase in the dead server count after a tserver is killed before proceeding with the test,  This eliminates the closed connection issue seen with reading the `TabletLocationState` as reported in #3762 

This is an alternate implementation for #3771. Only one of these should be merged,

The question in #3771 about strengthening the exception handling in `TabletLocationState` implementation is still open.  it is unclear if the code should to try an handle the EOF exception or to just continue throwing the runtime exception.

This fixes #3762 if implemented.