### PR TITLE
Revert #3737's EOFException changes

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java
@@ -22,7 +22,6 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-import java.io.EOFException;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.AbstractMap.SimpleImmutableEntry;
@@ -408,8 +407,7 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
             failures.putAll(tsFailures);
           }
         }
-      } catch (EOFException e) {
-        fatalException = e;
+
       } catch (IOException e) {
         if (!TabletServerBatchReaderIterator.this.queryThreadPool.isShutdown()) {
           synchronized (failures) {
@@ -912,13 +910,6 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
     } catch (TTransportException e) {
       log.debug("Server : {} msg : {}", server, e.getMessage());
       timeoutTracker.errorOccured();
-      if (e.getType() == TTransportException.END_OF_FILE) {
-        // END_OF_FILE is used in TEndpointTransport when the
-        // maxMessageSize has been reached.
-        EOFException eof = new EOFException(e.getMessage());
-        eof.addSuppressed(e);
-        throw eof;
-      }
       throw new IOException(e);
     } catch (ThriftSecurityException e) {
       log.debug("Server : {} msg : {}", server, e.getMessage(), e);


### PR DESCRIPTION
This commit partially reverts b1b2557f949e9212a1b1ca9b65f2d66c01a69edb from #3737, to restore the previous infinite retry behavior when an EOFException occurs in the transport. While this EOFException can be an indicator of a fatal exception that should not be retried, it also occurs during transient network failures, where a retry should occur. It is not possible to easily detect which of these two cases is ocurring. Since transient network failures are routine, and the fatal exception that caused the issue that #3737 tried to address has a workaround via configuration, this commit restores the previous behavior that assumes the exception is caused by a transient issue.

This fixes #3762

This fixes the issue in #3762, where the ManagerRepairsDualAssignmentIT intentionally triggered a transient network failure, and therefore triggered a scan to fail, causing the IT as a whole to fail.