### PR TITLE
Add additional initializer methods to StoredTabletFile

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/StoredTabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/StoredTabletFile.java
@@ -172,6 +172,14 @@ public class StoredTabletFile extends AbstractTabletFile<StoredTabletFile> {
     return new StoredTabletFile(new TabletFileCq(Objects.requireNonNull(path), range));
   }
 
+  public static StoredTabletFile of(final URI path) {
+    return of(path, new Range());
+  }
+
+  public static StoredTabletFile of(final Path path) {
+    return of(path, new Range());
+  }
+
   private static final Gson gson = ByteArrayToBase64TypeAdapter.createBase64Gson();
 
   private static TabletFileCq deserialize(String json) {


### PR DESCRIPTION
This commit adds two new methods to initialize a StoredTabletFile with just a path or a URI and will default to an infinite range which makes it a little bit more concise in the code when not needing to provide a range.