### PR TITLE
Moves compaction properties and adds 'compaction.opts.queue' property.

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -44,6 +44,24 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Preconditions;
 
 public enum Property {
+  COMPACTION_SERVICE_PREFIX("compaction.major.service.", null, PropertyType.PREFIX,
+      "Prefix for compaction services.", "3.1.0"),
+  COMPACTION_SERVICE_ROOT_PLANNER("compaction.major.service.root.planner",
+      DefaultCompactionPlanner.class.getName(), PropertyType.CLASSNAME,
+      "Compaction planner for root tablet service.", "3.1.0"),
+  COMPACTION_SERVICE_ROOT_MAX_OPEN("compaction.major.service.root.planner.opts.maxOpen", "30",
+      PropertyType.COUNT, "The maximum number of files a compaction will open.", "3.1.0"),
+  COMPACTION_SERVICE_META_PLANNER("compaction.major.service.meta.planner",
+      DefaultCompactionPlanner.class.getName(), PropertyType.CLASSNAME,
+      "Compaction planner for metadata table.", "3.1.0"),
+  COMPACTION_SERVICE_META_MAX_OPEN("compaction.major.service.meta.planner.opts.maxOpen", "30",
+      PropertyType.COUNT, "The maximum number of files a compaction will open.", "3.1.0"),
+  COMPACTION_SERVICE_DEFAULT_PLANNER("compaction.major.service.default.planner",
+      DefaultCompactionPlanner.class.getName(), PropertyType.CLASSNAME,
+      "Planner for default compaction service.", "3.1.0"),
+  COMPACTION_SERVICE_DEFAULT_MAX_OPEN("compaction.major.service.default.planner.opts.maxOpen", "10",
+      PropertyType.COUNT, "The maximum number of files a compaction will open.", "3.1.0"),
+
   // SSL properties local to each node (see also instance.ssl.enabled which must be consistent
   // across all nodes in an instance)
   RPC_PREFIX("rpc.", null, PropertyType.PREFIX,
@@ -211,6 +229,9 @@ public enum Property {
       "Properties in this category affect the behavior of accumulo overall, but"
           + " do not have to be consistent throughout a cloud.",
       "1.3.5"),
+  GENERAL_COMPACTION_WARN_TIME("general.compaction.warn.time", "10m", PropertyType.TIMEDURATION,
+      "When a compaction has not made progress for this time period, a warning will be logged.",
+      "3.1.0"),
   GENERAL_CONTEXT_CLASSLOADER_FACTORY("general.context.class.loader.factory", "",
       PropertyType.CLASSNAME,
       "Name of classloader factory to be used to create classloaders for named contexts,"
@@ -568,8 +589,12 @@ public enum Property {
       "The maximum number of concurrent tablet migrations for a tablet server.", "1.3.5"),
   TSERV_MAJC_DELAY("tserver.compaction.major.delay", "30s", PropertyType.TIMEDURATION,
       "Time a tablet server will sleep between checking which tablets need compaction.", "1.3.5"),
+  @Deprecated(since = "3.1")
+  @ReplacedBy(property = COMPACTION_SERVICE_PREFIX)
   TSERV_COMPACTION_SERVICE_PREFIX("tserver.compaction.major.service.", null, PropertyType.PREFIX,
       "Prefix for compaction services.", "2.1.0"),
+  @Deprecated(since = "3.1")
+  @ReplacedBy(property = COMPACTION_SERVICE_ROOT_PLANNER)
   TSERV_COMPACTION_SERVICE_ROOT_PLANNER("tserver.compaction.major.service.root.planner",
       DefaultCompactionPlanner.class.getName(), PropertyType.CLASSNAME,
       "Compaction planner for root tablet service.", "2.1.0"),
@@ -579,9 +604,12 @@ public enum Property {
       "Maximum number of bytes to read or write per second over all major"
           + " compactions in this compaction service, or 0B for unlimited.",
       "2.1.0"),
+  @Deprecated(since = "3.1")
+  @ReplacedBy(property = COMPACTION_SERVICE_ROOT_MAX_OPEN)
   TSERV_COMPACTION_SERVICE_ROOT_MAX_OPEN(
       "tserver.compaction.major.service.root.planner.opts.maxOpen", "30", PropertyType.COUNT,
       "The maximum number of files a compaction will open.", "2.1.0"),
+  @Deprecated(since = "3.1", forRemoval = true)
   TSERV_COMPACTION_SERVICE_ROOT_EXECUTORS(
       "tserver.compaction.major.service.root.planner.opts.executors",
       "[{'name':'small','type':'internal','maxSize':'32M','numThreads':1},{'name':'huge','type':'internal','numThreads':1}]"
@@ -589,6 +617,8 @@ public enum Property {
       PropertyType.STRING,
       "See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %}.",
       "2.1.0"),
+  @Deprecated(since = "3.1")
+  @ReplacedBy(property = COMPACTION_SERVICE_META_PLANNER)
   TSERV_COMPACTION_SERVICE_META_PLANNER("tserver.compaction.major.service.meta.planner",
       DefaultCompactionPlanner.class.getName(), PropertyType.CLASSNAME,
       "Compaction planner for metadata table.", "2.1.0"),
@@ -598,9 +628,12 @@ public enum Property {
       "Maximum number of bytes to read or write per second over all major"
           + " compactions in this compaction service, or 0B for unlimited.",
       "2.1.0"),
+  @Deprecated(since = "3.1")
+  @ReplacedBy(property = COMPACTION_SERVICE_META_MAX_OPEN)
   TSERV_COMPACTION_SERVICE_META_MAX_OPEN(
       "tserver.compaction.major.service.meta.planner.opts.maxOpen", "30", PropertyType.COUNT,
       "The maximum number of files a compaction will open.", "2.1.0"),
+  @Deprecated(since = "3.1", forRemoval = true)
   TSERV_COMPACTION_SERVICE_META_EXECUTORS(
       "tserver.compaction.major.service.meta.planner.opts.executors",
       "[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'huge','type':'internal','numThreads':2}]"
@@ -608,6 +641,8 @@ public enum Property {
       PropertyType.STRING,
       "See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %}.",
       "2.1.0"),
+  @Deprecated(since = "3.1")
+  @ReplacedBy(property = COMPACTION_SERVICE_DEFAULT_PLANNER)
   TSERV_COMPACTION_SERVICE_DEFAULT_PLANNER("tserver.compaction.major.service.default.planner",
       DefaultCompactionPlanner.class.getName(), PropertyType.CLASSNAME,
       "Planner for default compaction service.", "2.1.0"),
@@ -617,9 +652,12 @@ public enum Property {
       "Maximum number of bytes to read or write per second over all major"
           + " compactions in this compaction service, or 0B for unlimited.",
       "2.1.0"),
+  @Deprecated(since = "3.1")
+  @ReplacedBy(property = COMPACTION_SERVICE_DEFAULT_MAX_OPEN)
   TSERV_COMPACTION_SERVICE_DEFAULT_MAX_OPEN(
       "tserver.compaction.major.service.default.planner.opts.maxOpen", "10", PropertyType.COUNT,
       "The maximum number of files a compaction will open.", "2.1.0"),
+  @Deprecated(since = "3.1", forRemoval = true)
   TSERV_COMPACTION_SERVICE_DEFAULT_EXECUTORS(
       "tserver.compaction.major.service.default.planner.opts.executors",
       "[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'medium','type':'internal','maxSize':'128M','numThreads':2},{'name':'large','type':'internal','numThreads':2}]"
@@ -629,6 +667,8 @@ public enum Property {
       "2.1.0"),
   TSERV_MINC_MAXCONCURRENT("tserver.compaction.minor.concurrent.max", "4", PropertyType.COUNT,
       "The maximum number of concurrent minor compactions for a tablet server.", "1.3.5"),
+  @Deprecated(since = "3.1")
+  @ReplacedBy(property = GENERAL_COMPACTION_WARN_TIME)
   TSERV_COMPACTION_WARN_TIME("tserver.compaction.warn.time", "10m", PropertyType.TIMEDURATION,
       "When a compaction has not made progress for this time period, a warning will be logged.",
       "1.6.0"),
@@ -1315,6 +1355,8 @@ public enum Property {
     ReplacedBy rb = getAnnotation(ReplacedBy.class);
     if (rb != null) {
       replacedBy = rb.property();
+    } else {
+      isReplaced = false;
     }
     annotationsComputed = true;
   }
@@ -1455,9 +1497,11 @@ public enum Property {
     // white list prefixes
     return key.startsWith(Property.TABLE_PREFIX.getKey())
         || key.startsWith(Property.TSERV_PREFIX.getKey())
+        || key.startsWith(Property.COMPACTION_SERVICE_PREFIX.getKey())
         || key.startsWith(Property.MANAGER_PREFIX.getKey())
         || key.startsWith(Property.GC_PREFIX.getKey())
         || key.startsWith(Property.GENERAL_ARBITRARY_PROP_PREFIX.getKey())
+        || key.equals(Property.GENERAL_COMPACTION_WARN_TIME.getKey())
         || key.equals(Property.GENERAL_FILE_NAME_ALLOCATION_BATCH_SIZE_MIN.getKey())
         || key.equals(Property.GENERAL_FILE_NAME_ALLOCATION_BATCH_SIZE_MAX.getKey());
   }

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -47,7 +47,17 @@ public enum Property {
   COMPACTION_PREFIX("compaction.", null, PropertyType.PREFIX,
       "Both major and minor compaction properties can be included under this prefix.", "3.1.0"),
   COMPACTION_SERVICE_PREFIX(COMPACTION_PREFIX + "service.", null, PropertyType.PREFIX,
-      "Prefix for major compaction services.", "3.1.0"),
+      "This prefix should be used to define all properties for the compaction services."
+          + "See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %}.\n"
+          + "A new external compaction service would be defined like the following:\n"
+          + "`compaction.service.newService.planner="
+          + "\"org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner\".`\n"
+          + "`compaction.service.newService.opts.queues=\""
+          + "[{\"name\": \"small\", \"maxSize\":\"32M\"},"
+          + "{ \"name\":\"medium\", \"maxSize\":\"512M\"},{\"name\":\"large\"}]`\n"
+          + "`compaction.service.newService.opts.maxOpen=50`.\n"
+          + "Additional options can be defined using the `compaction.service.<service>.opts.<option>` property.",
+      "3.1.0"),
   COMPACTION_WARN_TIME(COMPACTION_PREFIX + "warn.time", "10m", PropertyType.TIMEDURATION,
       "When a compaction has not made progress for this time period, a warning will be logged.",
       "3.1.0"),
@@ -212,7 +222,6 @@ public enum Property {
           + "encryption, replace this classname with an implementation of the"
           + "org.apache.accumulo.core.spi.crypto.CryptoFactory interface.",
       "2.1.0"),
-
   // general properties
   GENERAL_PREFIX("general.", null, PropertyType.PREFIX,
       "Properties in this category affect the behavior of accumulo overall, but"

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -44,64 +44,13 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Preconditions;
 
 public enum Property {
-  COMPACTION_SERVICE_PREFIX("compaction.service.", null, PropertyType.PREFIX,
-      "Prefix for compaction services.", "3.1.0"),
-  COMPACTION_SERVICE_ROOT_PLANNER("compaction.major.service.root.planner",
-      DefaultCompactionPlanner.class.getName(), PropertyType.CLASSNAME,
-      "Compaction planner for root tablet service.", "3.1.0"),
-  @Deprecated(since = "3.1", forRemoval = true)
-  COMPACTION_SERVICE_ROOT_EXECUTORS("compaction.major.service.root.planner.opts.executors",
-      "[{'name':'small','type':'internal','maxSize':'32M','numThreads':1},{'name':'huge','type':'internal','numThreads':1}]"
-          .replaceAll("'", "\""),
-      PropertyType.STRING,
-      "See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %}.",
+  COMPACTION_PREFIX("compaction.", null, PropertyType.PREFIX,
+      "Both major and minor compaction properties can be included under this prefix.", "3.1.0"),
+  COMPACTION_SERVICE_PREFIX(COMPACTION_PREFIX + "service.", null, PropertyType.PREFIX,
+      "Prefix for major compaction services.", "3.1.0"),
+  COMPACTION_WARN_TIME(COMPACTION_PREFIX + "warn.time", "10m", PropertyType.TIMEDURATION,
+      "When a compaction has not made progress for this time period, a warning will be logged.",
       "3.1.0"),
-  COMPACTION_SERVICE_ROOT_MAX_OPEN("compaction.major.service.root.planner.opts.maxOpen", "30",
-      PropertyType.COUNT, "The maximum number of files a compaction will open.", "3.1.0"),
-  @Deprecated(since = "3.1", forRemoval = true)
-  COMPACTION_SERVICE_ROOT_RATE_LIMIT("compaction.major.service.root.rate.limit", "0B",
-      PropertyType.BYTES,
-      "Maximum number of bytes to read or write per second over all major"
-          + " compactions in this compaction service, or 0B for unlimited.",
-      "2.1.0"),
-  COMPACTION_SERVICE_META_PLANNER("compaction.major.service.meta.planner",
-      DefaultCompactionPlanner.class.getName(), PropertyType.CLASSNAME,
-      "Compaction planner for metadata table.", "3.1.0"),
-  @Deprecated(since = "3.1", forRemoval = true)
-  COMPACTION_SERVICE_META_EXECUTORS("compaction.major.service.meta.planner.opts.executors",
-      "[{'name':'small','type':'internal','maxSize':'32M','numThreads':1},{'name':'huge','type':'internal','numThreads':1}]"
-          .replaceAll("'", "\""),
-      PropertyType.STRING,
-      "See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %}.",
-      "3.1.0"),
-  COMPACTION_SERVICE_META_MAX_OPEN("compaction.major.service.meta.planner.opts.maxOpen", "30",
-      PropertyType.COUNT, "The maximum number of files a compaction will open.", "3.1.0"),
-
-  @Deprecated(since = "3.1", forRemoval = true)
-  COMPACTION_SERVICE_META_RATE_LIMIT("compaction.major.service.meta.rate.limit", "0B",
-      PropertyType.BYTES,
-      "Maximum number of bytes to read or write per second over all major"
-          + " compactions in this compaction service, or 0B for unlimited.",
-      "2.1.0"),
-  COMPACTION_SERVICE_DEFAULT_PLANNER("compaction.major.service.default.planner",
-      DefaultCompactionPlanner.class.getName(), PropertyType.CLASSNAME,
-      "Planner for default compaction service.", "3.1.0"),
-  @Deprecated(since = "3.1", forRemoval = true)
-  COMPACTION_SERVICE_DEFAULT_EXECUTORS("compaction.major.service.default.planner.opts.executors",
-      "[{'name':'small','type':'internal','maxSize':'32M','numThreads':1},{'name':'huge','type':'internal','numThreads':1}]"
-          .replaceAll("'", "\""),
-      PropertyType.STRING,
-      "See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %}.",
-      "3.1.0"),
-  COMPACTION_SERVICE_DEFAULT_MAX_OPEN("compaction.major.service.default.planner.opts.maxOpen", "10",
-      PropertyType.COUNT, "The maximum number of files a compaction will open.", "3.1.0"),
-  @Deprecated(since = "3.1", forRemoval = true)
-  COMPACTION_SERVICE_DEFAULT_RATE_LIMIT("compaction.major.service.default.rate.limit", "0B",
-      PropertyType.BYTES,
-      "Maximum number of bytes to read or write per second over all major"
-          + " compactions in this compaction service, or 0B for unlimited.",
-      "2.1.0"),
-
   // SSL properties local to each node (see also instance.ssl.enabled which must be consistent
   // across all nodes in an instance)
   RPC_PREFIX("rpc.", null, PropertyType.PREFIX,
@@ -269,9 +218,7 @@ public enum Property {
       "Properties in this category affect the behavior of accumulo overall, but"
           + " do not have to be consistent throughout a cloud.",
       "1.3.5"),
-  GENERAL_COMPACTION_WARN_TIME("general.compaction.warn.time", "10m", PropertyType.TIMEDURATION,
-      "When a compaction has not made progress for this time period, a warning will be logged.",
-      "3.1.0"),
+
   GENERAL_CONTEXT_CLASSLOADER_FACTORY("general.context.class.loader.factory", "",
       PropertyType.CLASSNAME,
       "Name of classloader factory to be used to create classloaders for named contexts,"
@@ -629,14 +576,80 @@ public enum Property {
       "The maximum number of concurrent tablet migrations for a tablet server.", "1.3.5"),
   TSERV_MAJC_DELAY("tserver.compaction.major.delay", "30s", PropertyType.TIMEDURATION,
       "Time a tablet server will sleep between checking which tablets need compaction.", "1.3.5"),
-  @Deprecated(since = "3.1")
+  @Deprecated(since = "3.1", forRemoval = true)
   @ReplacedBy(property = COMPACTION_SERVICE_PREFIX)
   TSERV_COMPACTION_SERVICE_PREFIX("tserver.compaction.major.service.", null, PropertyType.PREFIX,
       "Prefix for compaction services.", "2.1.0"),
+  @Deprecated(since = "3.1", forRemoval = true)
+  TSERV_COMPACTION_SERVICE_ROOT_PLANNER("tserver.compaction.major.service.root.planner",
+      DefaultCompactionPlanner.class.getName(), PropertyType.CLASSNAME,
+      "Compaction planner for root tablet service.", "2.1.0"),
+  @Deprecated(since = "3.1", forRemoval = true)
+  TSERV_COMPACTION_SERVICE_ROOT_RATE_LIMIT("tserver.compaction.major.service.root.rate.limit", "0B",
+      PropertyType.BYTES,
+      "Maximum number of bytes to read or write per second over all major"
+          + " compactions in this compaction service, or 0B for unlimited.",
+      "2.1.0"),
+  @Deprecated(since = "3.1", forRemoval = true)
+  TSERV_COMPACTION_SERVICE_ROOT_MAX_OPEN(
+      "tserver.compaction.major.service.root.planner.opts.maxOpen", "30", PropertyType.COUNT,
+      "The maximum number of files a compaction will open.", "2.1.0"),
+  @Deprecated(since = "3.1", forRemoval = true)
+  TSERV_COMPACTION_SERVICE_ROOT_EXECUTORS(
+      "tserver.compaction.major.service.root.planner.opts.executors",
+      "[{'name':'small','type':'internal','maxSize':'32M','numThreads':1},{'name':'huge','type':'internal','numThreads':1}]"
+          .replaceAll("'", "\""),
+      PropertyType.STRING,
+      "See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %}.",
+      "2.1.0"),
+  @Deprecated(since = "3.1", forRemoval = true)
+  TSERV_COMPACTION_SERVICE_META_PLANNER("tserver.compaction.major.service.meta.planner",
+      DefaultCompactionPlanner.class.getName(), PropertyType.CLASSNAME,
+      "Compaction planner for metadata table.", "2.1.0"),
+  @Deprecated(since = "3.1", forRemoval = true)
+  TSERV_COMPACTION_SERVICE_META_RATE_LIMIT("tserver.compaction.major.service.meta.rate.limit", "0B",
+      PropertyType.BYTES,
+      "Maximum number of bytes to read or write per second over all major"
+          + " compactions in this compaction service, or 0B for unlimited.",
+      "2.1.0"),
+  @Deprecated(since = "3.1", forRemoval = true)
+  TSERV_COMPACTION_SERVICE_META_MAX_OPEN(
+      "tserver.compaction.major.service.meta.planner.opts.maxOpen", "30", PropertyType.COUNT,
+      "The maximum number of files a compaction will open.", "2.1.0"),
+  @Deprecated(since = "3.1", forRemoval = true)
+  TSERV_COMPACTION_SERVICE_META_EXECUTORS(
+      "tserver.compaction.major.service.meta.planner.opts.executors",
+      "[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'huge','type':'internal','numThreads':2}]"
+          .replaceAll("'", "\""),
+      PropertyType.STRING,
+      "See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %}.",
+      "2.1.0"),
+  @Deprecated(since = "3.1", forRemoval = true)
+  TSERV_COMPACTION_SERVICE_DEFAULT_PLANNER("tserver.compaction.major.service.default.planner",
+      DefaultCompactionPlanner.class.getName(), PropertyType.CLASSNAME,
+      "Planner for default compaction service.", "2.1.0"),
+  @Deprecated(since = "3.1", forRemoval = true)
+  TSERV_COMPACTION_SERVICE_DEFAULT_RATE_LIMIT("tserver.compaction.major.service.default.rate.limit",
+      "0B", PropertyType.BYTES,
+      "Maximum number of bytes to read or write per second over all major"
+          + " compactions in this compaction service, or 0B for unlimited.",
+      "2.1.0"),
+  @Deprecated(since = "3.1", forRemoval = true)
+  TSERV_COMPACTION_SERVICE_DEFAULT_MAX_OPEN(
+      "tserver.compaction.major.service.default.planner.opts.maxOpen", "10", PropertyType.COUNT,
+      "The maximum number of files a compaction will open.", "2.1.0"),
+  @Deprecated(since = "3.1", forRemoval = true)
+  TSERV_COMPACTION_SERVICE_DEFAULT_EXECUTORS(
+      "tserver.compaction.major.service.default.planner.opts.executors",
+      "[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'medium','type':'internal','maxSize':'128M','numThreads':2},{'name':'large','type':'internal','numThreads':2}]"
+          .replaceAll("'", "\""),
+      PropertyType.STRING,
+      "See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %}.",
+      "2.1.0"),
   TSERV_MINC_MAXCONCURRENT("tserver.compaction.minor.concurrent.max", "4", PropertyType.COUNT,
       "The maximum number of concurrent minor compactions for a tablet server.", "1.3.5"),
   @Deprecated(since = "3.1")
-  @ReplacedBy(property = GENERAL_COMPACTION_WARN_TIME)
+  @ReplacedBy(property = COMPACTION_WARN_TIME)
   TSERV_COMPACTION_WARN_TIME("tserver.compaction.warn.time", "10m", PropertyType.TIMEDURATION,
       "When a compaction has not made progress for this time period, a warning will be logged.",
       "1.6.0"),
@@ -1469,7 +1482,7 @@ public enum Property {
         || key.startsWith(Property.MANAGER_PREFIX.getKey())
         || key.startsWith(Property.GC_PREFIX.getKey())
         || key.startsWith(Property.GENERAL_ARBITRARY_PROP_PREFIX.getKey())
-        || key.equals(Property.GENERAL_COMPACTION_WARN_TIME.getKey())
+        || key.equals(Property.COMPACTION_WARN_TIME.getKey())
         || key.equals(Property.GENERAL_FILE_NAME_ALLOCATION_BATCH_SIZE_MIN.getKey())
         || key.equals(Property.GENERAL_FILE_NAME_ALLOCATION_BATCH_SIZE_MAX.getKey());
   }

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -49,18 +49,58 @@ public enum Property {
   COMPACTION_SERVICE_ROOT_PLANNER("compaction.major.service.root.planner",
       DefaultCompactionPlanner.class.getName(), PropertyType.CLASSNAME,
       "Compaction planner for root tablet service.", "3.1.0"),
+  @Deprecated(since = "3.1", forRemoval = true)
+  COMPACTION_SERVICE_ROOT_EXECUTORS("compaction.major.service.root.planner.opts.executors",
+      "[{'name':'small','type':'internal','maxSize':'32M','numThreads':1},{'name':'huge','type':'internal','numThreads':1}]"
+          .replaceAll("'", "\""),
+      PropertyType.STRING,
+      "See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %}.",
+      "3.1.0"),
   COMPACTION_SERVICE_ROOT_MAX_OPEN("compaction.major.service.root.planner.opts.maxOpen", "30",
       PropertyType.COUNT, "The maximum number of files a compaction will open.", "3.1.0"),
+  @Deprecated(since = "3.1", forRemoval = true)
+  COMPACTION_SERVICE_ROOT_RATE_LIMIT("compaction.major.service.root.rate.limit", "0B",
+      PropertyType.BYTES,
+      "Maximum number of bytes to read or write per second over all major"
+          + " compactions in this compaction service, or 0B for unlimited.",
+      "2.1.0"),
   COMPACTION_SERVICE_META_PLANNER("compaction.major.service.meta.planner",
       DefaultCompactionPlanner.class.getName(), PropertyType.CLASSNAME,
       "Compaction planner for metadata table.", "3.1.0"),
+  @Deprecated(since = "3.1", forRemoval = true)
+  COMPACTION_SERVICE_META_EXECUTORS("compaction.major.service.meta.planner.opts.executors",
+      "[{'name':'small','type':'internal','maxSize':'32M','numThreads':1},{'name':'huge','type':'internal','numThreads':1}]"
+          .replaceAll("'", "\""),
+      PropertyType.STRING,
+      "See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %}.",
+      "3.1.0"),
   COMPACTION_SERVICE_META_MAX_OPEN("compaction.major.service.meta.planner.opts.maxOpen", "30",
       PropertyType.COUNT, "The maximum number of files a compaction will open.", "3.1.0"),
+
+  @Deprecated(since = "3.1", forRemoval = true)
+  COMPACTION_SERVICE_META_RATE_LIMIT("compaction.major.service.meta.rate.limit", "0B",
+      PropertyType.BYTES,
+      "Maximum number of bytes to read or write per second over all major"
+          + " compactions in this compaction service, or 0B for unlimited.",
+      "2.1.0"),
   COMPACTION_SERVICE_DEFAULT_PLANNER("compaction.major.service.default.planner",
       DefaultCompactionPlanner.class.getName(), PropertyType.CLASSNAME,
       "Planner for default compaction service.", "3.1.0"),
+  @Deprecated(since = "3.1", forRemoval = true)
+  COMPACTION_SERVICE_DEFAULT_EXECUTORS("compaction.major.service.default.planner.opts.executors",
+      "[{'name':'small','type':'internal','maxSize':'32M','numThreads':1},{'name':'huge','type':'internal','numThreads':1}]"
+          .replaceAll("'", "\""),
+      PropertyType.STRING,
+      "See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %}.",
+      "3.1.0"),
   COMPACTION_SERVICE_DEFAULT_MAX_OPEN("compaction.major.service.default.planner.opts.maxOpen", "10",
       PropertyType.COUNT, "The maximum number of files a compaction will open.", "3.1.0"),
+  @Deprecated(since = "3.1", forRemoval = true)
+  COMPACTION_SERVICE_DEFAULT_RATE_LIMIT("compaction.major.service.default.rate.limit", "0B",
+      PropertyType.BYTES,
+      "Maximum number of bytes to read or write per second over all major"
+          + " compactions in this compaction service, or 0B for unlimited.",
+      "2.1.0"),
 
   // SSL properties local to each node (see also instance.ssl.enabled which must be consistent
   // across all nodes in an instance)
@@ -593,78 +633,6 @@ public enum Property {
   @ReplacedBy(property = COMPACTION_SERVICE_PREFIX)
   TSERV_COMPACTION_SERVICE_PREFIX("tserver.compaction.major.service.", null, PropertyType.PREFIX,
       "Prefix for compaction services.", "2.1.0"),
-  @Deprecated(since = "3.1")
-  @ReplacedBy(property = COMPACTION_SERVICE_ROOT_PLANNER)
-  TSERV_COMPACTION_SERVICE_ROOT_PLANNER("tserver.compaction.major.service.root.planner",
-      DefaultCompactionPlanner.class.getName(), PropertyType.CLASSNAME,
-      "Compaction planner for root tablet service.", "2.1.0"),
-  @Deprecated(since = "3.1", forRemoval = true)
-  TSERV_COMPACTION_SERVICE_ROOT_RATE_LIMIT("tserver.compaction.major.service.root.rate.limit", "0B",
-      PropertyType.BYTES,
-      "Maximum number of bytes to read or write per second over all major"
-          + " compactions in this compaction service, or 0B for unlimited.",
-      "2.1.0"),
-  @Deprecated(since = "3.1")
-  @ReplacedBy(property = COMPACTION_SERVICE_ROOT_MAX_OPEN)
-  TSERV_COMPACTION_SERVICE_ROOT_MAX_OPEN(
-      "tserver.compaction.major.service.root.planner.opts.maxOpen", "30", PropertyType.COUNT,
-      "The maximum number of files a compaction will open.", "2.1.0"),
-  @Deprecated(since = "3.1", forRemoval = true)
-  TSERV_COMPACTION_SERVICE_ROOT_EXECUTORS(
-      "tserver.compaction.major.service.root.planner.opts.executors",
-      "[{'name':'small','type':'internal','maxSize':'32M','numThreads':1},{'name':'huge','type':'internal','numThreads':1}]"
-          .replaceAll("'", "\""),
-      PropertyType.STRING,
-      "See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %}.",
-      "2.1.0"),
-  @Deprecated(since = "3.1")
-  @ReplacedBy(property = COMPACTION_SERVICE_META_PLANNER)
-  TSERV_COMPACTION_SERVICE_META_PLANNER("tserver.compaction.major.service.meta.planner",
-      DefaultCompactionPlanner.class.getName(), PropertyType.CLASSNAME,
-      "Compaction planner for metadata table.", "2.1.0"),
-  @Deprecated(since = "3.1", forRemoval = true)
-  TSERV_COMPACTION_SERVICE_META_RATE_LIMIT("tserver.compaction.major.service.meta.rate.limit", "0B",
-      PropertyType.BYTES,
-      "Maximum number of bytes to read or write per second over all major"
-          + " compactions in this compaction service, or 0B for unlimited.",
-      "2.1.0"),
-  @Deprecated(since = "3.1")
-  @ReplacedBy(property = COMPACTION_SERVICE_META_MAX_OPEN)
-  TSERV_COMPACTION_SERVICE_META_MAX_OPEN(
-      "tserver.compaction.major.service.meta.planner.opts.maxOpen", "30", PropertyType.COUNT,
-      "The maximum number of files a compaction will open.", "2.1.0"),
-  @Deprecated(since = "3.1", forRemoval = true)
-  TSERV_COMPACTION_SERVICE_META_EXECUTORS(
-      "tserver.compaction.major.service.meta.planner.opts.executors",
-      "[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'huge','type':'internal','numThreads':2}]"
-          .replaceAll("'", "\""),
-      PropertyType.STRING,
-      "See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %}.",
-      "2.1.0"),
-  @Deprecated(since = "3.1")
-  @ReplacedBy(property = COMPACTION_SERVICE_DEFAULT_PLANNER)
-  TSERV_COMPACTION_SERVICE_DEFAULT_PLANNER("tserver.compaction.major.service.default.planner",
-      DefaultCompactionPlanner.class.getName(), PropertyType.CLASSNAME,
-      "Planner for default compaction service.", "2.1.0"),
-  @Deprecated(since = "3.1", forRemoval = true)
-  TSERV_COMPACTION_SERVICE_DEFAULT_RATE_LIMIT("tserver.compaction.major.service.default.rate.limit",
-      "0B", PropertyType.BYTES,
-      "Maximum number of bytes to read or write per second over all major"
-          + " compactions in this compaction service, or 0B for unlimited.",
-      "2.1.0"),
-  @Deprecated(since = "3.1")
-  @ReplacedBy(property = COMPACTION_SERVICE_DEFAULT_MAX_OPEN)
-  TSERV_COMPACTION_SERVICE_DEFAULT_MAX_OPEN(
-      "tserver.compaction.major.service.default.planner.opts.maxOpen", "10", PropertyType.COUNT,
-      "The maximum number of files a compaction will open.", "2.1.0"),
-  @Deprecated(since = "3.1", forRemoval = true)
-  TSERV_COMPACTION_SERVICE_DEFAULT_EXECUTORS(
-      "tserver.compaction.major.service.default.planner.opts.executors",
-      "[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'medium','type':'internal','maxSize':'128M','numThreads':2},{'name':'large','type':'internal','numThreads':2}]"
-          .replaceAll("'", "\""),
-      PropertyType.STRING,
-      "See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %}.",
-      "2.1.0"),
   TSERV_MINC_MAXCONCURRENT("tserver.compaction.minor.concurrent.max", "4", PropertyType.COUNT,
       "The maximum number of concurrent minor compactions for a tablet server.", "1.3.5"),
   @Deprecated(since = "3.1")

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Preconditions;
 
 public enum Property {
-  COMPACTION_SERVICE_PREFIX("compaction.major.service.", null, PropertyType.PREFIX,
+  COMPACTION_SERVICE_PREFIX("compaction.service.", null, PropertyType.PREFIX,
       "Prefix for compaction services.", "3.1.0"),
   COMPACTION_SERVICE_ROOT_PLANNER("compaction.major.service.root.planner",
       DefaultCompactionPlanner.class.getName(), PropertyType.CLASSNAME,

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
@@ -243,7 +243,7 @@ public class DefaultCompactionPlanner implements CompactionPlanner {
     }
 
     if (tmpExec.size() < 1) {
-      throw new IllegalStateException("No defined executors for this planner");
+      throw new IllegalStateException("No defined executors or queues for this planner");
     }
 
     Collections.sort(tmpExec, Comparator.comparing(Executor::getMaxSize,

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
@@ -175,17 +175,17 @@ public class DefaultCompactionPlanner implements CompactionPlanner {
     List<Executor> tmpExec = new ArrayList<>();
     ExecutorConfig[] execConfigs = null;
     QueueConfig[] queueConfigs = null;
+    String values = "";
 
-    try {
-      execConfigs =
-          GSON.get().fromJson(params.getOptions().get("executors"), ExecutorConfig[].class);
-    } catch (NullPointerException npe) {
-      // npe could result from executors not being set as properties.
-    } finally {
+    if (params.getOptions().containsKey("executors")) {
+      values = params.getOptions().get("executors");
+    }
+
+    if (!values.isBlank()) {
+      execConfigs = GSON.get().fromJson(values, ExecutorConfig[].class);
+    } else {
       // Generated a zero-length array to avoid a npe thrown by forEach
-      if (execConfigs == null) {
-        execConfigs = new ExecutorConfig[0];
-      }
+      execConfigs = new ExecutorConfig[0];
     }
 
     for (ExecutorConfig executorConfig : execConfigs) {
@@ -219,12 +219,14 @@ public class DefaultCompactionPlanner implements CompactionPlanner {
       tmpExec.add(new Executor(ceid, maxSize));
     }
 
-    try {
-      queueConfigs = GSON.get().fromJson(params.getOptions().get("queues"), QueueConfig[].class);
-    } catch (NullPointerException npe) {
-      // Valid state where no "queues" property may have been set.
+    values = "";
+    if (params.getOptions().containsKey("queues")) {
+      values = params.getOptions().get("queues");
     }
-    if (queueConfigs == null) {
+
+    if (!values.isBlank()) {
+      queueConfigs = GSON.get().fromJson(values, QueueConfig[].class);
+    } else {
       // Generated a zero-length array to avoid a npe thrown by forEach
       queueConfigs = new QueueConfig[0];
     }

--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionPlannerInitParams.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionPlannerInitParams.java
@@ -60,7 +60,7 @@ public class CompactionPlannerInitParams implements CompactionPlanner.InitParame
 
   @Override
   public String getFullyQualifiedOption(String key) {
-    return Property.TSERV_COMPACTION_SERVICE_PREFIX.getKey() + serviceId + ".opts." + key;
+    return Property.COMPACTION_SERVICE_PREFIX.getKey() + serviceId + ".opts." + key;
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionPlannerInitParams.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionPlannerInitParams.java
@@ -23,7 +23,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.spi.common.ServiceEnvironment;
 import org.apache.accumulo.core.spi.compaction.CompactionExecutorId;
 import org.apache.accumulo.core.spi.compaction.CompactionPlanner;
@@ -38,14 +37,16 @@ public class CompactionPlannerInitParams implements CompactionPlanner.InitParame
   private final Set<CompactionExecutorId> requestedExternalExecutors;
   private final ServiceEnvironment senv;
   private final CompactionServiceId serviceId;
+  private final String prefix;
 
-  public CompactionPlannerInitParams(CompactionServiceId serviceId, Map<String,String> plannerOpts,
-      ServiceEnvironment senv) {
+  public CompactionPlannerInitParams(CompactionServiceId serviceId, String prefix,
+      Map<String,String> plannerOpts, ServiceEnvironment senv) {
     this.serviceId = serviceId;
     this.plannerOpts = plannerOpts;
     this.requestedExecutors = new HashMap<>();
     this.requestedExternalExecutors = new HashSet<>();
     this.senv = senv;
+    this.prefix = prefix;
   }
 
   @Override
@@ -60,7 +61,7 @@ public class CompactionPlannerInitParams implements CompactionPlanner.InitParame
 
   @Override
   public String getFullyQualifiedOption(String key) {
-    return Property.COMPACTION_SERVICE_PREFIX.getKey() + serviceId + ".opts." + key;
+    return prefix + serviceId + ".opts." + key;
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionServicesConfig.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionServicesConfig.java
@@ -126,19 +126,16 @@ public class CompactionServicesConfig {
           throw new IllegalArgumentException(
               "Incomplete compaction service definition, missing planner class: " + prop);
         }
-        // Only add the compaction options if they match the planner's defined prefix.
-        if (plannerPrefixes.get(tokens[0]).equals(prefix)) {
-          if (tokens.length == 4 && tokens[1].equals("planner") && tokens[2].equals("opts")) {
-            options.computeIfAbsent(tokens[0], k -> new HashMap<>()).put(tokens[3], val);
-          } else if (tokens.length == 3 && tokens[1].equals("rate") && tokens[2].equals("limit")) {
-            var eprop = Property.getPropertyByKey(prop);
-            if (eprop == null || aconf.isPropertySet(eprop)) {
-              rateLimits.put(tokens[0], ConfigurationTypeHelper.getFixedMemoryAsBytes(val));
-            }
-          } else if (!(tokens.length == 2 && tokens[1].equals("planner"))) {
-            throw new IllegalArgumentException(
-                "Malformed compaction service property " + prefix + prop);
+        if (tokens.length == 4 && tokens[1].equals("planner") && tokens[2].equals("opts")) {
+          options.computeIfAbsent(tokens[0], k -> new HashMap<>()).put(tokens[3], val);
+        } else if (tokens.length == 3 && tokens[1].equals("rate") && tokens[2].equals("limit")) {
+          var eprop = Property.getPropertyByKey(prop);
+          if (eprop == null || aconf.isPropertySet(eprop)) {
+            rateLimits.put(tokens[0], ConfigurationTypeHelper.getFixedMemoryAsBytes(val));
           }
+        } else if (!(tokens.length == 2 && tokens[1].equals("planner"))) {
+          throw new IllegalArgumentException(
+              "Malformed compaction service property " + prefix + prop);
         } else {
           log.warn(
               "Ignoring compaction property {} as does not match the prefix used by the referenced planner definition",

--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionServicesConfig.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionServicesConfig.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.core.util.compaction;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.ConfigurationTypeHelper;
@@ -35,15 +36,16 @@ import com.google.common.collect.Sets;
  * This class serves to configure compaction services from an {@link AccumuloConfiguration} object.
  *
  * Specifically, compaction service properties (those prefixed by "tserver.compaction.major
- * .service" or "compaction.major.service") are used.
+ * .service" or "compaction.service") are used.
  */
-@SuppressWarnings("deprecation")
 public class CompactionServicesConfig {
 
   private static final Logger log = LoggerFactory.getLogger(CompactionServicesConfig.class);
   private final Map<String,String> planners = new HashMap<>();
+  private final Map<String,String> plannerPrefixes = new HashMap<>();
   private final Map<String,Long> rateLimits = new HashMap<>();
   private final Map<String,Map<String,String>> options = new HashMap<>();
+  @SuppressWarnings("removal")
   private final Property oldPrefix = Property.TSERV_COMPACTION_SERVICE_PREFIX;
   private final Property newPrefix = Property.COMPACTION_SERVICE_PREFIX;
   long defaultRateLimit;
@@ -53,26 +55,33 @@ public class CompactionServicesConfig {
   @SuppressWarnings("removal")
   private long getDefaultThroughput() {
     return ConfigurationTypeHelper
-        .getMemoryAsBytes(Property.COMPACTION_SERVICE_DEFAULT_RATE_LIMIT.getDefaultValue());
+        .getMemoryAsBytes(Property.TSERV_COMPACTION_SERVICE_DEFAULT_RATE_LIMIT.getDefaultValue());
   }
 
-  private Map<String,String> getConfiguration(AccumuloConfiguration aconf) {
+  private Map<String,Map<String,String>> getConfiguration(AccumuloConfiguration aconf) {
+    Map<String,Map<String,String>> properties = new HashMap<>();
 
-    var newProps =  aconf.getAllPropertiesWithPrefixStripped(newPrefix);
-    Map<String,String> properties = new HashMap<>(newProps);
+    var newProps = aconf.getAllPropertiesWithPrefixStripped(newPrefix);
+    properties.put(newPrefix.getKey(), newProps);
+
     // get all of the services under the new prefix
-    var newServices = newProps.keySet().stream().map(prop->prop.split("\\.")[0]).collect(Collectors.toSet());
+    var newServices =
+        newProps.keySet().stream().map(prop -> prop.split("\\.")[0]).collect(Collectors.toSet());
+
+    Map<String,String> oldServices = new HashMap<>();
 
     for (Map.Entry<String,String> entry : aconf.getAllPropertiesWithPrefixStripped(oldPrefix)
         .entrySet()) {
       // Discard duplicate service definitions
       var service = entry.getKey().split("\\.")[0];
       if (newServices.contains(service)) {
-        log.warn("Duplicate compaction service '{}' definition exists. Ignoring property : '{}'", service, entry.getKey());
+        log.warn("Duplicate compaction service '{}' definition exists. Ignoring property : '{}'",
+            service, entry.getKey());
       } else {
-        properties.put(entry.getKey(), entry.getValue());
+        oldServices.put(entry.getKey(), entry.getValue());
       }
     }
+    properties.put(oldPrefix.getKey(), oldServices);
     // Return unmodifiable map
     return Map.copyOf(properties);
   }
@@ -80,19 +89,30 @@ public class CompactionServicesConfig {
   public CompactionServicesConfig(AccumuloConfiguration aconf) {
     Map<String,Map<String,String>> configs = getConfiguration(aconf);
 
-    Map<String,String> validOpts = new HashMap<>();
-
     // Find compaction planner defs first.
     configs.forEach((prefix, props) -> {
       props.forEach((prop, val) -> {
         String[] tokens = prop.split("\\.");
         if (tokens.length == 2 && tokens[1].equals("planner")) {
           if (prefix.equals(oldPrefix.getKey())) {
-            log.warn(
-                "Found compaction planner '{}' using a deprecated prefix. Please update property to use the '{}' prefix",
-                tokens[0], newPrefix);
+            // Log a warning if the old prefix planner is defined by a user.
+            Property userDefined = null;
+            try {
+              userDefined = Property.valueOf(prefix + prop);
+            } catch (IllegalArgumentException e) {
+              log.trace("Property: {} is not set by default configuration", prefix + prop);
+            }
+            boolean isPropSet = true;
+            if (userDefined != null) {
+              isPropSet = aconf.isPropertySet(userDefined);
+            }
+            if (isPropSet) {
+              log.warn(
+                  "Found compaction planner '{}' using a deprecated prefix. Please update property to use the '{}' prefix",
+                  tokens[0], newPrefix);
+            }
           }
-          validOpts.put(tokens[0], prefix);
+          plannerPrefixes.put(tokens[0], prefix);
           planners.put(tokens[0], val);
         }
       });
@@ -102,13 +122,12 @@ public class CompactionServicesConfig {
     configs.forEach((prefix, props) -> {
       props.forEach((prop, val) -> {
         String[] tokens = prop.split("\\.");
-        if (!validOpts.containsKey(tokens[0])) {
+        if (!plannerPrefixes.containsKey(tokens[0])) {
           throw new IllegalArgumentException(
-              "Incomplete compaction service definition, missing planner class" + prop);
+              "Incomplete compaction service definition, missing planner class: " + prop);
         }
-        // Only add the compaction options if defined with the new prefix
-        // or match the planner's defined prefix.
-        if (prefix.equals(newPrefix.getKey()) || validOpts.get(tokens[0]).equals(prefix)) {
+        // Only add the compaction options if they match the planner's defined prefix.
+        if (plannerPrefixes.get(tokens[0]).equals(prefix)) {
           if (tokens.length == 4 && tokens[1].equals("planner") && tokens[2].equals("opts")) {
             options.computeIfAbsent(tokens[0], k -> new HashMap<>()).put(tokens[3], val);
           } else if (tokens.length == 3 && tokens[1].equals("rate") && tokens[2].equals("limit")) {
@@ -122,8 +141,7 @@ public class CompactionServicesConfig {
           }
         } else {
           log.warn(
-              "Ignoring compaction property {}, property either uses a deprecated prefix"
-                  + " or does not match the prefix used by the referenced planner definition",
+              "Ignoring compaction property {} as does not match the prefix used by the referenced planner definition",
               prop);
         }
       });
@@ -161,6 +179,10 @@ public class CompactionServicesConfig {
 
   public Map<String,String> getPlanners() {
     return planners;
+  }
+
+  public String getPlannerPrefix(String service) {
+    return plannerPrefixes.get(service);
   }
 
   public Map<String,Long> getRateLimits() {

--- a/core/src/test/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlannerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlannerTest.java
@@ -250,8 +250,25 @@ public class DefaultCompactionPlannerTest {
     EasyMock.expect(senv.getConfiguration()).andReturn(conf).anyTimes();
     EasyMock.replay(conf, senv);
 
-    String queues = "[{\"name\": \"midsize\", \"maxSize\":\"32M\"},{\"name\":\"small\"}]";
+    String queues = "[{\"name\": \"small\", \"maxSize\":\"32M\"},{\"name\":\"midsize\"}]";
     planner.init(getInitParamQueues(senv, queues));
+
+    var all = createCFs("F1", "1M", "F2", "1M", "F3", "1M", "F4", "1M");
+    var params = createPlanningParams(all, all, Set.of(), 2, CompactionKind.SYSTEM);
+    var plan = planner.makePlan(params);
+
+    var job = getOnlyElement(plan.getJobs());
+    assertEquals(all, job.getFiles());
+    assertEquals(CompactionExecutorIdImpl.externalId("small"), job.getExecutor());
+
+
+    all = createCFs("F1", "100M", "F2", "100M", "F3", "100M", "F4", "100M");
+    params = createPlanningParams(all, all, Set.of(), 2, CompactionKind.SYSTEM);
+    plan = planner.makePlan(params);
+
+    job = getOnlyElement(plan.getJobs());
+    assertEquals(all, job.getFiles());
+    assertEquals(CompactionExecutorIdImpl.externalId("midsize"), job.getExecutor());
   }
 
   /**

--- a/core/src/test/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlannerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlannerTest.java
@@ -241,7 +241,7 @@ public class DefaultCompactionPlannerTest {
   }
 
   @Test
-  public void testQueueCreation() {
+  public void testQueueCreation() throws Exception {
     DefaultCompactionPlanner planner = new DefaultCompactionPlanner();
     Configuration conf = EasyMock.createMock(Configuration.class);
     EasyMock.expect(conf.isSet(EasyMock.anyString())).andReturn(false).anyTimes();
@@ -260,7 +260,6 @@ public class DefaultCompactionPlannerTest {
     var job = getOnlyElement(plan.getJobs());
     assertEquals(all, job.getFiles());
     assertEquals(CompactionExecutorIdImpl.externalId("small"), job.getExecutor());
-
 
     all = createCFs("F1", "100M", "F2", "100M", "F3", "100M", "F4", "100M");
     params = createPlanningParams(all, all, Set.of(), 2, CompactionKind.SYSTEM);
@@ -376,7 +375,7 @@ public class DefaultCompactionPlannerTest {
 
     var e = assertThrows(IllegalStateException.class, () -> planner.init(execParams),
         "Failed to throw error");
-    assertEquals("No defined executors for this planner", e.getMessage(),
+    assertEquals("No defined executors or queues for this planner", e.getMessage(),
         "Error message was not equal");
 
     var params = getInitParamQueues(senv, "");
@@ -384,7 +383,7 @@ public class DefaultCompactionPlannerTest {
 
     var err = assertThrows(IllegalStateException.class, () -> planner.init(params),
         "Failed to throw error");
-    assertEquals("No defined executors for this planner", e.getMessage(),
+    assertEquals("No defined executors or queues for this planner", e.getMessage(),
         "Error message was not equal");
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/util/compaction/CompactionServicesConfigTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/compaction/CompactionServicesConfigTest.java
@@ -19,7 +19,6 @@
 package org.apache.accumulo.core.util.compaction;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -50,9 +49,7 @@ public class CompactionServicesConfigTest {
     conf.set(oldPrefix.getKey() + "default.planner.opts.validProp", "a");
 
     var compactionConfig = new CompactionServicesConfig(conf);
-    assertTrue(compactionConfig.getOptions().get("default").containsKey("validProp"));
-    assertEquals("1", compactionConfig.getOptions().get("default").get("validProp"));
-    assertNull(compactionConfig.getOptions().get("default").get("ignoredProp"));
+    assertEquals(Map.of("validProp", "1"), compactionConfig.getOptions().get("default"));
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/util/compaction/CompactionServicesConfigTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/compaction/CompactionServicesConfigTest.java
@@ -49,7 +49,9 @@ public class CompactionServicesConfigTest {
     conf.set(oldPrefix.getKey() + "default.planner.opts.validProp", "a");
 
     var compactionConfig = new CompactionServicesConfig(conf);
-    assertEquals(Map.of("validProp", "1"), compactionConfig.getOptions().get("default"));
+    assertEquals(Map.of("maxOpen", "10", "executors",
+        "[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'medium','type':'internal','maxSize':'128M','numThreads':2},{'name':'large','type':'internal','numThreads':2}]",
+        "validProp", "1"), compactionConfig.getOptions().get("default"));
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/util/compaction/CompactionServicesConfigTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/compaction/CompactionServicesConfigTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.util.compaction;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.accumulo.core.conf.ConfigurationCopy;
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("deprecation")
+public class CompactionServicesConfigTest {
+
+  private final Property oldPrefix = Property.TSERV_COMPACTION_SERVICE_PREFIX;
+  private final Property newPrefix = Property.COMPACTION_SERVICE_PREFIX;
+
+  @Test
+  public void testCompactionProps() {
+    ConfigurationCopy conf = new ConfigurationCopy();
+
+    conf.set("compaction.major.service.default.planner", DefaultCompactionPlanner.class.getName());
+    conf.set("compaction.major.service.default.planner.opts.maxOpen", "10");
+    conf.set("compaction.major.service.default.planner.opts.executors",
+        "[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'medium','type':'internal','maxSize':'128M','numThreads':2},{'name':'large','type':'internal','numThreads':2}]");
+
+    conf.set(oldPrefix.getKey() + "default.planner.opts.ignoredProp", "1");
+    conf.set(newPrefix.getKey() + "default.planner.opts.validProp", "1");
+
+    var compactionConfig = new CompactionServicesConfig(conf);
+    assertTrue(compactionConfig.getOptions().get("default").containsKey("validProp"));
+    assertEquals("1", compactionConfig.getOptions().get("default").get("validProp"));
+    assertNull(compactionConfig.getOptions().get("default").get("ignoredProp"));
+  }
+
+  @Test
+  public void testDuplicateCompactionPlannerDefs() {
+    ConfigurationCopy conf = new ConfigurationCopy();
+
+    String planner = DefaultCompactionPlanner.class.getName();
+    String oldPlanner = "OldPlanner";
+
+    conf.set(newPrefix.getKey() + "default.planner", planner);
+    conf.set(oldPrefix.getKey() + "default.planner", oldPlanner);
+
+    conf.set(oldPrefix.getKey() + "old.planner", oldPlanner);
+
+    var compactionConfig = new CompactionServicesConfig(conf);
+
+    assertTrue(compactionConfig.getPlanners().containsKey("default"));
+    assertEquals(planner, compactionConfig.getPlanners().get("default"));
+
+    assertTrue(compactionConfig.getPlanners().containsKey("old"));
+    assertEquals(oldPlanner, compactionConfig.getPlanners().get("old"));
+  }
+
+  @Test
+  public void testCompactionPlannerOldDef() {
+    ConfigurationCopy conf = new ConfigurationCopy();
+
+    conf.set(oldPrefix.getKey() + "cs1.planner", DefaultCompactionPlanner.class.getName());
+    conf.set(oldPrefix.getKey() + "cs1.planner.opts.maxOpen", "10");
+    conf.set(oldPrefix.getKey() + "cs1.planner.opts.executors",
+        "[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'medium','type':'internal','maxSize':'128M','numThreads':2},{'name':'large','type':'internal','numThreads':2}]");
+    conf.set(oldPrefix.getKey() + "cs1.planner.opts.foo", "1");
+    conf.set(newPrefix.getKey() + "cs1.planner.opts.bar", "2");
+
+    var compactionConfig = new CompactionServicesConfig(conf);
+    assertTrue(compactionConfig.getOptions().get("cs1").containsKey("foo"));
+    assertEquals("1", compactionConfig.getOptions().get("cs1").get("foo"));
+
+    assertTrue(compactionConfig.getOptions().get("cs1").containsKey("bar"));
+    assertEquals("2", compactionConfig.getOptions().get("cs1").get("bar"));
+  }
+
+  @Test
+  public void testCompactionRateLimits() {
+    ConfigurationCopy conf = new ConfigurationCopy();
+    CompactionServicesConfig compactionConfig;
+
+    conf.set(oldPrefix.getKey() + "cs1.planner", DefaultCompactionPlanner.class.getName());
+    conf.set(oldPrefix.getKey() + "cs1.rate.limit", "2M");
+    compactionConfig = new CompactionServicesConfig(conf);
+    assertEquals(2097152, compactionConfig.getRateLimits().get("cs1"));
+
+    // Test newPrefix property override
+    conf.set(newPrefix.getKey() + "cs1.rate.limit", "4M");
+    compactionConfig = new CompactionServicesConfig(conf);
+    assertEquals(4194304, compactionConfig.getRateLimits().get("cs1"));
+  }
+}

--- a/core/src/test/java/org/apache/accumulo/core/util/compaction/CompactionServicesConfigTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/compaction/CompactionServicesConfigTest.java
@@ -44,6 +44,7 @@ public class CompactionServicesConfigTest {
 
     conf.set(oldPrefix.getKey() + "default.planner.opts.ignoredProp", "1");
     conf.set(newPrefix.getKey() + "default.planner.opts.validProp", "1");
+    conf.set(oldPrefix.getKey() + "default.planner.opts.validProp", "a");
 
     var compactionConfig = new CompactionServicesConfig(conf);
     assertTrue(compactionConfig.getOptions().get("default").containsKey("validProp"));
@@ -65,11 +66,7 @@ public class CompactionServicesConfigTest {
 
     var compactionConfig = new CompactionServicesConfig(conf);
 
-    assertTrue(compactionConfig.getPlanners().containsKey("default"));
-    assertEquals(planner, compactionConfig.getPlanners().get("default"));
-
-    assertTrue(compactionConfig.getPlanners().containsKey("old"));
-    assertEquals(oldPlanner, compactionConfig.getPlanners().get("old"));
+assertEquals(Map.of("default",planner,"old",oldPlanner), compactionConfig.getPlanners());
   }
 
   @Test

--- a/server/base/src/main/java/org/apache/accumulo/server/compaction/CompactionWatcher.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/compaction/CompactionWatcher.java
@@ -98,7 +98,7 @@ public class CompactionWatcher implements Runnable {
     // remove any compaction that completed or made progress
     observedCompactions.keySet().retainAll(newKeys);
 
-    long warnTime = config.getTimeInMillis(Property.GENERAL_COMPACTION_WARN_TIME);
+    long warnTime = config.getTimeInMillis(Property.COMPACTION_WARN_TIME);
 
     // check for stuck compactions
     for (ObservedCompactionInfo oci : observedCompactions.values()) {

--- a/server/base/src/main/java/org/apache/accumulo/server/compaction/CompactionWatcher.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/compaction/CompactionWatcher.java
@@ -98,7 +98,7 @@ public class CompactionWatcher implements Runnable {
     // remove any compaction that completed or made progress
     observedCompactions.keySet().retainAll(newKeys);
 
-    long warnTime = config.getTimeInMillis(Property.TSERV_COMPACTION_WARN_TIME);
+    long warnTime = config.getTimeInMillis(Property.GENERAL_COMPACTION_WARN_TIME);
 
     // check for stuck compactions
     for (ObservedCompactionInfo oci : observedCompactions.values()) {

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/CheckCompactionConfig.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/CheckCompactionConfig.java
@@ -112,7 +112,8 @@ public class CheckCompactionConfig implements KeywordExecutable {
       CompactionPlanner planner = plannerClass.getDeclaredConstructor().newInstance();
 
       var initParams = new CompactionPlannerInitParams(CompactionServiceId.of(serviceId),
-          servicesConfig.getOptions().get(serviceId), senv);
+          servicesConfig.getPlannerPrefix(serviceId), servicesConfig.getOptions().get(serviceId),
+          senv);
 
       planner.init(initParams);
 

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/CheckCompactionConfigTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/CheckCompactionConfigTest.java
@@ -142,7 +142,7 @@ public class CheckCompactionConfigTest extends WithTestNames {
         + "[{'name':'small','type':'internal','maxSize':'16M','numThreads':8},\\\n"
         + "{'name':'medium','type':'internal','maxSize':'128M','numThreads':4},\\\n"
         + "{'name':'large','type':'internal','numThreads':2}]").replaceAll("'", "\"");
-    String expectedErrorMsg = "Incomplete compaction service definitions, missing planner class";
+    String expectedErrorMsg = "Incomplete compaction service definition, missing planner class";
 
     String filePath = writeToFileAndReturnPath(inputString);
 

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/CheckCompactionConfigTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/CheckCompactionConfigTest.java
@@ -80,6 +80,29 @@ public class CheckCompactionConfigTest extends WithTestNames {
   }
 
   @Test
+  public void testValidInput3() throws Exception {
+    String inputString = ("tserver.compaction.major.service.cs1.planner="
+        + "org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner \n"
+        + "tserver.compaction.major.service.cs1.planner.opts.executors=\\\n"
+        + "[{'name':'small','type':'internal','maxSize':'16M','numThreads':8},\\\n"
+        + "{'name':'medium','type':'internal','maxSize':'128M','numThreads':4},\\\n"
+        + "{'name':'large','type':'internal','numThreads':2}] \n"
+        + "tserver.compaction.major.service.cs2.planner="
+        + "org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner \n"
+        + "tserver.compaction.major.service.cs2.planner.opts.executors=\\\n"
+        + "[{'name':'small','type':'internal','maxSize':'16M','numThreads':7},\\\n"
+        + "{'name':'medium','type':'internal','maxSize':'128M','numThreads':5},\\\n"
+        + "{'name':'large','type':'external','queue':'DCQ1'}] \n"
+        + "compaction.major.service.cs3.planner="
+        + "org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner \n"
+        + "compaction.major.service.cs3.planner.opts.queues=\\\n"
+        + "[{'name':'small','maxSize':'16M'},{'name':'large'}]").replaceAll("'", "\"");
+
+    String filePath = writeToFileAndReturnPath(inputString);
+    CheckCompactionConfig.main(new String[] {filePath});
+  }
+
+  @Test
   public void testThrowsExternalNumThreadsError() throws IOException {
     String inputString = ("tserver.compaction.major.service.cs1.planner="
         + "org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner \n"
@@ -93,7 +116,7 @@ public class CheckCompactionConfigTest extends WithTestNames {
 
     var e = assertThrows(IllegalArgumentException.class,
         () -> CheckCompactionConfig.main(new String[] {filePath}));
-    assertEquals(e.getMessage(), expectedErrorMsg);
+    assertEquals(expectedErrorMsg, e.getMessage());
   }
 
   @Test
@@ -138,11 +161,29 @@ public class CheckCompactionConfigTest extends WithTestNames {
         + "{'name':'small','type':'internal','numThreads':2}]").replaceAll("'", "\"");
     String expectedErrorMsg = "Duplicate Compaction Executor ID found";
 
-    String filePath = writeToFileAndReturnPath(inputString);
+    final String filePath = writeToFileAndReturnPath(inputString);
 
     var e = assertThrows(IllegalStateException.class,
         () -> CheckCompactionConfig.main(new String[] {filePath}));
     assertTrue(e.getMessage().startsWith(expectedErrorMsg));
+  }
+
+  @Test
+  public void testRepeatedQueueName() throws Exception {
+    String inputString = ("tserver.compaction.major.service.cs1.planner="
+        + "org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner \n"
+        + "tserver.compaction.major.service.cs1.planner.opts.executors=\\\n"
+        + "[{'name':'small','type':'external','maxSize':'16M','queue':'failedQueue'}] \n"
+        + "compaction.major.service.cs1.planner.opts.queues=[{'name':'failedQueue'}]")
+        .replaceAll("'", "\"");
+
+    String expectedErrorMsg = "Duplicate external executor for queue failedQueue";
+
+    final String filePath = writeToFileAndReturnPath(inputString);
+
+    var err = assertThrows(IllegalArgumentException.class,
+        () -> CheckCompactionConfig.main(new String[] {filePath}));
+    assertEquals(err.getMessage(), expectedErrorMsg);
   }
 
   @Test

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/CheckCompactionConfigTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/CheckCompactionConfigTest.java
@@ -93,9 +93,9 @@ public class CheckCompactionConfigTest extends WithTestNames {
         + "[{'name':'small','type':'internal','maxSize':'16M','numThreads':7},\\\n"
         + "{'name':'medium','type':'internal','maxSize':'128M','numThreads':5},\\\n"
         + "{'name':'large','type':'external','queue':'DCQ1'}] \n"
-        + "compaction.major.service.cs3.planner="
+        + "compaction.service.cs3.planner="
         + "org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner \n"
-        + "compaction.major.service.cs3.planner.opts.queues=\\\n"
+        + "compaction.service.cs3.planner.opts.queues=\\\n"
         + "[{'name':'small','maxSize':'16M'},{'name':'large'}]").replaceAll("'", "\"");
 
     String filePath = writeToFileAndReturnPath(inputString);
@@ -170,11 +170,11 @@ public class CheckCompactionConfigTest extends WithTestNames {
 
   @Test
   public void testRepeatedQueueName() throws Exception {
-    String inputString = ("tserver.compaction.major.service.cs1.planner="
+    String inputString = ("compaction.service.cs1.planner="
         + "org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner \n"
-        + "tserver.compaction.major.service.cs1.planner.opts.executors=\\\n"
+        + "compaction.service.cs1.planner.opts.executors=\\\n"
         + "[{'name':'small','type':'external','maxSize':'16M','queue':'failedQueue'}] \n"
-        + "compaction.major.service.cs1.planner.opts.queues=[{'name':'failedQueue'}]")
+        + "compaction.service.cs1.planner.opts.queues=[{'name':'failedQueue'}]")
         .replaceAll("'", "\"");
 
     String expectedErrorMsg = "Duplicate external executor for queue failedQueue";

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionManager.java
@@ -205,7 +205,7 @@ public class CompactionManager {
       try {
         tmpServices.put(CompactionServiceId.of(serviceName),
             new CompactionService(serviceName, plannerClassName,
-                currentCfg.getRateLimit(serviceName),
+                currentCfg.getPlannerPrefix(serviceName), currentCfg.getRateLimit(serviceName),
                 currentCfg.getOptions().getOrDefault(serviceName, Map.of()), context, ceMetrics,
                 this::getExternalExecutor));
       } catch (RuntimeException e) {
@@ -249,11 +249,12 @@ public class CompactionManager {
             if (service == null) {
               tmpServices.put(csid,
                   new CompactionService(serviceName, plannerClassName,
-                      tmpCfg.getRateLimit(serviceName),
+                      tmpCfg.getPlannerPrefix(serviceName), tmpCfg.getRateLimit(serviceName),
                       tmpCfg.getOptions().getOrDefault(serviceName, Map.of()), context, ceMetrics,
                       this::getExternalExecutor));
             } else {
-              service.configurationChanged(plannerClassName, tmpCfg.getRateLimit(serviceName),
+              service.configurationChanged(plannerClassName, tmpCfg.getPlannerPrefix(serviceName),
+                  tmpCfg.getRateLimit(serviceName),
                   tmpCfg.getOptions().getOrDefault(serviceName, Map.of()));
               tmpServices.put(csid, service);
             }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionService.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionService.java
@@ -86,8 +86,8 @@ public class CompactionService {
 
   private static final Logger log = LoggerFactory.getLogger(CompactionService.class);
 
-  public CompactionService(String serviceName, String plannerClass, Long maxRate,
-      Map<String,String> plannerOptions, ServerContext context,
+  public CompactionService(String serviceName, String plannerClass, String plannerPrefix,
+      Long maxRate, Map<String,String> plannerOptions, ServerContext context,
       CompactionExecutorsMetrics ceMetrics,
       Function<CompactionExecutorId,ExternalCompactionExecutor> externExecutorSupplier) {
 
@@ -100,8 +100,8 @@ public class CompactionService {
     this.ceMetrics = ceMetrics;
     this.externExecutorSupplier = externExecutorSupplier;
 
-    var initParams =
-        new CompactionPlannerInitParams(myId, plannerOpts, new ServiceEnvironmentImpl(context));
+    var initParams = new CompactionPlannerInitParams(myId, plannerPrefix, plannerOpts,
+        new ServiceEnvironmentImpl(context));
     planner = createPlanner(myId, plannerClass, plannerOptions, initParams);
 
     Map<CompactionExecutorId,CompactionExecutor> tmpExecutors = new HashMap<>();
@@ -359,7 +359,7 @@ public class CompactionService {
         .anyMatch(job -> job.getStatus() == Status.QUEUED);
   }
 
-  public void configurationChanged(String plannerClassName, Long maxRate,
+  public void configurationChanged(String plannerClassName, String plannerPrefix, Long maxRate,
       Map<String,String> plannerOptions) {
     Preconditions.checkArgument(maxRate >= 0);
 
@@ -372,8 +372,8 @@ public class CompactionService {
       return;
     }
 
-    var initParams =
-        new CompactionPlannerInitParams(myId, plannerOptions, new ServiceEnvironmentImpl(context));
+    var initParams = new CompactionPlannerInitParams(myId, plannerPrefix, plannerOptions,
+        new ServiceEnvironmentImpl(context));
     var tmpPlanner = createPlanner(myId, plannerClassName, plannerOptions, initParams);
 
     Map<CompactionExecutorId,CompactionExecutor> tmpExecutors = new HashMap<>();

--- a/test/src/main/java/org/apache/accumulo/test/compaction/BadCompactionServiceConfigIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/BadCompactionServiceConfigIT.java
@@ -54,7 +54,7 @@ import com.google.common.collect.MoreCollectors;
 
 public class BadCompactionServiceConfigIT extends AccumuloClusterHarness {
 
-  private static final String CSP = Property.TSERV_COMPACTION_SERVICE_PREFIX.getKey();
+  private static final String CSP = Property.COMPACTION_SERVICE_PREFIX.getKey();
 
   @Override
   public void configureMiniCluster(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {

--- a/test/src/main/java/org/apache/accumulo/test/compaction/CompactionConfigChangeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/CompactionConfigChangeIT.java
@@ -57,10 +57,10 @@ public class CompactionConfigChangeIT extends AccumuloClusterHarness {
       final String table = getUniqueNames(1)[0];
 
       client.instanceOperations().setProperty(
-          Property.TSERV_COMPACTION_SERVICE_PREFIX.getKey() + "cs1.planner",
+          Property.COMPACTION_SERVICE_PREFIX.getKey() + "cs1.planner",
           DefaultCompactionPlanner.class.getName());
       client.instanceOperations().setProperty(
-          Property.TSERV_COMPACTION_SERVICE_PREFIX.getKey() + "cs1.planner.opts.executors",
+          Property.COMPACTION_SERVICE_PREFIX.getKey() + "cs1.planner.opts.executors",
           ("[{'name':'small','type':'internal','maxSize':'2M','numThreads':2},"
               + "{'name':'medium','type':'internal','maxSize':'128M','numThreads':2},"
               + "{'name':'large','type':'internal','numThreads':2}]").replaceAll("'", "\""));
@@ -91,7 +91,7 @@ public class CompactionConfigChangeIT extends AccumuloClusterHarness {
       // compactions. Because the compactions are running slow, expect this config change to overlap
       // with running compactions.
       client.instanceOperations().setProperty(
-          Property.TSERV_COMPACTION_SERVICE_PREFIX.getKey() + "cs1.planner.opts.executors",
+          Property.COMPACTION_SERVICE_PREFIX.getKey() + "cs1.planner.opts.executors",
           ("[{'name':'little','type':'internal','maxSize':'128M','numThreads':8},"
               + "{'name':'big','type':'internal','numThreads':2}]").replaceAll("'", "\""));
 

--- a/test/src/main/java/org/apache/accumulo/test/compaction/CompactionExecutorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/CompactionExecutorIT.java
@@ -140,7 +140,7 @@ public class CompactionExecutorIT extends SharedMiniClusterBase {
     SharedMiniClusterBase.startMiniClusterWithConfig((miniCfg, coreSite) -> {
       Map<String,String> siteCfg = new HashMap<>();
 
-      var csp = Property.TSERV_COMPACTION_SERVICE_PREFIX.getKey();
+      var csp = Property.COMPACTION_SERVICE_PREFIX.getKey();
       siteCfg.put(csp + "cs1.planner", TestPlanner.class.getName());
       siteCfg.put(csp + "cs1.planner.opts.executors", "3");
       siteCfg.put(csp + "cs1.planner.opts.filesPerCompaction", "5");
@@ -205,10 +205,11 @@ public class CompactionExecutorIT extends SharedMiniClusterBase {
 
       assertEquals(2, getFiles(client, "rctt").size());
 
-      client.instanceOperations().setProperty(Property.TSERV_COMPACTION_SERVICE_PREFIX.getKey()
-          + "recfg.planner.opts.filesPerCompaction", "5");
       client.instanceOperations().setProperty(
-          Property.TSERV_COMPACTION_SERVICE_PREFIX.getKey() + "recfg.planner.opts.executors", "1");
+          Property.COMPACTION_SERVICE_PREFIX.getKey() + "recfg.planner.opts.filesPerCompaction",
+          "5");
+      client.instanceOperations().setProperty(
+          Property.COMPACTION_SERVICE_PREFIX.getKey() + "recfg.planner.opts.executors", "1");
 
       addFiles(client, "rctt", 10);
 
@@ -223,15 +224,15 @@ public class CompactionExecutorIT extends SharedMiniClusterBase {
   @Test
   public void testAddCompactionService() throws Exception {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-      client.instanceOperations().setProperty(Property.TSERV_COMPACTION_SERVICE_PREFIX.getKey()
-          + "newcs.planner.opts.filesPerCompaction", "7");
       client.instanceOperations().setProperty(
-          Property.TSERV_COMPACTION_SERVICE_PREFIX.getKey() + "newcs.planner.opts.process",
-          "SYSTEM");
+          Property.COMPACTION_SERVICE_PREFIX.getKey() + "newcs.planner.opts.filesPerCompaction",
+          "7");
       client.instanceOperations().setProperty(
-          Property.TSERV_COMPACTION_SERVICE_PREFIX.getKey() + "newcs.planner.opts.executors", "3");
+          Property.COMPACTION_SERVICE_PREFIX.getKey() + "newcs.planner.opts.process", "SYSTEM");
       client.instanceOperations().setProperty(
-          Property.TSERV_COMPACTION_SERVICE_PREFIX.getKey() + "newcs.planner",
+          Property.COMPACTION_SERVICE_PREFIX.getKey() + "newcs.planner.opts.executors", "3");
+      client.instanceOperations().setProperty(
+          Property.COMPACTION_SERVICE_PREFIX.getKey() + "newcs.planner",
           TestPlanner.class.getName());
 
       createTable(client, "acst", "newcs");

--- a/test/src/main/java/org/apache/accumulo/test/compaction/CompactionRateLimitingIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/CompactionRateLimitingIT.java
@@ -41,7 +41,7 @@ public class CompactionRateLimitingIT extends ConfigurableMacBase {
 
   @SuppressWarnings("removal")
   protected Property getThroughputProp() {
-    return Property.COMPACTION_SERVICE_DEFAULT_RATE_LIMIT;
+    return Property.TSERV_COMPACTION_SERVICE_DEFAULT_RATE_LIMIT;
   }
 
   @Override

--- a/test/src/main/java/org/apache/accumulo/test/compaction/CompactionRateLimitingIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/CompactionRateLimitingIT.java
@@ -41,7 +41,7 @@ public class CompactionRateLimitingIT extends ConfigurableMacBase {
 
   @SuppressWarnings("removal")
   protected Property getThroughputProp() {
-    return Property.TSERV_COMPACTION_SERVICE_DEFAULT_RATE_LIMIT;
+    return Property.COMPACTION_SERVICE_DEFAULT_RATE_LIMIT;
   }
 
   @Override

--- a/test/src/main/java/org/apache/accumulo/test/shell/ConfigSetIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ConfigSetIT.java
@@ -49,6 +49,7 @@ public class ConfigSetIT extends SharedMiniClusterBase {
   private static final Logger log = LoggerFactory.getLogger(ConfigSetIT.class);
 
   @Test
+  @SuppressWarnings("removal")
   public void setInvalidJson() throws Exception {
     log.debug("Starting setInvalidJson test ------------------");
 
@@ -61,7 +62,6 @@ public class ConfigSetIT extends SharedMiniClusterBase {
 
     try (AccumuloClient client =
         getCluster().createAccumuloClient("root", new PasswordToken(getRootPassword()))) {
-
       client.instanceOperations().setProperty(TSERV_COMPACTION_SERVICE_ROOT_EXECUTORS.getKey(),
           validJson);
       assertThrows(AccumuloException.class, () -> client.instanceOperations()

--- a/test/src/main/java/org/apache/accumulo/test/util/SlowOps.java
+++ b/test/src/main/java/org/apache/accumulo/test/util/SlowOps.java
@@ -79,6 +79,7 @@ public class SlowOps {
     createData();
   }
 
+  @SuppressWarnings("removal")
   public static void setExpectedCompactions(AccumuloClient client, final int numParallelExpected) {
     final int target = numParallelExpected + 1;
     try {

--- a/test/src/main/java/org/apache/accumulo/test/util/SlowOps.java
+++ b/test/src/main/java/org/apache/accumulo/test/util/SlowOps.java
@@ -84,7 +84,7 @@ public class SlowOps {
     final int target = numParallelExpected + 1;
     try {
       client.instanceOperations().setProperty(
-          Property.COMPACTION_SERVICE_DEFAULT_EXECUTORS.getKey(),
+          Property.TSERV_COMPACTION_SERVICE_DEFAULT_EXECUTORS.getKey(),
           "[{'name':'any','numThreads':" + target + "}]".replaceAll("'", "\""));
       UtilWaitThread.sleep(3_000); // give it time to propagate
     } catch (AccumuloException | AccumuloSecurityException | NumberFormatException ex) {

--- a/test/src/main/java/org/apache/accumulo/test/util/SlowOps.java
+++ b/test/src/main/java/org/apache/accumulo/test/util/SlowOps.java
@@ -84,7 +84,7 @@ public class SlowOps {
     final int target = numParallelExpected + 1;
     try {
       client.instanceOperations().setProperty(
-          Property.TSERV_COMPACTION_SERVICE_DEFAULT_EXECUTORS.getKey(),
+          Property.COMPACTION_SERVICE_DEFAULT_EXECUTORS.getKey(),
           "[{'name':'any','numThreads':" + target + "}]".replaceAll("'", "\""));
       UtilWaitThread.sleep(3_000); // give it time to propagate
     } catch (AccumuloException | AccumuloSecurityException | NumberFormatException ex) {


### PR DESCRIPTION
These changes are part of #3472 and also handles the movement of the compaction properties out of the `TSERV` prefix and under a new compaction service prefix. 

* Part of the SPI deprecation means that the JSON object in `opts.executors` needed to be modified and only use a subset of its current fields. 
  * This PR creates a new property for the compaction service called `opts.queues` which allows external compaction queues to be defined.
  * While this new property has overlap with `executors` use, it does not allow for internal compaction executors to be defined.
  * I did not add the new property to the Property.java definition as that would require the default compaction services (`meta`, `root`, `default`) to use external compaction executors. 

* This PR also fixes issue in DocGen where NPE's were being thrown when a prefix was deprecated and replaced, but a property under that prefix was only being deprecated and not replaced. 