### PR TITLE
Add json property type with simple validation

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -35,6 +35,10 @@
       <artifactId>jcommander</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
     </dependency>

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -680,7 +680,7 @@ public enum Property {
       "tserver.compaction.major.service.meta.planner.opts.executors",
       "[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'huge','type':'internal','numThreads':2}]"
           .replaceAll("'", "\""),
-      PropertyType.STRING,
+      PropertyType.JSON,
       "See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %}.",
       "2.1.0"),
   TSERV_COMPACTION_SERVICE_DEFAULT_PLANNER("tserver.compaction.major.service.default.planner",
@@ -950,7 +950,7 @@ public enum Property {
       "A comma-separate list of allowed SSL protocols.", "1.5.3"),
   MONITOR_LOCK_CHECK_INTERVAL("monitor.lock.check.interval", "5s", PropertyType.TIMEDURATION,
       "The amount of time to sleep between checking for the Monitor ZooKeeper lock.", "1.5.1"),
-  MONITOR_RESOURCES_EXTERNAL("monitor.resources.external", "", PropertyType.STRING,
+  MONITOR_RESOURCES_EXTERNAL("monitor.resources.external", "", PropertyType.JSON,
       "A JSON Map of Strings. Each String should be an HTML tag of an external"
           + " resource (JS or CSS) to be imported by the Monitor. Be sure to wrap"
           + " with CDATA tags. If this value is set, all of the external resources"

--- a/core/src/main/java/org/apache/accumulo/core/conf/PropertyType.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/PropertyType.java
@@ -141,7 +141,7 @@ public enum PropertyType {
       "An arbitrary string of characters whose format is unspecified and"
           + " interpreted based on the context of the property to which it applies."),
 
-  JSON("json", x -> new ValidJson().test(x),
+  JSON("json", new ValidJson(),
       "An arbitrary string that is represents a valid, parsable generic json object."
           + "The validity of the json object in the context of the property usage is not checked by this type."),
   BOOLEAN("boolean", in(false, null, "true", "false"),
@@ -195,12 +195,6 @@ public enum PropertyType {
     return predicate.test(value);
   }
 
-  // ObjectMapper is thread-safe, but uses synchronization. If this causes contention, ThreadLocal
-  // may be an option.
-  private static final ObjectMapper jsonMapper =
-      new ObjectMapper().enable(DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY)
-          .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
-
   /**
    * Validate that the provided string can be parsed into a json object. This implementation uses
    * jackson databind because it is less permissive that GSON for what is considered valid. This
@@ -210,6 +204,12 @@ public enum PropertyType {
    */
   private static class ValidJson implements Predicate<String> {
     private static final Logger log = LoggerFactory.getLogger(ValidJson.class);
+
+    // ObjectMapper is thread-safe, but uses synchronization. If this causes contention, ThreadLocal
+    // may be an option.
+    private final ObjectMapper jsonMapper =
+        new ObjectMapper().enable(DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY)
+            .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
 
     // set a limit of 1 million characters on the string as rough guard on invalid input
     private static final int ONE_MILLION = 1024 * 1024;

--- a/core/src/main/java/org/apache/accumulo/core/conf/PropertyType.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/PropertyType.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.core.conf;
 
 import static java.util.Objects.requireNonNull;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Function;
@@ -32,7 +33,11 @@ import java.util.stream.Stream;
 import org.apache.accumulo.core.file.rfile.RFile;
 import org.apache.commons.lang3.Range;
 import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 
 /**
@@ -136,6 +141,9 @@ public enum PropertyType {
       "An arbitrary string of characters whose format is unspecified and"
           + " interpreted based on the context of the property to which it applies."),
 
+  JSON("json", x -> new ValidJson().test(x),
+      "An arbitrary string that is represents a valid, parsable generic json object."
+          + "The validity of the json object in the context of the property usage is not checked by this type."),
   BOOLEAN("boolean", in(false, null, "true", "false"),
       "Has a value of either 'true' or 'false' (case-insensitive)"),
 
@@ -145,14 +153,15 @@ public enum PropertyType {
       "One of the currently supported filename extensions for storing table data files. "
           + "Currently, only " + RFile.EXTENSION + " is supported.");
 
-  private String shortname, format;
+  private final String shortname;
+  private final String format;
   // Field is transient because enums are Serializable, but Predicates aren't necessarily,
   // and our lambdas certainly aren't; This shouldn't matter because enum serialization doesn't
   // store fields, so this is a false positive in our spotbugs version
   // see https://github.com/spotbugs/spotbugs/issues/740
-  private transient Predicate<String> predicate;
+  private transient final Predicate<String> predicate;
 
-  private PropertyType(String shortname, Predicate<String> predicate, String formatDescription) {
+  PropertyType(String shortname, Predicate<String> predicate, String formatDescription) {
     this.shortname = shortname;
     this.predicate = Objects.requireNonNull(predicate);
     this.format = formatDescription;
@@ -184,6 +193,39 @@ public enum PropertyType {
     Preconditions.checkState(predicate != null,
         "Predicate was null, maybe this enum was serialized????");
     return predicate.test(value);
+  }
+
+  /**
+   * Validate that the provided string can be parsed into a json object. This implementation uses
+   * jackson databind because it is less permissive that GSON for what is considered valid. This
+   * implementation cannot guarantee that the json is valid for the target usage. That would require
+   * something like a json schema or a check specific to the use-case. This is only trying to
+   * provide a generic, minimal check that at least the json is valid.
+   */
+  private static class ValidJson implements Predicate<String> {
+    private static final Logger log = LoggerFactory.getLogger(ValidJson.class);
+
+    // set a limit of 1 million characters on the string as rough sanity check
+    private static final int ONE_MILLION = 1024 * 1024;
+
+    @Override
+    public boolean test(String value) {
+      try {
+        if (value.length() > ONE_MILLION) {
+          log.info("provided json string length {} is greater than limit of {} for parsing",
+              value.length(), ONE_MILLION);
+          return false;
+        }
+        ObjectMapper mapper =
+            new ObjectMapper().enable(DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY)
+                .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
+
+        mapper.readTree(value);
+        return true;
+      } catch (IOException ex) {
+        return false;
+      }
+    }
   }
 
   private static Predicate<String> in(final boolean caseSensitive, final String... allowedSet) {

--- a/core/src/test/java/org/apache/accumulo/core/conf/PropertyTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/PropertyTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.core.conf;
 
-import static org.apache.accumulo.core.conf.Property.TSERV_COMPACTION_SERVICE_META_EXECUTORS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -109,9 +108,7 @@ public class PropertyTest {
 
   @Test
   public void testJson() {
-    assertFalse(TSERV_COMPACTION_SERVICE_META_EXECUTORS.getType().isValidFormat("notJson"));
-
-    // use "real" example
+    // using "real" example
     String json1 =
         "[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'huge','type':'internal','numThreads':2}]"
             .replaceAll("'", "\"");
@@ -119,10 +116,11 @@ public class PropertyTest {
     String json2 =
         "[{'foo':'bar','type':'test','fooBar':'32'},{'foo':'bar','type':'test','fooBar':32}]"
             .replaceAll("'", "\"");
+    String json3 = "{'foo':'bar','type':'test','fooBar':'32'}".replaceAll("'", "\"");
 
-    List<String> valids = List.of(json1, json2);
+    List<String> valids = List.of(json1, json2, json3);
 
-    List<String> invalids = List.of("not json", "{\"x}", "{\"y\"", "{name:value}",
+    List<String> invalids = List.of("notJson", "also not json", "{\"x}", "{\"y\"", "{name:value}",
         "{ \"foo\" : \"bar\", \"foo\" : \"baz\" }", "{\"y\":123}extra");
 
     for (Property prop : Property.values()) {

--- a/core/src/test/java/org/apache/accumulo/core/conf/PropertyTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/PropertyTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map.Entry;
 import java.util.TreeMap;
 import java.util.function.Predicate;
@@ -108,16 +109,31 @@ public class PropertyTest {
 
   @Test
   public void testJson() {
-    // JsonParser.parseString("not json");
-
-    var p1 = TSERV_COMPACTION_SERVICE_META_EXECUTORS;
     assertFalse(TSERV_COMPACTION_SERVICE_META_EXECUTORS.getType().isValidFormat("notJson"));
 
-    String json =
+    // use "real" example
+    String json1 =
         "[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'huge','type':'internal','numThreads':2}]"
             .replaceAll("'", "\"");
-    assertTrue(Property.isValidProperty(p1.getKey(), json));
+    // use synthetic, but valid json
+    String json2 =
+        "[{'foo':'bar','type':'test','fooBar':'32'},{'foo':'bar','type':'test','fooBar':32}]"
+            .replaceAll("'", "\"");
 
+    List<String> valids = List.of(json1, json2);
+
+    List<String> invalids = List.of("not json", "{\"x}", "{\"y\"", "{name:value}",
+        "{ \"foo\" : \"bar\", \"foo\" : \"baz\" }", "{\"y\":123}extra");
+
+    for (Property prop : Property.values()) {
+      if (prop.getType().equals(PropertyType.JSON)) {
+        valids.forEach(j -> assertTrue(Property.isValidProperty(prop.getKey(), j)));
+        valids.forEach(j -> assertTrue(prop.getType().isValidFormat(j)));
+
+        invalids.forEach(j -> assertFalse(Property.isValidProperty(prop.getKey(), j)));
+        invalids.forEach(j -> assertFalse(prop.getType().isValidFormat(j)));
+      }
+    }
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/conf/PropertyTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/PropertyTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.conf;
 
+import static org.apache.accumulo.core.conf.Property.TSERV_COMPACTION_SERVICE_META_EXECUTORS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -106,6 +107,20 @@ public class PropertyTest {
   }
 
   @Test
+  public void testJson() {
+    // JsonParser.parseString("not json");
+
+    var p1 = TSERV_COMPACTION_SERVICE_META_EXECUTORS;
+    assertFalse(TSERV_COMPACTION_SERVICE_META_EXECUTORS.getType().isValidFormat("notJson"));
+
+    String json =
+        "[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'huge','type':'internal','numThreads':2}]"
+            .replaceAll("'", "\"");
+    assertTrue(Property.isValidProperty(p1.getKey(), json));
+
+  }
+
+  @Test
   public void testPropertyValidation() {
 
     for (Property property : Property.values()) {
@@ -161,6 +176,9 @@ public class PropertyTest {
           break;
         case BOOLEAN:
           invalidValue = "fooFalse";
+          break;
+        case JSON:
+          invalidValue = "not json";
           break;
         default:
           LOG.debug("Property type: {} has no defined test case", propertyType);

--- a/core/src/test/java/org/apache/accumulo/core/conf/PropertyTypeTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/PropertyTypeTest.java
@@ -77,7 +77,7 @@ public class PropertyTypeTest extends WithTestNames {
         .collect(Collectors.toSet());
 
     Set<String> types =
-        Stream.of(PropertyType.values()).map(Enum<PropertyType>::name).collect(Collectors.toSet());
+        Stream.of(PropertyType.values()).map(Enum::name).collect(Collectors.toSet());
 
     assertEquals(types, typesTested, "Expected to see a test method for each property type");
   }
@@ -187,6 +187,15 @@ public class PropertyTypeTest extends WithTestNames {
   public void testTypePORT() {
     valid(null, "0", "1024", "30000", "65535");
     invalid("65536", "-65535", "-1", "1023");
+  }
+
+  @Test
+  public void testTypeJSON() {
+    valid("{\"y\":123}",
+        "[{'name':'small','type':'internal','maxSize':'32M','numThreads':1},{'name':'huge','type':'internal','numThreads':1}]"
+            .replaceAll("'", "\""));
+    invalid("not json", "{\"x}", "{\"y\"", "{name:value}",
+        "{ \"foo\" : \"bar\", \"foo\" : \"baz\" }", "{\"y\":123}extra");
   }
 
   @Test

--- a/test/src/main/java/org/apache/accumulo/test/shell/ConfigSetIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ConfigSetIT.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test.shell;
+
+import static org.apache.accumulo.core.conf.Property.MONITOR_RESOURCES_EXTERNAL;
+import static org.apache.accumulo.core.conf.Property.TSERV_COMPACTION_SERVICE_ROOT_EXECUTORS;
+import static org.apache.accumulo.harness.AccumuloITBase.MINI_CLUSTER_ONLY;
+import static org.apache.accumulo.harness.AccumuloITBase.SUNNY_DAY;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.security.tokens.PasswordToken;
+import org.apache.accumulo.harness.SharedMiniClusterBase;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Tag(MINI_CLUSTER_ONLY)
+@Tag(SUNNY_DAY)
+public class ConfigSetIT extends SharedMiniClusterBase {
+  @BeforeAll
+  public static void setup() throws Exception {
+    SharedMiniClusterBase.startMiniCluster();
+  }
+
+  @AfterAll
+  public static void teardown() {
+    SharedMiniClusterBase.stopMiniCluster();
+  }
+
+  private static final Logger log = LoggerFactory.getLogger(ConfigSetIT.class);
+
+  @Test
+  public void setInvalidJson() throws Exception {
+    log.debug("Starting setInvalidJson test ------------------");
+
+    String validJson =
+        "[{'name':'small','type':'internal','maxSize':'64M','numThreads':2},{'name':'huge','type':'internal','numThreads':2}]"
+            .replaceAll("'", "\"");
+
+    // missing first value
+    String invalidJson = "notJson";
+
+    try (AccumuloClient client =
+        getCluster().createAccumuloClient("root", new PasswordToken(getRootPassword()))) {
+
+      client.instanceOperations().setProperty(TSERV_COMPACTION_SERVICE_ROOT_EXECUTORS.getKey(),
+          validJson);
+      assertThrows(AccumuloException.class, () -> client.instanceOperations()
+          .setProperty(MONITOR_RESOURCES_EXTERNAL.getKey(), invalidJson));
+
+    }
+  }
+}

--- a/test/src/main/java/org/apache/accumulo/test/shell/ConfigSetIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ConfigSetIT.java
@@ -21,7 +21,6 @@ package org.apache.accumulo.test.shell;
 import static org.apache.accumulo.core.conf.Property.MONITOR_RESOURCES_EXTERNAL;
 import static org.apache.accumulo.core.conf.Property.TSERV_COMPACTION_SERVICE_ROOT_EXECUTORS;
 import static org.apache.accumulo.harness.AccumuloITBase.MINI_CLUSTER_ONLY;
-import static org.apache.accumulo.harness.AccumuloITBase.SUNNY_DAY;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -36,7 +35,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Tag(MINI_CLUSTER_ONLY)
-@Tag(SUNNY_DAY)
 public class ConfigSetIT extends SharedMiniClusterBase {
   @BeforeAll
   public static void setup() throws Exception {

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellIT.java
@@ -496,6 +496,7 @@ public class ShellIT extends SharedMiniClusterBase {
         case PATH:
         case PREFIX:
         case STRING:
+        case JSON:
           Shell.log.debug("Skipping " + propertyType + " Property Types");
           continue;
         case TIMEDURATION:
@@ -714,5 +715,4 @@ public class ShellIT extends SharedMiniClusterBase {
     exec("getsplits -m 0", true,
         "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\na\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\nl\nm\nn\no\np\nq\nr\ns\nt\n");
   }
-
 }


### PR DESCRIPTION
Adds a JSON PropertyType and minimal validation that verifies the property value can be parsed into a JSON object.

This was inspired by issue #3909, but does not directly address it.

1. Some current properties defer validation until use and this PR does not address that. (That could be done in a follow-on PR)
2. Some configurations require multiple, independent properties be set for a valid configuration, This PR does not  attempt to perform that validation - that responsibility is deferred to the implementations that use those properties.

This implementation was to provide a minimal check, that follow on PRs could extend / leverage to introduce additional property validation.
