### PR TITLE
improves ComprehensiveIT and adjust sunny ITs

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/functional/LocalityGroupIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/LocalityGroupIT.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test.functional;
+
+import static org.apache.accumulo.test.functional.ReadWriteIT.ROWS;
+import static org.apache.accumulo.test.functional.ReadWriteIT.ingest;
+import static org.apache.accumulo.test.functional.ReadWriteIT.m;
+import static org.apache.accumulo.test.functional.ReadWriteIT.t;
+import static org.apache.accumulo.test.functional.ReadWriteIT.verify;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import org.apache.accumulo.cluster.standalone.StandaloneAccumuloCluster;
+import org.apache.accumulo.core.client.Accumulo;
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.BatchScanner;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
+import org.apache.accumulo.core.client.admin.TableOperations;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.file.rfile.PrintInfo;
+import org.apache.accumulo.core.metadata.MetadataTable;
+import org.apache.accumulo.core.metadata.StoredTabletFile;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.harness.AccumuloClusterHarness;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.Text;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LocalityGroupIT extends AccumuloClusterHarness {
+
+  private static final Logger log = LoggerFactory.getLogger(LocalityGroupIT.class);
+
+  @Test
+  public void localityGroupPerf() throws Exception {
+    // verify that locality groups can make look-ups faster
+    try (AccumuloClient accumuloClient = Accumulo.newClient().from(getClientProps()).build()) {
+      final String tableName = getUniqueNames(1)[0];
+      accumuloClient.tableOperations().create(tableName);
+      accumuloClient.tableOperations().setProperty(tableName, "table.group.g1", "colf");
+      accumuloClient.tableOperations().setProperty(tableName, "table.groups.enabled", "g1");
+      ingest(accumuloClient, 2000, 1, 50, 0, tableName);
+      accumuloClient.tableOperations().compact(tableName, null, null, true, true);
+      try (BatchWriter bw = accumuloClient.createBatchWriter(tableName)) {
+        bw.addMutation(m("zzzzzzzzzzz", "colf2", "cq", "value"));
+      }
+      long now = System.currentTimeMillis();
+      try (Scanner scanner = accumuloClient.createScanner(tableName, Authorizations.EMPTY)) {
+        scanner.fetchColumnFamily(new Text("colf"));
+        scanner.forEach((k, v) -> {});
+      }
+      long diff = System.currentTimeMillis() - now;
+      now = System.currentTimeMillis();
+
+      try (Scanner scanner = accumuloClient.createScanner(tableName, Authorizations.EMPTY)) {
+        scanner.fetchColumnFamily(new Text("colf2"));
+        scanner.forEach((k, v) -> {});
+      }
+      long diff2 = System.currentTimeMillis() - now;
+      assertTrue(diff2 < diff);
+    }
+  }
+
+  /**
+   * create a locality group, write to it and ensure it exists in the RFiles that result
+   */
+  @Test
+  public void sunnyLG() throws Exception {
+    try (AccumuloClient accumuloClient = Accumulo.newClient().from(getClientProps()).build()) {
+      final String tableName = getUniqueNames(1)[0];
+      accumuloClient.tableOperations().create(tableName);
+      Map<String,Set<Text>> groups = new TreeMap<>();
+      groups.put("g1", Collections.singleton(t("colf")));
+      accumuloClient.tableOperations().setLocalityGroups(tableName, groups);
+      verifyLocalityGroupsInRFile(accumuloClient, tableName);
+    }
+  }
+
+  /**
+   * Pretty much identical to sunnyLG, but verifies locality groups are created when configured in
+   * NewTableConfiguration prior to table creation.
+   */
+  @Test
+  public void sunnyLGUsingNewTableConfiguration() throws Exception {
+    // create a locality group, write to it and ensure it exists in the RFiles that result
+    try (AccumuloClient accumuloClient = Accumulo.newClient().from(getClientProps()).build()) {
+      final String tableName = getUniqueNames(1)[0];
+      NewTableConfiguration ntc = new NewTableConfiguration();
+      Map<String,Set<Text>> groups = new HashMap<>();
+      groups.put("g1", Collections.singleton(t("colf")));
+      ntc.setLocalityGroups(groups);
+      accumuloClient.tableOperations().create(tableName, ntc);
+      verifyLocalityGroupsInRFile(accumuloClient, tableName);
+    }
+  }
+
+  private void verifyLocalityGroupsInRFile(final AccumuloClient accumuloClient,
+      final String tableName) throws Exception {
+    ingest(accumuloClient, 2000, 1, 50, 0, tableName);
+    verify(accumuloClient, 2000, 1, 50, 0, tableName);
+    accumuloClient.tableOperations().flush(tableName, null, null, true);
+    try (BatchScanner bscanner =
+        accumuloClient.createBatchScanner(MetadataTable.NAME, Authorizations.EMPTY, 1)) {
+      String tableId = accumuloClient.tableOperations().tableIdMap().get(tableName);
+      bscanner.setRanges(
+          Collections.singletonList(new Range(new Text(tableId + ";"), new Text(tableId + "<"))));
+      bscanner.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);
+      boolean foundFile = false;
+      for (Map.Entry<Key,Value> entry : bscanner) {
+        foundFile = true;
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream oldOut = System.out;
+        try (PrintStream newOut = new PrintStream(baos)) {
+          System.setOut(newOut);
+          List<String> args = new ArrayList<>();
+          args.add(StoredTabletFile.of(entry.getKey().getColumnQualifier()).getMetadataPath());
+          args.add("--props");
+          args.add(getCluster().getAccumuloPropertiesPath());
+          if (getClusterType() == ClusterType.STANDALONE && saslEnabled()) {
+            args.add("--config");
+            StandaloneAccumuloCluster sac = (StandaloneAccumuloCluster) cluster;
+            String hadoopConfDir = sac.getHadoopConfDir();
+            args.add(new Path(hadoopConfDir, "core-site.xml").toString());
+            args.add(new Path(hadoopConfDir, "hdfs-site.xml").toString());
+          }
+          log.info("Invoking PrintInfo with {}", args);
+          PrintInfo.main(args.toArray(new String[args.size()]));
+          newOut.flush();
+          String stdout = baos.toString();
+          assertTrue(stdout.contains("Locality group           : g1"));
+          assertTrue(stdout.contains("families        : [colf]"));
+        } finally {
+          System.setOut(oldOut);
+        }
+      }
+      assertTrue(foundFile);
+    }
+  }
+
+  @Test
+  public void localityGroupChange() throws Exception {
+    // Make changes to locality groups and ensure nothing is lost
+    try (AccumuloClient accumuloClient = Accumulo.newClient().from(getClientProps()).build()) {
+      String table = getUniqueNames(1)[0];
+      TableOperations to = accumuloClient.tableOperations();
+      to.create(table);
+      String[] config = {"lg1:colf", null, "lg1:colf,xyz", "lg1:colf,xyz;lg2:c1,c2"};
+      int i = 0;
+      for (String cfg : config) {
+        to.setLocalityGroups(table, getGroups(cfg));
+        ingest(accumuloClient, ROWS * (i + 1), 1, 50, ROWS * i, table);
+        to.flush(table, null, null, true);
+        verify(accumuloClient, 0, 1, 50, ROWS * (i + 1), table);
+        i++;
+      }
+      to.delete(table);
+      to.create(table);
+      config = new String[] {"lg1:colf", null, "lg1:colf,xyz", "lg1:colf;lg2:colf",};
+      i = 1;
+      for (String cfg : config) {
+        ingest(accumuloClient, ROWS * i, 1, 50, 0, table);
+        ingest(accumuloClient, ROWS * i, 1, 50, 0, "xyz", table);
+        to.setLocalityGroups(table, getGroups(cfg));
+        to.flush(table, null, null, true);
+        verify(accumuloClient, ROWS * i, 1, 50, 0, table);
+        verify(accumuloClient, ROWS * i, 1, 50, 0, "xyz", table);
+        i++;
+      }
+    }
+  }
+
+  private Map<String,Set<Text>> getGroups(String cfg) {
+    Map<String,Set<Text>> groups = new TreeMap<>();
+    if (cfg != null) {
+      for (String group : cfg.split(";")) {
+        String[] parts = group.split(":");
+        Set<Text> cols = new HashSet<>();
+        for (String col : parts[1].split(",")) {
+          cols.add(t(col));
+        }
+        groups.put(parts[1], cols);
+      }
+    }
+    return groups;
+  }
+}

