### PR TITLE
Bump ZooKeeper for CVE-2023-44981

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
     <version.powermock>2.0.9</version.powermock>
     <version.slf4j>2.0.7</version.slf4j>
     <version.thrift>0.17.0</version.thrift>
-    <version.zookeeper>3.8.2</version.zookeeper>
+    <version.zookeeper>3.8.3</version.zookeeper>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
Bump ZooKeeper to 3.8.3 to address warnings about CVE-2023-44981

(Note: this CVE affects SASL-configured server deployments of ZK, not ZK client code, like how Accumulo uses it, but this removes the warning from GitHub about critical vulnerabilities in Accumulo, and in general, Accumulo tries to develop against the latest patched version of a particular release anyway.)