### PR TITLE
fixes bug in tablet refresh

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -1467,6 +1467,7 @@ public class Tablet extends TabletBase {
       TabletMetadata tabletMetadata = getContext().getAmple().readTablet(getExtent());
 
       synchronized (this) {
+        var prevMetadata = latestMetadata;
         latestMetadata = tabletMetadata;
 
         if (refreshPurpose == RefreshPurpose.MINC_COMPLETION) {
@@ -1484,7 +1485,7 @@ public class Tablet extends TabletBase {
 
           // important to call this after updating latestMetadata and tabletMemory
           computeNumEntries();
-        } else if (!latestMetadata.getFilesMap().equals(tabletMetadata.getFilesMap())) {
+        } else if (!prevMetadata.getFilesMap().equals(latestMetadata.getFilesMap())) {
 
           // the files changed, incrementing this will cause scans to switch data sources
           dataSourceDeletions.incrementAndGet();


### PR DESCRIPTION
The tablet refresh code was comparing a tablet metdata object to itself. The intention was to compare the tablet metadata to the previous version of the tablet metadata.