### PR TITLE
removes CHOP from CompactionKind SPI type.

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionKind.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionKind.java
@@ -36,10 +36,5 @@ public enum CompactionKind {
   /**
    * A user initiated a one time compaction using an Accumulo client.
    */
-  USER,
-  /**
-   * @deprecated Chop Compactions have been deprecated
-   */
-  @Deprecated(since = "3.1")
-  CHOP
+  USER
 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
@@ -309,8 +309,6 @@ public class CompactableImpl implements Compactable {
           // intentional fall through
         case USER:
           return handleUserSelectorCompaction(currFiles, kind);
-        case CHOP:
-          return Set.of();
         default:
           throw new AssertionError();
       }


### PR DESCRIPTION
This change removes CompactionKind.CHOP from the SPI w/o a deprecation cycle.  This is allowed under the rules for SPI changes.  The rationale for this is if CHOP is left then code will need to be added to Accumulo to avoid its use and fail if it's ever seen.  Also documentation will need to be added to the SPI explaining that Accumulo should never pass CHOP to any plugins ever again that ideally plugins should error if they see it.

Removing it seems like the least confusing option.