### PR TITLE
Update ImportExportIT to test fenced files

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -203,6 +203,10 @@
       <artifactId>junit-jupiter-engine</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
@@ -357,13 +357,13 @@ public class ImportExportIT extends AccumuloClusterHarness {
 
   private void verifyRange(StoredTabletFile tabFile, boolean fenced) {
     if (fenced) {
-      assertTrue(!tabFile.getRange().isInfiniteStartKey()
-              || !tabFile.getRange().isInfiniteStopKey());
+      assertTrue(
+          !tabFile.getRange().isInfiniteStartKey() || !tabFile.getRange().isInfiniteStopKey());
     } else {
-      assertTrue(tabFile.getRange().isInfiniteStartKey()
-              && tabFile.getRange().isInfiniteStopKey());
+      assertTrue(tabFile.getRange().isInfiniteStartKey() && tabFile.getRange().isInfiniteStopKey());
     }
   }
+
   private boolean verifyMappingsFile(String destTableId) throws IOException {
     AccumuloCluster cluster = getCluster();
     assertTrue(cluster instanceof MiniAccumuloClusterImpl);

--- a/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
@@ -201,7 +201,8 @@ public class ImportExportIT extends AccumuloClusterHarness {
             // (/b-000.../I000001.rf)
             var tabFile = StoredTabletFile.of(k.getColumnQualifier());
             // Verify that the range is set correctly on the StoredTabletFile
-            verifyRange(tabFile, fenced);
+            assertEquals(fenced, !tabFile.getRange().isInfiniteStartKey()
+                || !tabFile.getRange().isInfiniteStopKey());
             assertFalse(looksLikeRelativePath(tabFile.getMetadataPath()),
                 "Imported files should have absolute URIs, not relative: " + tabFile);
           } else if (k.getColumnFamily().equals(ServerColumnFamily.NAME)) {
@@ -335,7 +336,8 @@ public class ImportExportIT extends AccumuloClusterHarness {
             // file should be an absolute URI (file:///...), not relative (/b-000.../I000001.rf)
             var tabFile = StoredTabletFile.of(k.getColumnQualifier());
             // Verify that the range is set correctly on the StoredTabletFile
-            verifyRange(tabFile, fenced);
+            assertEquals(fenced, !tabFile.getRange().isInfiniteStartKey()
+                || !tabFile.getRange().isInfiniteStopKey());
             assertFalse(looksLikeRelativePath(tabFile.getMetadataPath()),
                 "Imported files should have absolute URIs, not relative: "
                     + tabFile.getMetadataPath());
@@ -352,15 +354,6 @@ public class ImportExportIT extends AccumuloClusterHarness {
 
       verifyTableEquality(client, srcTable, destTable, expected);
       assertTrue(verifyMappingsFile(tableId), "Did not find mappings file");
-    }
-  }
-
-  private void verifyRange(StoredTabletFile tabFile, boolean fenced) {
-    if (fenced) {
-      assertTrue(
-          !tabFile.getRange().isInfiniteStartKey() || !tabFile.getRange().isInfiniteStopKey());
-    } else {
-      assertTrue(tabFile.getRange().isInfiniteStartKey() && tabFile.getRange().isInfiniteStopKey());
     }
   }
 


### PR DESCRIPTION
This change updates `ImportExportIT` to also test that files that are fenced off by ranges will work correctly with export/import of a table

This addresses part of #3766