### PR TITLE
adds range to compactable file

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/admin/compaction/CompactableFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/compaction/CompactableFile.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.core.client.admin.compaction;
 
 import java.net.URI;
 
+import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.metadata.CompactableFileImpl;
 
 /**
@@ -33,6 +34,16 @@ public interface CompactableFile {
 
   public URI getUri();
 
+  /**
+   * @return A range associated with the file. If a file has an associated range then Accumulo will
+   *         limit reads to within the range. Not all files have an associated range, it a file does
+   *         not have a range then an infinite range is returned. The URI plus this range uniquely
+   *         identify a file.
+   *
+   * @since 3.1.0
+   */
+  public Range getRange();
+
   public long getEstimatedSize();
 
   public long getEstimatedEntries();
@@ -41,4 +52,12 @@ public interface CompactableFile {
     return new CompactableFileImpl(uri, estimatedSize, estimatedEntries);
   }
 
+  /**
+   * Creates a new CompactableFile object that implements this interface.
+   *
+   * @since 3.1.0
+   */
+  static CompactableFile create(URI uri, Range range, long estimatedSize, long estimatedEntries) {
+    return new CompactableFileImpl(uri, range, estimatedSize, estimatedEntries);
+  }
 }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/CompactableFileImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/CompactableFileImpl.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.util.Objects;
 
 import org.apache.accumulo.core.client.admin.compaction.CompactableFile;
+import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 
 public class CompactableFileImpl implements CompactableFile {
@@ -34,6 +35,11 @@ public class CompactableFileImpl implements CompactableFile {
     this.dataFileValue = new DataFileValue(size, entries);
   }
 
+  public CompactableFileImpl(URI uri, Range range, long size, long entries) {
+    this.storedTabletFile = StoredTabletFile.of(uri, range);
+    this.dataFileValue = new DataFileValue(size, entries);
+  }
+
   public CompactableFileImpl(StoredTabletFile storedTabletFile, DataFileValue dataFileValue) {
     this.storedTabletFile = Objects.requireNonNull(storedTabletFile);
     this.dataFileValue = Objects.requireNonNull(dataFileValue);
@@ -42,6 +48,11 @@ public class CompactableFileImpl implements CompactableFile {
   @Override
   public URI getUri() {
     return storedTabletFile.getPath().toUri();
+  }
+
+  @Override
+  public Range getRange() {
+    return storedTabletFile.getRange();
   }
 
   @Override


### PR DESCRIPTION
Now that tablet files have an associated range, this information should be made available to compaction plugins.  Making this information available to plugins enable uses cases like selecting files with ranges for compaction. This commit makes that information avialable by adding a getRange method to CompactableFile