### PR TITLE
Prevent merge/delete operations when wals exist

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementIterator.java
@@ -279,6 +279,11 @@ public class TabletManagementIterator extends SkippingIterator {
             || (tm.getHostingGoal() == TabletHostingGoal.ONDEMAND && tm.getHostingRequested()))) {
           return true;
         }
+        // If the Tablet has walogs and operation id then need to return so
+        // TGW can bring online to process the logs
+        if (tm.getLogs().isEmpty() && tm.getOperationId() != null) {
+          return true;
+        }
         break;
       default:
         throw new AssertionError("Inconceivable! The tablet is an unrecognized state: " + state);

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementIterator.java
@@ -69,6 +69,7 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.Se
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.SuspendLocationColumn;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.metadata.schema.TabletOperationType;
 import org.apache.accumulo.core.spi.balancer.SimpleLoadBalancer;
 import org.apache.accumulo.core.spi.balancer.TabletBalancer;
 import org.apache.accumulo.core.spi.balancer.data.TabletServerId;
@@ -281,7 +282,8 @@ public class TabletManagementIterator extends SkippingIterator {
         }
         // If the Tablet has walogs and operation id then need to return so
         // TGW can bring online to process the logs
-        if (tm.getLogs().isEmpty() && tm.getOperationId() != null) {
+        if (tm.getLogs().isEmpty() && tm.getOperationId() != null
+            && tm.getOperationId().getType() == TabletOperationType.MERGING) {
           return true;
         }
         break;

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementIterator.java
@@ -282,7 +282,7 @@ public class TabletManagementIterator extends SkippingIterator {
         }
         // If the Tablet has walogs and operation id then need to return so
         // TGW can bring online to process the logs
-        if (tm.getLogs().isEmpty() && tm.getOperationId() != null
+        if (!tm.getLogs().isEmpty() && tm.getOperationId() != null
             && tm.getOperationId().getType() == TabletOperationType.MERGING) {
           return true;
         }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
@@ -66,6 +66,7 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.Cu
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.FutureLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
+import org.apache.accumulo.core.metadata.schema.TabletOperationType;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.spi.balancer.data.TabletServerId;
 import org.apache.accumulo.core.util.TextUtil;
@@ -397,8 +398,9 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
 
       if (tm.getOperationId() != null) {
         // If there are still wals the tablet needs to be hosted
-        // to process the wals before starting the op
-        if (tm.getLogs().isEmpty()) {
+        // to process the wals before starting the merge op
+        if (tm.getLogs().isEmpty()
+            && tm.getOperationId().getType() == TabletOperationType.MERGING) {
           goal = TabletGoalState.UNASSIGNED;
         } else {
           goal = TabletGoalState.HOSTED;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
@@ -396,7 +396,13 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
       }
 
       if (tm.getOperationId() != null) {
-        goal = TabletGoalState.UNASSIGNED;
+        // If there are still wals the tablet needs to be hosted
+        // to process the wals before starting the op
+        if (tm.getLogs().isEmpty()) {
+          goal = TabletGoalState.UNASSIGNED;
+        } else {
+          goal = TabletGoalState.HOSTED;
+        }
       }
 
       if (Manager.log.isTraceEnabled()) {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
@@ -399,11 +399,11 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
       if (tm.getOperationId() != null) {
         // If there are still wals the tablet needs to be hosted
         // to process the wals before starting the merge op
-        if (tm.getLogs().isEmpty()
+        if (!tm.getLogs().isEmpty()
             && tm.getOperationId().getType() == TabletOperationType.MERGING) {
-          goal = TabletGoalState.UNASSIGNED;
-        } else {
           goal = TabletGoalState.HOSTED;
+        } else {
+          goal = TabletGoalState.UNASSIGNED;
         }
       }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/DeleteRows.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/DeleteRows.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.manager.tableOps.merge;
 
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.FILES;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LOCATION;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LOGS;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.OPID;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.PREV_ROW;
 import static org.apache.accumulo.manager.tableOps.merge.MergeTablets.validateTablet;
@@ -90,7 +91,7 @@ public class DeleteRows extends ManagerRepo {
     try (
         var tabletsMetadata = manager.getContext().getAmple().readTablets()
             .forTable(range.tableId()).overlapping(range.prevEndRow(), range.endRow())
-            .fetch(OPID, LOCATION, FILES, PREV_ROW).checkConsistency().build();
+            .fetch(OPID, LOCATION, FILES, PREV_ROW, LOGS).checkConsistency().build();
         var tabletsMutator = manager.getContext().getAmple().conditionallyMutateTablets()) {
 
       KeyExtent firstCompleteContained = null;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/MergeTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/MergeTablets.java
@@ -23,6 +23,7 @@ import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.FILES;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.HOSTING_GOAL;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LOCATION;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LOGS;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.OPID;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.PREV_ROW;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.TIME;
@@ -95,7 +96,7 @@ public class MergeTablets extends ManagerRepo {
 
     try (var tabletsMetadata = manager.getContext().getAmple().readTablets()
         .forTable(range.tableId()).overlapping(range.prevEndRow(), range.endRow())
-        .fetch(OPID, LOCATION, HOSTING_GOAL, FILES, TIME, DIR, ECOMP, PREV_ROW).build()) {
+        .fetch(OPID, LOCATION, HOSTING_GOAL, FILES, TIME, DIR, ECOMP, PREV_ROW, LOGS).build()) {
 
       int tabletsSeen = 0;
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/MergeTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/MergeTablets.java
@@ -233,6 +233,9 @@ public class MergeTablets extends ManagerRepo {
     Preconditions.checkState(expectedTableId.equals(tabletMeta.getTableId()),
         "%s tablet %s has unexpected table id %s expected %s", fateStr, tabletMeta.getExtent(),
         tabletMeta.getTableId(), expectedTableId);
+    Preconditions.checkState(tabletMeta.getLogs().isEmpty(),
+        "%s merging tablet %s has unexpected walogs %s", fateStr, tabletMeta.getExtent(),
+        tabletMeta.getLogs().size());
   }
 
   /**

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/ReserveTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/ReserveTablets.java
@@ -62,6 +62,7 @@ public class ReserveTablets extends ManagerRepo {
       int otherOps = 0;
       int opsSet = 0;
       int locations = 0;
+      int wals = 0;
 
       for (var tabletMeta : tablets) {
 
@@ -77,6 +78,8 @@ public class ReserveTablets extends ManagerRepo {
           locations++;
         }
 
+        wals += tabletMeta.getLogs().size();
+
         count++;
       }
 
@@ -84,8 +87,8 @@ public class ReserveTablets extends ManagerRepo {
           .filter(conditionalResult -> conditionalResult.getStatus() == Status.ACCEPTED).count();
 
       log.debug(
-          "{} reserve tablets op:{} count:{} other opids:{} opids set:{} locations:{} accepted:{}",
-          FateTxId.formatTid(tid), data.op, count, otherOps, opsSet, locations, opsAccepted);
+          "{} reserve tablets op:{} count:{} other opids:{} opids set:{} locations:{} accepted:{} wals:{}",
+          FateTxId.formatTid(tid), data.op, count, otherOps, opsSet, locations, opsAccepted, wals);
 
       // while there are table lock a tablet can be concurrently deleted, so should always see
       // tablets
@@ -98,7 +101,7 @@ public class ReserveTablets extends ManagerRepo {
             FateTxId.formatTid(tid));
       }
 
-      if (locations > 0 || otherOps > 0) {
+      if (locations > 0 || otherOps > 0 || wals > 0) {
         // need to wait on these tablets
         return Math.max(1000, count);
       }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/ReserveTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/ReserveTablets.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.manager.tableOps.merge;
 
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LOCATION;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LOGS;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.OPID;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.PREV_ROW;
 
@@ -54,7 +55,7 @@ public class ReserveTablets extends ManagerRepo {
 
     try (
         var tablets = env.getContext().getAmple().readTablets().forTable(data.tableId)
-            .overlapping(range.prevEndRow(), range.endRow()).fetch(PREV_ROW, LOCATION, OPID)
+            .overlapping(range.prevEndRow(), range.endRow()).fetch(PREV_ROW, LOCATION, LOGS, OPID)
             .checkConsistency().build();
         var tabletsMutator = env.getContext().getAmple().conditionallyMutateTablets();) {
 


### PR DESCRIPTION
This commit updates the merge and delete rows FATE ops to verify that if tablets being processed do not have any wals

This closes #3845

This PR makes the following changes:

1. Modifies ReserveTablets FATE op to check that the tablets have no wals when reserving
2. Modifies `MergeTablets` and `DeleteRows` FATE ops to add verification that the tablets have no wals
3. Modifies `TabletManagementIterator` to return a tablet back for processing again by TGW if there's no location, an op id set and wals exist
4. Modifies `TabletGroupWatcher` to set the tablet goal to be hosted to bring a tablet online if wals exist and a fate id is also set

I have marked this as a draft for now because I believe these are all the changes needed but I wanted to explore adding a test or 2 if possible (maybe `TabletManagementIteratorIT`, etc)