### PR TITLE
updates delete table to use conditional muations

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
@@ -231,6 +231,9 @@ public interface Ample {
    * @param resultsConsumer as conditional mutations are processed in the background their result is
    *        passed to this consumer. This consumer should be thread safe as it may be called from a
    *        different thread.
+   * @return A conditional tablet mutator that will asynchronously report results. Closing this
+   *         object will force everything to be processed and reported. The returned object is not
+   *         thread safe and is only intended to be used by a single thread.
    * @see ConditionalTabletMutator#submit(RejectionHandler)
    */
   default AsyncConditionalTabletsMutator
@@ -320,6 +323,9 @@ public interface Ample {
      */
     OperationRequirements mutateTablet(KeyExtent extent);
 
+    /**
+     * Closing ensures that all mutations are processed and their results are reported.
+     */
     @Override
     void close();
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/AsyncConditionalTabletsMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/AsyncConditionalTabletsMutatorImpl.java
@@ -47,7 +47,7 @@ public class AsyncConditionalTabletsMutatorImpl implements Ample.AsyncConditiona
     this.context = context;
     var creatorId = Thread.currentThread().getId();
     this.executor = Executors.newSingleThreadExecutor(runnable -> Threads.createThread(
-        "Async conditional tablets mutator background thread, created by : " + creatorId,
+        "Async conditional tablets mutator background thread, created by : #" + creatorId,
         runnable));
 
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/AsyncConditionalTabletsMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/AsyncConditionalTabletsMutatorImpl.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.metadata;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.function.BiConsumer;
+
+import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.core.metadata.schema.Ample;
+import org.apache.accumulo.server.ServerContext;
+
+public class AsyncConditionalTabletsMutatorImpl implements Ample.AsyncConditionalTabletsMutator {
+  private final BiConsumer<KeyExtent,Ample.ConditionalResult> resultsConsumer;
+  private final ExecutorService executor;
+  private Future<Map<KeyExtent,Ample.ConditionalResult>> backgroundProcessing = null;
+  private ConditionalTabletsMutatorImpl bufferingMutator;
+  private final ServerContext context;
+  private long mutatedTablets = 0;
+
+  public static final int BATCH_SIZE = 1000;
+
+  AsyncConditionalTabletsMutatorImpl(ServerContext context,
+      BiConsumer<KeyExtent,Ample.ConditionalResult> resultsConsumer) {
+    this.resultsConsumer = Objects.requireNonNull(resultsConsumer);
+    this.bufferingMutator = new ConditionalTabletsMutatorImpl(context);
+    this.context = context;
+    this.executor = Executors.newSingleThreadExecutor();
+
+  }
+
+  @Override
+  public Ample.OperationRequirements mutateTablet(KeyExtent extent) {
+    if (mutatedTablets > BATCH_SIZE) {
+      if (backgroundProcessing != null) {
+        // a previous batch of mutations was submitted for processing so wait on it.
+        try {
+          backgroundProcessing.get().forEach(resultsConsumer);
+        } catch (InterruptedException | ExecutionException e) {
+          throw new IllegalStateException(e);
+        }
+      }
+
+      // Spin up processing of the mutations submitted so far in a background thread. Must copy the
+      // reference for the background thread because a new one is about to be created.
+      var bufferingMutatorRef = bufferingMutator;
+      backgroundProcessing = executor.submit(() -> {
+        var result = bufferingMutatorRef.process();
+        bufferingMutatorRef.close();
+        return result;
+      });
+
+      bufferingMutator = new ConditionalTabletsMutatorImpl(context);
+      mutatedTablets = 0;
+    }
+    mutatedTablets++;
+    return bufferingMutator.mutateTablet(extent);
+  }
+
+  @Override
+  public void close() {
+    if (backgroundProcessing != null) {
+      // a previous batch of mutations was submitted for processing so wait on it.
+      try {
+        backgroundProcessing.get().forEach(resultsConsumer);
+      } catch (InterruptedException | ExecutionException e) {
+        throw new IllegalStateException(e);
+      }
+    }
+    // process anything not processed so far
+    bufferingMutator.process().forEach(resultsConsumer);
+    bufferingMutator.close();
+    executor.shutdownNow();
+  }
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -91,6 +92,12 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
   @Override
   public ConditionalTabletsMutator conditionallyMutateTablets() {
     return new ConditionalTabletsMutatorImpl(context);
+  }
+
+  @Override
+  public AsyncConditionalTabletsMutator
+      conditionallyMutateTablets(BiConsumer<KeyExtent,ConditionalResult> resultsConsumer) {
+    return new AsyncConditionalTabletsMutatorImpl(context, resultsConsumer);
   }
 
   private void mutateRootGcCandidates(Consumer<RootGcCandidates> mutator) {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/DeleteTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/DeleteTable.java
@@ -49,7 +49,7 @@ public class DeleteTable extends ManagerRepo {
   public Repo<Manager> call(long tid, Manager env) {
     env.getTableManager().transitionTableState(tableId, TableState.DELETING);
     env.getEventCoordinator().event(tableId, "deleting table %s ", tableId);
-    return new CleanUp(tableId, namespaceId);
+    return new ReserveTablets(tableId, namespaceId);
   }
 
   @Override

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/PreDeleteTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/PreDeleteTable.java
@@ -57,6 +57,7 @@ public class PreDeleteTable extends ManagerRepo {
 
   private void preventFutureCompactions(Manager environment)
       throws KeeperException, InterruptedException {
+    // ELASTICITY_TODO investigate this. Is still needed? Is it still working as expected?
     String deleteMarkerPath = createDeleteMarkerPath(environment.getInstanceID(), tableId);
     ZooReaderWriter zoo = environment.getContext().getZooReaderWriter();
     zoo.putPersistentData(deleteMarkerPath, new byte[] {}, NodeExistsPolicy.SKIP);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/ReserveTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/ReserveTablets.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.manager.tableOps.delete;
+
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LOCATION;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.OPID;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.PREV_ROW;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiConsumer;
+
+import org.apache.accumulo.core.data.NamespaceId;
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.metadata.schema.Ample;
+import org.apache.accumulo.core.metadata.schema.TabletOperationId;
+import org.apache.accumulo.core.metadata.schema.TabletOperationType;
+import org.apache.accumulo.manager.Manager;
+import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ReserveTablets extends ManagerRepo {
+
+  private static final Logger log = LoggerFactory.getLogger(ReserveTablets.class);
+
+  private static final long serialVersionUID = 1L;
+
+  private final TableId tableId;
+  private final NamespaceId namespaceId;
+
+  public ReserveTablets(TableId tableId, NamespaceId namespaceId) {
+    this.tableId = tableId;
+    this.namespaceId = namespaceId;
+  }
+
+  @Override
+  public long isReady(long tid, Manager manager) throws Exception {
+
+    var opid = TabletOperationId.from(TabletOperationType.DELETING, tid);
+
+    // The consumer may be called in another thread so use an AtomicLong
+    AtomicLong accepted = new AtomicLong(0);
+    BiConsumer<KeyExtent,Ample.ConditionalResult> resultsConsumer = (extent, result) -> {
+      if (result.getStatus() == Ample.ConditionalResult.Status.ACCEPTED) {
+        accepted.incrementAndGet();
+      } else {
+        log.debug("Failed to set operation id {} {}", opid, extent);
+      }
+    };
+
+    long locations = 0;
+    long otherOps = 0;
+    long submitted = 0;
+    long tabletsSeen = 0;
+
+    try (
+        var tablets = manager.getContext().getAmple().readTablets().forTable(tableId)
+            .fetch(OPID, PREV_ROW, LOCATION).checkConsistency().build();
+        var conditionalMutator =
+            manager.getContext().getAmple().conditionallyMutateTablets(resultsConsumer)) {
+      tabletsSeen++;
+      for (var tabletMeta : tablets) {
+        if (tabletMeta.getLocation() != null) {
+          locations++;
+        }
+
+        if (tabletMeta.getOperationId() != null) {
+          if (!opid.equals(tabletMeta.getOperationId())) {
+            otherOps++;
+          }
+        } else {
+          conditionalMutator.mutateTablet(tabletMeta.getExtent()).requireAbsentOperation()
+              .putOperation(opid).submit(tm -> opid.equals(tm.getOperationId()));
+          submitted++;
+        }
+      }
+    }
+
+    if (locations > 0 || otherOps > 0 || submitted != accepted.get()) {
+      log.debug("Waiting to delete table locations:{} operations:{}  submitted:{} accepted:{}",
+          locations, otherOps, submitted, accepted.get());
+      return Math.min(Math.max(100, tabletsSeen), 30000);
+    }
+
+    return 0;
+  }
+
+  @Override
+  public Repo<Manager> call(long tid, Manager manager) throws Exception {
+    return new CleanUp(tableId, namespaceId);
+  }
+}

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/ReserveTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/ReserveTablets.java
@@ -76,8 +76,9 @@ public class ReserveTablets extends ManagerRepo {
             .fetch(OPID, PREV_ROW, LOCATION).checkConsistency().build();
         var conditionalMutator =
             manager.getContext().getAmple().conditionallyMutateTablets(resultsConsumer)) {
-      tabletsSeen++;
+
       for (var tabletMeta : tablets) {
+        tabletsSeen++;
         if (tabletMeta.getLocation() != null) {
           locations++;
         }


### PR DESCRIPTION
Updates the delete table fate operation to use conditional mutations. Also introduces a new mechanism in Ample for processing conditional mutations that does not buffer everything in memory.  This avoid buffering large amounts of tablet metadata in memory when deleting a large table.  The IT that creates 1 million splits in a table and deletes it passes with these changes.