### PR TITLE
Disable failsafe plugin in start and compactor modules

### DIFF
--- a/server/compactor/pom.xml
+++ b/server/compactor/pom.xml
@@ -76,4 +76,17 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
   </dependencies>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <configuration>
+            <skipITs>true</skipITs>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -76,6 +76,13 @@
             <reuseForks>false</reuseForks>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <configuration>
+            <skipITs>true</skipITs>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>


### PR DESCRIPTION
After the changes in #3817 junit is no longer a dependency for the start and compactor modules and this causes errors when running int tests as failsafe gives an error because Junit is not a dependency.

Adding back junit as a dependency also fails as there are no unit tests to run currently so this disables the failsafe plugin inside the modules. It can be re-enabled in the future if tests are added.