### PR TITLE
Fix errors in DefaultCompactionPlanner javadoc

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
@@ -95,9 +95,10 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  *
  * <pre>
  * {@code
- * [{"name":"small", "type": "internal", "maxSize":"100M","numThreads":3},
+ * [
+ *  {"name":"small", "type": "internal", "maxSize":"100M","numThreads":3},
  *  {"name":"medium", "type": "internal", "maxSize":"500M","numThreads":3},
- *  {"name: "large", "type": "external", "queue", "Queue1"}
+ *  {"name": "large", "type": "external", "queue", "Queue1"}
  * ]}
  * </pre>
  *


### PR DESCRIPTION
There was a missing quote in the json in DefaultCompactionPlanner javadoc:
![Screenshot from 2023-10-31 11-08-29](https://github.com/apache/accumulo/assets/47725857/797c46c1-0dfc-4c1e-a0a4-142db3d50492)

After adding the quote and adding a line:
![Screenshot from 2023-10-31 11-08-56](https://github.com/apache/accumulo/assets/47725857/1f94c980-69b0-45e5-a2de-eebf3fbb60e0)
