### PR TITLE
Replace logic for determining whether a Tablet is in use

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -1144,12 +1144,7 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
     if (t == null) {
       return false;
     }
-    t.updateRates(System.currentTimeMillis());
-    if (t.ingestRate() != 0.0 && t.queryRate() != 0.0 && t.scanRate() != 0.0) {
-      // tablet is ingesting or scanning
-      return true;
-    }
-    return false;
+    return t.isInUse();
   }
 
   public void evaluateOnDemandTabletsForUnload() {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -1597,4 +1597,12 @@ public class Tablet extends TabletBase {
     this.lastAccessTime = System.nanoTime();
   }
 
+  public boolean isInUse() {
+    // We can't use the lastAccessTime to determine if a Tablet is in use
+    // because it is only set when TabletServer.getOnlineTablet is called
+    // **and** that method is not called in every case where the Tablet
+    // is used.
+    return !activeScans.isEmpty() || writesInProgress > 0;
+  }
+
 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -1597,7 +1597,7 @@ public class Tablet extends TabletBase {
     this.lastAccessTime = System.nanoTime();
   }
 
-  public boolean isInUse() {
+  public synchronized boolean isInUse() {
     // We can't use the lastAccessTime to determine if a Tablet is in use
     // because it is only set when TabletServer.getOnlineTablet is called
     // **and** that method is not called in every case where the Tablet

--- a/test/src/main/java/org/apache/accumulo/test/functional/OnDemandTabletUnloadingIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/OnDemandTabletUnloadingIT.java
@@ -160,17 +160,11 @@ public class OnDemandTabletUnloadingIT extends SharedMiniClusterBase {
       assertEquals(4, stats.size());
       assertTrue(ClientTabletCache.getInstance((ClientContext) c, TableId.of(tableId))
           .getTabletHostingRequestCount() > 0);
-
-      while (ONDEMAND_ONLINE_COUNT != 4) {
-        Thread.sleep(100);
-      }
+      Wait.waitFor(() -> ONDEMAND_ONLINE_COUNT == 4);
 
       // Waiting for tablets to be unloaded due to inactivity
-      while (stats.size() != 0) {
-        Thread.sleep(1000);
-        stats = ManagerAssignmentIT.getTabletStats(c, tableId);
-      }
-
+      Wait.waitFor(() -> ONDEMAND_ONLINE_COUNT == 0);
+      Wait.waitFor(() -> ManagerAssignmentIT.getTabletStats(c, tableId).size() == 0);
     }
   }
 


### PR DESCRIPTION
The previous logic used the ingest and scan rates and would say a Tablet was not in use when the rates were zero. However, due to a smoothing function on the Rate class, this may not happen or would take a really long time. The logic was modified to use the internal Tablet activeScans and writesInProgress variables to determine if activity was currently happening instead of using the Rate-based metrics.

Fixes #3907