### PR TITLE
Make sure tablets with WALs are not merged

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -658,6 +658,12 @@ public class Manager extends AbstractServer
 
               return TabletGoalState.HOSTED;
             case WAITING_FOR_OFFLINE:
+              // If we have walogs we need to be HOSTED to recover
+              if (!tls.walogs.isEmpty()) {
+                return TabletGoalState.HOSTED;
+              } else {
+                return TabletGoalState.UNASSIGNED;
+              }
             case MERGING:
               return TabletGoalState.UNASSIGNED;
           }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
@@ -798,7 +798,7 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
         if (key.getColumnFamily().equals(CurrentLocationColumnFamily.NAME)) {
           throw new IllegalStateException(
               "Tablet " + key.getRow() + " is assigned during a merge!");
-        // Verify that Tablet has no WALs
+          // Verify that Tablet has no WALs
         } else if (key.getColumnFamily().equals(LogColumnFamily.NAME)) {
           throw new IllegalStateException("Tablet " + key.getRow() + " has walogs during a merge!");
         } else if (key.getColumnFamily().equals(DataFileColumnFamily.NAME)) {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/state/MergeStats.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/state/MergeStats.java
@@ -204,7 +204,6 @@ public class MergeStats {
 
   private boolean verifyMergeConsistency(AccumuloClient accumuloClient, CurrentState manager)
       throws TableNotFoundException, IOException {
-
     // The only expected state when this method is called is WAITING_FOR_OFFLINE
     verifyState(info, MergeState.WAITING_FOR_OFFLINE);
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/state/MergeStats.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/state/MergeStats.java
@@ -291,10 +291,7 @@ public class MergeStats {
 
   @VisibleForTesting
   boolean verifyWalogs(TabletLocationState tls) {
-    if (!tls.walogs.isEmpty()) {
-      return false;
-    }
-    return true;
+    return tls.walogs.isEmpty();
   }
 
   public static void main(String[] args) throws Exception {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/state/MergeStats.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/state/MergeStats.java
@@ -281,7 +281,7 @@ public class MergeStats {
 
   @VisibleForTesting
   void verifyState(MergeInfo info, MergeState expectedState) {
-    Preconditions.checkState(info.getState() == expectedState, "Unexpected merge state %",
+    Preconditions.checkState(info.getState() == expectedState, "Unexpected merge state %s",
         info.getState());
   }
 

--- a/server/manager/src/test/java/org/apache/accumulo/manager/state/MergeStatsTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/state/MergeStatsTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.manager.state;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.core.metadata.TabletLocationState;
+import org.apache.accumulo.core.metadata.TabletLocationState.BadLocationStateException;
+import org.apache.accumulo.server.manager.state.MergeInfo;
+import org.apache.accumulo.server.manager.state.MergeInfo.Operation;
+import org.apache.accumulo.server.manager.state.MergeState;
+import org.apache.hadoop.io.Text;
+import org.junit.jupiter.api.Test;
+
+public class MergeStatsTest {
+
+  @Test
+  public void testVerifyState() {
+    KeyExtent keyExtent = new KeyExtent(TableId.of("table"), new Text("end"), new Text("begin"));
+    MergeInfo mergeInfo = new MergeInfo(keyExtent, Operation.MERGE);
+    MergeStats stats = new MergeStats(mergeInfo);
+
+    // Verify only WAITING_FOR_OFFLINE state returns true and is valid
+    for (MergeState value : MergeState.values()) {
+      mergeInfo.setState(value);
+      assertEquals(value == MergeState.WAITING_FOR_OFFLINE, stats.verifyState(mergeInfo));
+    }
+  }
+
+  @Test
+  public void testVerifyWalogs() throws BadLocationStateException {
+    KeyExtent keyExtent = new KeyExtent(TableId.of("table"), new Text("end"), new Text("begin"));
+    MergeStats stats = new MergeStats(new MergeInfo(keyExtent, Operation.MERGE));
+
+    // Verify that if there are Walogs the return true, else false
+    assertTrue(stats.verifyWalogs(getState(keyExtent, List.of())));
+    assertFalse(stats.verifyWalogs(getState(keyExtent, List.of(List.of("log1")))));
+  }
+
+  private TabletLocationState getState(KeyExtent keyExtent, Collection<Collection<String>> walogs)
+      throws BadLocationStateException {
+    return new TabletLocationState(keyExtent, null, null, null, null, walogs, true);
+  }
+}


### PR DESCRIPTION
Add extra verification to make sure that no tablets that are merged contain any WALs to prevent losing data

This fixes #3845 for the 2.1 branch. For main there will be some slight modifications due to no-chopped merge but the fix is mostly going to be the same and I can fix conflicts on the merge.