### PR TITLE
Update MetaSplitIT to verify fenced files

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/MetaSplitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MetaSplitIT.java
@@ -18,8 +18,10 @@
  */
 package org.apache.accumulo.test;
 
+import static org.apache.accumulo.test.util.FileMetadataUtil.countFencedFiles;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -33,9 +35,12 @@ import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.admin.CompactionConfig;
 import org.apache.accumulo.core.client.admin.TableOperations;
+import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
+import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.AfterEach;
@@ -111,29 +116,63 @@ public class MetaSplitIT extends AccumuloClusterHarness {
   @Test
   public void testMetadataTableSplit() throws Exception {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
+      // disable compactions
+      client.tableOperations().setProperty(MetadataTable.NAME, Property.TABLE_MAJC_RATIO.getKey(),
+          "9999");
+
       TableOperations opts = client.tableOperations();
       for (int i = 1; i <= 10; i++) {
         opts.create(Integer.toString(i));
       }
       try {
+        assertEquals(0, countFencedFiles(getServerContext(), MetadataTable.NAME));
+        verifyMetadataTableScan(client);
         opts.merge(MetadataTable.NAME, new Text("01"), new Text("02"));
         checkMetadataSplits(1, opts);
+        verifyMetadataTableScan(client);
         addSplits(opts, "4 5 6 7 8".split(" "));
         checkMetadataSplits(6, opts);
+        verifyMetadataTableScan(client);
+
         opts.merge(MetadataTable.NAME, new Text("6"), new Text("9"));
         checkMetadataSplits(4, opts);
+        // Merging tablets should produce fenced files because of no-chop merge
+        assertTrue(countFencedFiles(getServerContext(), MetadataTable.NAME) > 0);
+        verifyMetadataTableScan(client);
+
         addSplits(opts, "44 55 66 77 88".split(" "));
         checkMetadataSplits(9, opts);
+        assertTrue(countFencedFiles(getServerContext(), MetadataTable.NAME) > 0);
+        verifyMetadataTableScan(client);
+
         opts.merge(MetadataTable.NAME, new Text("5"), new Text("7"));
         checkMetadataSplits(6, opts);
+        assertTrue(countFencedFiles(getServerContext(), MetadataTable.NAME) > 0);
+        verifyMetadataTableScan(client);
+
         opts.merge(MetadataTable.NAME, null, null);
         checkMetadataSplits(0, opts);
+        assertTrue(countFencedFiles(getServerContext(), MetadataTable.NAME) > 0);
+        verifyMetadataTableScan(client);
+
+        opts.compact(MetadataTable.NAME, new CompactionConfig());
+        // Should be no more fenced files after compaction
+        assertEquals(0, countFencedFiles(getServerContext(), MetadataTable.NAME));
       } finally {
         for (int i = 1; i <= 10; i++) {
           opts.delete(Integer.toString(i));
         }
       }
     }
+  }
+
+  // Count the number of entries that can be read in the Metadata table
+  // This verifies all the entries can still be read after splits/merges
+  // when ranged files are used
+  private void verifyMetadataTableScan(AccumuloClient client) throws Exception {
+    // There should be 50 entries, 5 entries per Tablet
+    assertEquals(50,
+        client.createScanner(MetadataTable.NAME, Authorizations.EMPTY).stream().count());
   }
 
   private static void checkMetadataSplits(int numSplits, TableOperations opts)

--- a/test/src/main/java/org/apache/accumulo/test/util/FileMetadataUtil.java
+++ b/test/src/main/java/org/apache/accumulo/test/util/FileMetadataUtil.java
@@ -29,6 +29,7 @@ import java.util.TreeMap;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.core.metadata.AbstractTabletFile;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.Ample.TabletMutator;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
@@ -92,6 +93,20 @@ public class FileMetadataUtil {
     try (TabletsMetadata tabletsMetadata = ctx.getAmple().readTablets().forTable(tableId)
         .overlapping(tabletStartRow, tabletEndRow).fetch(ColumnType.FILES).build()) {
       return tabletsMetadata.stream().mapToInt(tm -> tm.getFilesMap().size()).sum();
+    }
+  }
+
+  public static int countFencedFiles(final ServerContext ctx, String tableName) {
+    return countFencedFiles(ctx, tableName, null, null);
+  }
+
+  public static int countFencedFiles(final ServerContext ctx, String tableName, Text tabletStartRow,
+      Text tabletEndRow) {
+    final TableId tableId = TableId.of(ctx.tableOperations().tableIdMap().get(tableName));
+    try (TabletsMetadata tabletsMetadata = ctx.getAmple().readTablets().forTable(tableId)
+        .overlapping(tabletStartRow, tabletEndRow).fetch(ColumnType.FILES).build()) {
+      return (int) tabletsMetadata.stream().flatMap(tm -> tm.getFilesMap().keySet().stream())
+          .filter(AbstractTabletFile::hasRange).count();
     }
   }
 


### PR DESCRIPTION
This test already splits and merges the metadata table so the updates here add some extra checks to verify ranged files have been created when they should and that all data can still be scanned after ranged files were created on merge.

This addresses part of #3766 to check that no-chop merges work on the Metadata table