### PR TITLE
Improve logging of failing tests

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/functional/FunctionalTestUtils.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FunctionalTestUtils.java
@@ -133,14 +133,17 @@ public class FunctionalTestUtils {
       }
 
       if (tabletFileCounts.size() < minTablets || tabletFileCounts.size() > maxTablets) {
-        throw new Exception("Did not find expected number of tablets " + tabletFileCounts.size());
+        throw new Exception("table " + tableName + " has unexpected number of tablets. Found: "
+            + tabletFileCounts.size() + ". expected " + minTablets + " < numTablets < "
+            + maxTablets);
       }
 
       Set<Entry<Text,Integer>> es = tabletFileCounts.entrySet();
       for (Entry<Text,Integer> entry : es) {
         if (entry.getValue() > maxRFiles || entry.getValue() < minRFiles) {
           throw new Exception(
-              "tablet " + entry.getKey() + " has " + entry.getValue() + " data files");
+              "tablet " + entry.getKey() + " has unexpected number of data files. Found: "
+                  + entry.getValue() + ". expected " + minTablets + " < numFiles < " + maxTablets);
         }
       }
     }

--- a/test/src/main/java/org/apache/accumulo/test/functional/HalfClosedTabletIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/HalfClosedTabletIT.java
@@ -52,6 +52,8 @@ import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Sets;
 
@@ -62,6 +64,8 @@ import com.google.common.collect.Sets;
 // been failing the Tablet needs to be recovered when it's ultimately re-assigned.
 //
 public class HalfClosedTabletIT extends SharedMiniClusterBase {
+
+  public static final Logger log = LoggerFactory.getLogger(HalfClosedTabletIT.class);
 
   public static class HalfClosedTabletITConfiguration implements MiniClusterConfigurationCallback {
 
@@ -269,6 +273,7 @@ public class HalfClosedTabletIT extends SharedMiniClusterBase {
       FunctionalTestUtils.checkRFiles(c, tableName, minTablets, maxTablets, minRFiles, maxRFiles);
       return true;
     } catch (Exception e) {
+      log.info(e.getMessage());
       return false;
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/lock/ServiceLockIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/lock/ServiceLockIT.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.test.lock;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.harness.AccumuloITBase.ZOOKEEPER_TESTING_SERVER;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -637,12 +638,13 @@ public class ServiceLockIT {
         String first = children.get(0);
         int workerWithLock = parseLockWorkerName(first);
         LockWorker worker = workers.get(workerWithLock);
-        assertTrue(worker.holdsLock());
-        workers.forEach(w -> {
-          if (w != worker) {
-            assertFalse(w.holdsLock());
-          }
-        });
+        assertAll(() -> assertTrue(worker.holdsLock(),
+            "Expected worker, " + worker + " did not hold lock"), () -> workers.forEach(w -> {
+              if (w != worker) {
+                assertFalse(w.holdsLock(),
+                    "Expected worker, " + worker + " to hold lock. Instead " + w + " holds lock");
+              }
+            }));
         worker.unlock();
         Thread.sleep(100); // need to wait here so that the watchers fire.
       }


### PR DESCRIPTION
This PR improves the messages logged when an assert fails. 

[`HalfClosedTablet2IT.testInvalidContextCausesVolumeChooserFailure` ](https://ci-builds.apache.org/job/Accumulo/job/main/org.apache.accumulo$accumulo-test/593/testReport/junit/org.apache.accumulo.test.functional/HalfClosedTablet2IT/testInvalidContextCausesVolumeChooserFailure/)and [`ServiceLockIT.testLockParallel`](https://ci-builds.apache.org/job/Accumulo/job/main/org.apache.accumulo$accumulo-test/594/testReport/junit/org.apache.accumulo.test.lock/ServiceLockIT/testLockParallel/) have both seen failures in recent builds (linked). I have not looked into what might be causing these failures yet but figured this is a good first step which might help if they fail again.

