### PR TITLE
Fixes 3485. Update jline version to 3.24.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -629,7 +629,6 @@
         <version>2.2.1.Final</version>
       </dependency>
       <dependency>
-        <!-- stay on 3.21.0 for now due to https://github.com/apache/accumulo/issues/3446 -->
         <groupId>org.jline</groupId>
         <artifactId>jline</artifactId>
         <version>3.24.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -632,7 +632,7 @@
         <!-- stay on 3.21.0 for now due to https://github.com/apache/accumulo/issues/3446 -->
         <groupId>org.jline</groupId>
         <artifactId>jline</artifactId>
-        <version>3.21.0</version>
+        <version>3.24.0</version>
       </dependency>
       <dependency>
         <groupId>org.latencyutils</groupId>


### PR DESCRIPTION
This closes #3485 to update Jline past 3.21.0 to version 3.24.0.

Verified that stdout and stderr output is redirected to the desired files using uno and the following:

```
accumulo shell -e 'tables -np' 1>/tmp/ashell.stdout 2>/tmp/ashell.stderr
```

The output of the stdout file:
```
Loading configuration from [...]/fluo-uno/install/accumulo-2.1.3-SNAPSHOT/conf/accumulo-client.properties
accumulo.metadata
accumulo.replication
accumulo.root
tableA
tableB
tableC
tableD

```
The output of the stderr file:
```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.jline.terminal.impl.exec.ExecTerminalProvider$ReflectionRedirectPipeCreator (file:[...]/fluo-uno/install/accumulo-2.1.3-SNAPSHOT/lib/jline-3.24.0.jar) to constructor java.lang.ProcessBuilder$RedirectPipeImpl()
WARNING: Please consider reporting this to the maintainers of org.jline.terminal.impl.exec.ExecTerminalProvider$ReflectionRedirectPipeCreator
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
Oct 26, 2023 4:18:20 PM org.jline.utils.Log logr
WARNING: Unable to create a system terminal, creating a dumb terminal (enable debug logging for more information)

```
