### PR TITLE
adds hosting goal support to import/export table

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableExport/WriteExportFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableExport/WriteExportFiles.java
@@ -55,6 +55,7 @@ import org.apache.accumulo.core.metadata.ValidationUtil;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.FutureLocationColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.HostingColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LogColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
@@ -229,6 +230,7 @@ class WriteExportFiles extends ManagerRepo {
 
     Scanner metaScanner = context.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
     metaScanner.fetchColumnFamily(DataFileColumnFamily.NAME);
+    HostingColumnFamily.GOAL_COLUMN.fetch(metaScanner);
     TabletColumnFamily.PREV_ROW_COLUMN.fetch(metaScanner);
     ServerColumnFamily.TIME_COLUMN.fetch(metaScanner);
     metaScanner.setRange(new KeyExtent(tableID, null, null).toMetaRange());

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/PopulateMetadataTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/PopulateMetadataTable.java
@@ -34,6 +34,7 @@ import java.util.zip.ZipInputStream;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.admin.TabletHostingGoal;
 import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
@@ -45,6 +46,7 @@ import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.HostingColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.util.FastFormat;
@@ -119,6 +121,8 @@ class PopulateMetadataTable extends ManagerRepo {
           Text currentRow = null;
           int dirCount = 0;
 
+          boolean sawHostingGoal = false;
+
           while (true) {
             key.readFields(in);
             val.readFields(in);
@@ -149,6 +153,11 @@ class PopulateMetadataTable extends ManagerRepo {
             if (m == null || !currentRow.equals(metadataRow)) {
 
               if (m != null) {
+                if (!sawHostingGoal) {
+                  // add a default hosting goal
+                  HostingColumnFamily.GOAL_COLUMN.put(m,
+                      new Value(TabletHostingGoal.ONDEMAND.name()));
+                }
                 mbw.addMutation(m);
               }
 
@@ -161,11 +170,22 @@ class PopulateMetadataTable extends ManagerRepo {
               m = new Mutation(metadataRow);
               ServerColumnFamily.DIRECTORY_COLUMN.put(m, new Value(tabletDir));
               currentRow = metadataRow;
+              sawHostingGoal = false;
             }
 
+            if (HostingColumnFamily.GOAL_COLUMN.hasColumns(key)) {
+              sawHostingGoal = true;
+            }
             m.put(key.getColumnFamily(), cq, val);
 
             if (endRow == null && TabletColumnFamily.PREV_ROW_COLUMN.hasColumns(key)) {
+
+              if (!sawHostingGoal) {
+                // add a default hosting goal
+                HostingColumnFamily.GOAL_COLUMN.put(m,
+                    new Value(TabletHostingGoal.ONDEMAND.name()));
+              }
+
               mbw.addMutation(m);
               break; // its the last column in the last row
             }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/PopulateMetadataTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/PopulateMetadataTable.java
@@ -184,7 +184,7 @@ class PopulateMetadataTable extends ManagerRepo {
               if (!sawHostingGoal) {
                 // add a default hosting goal
                 HostingColumnFamily.GOAL_COLUMN.put(m,
-                    new Value(TabletHostingGoal.ONDEMAND.name()));
+                    TabletHostingGoalUtil.toValue(TabletHostingGoal.ONDEMAND));
               }
 
               mbw.addMutation(m);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/PopulateMetadataTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/PopulateMetadataTable.java
@@ -156,7 +156,7 @@ class PopulateMetadataTable extends ManagerRepo {
                 if (!sawHostingGoal) {
                   // add a default hosting goal
                   HostingColumnFamily.GOAL_COLUMN.put(m,
-                      new Value(TabletHostingGoal.ONDEMAND.name()));
+                      TabletHostingGoalUtil.toValue(TabletHostingGoal.ONDEMAND);
                 }
                 mbw.addMutation(m);
               }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/PopulateMetadataTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/PopulateMetadataTable.java
@@ -36,6 +36,7 @@ import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.admin.TabletHostingGoal;
 import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
+import org.apache.accumulo.core.clientImpl.TabletHostingGoalUtil;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
 import org.apache.accumulo.core.data.Key;
@@ -156,7 +157,7 @@ class PopulateMetadataTable extends ManagerRepo {
                 if (!sawHostingGoal) {
                   // add a default hosting goal
                   HostingColumnFamily.GOAL_COLUMN.put(m,
-                      TabletHostingGoalUtil.toValue(TabletHostingGoal.ONDEMAND);
+                      TabletHostingGoalUtil.toValue(TabletHostingGoal.ONDEMAND));
                 }
                 mbw.addMutation(m);
               }


### PR DESCRIPTION
Modified export table to write out the hosting goal. Modified import table to read the hosting goal or set it to a default if not seen. Also added setting and getting hosting goals to ComprehensiveIT

fixes #3850