### PR TITLE
fixes tablet location checks in tabletserver

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataTime.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataTime.java
@@ -121,4 +121,9 @@ public final class MetadataTime implements Comparable<MetadataTime> {
           "Cannot compare different time types: " + this + " and " + mtime);
     }
   }
+
+  @Override
+  public String toString() {
+    return encode();
+  }
 }

--- a/test/src/main/java/org/apache/accumulo/test/functional/RestartIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/RestartIT.java
@@ -117,7 +117,6 @@ public class RestartIT extends AccumuloClusterHarness {
   }
 
   @Test
-  @Disabled // ELASTICITY_TODO
   public void restartManagerRecovery() throws Exception {
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
       String tableName = getUniqueNames(1)[0];
@@ -203,7 +202,6 @@ public class RestartIT extends AccumuloClusterHarness {
   }
 
   @Test
-  @Disabled // ELASTICITY_TODO
   public void killedTabletServer() throws Exception {
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
       String tableName = getUniqueNames(1)[0];
@@ -218,7 +216,6 @@ public class RestartIT extends AccumuloClusterHarness {
   }
 
   @Test
-  @Disabled // ELASTICITY_TODO
   public void killedTabletServer2() throws Exception {
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
       final String[] names = getUniqueNames(2);


### PR DESCRIPTION
During write ahead log recovery the tablet server was trying to write a new file and require the tablets current location to be the tablet server.  However at that time the tablet server was the tablets future location and therefore the update failed.  This commit adust the expected location to be the future location during recovery.