### PR TITLE
New data version to support no-chop changes, disable upgrade

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/AccumuloDataVersion.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/AccumuloDataVersion.java
@@ -37,6 +37,12 @@ import java.util.Set;
 public class AccumuloDataVersion {
 
   /**
+   * version (12) reflect changes to support no chop merges including json encoding of the file
+   * column family stored in root and metadata tables.
+   */
+  public static final int METADATA_FILE_JSON_ENCODING = 12;
+
+  /**
    * version (11) reflects removal of replication starting with 3.0
    */
   public static final int REMOVE_DEPRECATIONS_FOR_VERSION_3 = 11;
@@ -59,7 +65,7 @@ public class AccumuloDataVersion {
    * <li>version (4) moves logging to HDFS in 1.5.0
    * </ul>
    */
-  private static final int CURRENT_VERSION = REMOVE_DEPRECATIONS_FOR_VERSION_3;
+  private static final int CURRENT_VERSION = METADATA_FILE_JSON_ENCODING;
 
   /**
    * Get the current Accumulo Data Version. See Javadoc of static final integers for a detailed
@@ -71,7 +77,11 @@ public class AccumuloDataVersion {
     return CURRENT_VERSION;
   }
 
-  public static final Set<Integer> CAN_RUN = Set.of(ROOT_TABLET_META_CHANGES, CURRENT_VERSION);
+  // TODO - this is currently set to disable upgrades until metadata file json conversion
+  // implemented
+  // public static final Set<Integer> CAN_RUN = Set.of(REMOVE_DEPRECATIONS_FOR_VERSION_3,
+  // CURRENT_VERSION);
+  public static final Set<Integer> CAN_RUN = Set.of(CURRENT_VERSION);
 
   /**
    * Get the stored, current working version.
@@ -96,6 +106,8 @@ public class AccumuloDataVersion {
         return "2.1.0";
       case REMOVE_DEPRECATIONS_FOR_VERSION_3:
         return "3.0.0";
+      case METADATA_FILE_JSON_ENCODING:
+        return "3.1.0";
     }
     throw new IllegalArgumentException("Unsupported data version " + version);
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/AccumuloDataVersion.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/AccumuloDataVersion.java
@@ -78,8 +78,8 @@ public class AccumuloDataVersion {
   }
 
   // TODO - this disables upgrades until https://github.com/apache/accumulo/issues/3768 is done
-  // public static final Set<Integer> CAN_RUN = Set.of(REMOVE_DEPRECATIONS_FOR_VERSION_3,
-  // CURRENT_VERSION);
+  // public static final Set<Integer> CAN_RUN = Set.of(ROOT_TABLET_META_CHANGES,
+  // REMOVE_DEPRECATIONS_FOR_VERSION_3, CURRENT_VERSION);
   public static final Set<Integer> CAN_RUN = Set.of(CURRENT_VERSION);
 
   /**

--- a/server/base/src/main/java/org/apache/accumulo/server/AccumuloDataVersion.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/AccumuloDataVersion.java
@@ -77,8 +77,7 @@ public class AccumuloDataVersion {
     return CURRENT_VERSION;
   }
 
-  // TODO - this is currently set to disable upgrades until metadata file json conversion
-  // implemented
+  // TODO - this disables upgrades until https://github.com/apache/accumulo/issues/3768 is done
   // public static final Set<Integer> CAN_RUN = Set.of(REMOVE_DEPRECATIONS_FOR_VERSION_3,
   // CURRENT_VERSION);
   public static final Set<Integer> CAN_RUN = Set.of(CURRENT_VERSION);

--- a/server/base/src/test/java/org/apache/accumulo/server/ServerContextTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/ServerContextTest.java
@@ -135,7 +135,9 @@ public class ServerContextTest {
     // ensure this fails with older versions; the oldest supported version is hard-coded here
     // to ensure we don't unintentionally break upgrade support; changing this should be a conscious
     // decision and this check will ensure we don't overlook it
-    final int oldestSupported = AccumuloDataVersion.ROOT_TABLET_META_CHANGES;
+
+    // TODO basically disable check until upgrade to 3.1 is supported.
+    final int oldestSupported = AccumuloDataVersion.METADATA_FILE_JSON_ENCODING;
     final int currentVersion = AccumuloDataVersion.get();
     IntConsumer shouldPass = ServerContext::ensureDataVersionCompatible;
     IntConsumer shouldFail = v -> assertThrows(IllegalStateException.class,

--- a/server/base/src/test/java/org/apache/accumulo/server/ServerContextTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/ServerContextTest.java
@@ -136,7 +136,8 @@ public class ServerContextTest {
     // to ensure we don't unintentionally break upgrade support; changing this should be a conscious
     // decision and this check will ensure we don't overlook it
 
-    // TODO basically disable check until upgrade to 3.1 is supported.
+    // TODO basically disable check until upgrade to 3.1 is supported. Should be:
+    // final int oldestSupported = AccumuloDataVersion.ROOT_TABLET_META_CHANGES;
     final int oldestSupported = AccumuloDataVersion.METADATA_FILE_JSON_ENCODING;
     final int currentVersion = AccumuloDataVersion.get();
     IntConsumer shouldPass = ServerContext::ensureDataVersionCompatible;


### PR DESCRIPTION
Adds a new Accumulo data version (12) to reflect no-chop changes that encode the metadata file entries in json to support fencing.  

The json file entries are incompatible with metadata file entries prior to 3.1.  Until the upgrade code is implemented trying to upgrade from a previous version will fail.  This change makes it explicit why.

For example, with this change, trying to upgrade from a 2.1.x will include the following in the manager log. 

```
2023-09-26T14:34:03,211 [start.Main] ERROR: Thread 'manager' died.
java.lang.IllegalStateException: This version of accumulo (3.1.0-SNAPSHOT) is not compatible with files stored using data version 10. Please upgrade from 3.1.0 or later.
        at org.apache.accumulo.server.ServerContext.ensureDataVersionCompatible(ServerContext.java:308) ~[accumulo-server-base-3.1.0-SNAPSHOT.jar:3.1.0-SNAPSHOT]

```

This is a preliminary step towards full implementation of #3768 - but will not close it.