--- a/test/src/main/java/org/apache/accumulo/test/functional/ReadWriteIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ReadWriteIT.java
@@ -151,16 +151,6 @@ public class ReadWriteIT extends AccumuloClusterHarness {
     }
   }
 
-  @Test
-  public void largeTest() throws Exception {
-    // write a few large values
-    try (AccumuloClient accumuloClient = Accumulo.newClient().from(getClientProps()).build()) {
-      String table = getUniqueNames(1)[0];
-      ingest(accumuloClient, 2, 1, 500000, 0, table);
-      verify(accumuloClient, 2, 1, 500000, 0, table);
-    }
-  }
-
   public static void ingest(AccumuloClient accumuloClient, int rows, int cols, int width,
       int offset, String tableName) throws Exception {
     ingest(accumuloClient, rows, cols, width, offset, COLF, tableName);
@@ -243,6 +233,16 @@ public class ReadWriteIT extends AccumuloClusterHarness {
     Mutation m = new Mutation(t(row));
     m.put(t(cf), t(cq), new Value(value));
     return m;
+  }
+
+  @Test
+  public void largeTest() throws Exception {
+    // write a few large values
+    try (AccumuloClient accumuloClient = Accumulo.newClient().from(getClientProps()).build()) {
+      String table = getUniqueNames(1)[0];
+      ingest(accumuloClient, 2, 1, 500000, 0, table);
+      verify(accumuloClient, 2, 1, 500000, 0, table);
+    }
   }
 
   @SuppressFBWarnings(value = "WEAK_TRUST_MANAGER",

--- a/test/src/main/java/org/apache/accumulo/test/functional/ReadWriteIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ReadWriteIT.java
@@ -194,6 +194,16 @@ public class ReadWriteIT extends AccumuloClusterHarness {
   }
 
   @Test
+  public void largeTest() throws Exception {
+    // write a few large values
+    try (AccumuloClient accumuloClient = Accumulo.newClient().from(getClientProps()).build()) {
+      String table = getUniqueNames(1)[0];
+      ingest(accumuloClient, 2, 1, 500000, 0, table);
+      verify(accumuloClient, 2, 1, 500000, 0, table);
+    }
+  }
+
+  @Test
   public void interleaved() throws Exception {
     // read and write concurrently
     try (AccumuloClient accumuloClient = Accumulo.newClient().from(getClientProps()).build()) {
@@ -233,16 +243,6 @@ public class ReadWriteIT extends AccumuloClusterHarness {
     Mutation m = new Mutation(t(row));
     m.put(t(cf), t(cq), new Value(value));
     return m;
-  }
-
-  @Test
-  public void largeTest() throws Exception {
-    // write a few large values
-    try (AccumuloClient accumuloClient = Accumulo.newClient().from(getClientProps()).build()) {
-      String table = getUniqueNames(1)[0];
-      ingest(accumuloClient, 2, 1, 500000, 0, table);
-      verify(accumuloClient, 2, 1, 500000, 0, table);
-    }
   }
 
   @SuppressFBWarnings(value = "WEAK_TRUST_MANAGER",

--- a/test/src/main/java/org/apache/accumulo/test/functional/ReadWriteIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ReadWriteIT.java
@@ -21,31 +21,13 @@ package org.apache.accumulo.test.functional;
 import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.apache.accumulo.harness.AccumuloITBase.STANDALONE_CAPABLE_CLUSTER;
 import static org.apache.accumulo.harness.AccumuloITBase.SUNNY_DAY;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.PrintStream;
 import java.net.URL;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.net.ssl.HostnameVerifier;
@@ -61,37 +43,23 @@ import org.apache.accumulo.cluster.standalone.StandaloneAccumuloCluster;
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
-import org.apache.accumulo.core.client.BatchScanner;
-import org.apache.accumulo.core.client.BatchWriter;
-import org.apache.accumulo.core.client.Scanner;
-import org.apache.accumulo.core.client.admin.NewTableConfiguration;
-import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.conf.Property;
-import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
-import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.fate.zookeeper.ZooCache;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
-import org.apache.accumulo.core.file.rfile.PrintInfo;
 import org.apache.accumulo.core.lock.ServiceLock;
 import org.apache.accumulo.core.lock.ServiceLockData;
-import org.apache.accumulo.core.metadata.MetadataTable;
-import org.apache.accumulo.core.metadata.StoredTabletFile;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
-import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.MonitorUtil;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.test.TestIngest;
 import org.apache.accumulo.test.TestIngest.IngestParams;
-import org.apache.accumulo.test.TestMultiTableIngest;
 import org.apache.accumulo.test.VerifyIngest;
 import org.apache.accumulo.test.VerifyIngest.VerifyParams;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -119,14 +87,6 @@ public class ReadWriteIT extends AccumuloClusterHarness {
   static final int ROWS = 100000;
   static final int COLS = 1;
   static final String COLF = "colf";
-
-  @Test
-  public void invalidInstanceName() {
-    try (var client = Accumulo.newClient().to("fake_instance_name", cluster.getZooKeepers())
-        .as(getAdminPrincipal(), getAdminToken()).build()) {
-      assertThrows(RuntimeException.class, () -> client.instanceOperations().getTabletServers());
-    }
-  }
 
   @SuppressFBWarnings(value = {"PATH_TRAVERSAL_IN", "URLCONNECTION_SSRF_FD"},
       justification = "path provided by test; url provided by test")
@@ -191,6 +151,16 @@ public class ReadWriteIT extends AccumuloClusterHarness {
     }
   }
 
+  @Test
+  public void largeTest() throws Exception {
+    // write a few large values
+    try (AccumuloClient accumuloClient = Accumulo.newClient().from(getClientProps()).build()) {
+      String table = getUniqueNames(1)[0];
+      ingest(accumuloClient, 2, 1, 500000, 0, table);
+      verify(accumuloClient, 2, 1, 500000, 0, table);
+    }
+  }
+
   public static void ingest(AccumuloClient accumuloClient, int rows, int cols, int width,
       int offset, String tableName) throws Exception {
     ingest(accumuloClient, rows, cols, width, offset, COLF, tableName);
@@ -218,7 +188,7 @@ public class ReadWriteIT extends AccumuloClusterHarness {
     verify(accumuloClient, rows, cols, width, offset, COLF, tableName);
   }
 
-  private static void verify(AccumuloClient accumuloClient, int rows, int cols, int width,
+  public static void verify(AccumuloClient accumuloClient, int rows, int cols, int width,
       int offset, String colf, String tableName) throws Exception {
     VerifyParams params = new VerifyParams(accumuloClient.properties(), tableName, rows);
     params.rows = rows;
@@ -231,48 +201,6 @@ public class ReadWriteIT extends AccumuloClusterHarness {
 
   public static String[] args(String... args) {
     return args;
-  }
-
-  @Test
-  public void multiTableTest() throws Exception {
-    // Write to multiple tables
-    final ClusterControl control = cluster.getClusterControl();
-    final String prefix = getClass().getSimpleName() + "_" + testName();
-    ExecutorService svc = Executors.newFixedThreadPool(2);
-    Future<Integer> p1 = svc.submit(() -> {
-      try {
-        return control.exec(TestMultiTableIngest.class, args("--count", Integer.toString(ROWS),
-            "-c", cluster.getClientPropsPath(), "--tablePrefix", prefix));
-      } catch (IOException e) {
-        log.error("Error running MultiTableIngest", e);
-        return -1;
-      }
-    });
-    Future<Integer> p2 = svc.submit(() -> {
-      try {
-        return control.exec(TestMultiTableIngest.class, args("--count", Integer.toString(ROWS),
-            "--readonly", "-c", cluster.getClientPropsPath(), "--tablePrefix", prefix));
-      } catch (IOException e) {
-        log.error("Error running MultiTableIngest", e);
-        return -1;
-      }
-    });
-    svc.shutdown();
-    while (!svc.isTerminated()) {
-      svc.awaitTermination(15, TimeUnit.SECONDS);
-    }
-    assertEquals(0, p1.get().intValue());
-    assertEquals(0, p2.get().intValue());
-  }
-
-  @Test
-  public void largeTest() throws Exception {
-    // write a few large values
-    try (AccumuloClient accumuloClient = Accumulo.newClient().from(getClientProps()).build()) {
-      String table = getUniqueNames(1)[0];
-      ingest(accumuloClient, 2, 1, 500000, 0, table);
-      verify(accumuloClient, 2, 1, 500000, 0, table);
-    }
   }
 
   @Test
@@ -315,159 +243,6 @@ public class ReadWriteIT extends AccumuloClusterHarness {
     Mutation m = new Mutation(t(row));
     m.put(t(cf), t(cq), new Value(value));
     return m;
-  }
-
-  @Test
-  public void localityGroupPerf() throws Exception {
-    // verify that locality groups can make look-ups faster
-    try (AccumuloClient accumuloClient = Accumulo.newClient().from(getClientProps()).build()) {
-      final String tableName = getUniqueNames(1)[0];
-      accumuloClient.tableOperations().create(tableName);
-      accumuloClient.tableOperations().setProperty(tableName, "table.group.g1", "colf");
-      accumuloClient.tableOperations().setProperty(tableName, "table.groups.enabled", "g1");
-      ingest(accumuloClient, 2000, 1, 50, 0, tableName);
-      accumuloClient.tableOperations().compact(tableName, null, null, true, true);
-      try (BatchWriter bw = accumuloClient.createBatchWriter(tableName)) {
-        bw.addMutation(m("zzzzzzzzzzz", "colf2", "cq", "value"));
-      }
-      long now = System.currentTimeMillis();
-      try (Scanner scanner = accumuloClient.createScanner(tableName, Authorizations.EMPTY)) {
-        scanner.fetchColumnFamily(new Text("colf"));
-        scanner.forEach((k, v) -> {});
-      }
-      long diff = System.currentTimeMillis() - now;
-      now = System.currentTimeMillis();
-
-      try (Scanner scanner = accumuloClient.createScanner(tableName, Authorizations.EMPTY)) {
-        scanner.fetchColumnFamily(new Text("colf2"));
-        scanner.forEach((k, v) -> {});
-      }
-      long diff2 = System.currentTimeMillis() - now;
-      assertTrue(diff2 < diff);
-    }
-  }
-
-  /**
-   * create a locality group, write to it and ensure it exists in the RFiles that result
-   */
-  @Test
-  public void sunnyLG() throws Exception {
-    try (AccumuloClient accumuloClient = Accumulo.newClient().from(getClientProps()).build()) {
-      final String tableName = getUniqueNames(1)[0];
-      accumuloClient.tableOperations().create(tableName);
-      Map<String,Set<Text>> groups = new TreeMap<>();
-      groups.put("g1", Collections.singleton(t("colf")));
-      accumuloClient.tableOperations().setLocalityGroups(tableName, groups);
-      verifyLocalityGroupsInRFile(accumuloClient, tableName);
-    }
-  }
-
-  /**
-   * Pretty much identical to sunnyLG, but verifies locality groups are created when configured in
-   * NewTableConfiguration prior to table creation.
-   */
-  @Test
-  public void sunnyLGUsingNewTableConfiguration() throws Exception {
-    // create a locality group, write to it and ensure it exists in the RFiles that result
-    try (AccumuloClient accumuloClient = Accumulo.newClient().from(getClientProps()).build()) {
-      final String tableName = getUniqueNames(1)[0];
-      NewTableConfiguration ntc = new NewTableConfiguration();
-      Map<String,Set<Text>> groups = new HashMap<>();
-      groups.put("g1", Collections.singleton(t("colf")));
-      ntc.setLocalityGroups(groups);
-      accumuloClient.tableOperations().create(tableName, ntc);
-      verifyLocalityGroupsInRFile(accumuloClient, tableName);
-    }
-  }
-
-  private void verifyLocalityGroupsInRFile(final AccumuloClient accumuloClient,
-      final String tableName) throws Exception {
-    ingest(accumuloClient, 2000, 1, 50, 0, tableName);
-    verify(accumuloClient, 2000, 1, 50, 0, tableName);
-    accumuloClient.tableOperations().flush(tableName, null, null, true);
-    try (BatchScanner bscanner =
-        accumuloClient.createBatchScanner(MetadataTable.NAME, Authorizations.EMPTY, 1)) {
-      String tableId = accumuloClient.tableOperations().tableIdMap().get(tableName);
-      bscanner.setRanges(
-          Collections.singletonList(new Range(new Text(tableId + ";"), new Text(tableId + "<"))));
-      bscanner.fetchColumnFamily(DataFileColumnFamily.NAME);
-      boolean foundFile = false;
-      for (Entry<Key,Value> entry : bscanner) {
-        foundFile = true;
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        PrintStream oldOut = System.out;
-        try (PrintStream newOut = new PrintStream(baos)) {
-          System.setOut(newOut);
-          List<String> args = new ArrayList<>();
-          args.add(StoredTabletFile.of(entry.getKey().getColumnQualifier()).getMetadataPath());
-          args.add("--props");
-          args.add(getCluster().getAccumuloPropertiesPath());
-          if (getClusterType() == ClusterType.STANDALONE && saslEnabled()) {
-            args.add("--config");
-            StandaloneAccumuloCluster sac = (StandaloneAccumuloCluster) cluster;
-            String hadoopConfDir = sac.getHadoopConfDir();
-            args.add(new Path(hadoopConfDir, "core-site.xml").toString());
-            args.add(new Path(hadoopConfDir, "hdfs-site.xml").toString());
-          }
-          log.info("Invoking PrintInfo with {}", args);
-          PrintInfo.main(args.toArray(new String[args.size()]));
-          newOut.flush();
-          String stdout = baos.toString();
-          assertTrue(stdout.contains("Locality group           : g1"));
-          assertTrue(stdout.contains("families        : [colf]"));
-        } finally {
-          System.setOut(oldOut);
-        }
-      }
-      assertTrue(foundFile);
-    }
-  }
-
-  @Test
-  public void localityGroupChange() throws Exception {
-    // Make changes to locality groups and ensure nothing is lost
-    try (AccumuloClient accumuloClient = Accumulo.newClient().from(getClientProps()).build()) {
-      String table = getUniqueNames(1)[0];
-      TableOperations to = accumuloClient.tableOperations();
-      to.create(table);
-      String[] config = {"lg1:colf", null, "lg1:colf,xyz", "lg1:colf,xyz;lg2:c1,c2"};
-      int i = 0;
-      for (String cfg : config) {
-        to.setLocalityGroups(table, getGroups(cfg));
-        ingest(accumuloClient, ROWS * (i + 1), 1, 50, ROWS * i, table);
-        to.flush(table, null, null, true);
-        verify(accumuloClient, 0, 1, 50, ROWS * (i + 1), table);
-        i++;
-      }
-      to.delete(table);
-      to.create(table);
-      config = new String[] {"lg1:colf", null, "lg1:colf,xyz", "lg1:colf;lg2:colf",};
-      i = 1;
-      for (String cfg : config) {
-        ingest(accumuloClient, ROWS * i, 1, 50, 0, table);
-        ingest(accumuloClient, ROWS * i, 1, 50, 0, "xyz", table);
-        to.setLocalityGroups(table, getGroups(cfg));
-        to.flush(table, null, null, true);
-        verify(accumuloClient, ROWS * i, 1, 50, 0, table);
-        verify(accumuloClient, ROWS * i, 1, 50, 0, "xyz", table);
-        i++;
-      }
-    }
-  }
-
-  private Map<String,Set<Text>> getGroups(String cfg) {
-    Map<String,Set<Text>> groups = new TreeMap<>();
-    if (cfg != null) {
-      for (String group : cfg.split(";")) {
-        String[] parts = group.split(":");
-        Set<Text> cols = new HashSet<>();
-        for (String col : parts[1].split(",")) {
-          cols.add(t(col));
-        }
-        groups.put(parts[1], cols);
-      }
-    }
-    return groups;
   }
 
   @SuppressFBWarnings(value = "WEAK_TRUST_MANAGER",

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellCreateNamespaceIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellCreateNamespaceIT.java
@@ -19,7 +19,6 @@
 package org.apache.accumulo.test.shell;
 
 import static org.apache.accumulo.harness.AccumuloITBase.MINI_CLUSTER_ONLY;
-import static org.apache.accumulo.harness.AccumuloITBase.SUNNY_DAY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -40,7 +39,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 @Tag(MINI_CLUSTER_ONLY)
-@Tag(SUNNY_DAY)
 public class ShellCreateNamespaceIT extends SharedMiniClusterBase {
 
   private MockShell ts;

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellCreateTableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellCreateTableIT.java
@@ -23,7 +23,6 @@ import static java.nio.file.Files.newBufferedReader;
 import static java.util.Objects.requireNonNull;
 import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.apache.accumulo.harness.AccumuloITBase.MINI_CLUSTER_ONLY;
-import static org.apache.accumulo.harness.AccumuloITBase.SUNNY_DAY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -68,7 +67,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 @Tag(MINI_CLUSTER_ONLY)
-@Tag(SUNNY_DAY)
 public class ShellCreateTableIT extends SharedMiniClusterBase {
 
   private MockShell ts;

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellIT.java
@@ -19,7 +19,6 @@
 package org.apache.accumulo.test.shell;
 
 import static org.apache.accumulo.harness.AccumuloITBase.MINI_CLUSTER_ONLY;
-import static org.apache.accumulo.harness.AccumuloITBase.SUNNY_DAY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -53,7 +52,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Tag(MINI_CLUSTER_ONLY)
-@Tag(SUNNY_DAY)
 public class ShellIT extends SharedMiniClusterBase {
 
   @Override

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
@@ -22,7 +22,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.apache.accumulo.harness.AccumuloITBase.MINI_CLUSTER_ONLY;
-import static org.apache.accumulo.harness.AccumuloITBase.SUNNY_DAY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -102,7 +101,6 @@ import com.google.common.collect.Iterables;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @Tag(MINI_CLUSTER_ONLY)
-@Tag(SUNNY_DAY)
 public class ShellServerIT extends SharedMiniClusterBase {
 
   private static final Logger log = LoggerFactory.getLogger(ShellServerIT.class);


### PR DESCRIPTION
This change adds a new security test to Comprehensive IT and moves some test from ReadWriteIT into comprehensive IT.  Each test in ReadWriteIT spins up a mini cluster, which takes a lot of time for really simple test.  Also remove the sunny tag from shell ITs as ComprehensiveIT now covers most of what thost test were covering, but using public API instead of shell.