### PR TITLE
Bump default Accumulo RPC client to TLSv1.3

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -77,9 +77,10 @@ public enum Property {
       "1.6.0"),
   RPC_SSL_CIPHER_SUITES("rpc.ssl.cipher.suites", "", PropertyType.STRING,
       "Comma separated list of cipher suites that can be used by accepted connections", "1.6.1"),
-  RPC_SSL_ENABLED_PROTOCOLS("rpc.ssl.server.enabled.protocols", "TLSv1.2", PropertyType.STRING,
+  RPC_SSL_ENABLED_PROTOCOLS("rpc.ssl.server.enabled.protocols", "TLSv1.2,TLSv1.3",
+      PropertyType.STRING,
       "Comma separated list of protocols that can be used to accept connections", "1.6.2"),
-  RPC_SSL_CLIENT_PROTOCOL("rpc.ssl.client.protocol", "TLSv1.2", PropertyType.STRING,
+  RPC_SSL_CLIENT_PROTOCOL("rpc.ssl.client.protocol", "TLSv1.3", PropertyType.STRING,
       "The protocol used to connect to a secure server, must be in the list of enabled protocols "
           + "on the server side (rpc.ssl.server.enabled.protocols)",
       "1.6.2"),
@@ -797,8 +798,8 @@ public enum Property {
       "A comma-separated list of disallowed SSL Ciphers, see"
           + " monitor.ssl.include.ciphers to allow ciphers",
       "1.6.1"),
-  MONITOR_SSL_INCLUDE_PROTOCOLS("monitor.ssl.include.protocols", "TLSv1.2", PropertyType.STRING,
-      "A comma-separate list of allowed SSL protocols", "1.5.3"),
+  MONITOR_SSL_INCLUDE_PROTOCOLS("monitor.ssl.include.protocols", "TLSv1.2,TLSv1.3",
+      PropertyType.STRING, "A comma-separate list of allowed SSL protocols", "1.5.3"),
   MONITOR_LOCK_CHECK_INTERVAL("monitor.lock.check.interval", "5s", PropertyType.TIMEDURATION,
       "The amount of time to sleep between checking for the Monitor ZooKeeper lock", "1.5.1"),
   MONITOR_RESOURCES_EXTERNAL("monitor.resources.external", "", PropertyType.STRING,

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -77,7 +77,7 @@ public enum Property {
       "1.6.0"),
   RPC_SSL_CIPHER_SUITES("rpc.ssl.cipher.suites", "", PropertyType.STRING,
       "Comma separated list of cipher suites that can be used by accepted connections", "1.6.1"),
-  RPC_SSL_ENABLED_PROTOCOLS("rpc.ssl.server.enabled.protocols", "TLSv1.2,TLSv1.3",
+  RPC_SSL_ENABLED_PROTOCOLS("rpc.ssl.server.enabled.protocols", "TLSv1.3",
       PropertyType.STRING,
       "Comma separated list of protocols that can be used to accept connections", "1.6.2"),
   RPC_SSL_CLIENT_PROTOCOL("rpc.ssl.client.protocol", "TLSv1.3", PropertyType.STRING,
@@ -798,7 +798,7 @@ public enum Property {
       "A comma-separated list of disallowed SSL Ciphers, see"
           + " monitor.ssl.include.ciphers to allow ciphers",
       "1.6.1"),
-  MONITOR_SSL_INCLUDE_PROTOCOLS("monitor.ssl.include.protocols", "TLSv1.2,TLSv1.3",
+  MONITOR_SSL_INCLUDE_PROTOCOLS("monitor.ssl.include.protocols", "TLSv1.3",
       PropertyType.STRING, "A comma-separate list of allowed SSL protocols", "1.5.3"),
   MONITOR_LOCK_CHECK_INTERVAL("monitor.lock.check.interval", "5s", PropertyType.TIMEDURATION,
       "The amount of time to sleep between checking for the Monitor ZooKeeper lock", "1.5.1"),

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -77,8 +77,7 @@ public enum Property {
       "1.6.0"),
   RPC_SSL_CIPHER_SUITES("rpc.ssl.cipher.suites", "", PropertyType.STRING,
       "Comma separated list of cipher suites that can be used by accepted connections", "1.6.1"),
-  RPC_SSL_ENABLED_PROTOCOLS("rpc.ssl.server.enabled.protocols", "TLSv1.3",
-      PropertyType.STRING,
+  RPC_SSL_ENABLED_PROTOCOLS("rpc.ssl.server.enabled.protocols", "TLSv1.3", PropertyType.STRING,
       "Comma separated list of protocols that can be used to accept connections", "1.6.2"),
   RPC_SSL_CLIENT_PROTOCOL("rpc.ssl.client.protocol", "TLSv1.3", PropertyType.STRING,
       "The protocol used to connect to a secure server, must be in the list of enabled protocols "
@@ -798,8 +797,8 @@ public enum Property {
       "A comma-separated list of disallowed SSL Ciphers, see"
           + " monitor.ssl.include.ciphers to allow ciphers",
       "1.6.1"),
-  MONITOR_SSL_INCLUDE_PROTOCOLS("monitor.ssl.include.protocols", "TLSv1.3",
-      PropertyType.STRING, "A comma-separate list of allowed SSL protocols", "1.5.3"),
+  MONITOR_SSL_INCLUDE_PROTOCOLS("monitor.ssl.include.protocols", "TLSv1.3", PropertyType.STRING,
+      "A comma-separate list of allowed SSL protocols", "1.5.3"),
   MONITOR_LOCK_CHECK_INTERVAL("monitor.lock.check.interval", "5s", PropertyType.TIMEDURATION,
       "The amount of time to sleep between checking for the Monitor ZooKeeper lock", "1.5.1"),
   MONITOR_RESOURCES_EXTERNAL("monitor.resources.external", "", PropertyType.STRING,

--- a/test/src/main/java/org/apache/accumulo/test/functional/MonitorSslIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MonitorSslIT.java
@@ -62,7 +62,7 @@ public class MonitorSslIT extends ConfigurableMacBase {
 
   @BeforeAll
   public static void initHttps() throws NoSuchAlgorithmException, KeyManagementException {
-    SSLContext ctx = SSLContext.getInstance("TLSv1.2");
+    SSLContext ctx = SSLContext.getInstance("TLSv1.3");
     TrustManager[] tm = {new TestTrustManager()};
     ctx.init(new KeyManager[0], tm, RANDOM.get());
     SSLContext.setDefault(ctx);

--- a/test/src/main/java/org/apache/accumulo/test/functional/ReadWriteIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ReadWriteIT.java
@@ -154,8 +154,7 @@ public class ReadWriteIT extends AccumuloClusterHarness {
         if (monitorSslKeystore != null && !monitorSslKeystore.isEmpty()) {
           log.info(
               "Using HTTPS since monitor ssl keystore configuration was observed in accumulo configuration");
-          SSLContext ctx =
-              SSLContext.getInstance(Property.RPC_SSL_CLIENT_PROTOCOL.getDefaultValue());
+          var ctx = SSLContext.getInstance(Property.RPC_SSL_CLIENT_PROTOCOL.getDefaultValue());
           TrustManager[] tm = {new TestTrustManager()};
           ctx.init(new KeyManager[0], tm, RANDOM.get());
           SSLContext.setDefault(ctx);

--- a/test/src/main/java/org/apache/accumulo/test/functional/ReadWriteIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ReadWriteIT.java
@@ -154,7 +154,8 @@ public class ReadWriteIT extends AccumuloClusterHarness {
         if (monitorSslKeystore != null && !monitorSslKeystore.isEmpty()) {
           log.info(
               "Using HTTPS since monitor ssl keystore configuration was observed in accumulo configuration");
-          SSLContext ctx = SSLContext.getInstance("TLSv1.2");
+          SSLContext ctx =
+              SSLContext.getInstance(Property.RPC_SSL_CLIENT_PROTOCOL.getDefaultValue());
           TrustManager[] tm = {new TestTrustManager()};
           ctx.init(new KeyManager[0], tm, RANDOM.get());
           SSLContext.setDefault(ctx);


### PR DESCRIPTION
This also adds TLSv1.3 to the list of accepted protocols for the RPC server and Monitor server, while still supporting TLSv1.2.

I didn't add any extra tests as all of the existing SSL/TLS testing should provide sufficient coverage.

This closes #3786