### PR TITLE
Modified Compactor and ScanServer to advertise Client service

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -1487,7 +1487,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
         // this operation may us a lot of memory... it's likely that connections to tabletservers
         // hosting metadata tablets will be cached, so do not use cached
         // connections
-        pair = ThriftClientTypes.CLIENT.getTabletServerConnection(context, false);
+        pair = ThriftClientTypes.CLIENT.getThriftServerConnection(context, false);
         diskUsages = pair.getSecond().getDiskUsage(tableNames, context.rpcCreds());
       } catch (ThriftTableOperationException e) {
         switch (e.getType()) {

--- a/core/src/main/java/org/apache/accumulo/core/rpc/clients/ClientServiceThriftClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/clients/ClientServiceThriftClient.java
@@ -24,6 +24,7 @@ import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.clientImpl.thrift.ClientService.Client;
+import org.apache.accumulo.core.lock.ServiceLockData.ThriftService;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
@@ -40,10 +41,10 @@ public class ClientServiceThriftClient extends ThriftClientTypes<Client>
   }
 
   @Override
-  public Pair<String,Client> getTabletServerConnection(ClientContext context,
+  public Pair<String,Client> getThriftServerConnection(ClientContext context,
       boolean preferCachedConnections) throws TTransportException {
-    return getTabletServerConnection(LOG, this, context, preferCachedConnections,
-        warnedAboutTServersBeingDown);
+    return getThriftServerConnection(LOG, this, context, preferCachedConnections,
+        warnedAboutTServersBeingDown, ThriftService.CLIENT);
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/rpc/clients/TServerClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/clients/TServerClient.java
@@ -21,8 +21,11 @@ package org.apache.accumulo.core.rpc.clients;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.accumulo.core.Constants;
@@ -48,25 +51,33 @@ import org.slf4j.Logger;
 
 public interface TServerClient<C extends TServiceClient> {
 
-  Pair<String,C> getTabletServerConnection(ClientContext context, boolean preferCachedConnections)
+  Pair<String,C> getThriftServerConnection(ClientContext context, boolean preferCachedConnections)
       throws TTransportException;
 
-  default Pair<String,C> getTabletServerConnection(Logger LOG, ThriftClientTypes<C> type,
-      ClientContext context, boolean preferCachedConnections, AtomicBoolean warned)
-      throws TTransportException {
+  default Pair<String,C> getThriftServerConnection(Logger LOG, ThriftClientTypes<C> type,
+      ClientContext context, boolean preferCachedConnections, AtomicBoolean warned,
+      ThriftService service) throws TTransportException {
     checkArgument(context != null, "context is null");
     long rpcTimeout = context.getClientTimeoutInMillis();
     // create list of servers
     ArrayList<ThriftTransportKey> servers = new ArrayList<>();
 
     // add tservers
+    List<String> serverPaths = new ArrayList<>();
+    serverPaths.add(context.getZooKeeperRoot() + Constants.ZTSERVERS);
+    if (type == ThriftClientTypes.CLIENT) {
+      serverPaths.add(context.getZooKeeperRoot() + Constants.ZCOMPACTORS);
+      serverPaths.add(context.getZooKeeperRoot() + Constants.ZSSERVERS);
+      Collections.shuffle(serverPaths, RANDOM.get());
+    }
     ZooCache zc = context.getZooCache();
-    for (String tserver : zc.getChildren(context.getZooKeeperRoot() + Constants.ZTSERVERS)) {
-      var zLocPath =
-          ServiceLock.path(context.getZooKeeperRoot() + Constants.ZTSERVERS + "/" + tserver);
-      zc.getLockData(zLocPath).map(sld -> sld.getAddress(ThriftService.TSERV))
-          .map(address -> new ThriftTransportKey(address, rpcTimeout, context))
-          .ifPresent(servers::add);
+    for (String serverPath : serverPaths) {
+      for (String server : zc.getChildren(serverPath)) {
+        var zLocPath = ServiceLock.path(serverPath + "/" + server);
+        zc.getLockData(zLocPath).map(sld -> sld.getAddress(service))
+            .map(address -> new ThriftTransportKey(address, rpcTimeout, context))
+            .ifPresent(servers::add);
+      }
     }
 
     boolean opened = false;
@@ -96,7 +107,7 @@ public interface TServerClient<C extends TServiceClient> {
       String server = null;
       C client = null;
       try {
-        Pair<String,C> pair = getTabletServerConnection(context, true);
+        Pair<String,C> pair = getThriftServerConnection(context, true);
         server = pair.getFirst();
         client = pair.getSecond();
         return exec.execute(client);
@@ -123,7 +134,7 @@ public interface TServerClient<C extends TServiceClient> {
       String server = null;
       C client = null;
       try {
-        Pair<String,C> pair = getTabletServerConnection(context, true);
+        Pair<String,C> pair = getThriftServerConnection(context, true);
         server = pair.getFirst();
         client = pair.getSecond();
         exec.execute(client);

--- a/core/src/main/java/org/apache/accumulo/core/rpc/clients/TabletManagementClientServiceThriftClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/clients/TabletManagementClientServiceThriftClient.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.clientImpl.ClientContext;
+import org.apache.accumulo.core.lock.ServiceLockData.ThriftService;
 import org.apache.accumulo.core.tablet.thrift.TabletManagementClientService.Client;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.thrift.transport.TTransportException;
@@ -45,10 +46,10 @@ public class TabletManagementClientServiceThriftClient extends ThriftClientTypes
   }
 
   @Override
-  public Pair<String,Client> getTabletServerConnection(ClientContext context,
+  public Pair<String,Client> getThriftServerConnection(ClientContext context,
       boolean preferCachedConnections) throws TTransportException {
-    return getTabletServerConnection(LOG, this, context, preferCachedConnections,
-        warnedAboutTServersBeingDown);
+    return getThriftServerConnection(LOG, this, context, preferCachedConnections,
+        warnedAboutTServersBeingDown, ThriftService.TABLET_MANAGEMENT);
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/rpc/clients/TabletServerThriftClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/clients/TabletServerThriftClient.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.clientImpl.ClientContext;
+import org.apache.accumulo.core.lock.ServiceLockData.ThriftService;
 import org.apache.accumulo.core.tabletserver.thrift.TabletServerClientService.Client;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.thrift.transport.TTransportException;
@@ -44,10 +45,10 @@ public class TabletServerThriftClient extends ThriftClientTypes<Client>
   }
 
   @Override
-  public Pair<String,Client> getTabletServerConnection(ClientContext context,
+  public Pair<String,Client> getThriftServerConnection(ClientContext context,
       boolean preferCachedConnections) throws TTransportException {
-    return getTabletServerConnection(LOG, this, context, preferCachedConnections,
-        warnedAboutTServersBeingDown);
+    return getThriftServerConnection(LOG, this, context, preferCachedConnections,
+        warnedAboutTServersBeingDown, ThriftService.TSERV);
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/ThriftProcessorTypes.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/ThriftProcessorTypes.java
@@ -95,9 +95,11 @@ public class ThriftProcessorTypes<C extends TServiceClient> extends ThriftClient
   public static final ThriftProcessorTypes<TabletManagementClientService.Client> TABLET_MGMT =
       new ThriftProcessorTypes<>(ThriftClientTypes.TABLET_MGMT);
 
-  public static TMultiplexedProcessor getCompactorTProcessor(CompactorService.Iface serviceHandler,
-      ServerContext context) {
+  public static TMultiplexedProcessor getCompactorTProcessor(ClientServiceHandler clientHandler,
+      CompactorService.Iface serviceHandler, ServerContext context) {
     TMultiplexedProcessor muxProcessor = new TMultiplexedProcessor();
+    muxProcessor.registerProcessor(CLIENT.getServiceName(), CLIENT.getTProcessor(
+        ClientService.Processor.class, ClientService.Iface.class, clientHandler, context));
     muxProcessor.registerProcessor(COMPACTOR.getServiceName(), COMPACTOR.getTProcessor(
         CompactorService.Processor.class, CompactorService.Iface.class, serviceHandler, context));
     return muxProcessor;
@@ -126,9 +128,11 @@ public class ThriftProcessorTypes<C extends TServiceClient> extends ThriftClient
     return muxProcessor;
   }
 
-  public static TMultiplexedProcessor
-      getScanServerTProcessor(TabletScanClientService.Iface tserverHandler, ServerContext context) {
+  public static TMultiplexedProcessor getScanServerTProcessor(ClientServiceHandler clientHandler,
+      TabletScanClientService.Iface tserverHandler, ServerContext context) {
     TMultiplexedProcessor muxProcessor = new TMultiplexedProcessor();
+    muxProcessor.registerProcessor(CLIENT.getServiceName(), CLIENT.getTProcessor(
+        ClientService.Processor.class, ClientService.Iface.class, clientHandler, context));
     muxProcessor.registerProcessor(TABLET_SCAN.getServiceName(),
         TABLET_SCAN.getTProcessor(TabletScanClientService.Processor.class,
             TabletScanClientService.Iface.class, tserverHandler, context));


### PR DESCRIPTION
Modified Compactor and ScanServer to advertise Client service and modified client code to use TabletServer, ScanServer, and Compactor addresses when trying to execute an operation on the Client service API.

Fixes #3624