### PR TITLE
Fix off-by-one in ManagerAssignmentIT test

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/functional/ManagerAssignmentIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ManagerAssignmentIT.java
@@ -320,8 +320,8 @@ public class ManagerAssignmentIT extends SharedMiniClusterBase {
 
       stats = getTabletStats(c, tableId);
       assertEquals(3, stats.size());
-      // Add 1 for the t tablet
-      assertEquals(hostingRequestCount + 1, ClientTabletCache
+      // No more tablets should have been brought online
+      assertEquals(hostingRequestCount, ClientTabletCache
           .getInstance((ClientContext) c, TableId.of(tableId)).getTabletHostingRequestCount());
 
     }


### PR DESCRIPTION
Revert change introduced in #3654 to ManagerAssignmentIT for an extra tablet being brought online, something that was introduced in #3429 and fixed in #3812.