### PR TITLE
Validate compaction planner json property, increase backoff on config error

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/util/Retry.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/Retry.java
@@ -73,8 +73,6 @@ public class Retry {
 
   }
 
-  // Visible for testing
-  @VisibleForTesting
   public void setBackOffFactor(double baskOffFactor) {
     this.backOffFactor = baskOffFactor;
     this.currentBackOffFactor = this.backOffFactor;

--- a/server/base/src/main/java/org/apache/accumulo/server/util/PropUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/PropUtil.java
@@ -26,6 +26,9 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.conf.store.PropStoreKey;
 
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+
 public final class PropUtil {
 
   private PropUtil() {}
@@ -70,6 +73,14 @@ public final class PropUtil {
           && !ClassLoaderUtil.isValidContext(prop.getValue())) {
         throw new IllegalArgumentException(
             "Unable to resolve classloader for context: " + prop.getValue());
+      } else if (prop.getKey().startsWith(Property.TSERV_COMPACTION_SERVICE_PREFIX.getKey())
+          && prop.getKey().endsWith("planner.opts.executors")) {
+        try {
+          JsonParser.parseString(prop.getValue());
+        } catch (JsonSyntaxException e) {
+          throw new IllegalArgumentException(
+              Property.TSERV_COMPACTION_SERVICE_PREFIX.getKey() + " contains invalid JSON.");
+        }
       }
     }
   }


### PR DESCRIPTION
This commit changes PropUtil.vlaidateProperties such that it attempts to parse the JSON for the CompactionService planner.opts.executors property to ensure that it's valid JSON. This commit also changes the CompactionManager such that when a configuration error happens that it increases the Retry backoff for the compactions to reduce the number of log entries.

Fixes #3909