### PR TITLE
Modify ClientTabletCacheImpl.findExtentsToHost end key comparison

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientTabletCacheImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientTabletCacheImpl.java
@@ -600,7 +600,8 @@ public class ClientTabletCacheImpl extends ClientTabletCache {
       var currTablet = extent;
 
       for (int i = 0; i < hostAheadCount; i++) {
-        if (currTablet.endRow() == null || !hostAheadRange.contains(new Key(currTablet.endRow()))) {
+        if (currTablet.endRow() == null || hostAheadRange
+            .afterEndKey(new Key(currTablet.endRow()).followingKey(PartialKey.ROW))) {
           break;
         }
 


### PR DESCRIPTION
The change in #3429 modified ClientTabletCache so that it would preload Tablets for Scanners. It appears this change may have caused the test in #3809 to fail. I modified the comparison of the range to the tablet end key using the same logic that ThriftScanner uses and it fixed the test.

Fixes #3809