### PR TITLE
Fix use of ServiceLockData Optional and nulls

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/lock/ServiceLockData.java
+++ b/core/src/main/java/org/apache/accumulo/core/lock/ServiceLockData.java
@@ -25,6 +25,7 @@ import static org.apache.accumulo.core.util.LazySingletons.GSON;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -164,30 +165,22 @@ public class ServiceLockData implements Comparable<ServiceLockData> {
 
   public String getAddressString(ThriftService service) {
     ServiceDescriptor sd = services.get(service);
-    if (sd == null) {
-      return null;
-    }
-    return sd.getAddress();
+    return sd == null ? null : sd.getAddress();
   }
 
   public HostAndPort getAddress(ThriftService service) {
-    return AddressUtil.parseAddress(getAddressString(service), false);
+    String s = getAddressString(service);
+    return s == null ? null : AddressUtil.parseAddress(s, false);
   }
 
   public String getGroup(ThriftService service) {
     ServiceDescriptor sd = services.get(service);
-    if (sd == null) {
-      return null;
-    }
-    return sd.getGroup();
+    return sd == null ? null : sd.getGroup();
   }
 
   public UUID getServerUUID(ThriftService service) {
     ServiceDescriptor sd = services.get(service);
-    if (sd == null) {
-      return null;
-    }
-    return sd.getUUID();
+    return sd == null ? null : sd.getUUID();
   }
 
   public byte[] serialize() {
@@ -208,10 +201,7 @@ public class ServiceLockData implements Comparable<ServiceLockData> {
 
   @Override
   public boolean equals(Object o) {
-    if (o instanceof ServiceLockData) {
-      return toString().equals(o.toString());
-    }
-    return false;
+    return o instanceof ServiceLockData ? Objects.equals(toString(), o.toString()) : false;
   }
 
   @Override
@@ -224,10 +214,8 @@ public class ServiceLockData implements Comparable<ServiceLockData> {
       return Optional.empty();
     }
     String data = new String(lockData, UTF_8);
-    if (data.isBlank()) {
-      return Optional.empty();
-    }
-    return Optional.of(new ServiceLockData(GSON.get().fromJson(data, ServiceDescriptors.class)));
+    return data.isBlank() ? Optional.empty()
+        : Optional.of(new ServiceLockData(GSON.get().fromJson(data, ServiceDescriptors.class)));
   }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -538,18 +538,11 @@ public class TabletMetadata {
    */
   private static Optional<TServerInstance> checkServer(ClientContext context, String path,
       String zPath) {
-    Optional<TServerInstance> server = Optional.empty();
     final var lockPath = ServiceLock.path(path + "/" + zPath);
     ZooCache.ZcStat stat = new ZooCache.ZcStat();
-    Optional<ServiceLockData> sld = ServiceLock.getLockData(context.getZooCache(), lockPath, stat);
-
-    if (sld.isPresent()) {
-      log.trace("Checking server at ZK path = " + lockPath);
-      HostAndPort client = sld.orElseThrow().getAddress(ServiceLockData.ThriftService.TSERV);
-      if (client != null) {
-        server = Optional.of(new TServerInstance(client, stat.getEphemeralOwner()));
-      }
-    }
-    return server;
+    log.trace("Checking server at ZK path = " + lockPath);
+    return ServiceLock.getLockData(context.getZooCache(), lockPath, stat)
+        .map(sld -> sld.getAddress(ServiceLockData.ThriftService.TSERV))
+        .map(address -> new TServerInstance(address, stat.getEphemeralOwner()));
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/ExternalCompactionUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/ExternalCompactionUtil.java
@@ -36,7 +36,6 @@ import org.apache.accumulo.core.compaction.thrift.CompactorService;
 import org.apache.accumulo.core.fate.zookeeper.ZooReader;
 import org.apache.accumulo.core.fate.zookeeper.ZooSession;
 import org.apache.accumulo.core.lock.ServiceLock;
-import org.apache.accumulo.core.lock.ServiceLockData;
 import org.apache.accumulo.core.lock.ServiceLockData.ThriftService;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
 import org.apache.accumulo.core.rpc.ThriftUtil;
@@ -104,11 +103,8 @@ public class ExternalCompactionUtil {
     try {
       var zk = ZooSession.getAnonymousSession(context.getZooKeepers(),
           context.getZooKeepersSessionTimeOut());
-      Optional<ServiceLockData> sld = ServiceLock.getLockData(zk, ServiceLock.path(lockPath));
-      if (sld.isEmpty()) {
-        return Optional.empty();
-      }
-      return Optional.ofNullable(sld.orElseThrow().getAddress(ThriftService.COORDINATOR));
+      return ServiceLock.getLockData(zk, ServiceLock.path(lockPath))
+          .map(sld -> sld.getAddress(ThriftService.COORDINATOR));
     } catch (KeeperException | InterruptedException e) {
       throw new IllegalStateException(e);
     }

--- a/core/src/test/java/org/apache/accumulo/core/lock/ServiceLockDataTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/lock/ServiceLockDataTest.java
@@ -47,7 +47,7 @@ public class ServiceLockDataTest {
     assertEquals(ServiceDescriptor.DEFAULT_GROUP_NAME, ss.getGroup(ThriftService.TSERV));
     assertNull(ss.getServerUUID(ThriftService.TABLET_SCAN));
     assertNull(ss.getAddressString(ThriftService.TABLET_SCAN));
-    assertThrows(NullPointerException.class, () -> ss.getAddress(ThriftService.TABLET_SCAN));
+    assertNull(ss.getAddress(ThriftService.TABLET_SCAN));
     assertNull(ss.getGroup(ThriftService.TABLET_SCAN));
   }
 
@@ -77,7 +77,7 @@ public class ServiceLockDataTest {
     assertEquals("meta", ss.getGroup(ThriftService.TSERV));
     assertNull(ss.getServerUUID(ThriftService.TABLET_SCAN));
     assertNull(ss.getAddressString(ThriftService.TABLET_SCAN));
-    assertThrows(NullPointerException.class, () -> ss.getAddress(ThriftService.TABLET_SCAN));
+    assertNull(ss.getAddress(ThriftService.TABLET_SCAN));
     assertNull(ss.getGroup(ThriftService.TABLET_SCAN));
   }
 
@@ -90,7 +90,7 @@ public class ServiceLockDataTest {
     assertEquals("meta", ss.getGroup(ThriftService.TSERV));
     assertEquals(serverUUID, ss.getServerUUID(ThriftService.TSERV));
     assertNull(ss.getAddressString(ThriftService.TABLET_SCAN));
-    assertThrows(NullPointerException.class, () -> ss.getAddress(ThriftService.TABLET_SCAN));
+    assertNull(ss.getAddress(ThriftService.TABLET_SCAN));
     assertNull(ss.getGroup(ThriftService.TABLET_SCAN));
   }
 
@@ -111,6 +111,9 @@ public class ServiceLockDataTest {
     assertEquals(HostAndPort.fromString("127.0.0.1:9998"),
         ss.getAddress(ThriftService.TABLET_SCAN));
     assertEquals("ns1", ss.getGroup(ThriftService.TABLET_SCAN));
+    assertNull(ss.getAddressString(ThriftService.COMPACTOR));
+    assertNull(ss.getAddress(ThriftService.COMPACTOR));
+    assertNull(ss.getGroup(ThriftService.COMPACTOR));
   }
 
   @Test


### PR DESCRIPTION
* Simplify ServiceLockData's if conditions in methods that return null
* Ensure ServiceLockData.getAddress() returns null when .getAddressString() returns null
* Handle null toString() in ServiceLockData.equals() using Objects.equals()
* Simplify TabletMetadata.checkServer(), TServerClient.getTabletServerConnection(), ExternalCompactionUtil.findCompactionCoordinator(), LiveTServerSet.checkServer(), and Monitor.fetchGcStatus() by using Optional.map(), Optional.ifPresent(), and Optional.orElse(null)
* Improve Monitor.fetchGcStatus() by short-circuiting the warning and returning null results when the address is null, rather than wait for an exception to be thrown while trying to connect to the service using a null address
* Update ServiceLockDataTest to ensure getAddress() returns null when it's expected to, instead of throwing a NullPointerException

This fixes #3782