### PR TITLE
Modify TGW to unload root table after metadata table on tserver shutdown

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/manager/LiveTServerSet.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/LiveTServerSet.java
@@ -114,6 +114,17 @@ public class LiveTServerSet implements Watcher {
       }
     }
 
+    public boolean isHostingTablets(TableId tid) throws TException {
+      TabletServerClientService.Client client =
+          ThriftUtil.getClient(ThriftClientTypes.TABLET_SERVER, address, context);
+      try {
+        return !client.getTabletStats(TraceUtil.traceInfo(), context.rpcCreds(), tid.canonical())
+            .isEmpty();
+      } finally {
+        ThriftUtil.returnClient(client, context);
+      }
+    }
+
     public void unloadTablet(ServiceLock lock, KeyExtent extent, TUnloadTabletGoal goal,
         long requestTime) throws TException {
       TabletManagementClientService.Client client =

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -615,7 +615,7 @@ public class Manager extends AbstractServer
     }
   }
 
-  TabletGoalState getGoalState(TabletMetadata tm) {
+  TabletGoalState getGoalState(TabletMetadata tm, TabletGroupWatcher tgw) {
     KeyExtent extent = tm.getExtent();
     // Shutting down?
     TabletGoalState state = getSystemGoalState(tm);
@@ -632,7 +632,11 @@ public class Manager extends AbstractServer
       }
 
       if (tm.hasCurrent() && serversToShutdown.contains(tm.getLocation().getServerInstance())) {
-        return TabletGoalState.SUSPENDED;
+        if (tgw.canSuspendTablets()) {
+          return TabletGoalState.SUSPENDED;
+        } else {
+          return TabletGoalState.UNASSIGNED;
+        }
       }
 
       // taking table offline?


### PR DESCRIPTION
The following tests pass locally for me with these changes.

SslIT.adminStop
SslWithClientAuthIT.adminStop
ShutdownIT.adminStop
