### PR TITLE
Updates merge code to support merging many tablets

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -937,6 +937,13 @@ public enum Property {
           + " from having more RFiles than can be opened. Setting this property low may"
           + " throttle ingest and increase query performance.",
       "1.4.0"),
+  TABLE_MERGE_FILE_MAX("table.merge.file.max", "10000", PropertyType.COUNT,
+      "The maximum number of files that a merge operation will process.  Before "
+          + "merging a sum of the number of files in the merge range is computed and if it "
+          + "exceeds this configuration then the merge will error and fail.  For example if "
+          + "there are 100 tablets each having 10 files in the merge range, then the sum would "
+          + "be 1000 and the merge will only proceed if this property is greater than 1000.",
+      "4.0.0"),
   TABLE_FILE_SUMMARY_MAX_SIZE("table.file.summary.maxSize", "256k", PropertyType.BYTES,
       "The maximum size summary that will be stored. The number of RFiles that"
           + " had summary data exceeding this threshold is reported by"

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/CountFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/CountFiles.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.manager.tableOps.merge;
+
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.FILES;
+
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.fate.FateTxId;
+import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.manager.Manager;
+import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CountFiles extends ManagerRepo {
+  private static final Logger log = LoggerFactory.getLogger(CountFiles.class);
+  private static final long serialVersionUID = 1L;
+  private final MergeInfo data;
+
+  public CountFiles(MergeInfo mergeInfo) {
+    this.data = mergeInfo;
+  }
+
+  @Override
+  public Repo<Manager> call(long tid, Manager env) throws Exception {
+
+    var range = data.getReserveExtent();
+
+    long totalFiles = 0;
+
+    try (var tablets = env.getContext().getAmple().readTablets().forTable(data.tableId)
+        .overlapping(range.prevEndRow(), range.endRow()).fetch(FILES).checkConsistency().build()) {
+
+      switch (data.op) {
+        case MERGE:
+          for (var tabletMeta : tablets) {
+            totalFiles += tabletMeta.getFiles().size();
+          }
+          break;
+        case DELETE:
+          for (var tabletMeta : tablets) {
+            // Files in tablets that are completely contained within the merge range will be
+            // deleted, so do not count these files .
+            if (!data.getOriginalExtent().contains(tabletMeta.getExtent())) {
+              totalFiles += tabletMeta.getFiles().size();
+            }
+          }
+          break;
+        default:
+          throw new IllegalStateException("Unknown op " + data.op);
+      }
+    }
+
+    long maxFiles = env.getContext().getTableConfiguration(data.getOriginalExtent().tableId())
+        .getCount(Property.TABLE_MERGE_FILE_MAX);
+
+    log.debug("{} found {} files in the merge range, maxFiles is {}", FateTxId.formatTid(tid),
+        totalFiles, maxFiles);
+
+    if (totalFiles >= maxFiles) {
+      return new UnreserveAndError(data, totalFiles, maxFiles);
+    } else {
+      if (data.op == MergeInfo.Operation.MERGE) {
+        return new MergeTablets(data);
+      } else {
+        return new DeleteRows(data);
+      }
+    }
+  }
+}

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/MergeTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/MergeTablets.java
@@ -263,8 +263,8 @@ public class MergeTablets extends ManagerRepo {
     }
 
     Preconditions.checkState(acceptedCount.get() == submitted && rejectedCount.get() == 0,
-            "Failed to delete tablets accepted:%s != %s rejected:%s", acceptedCount.get(), submitted,
-            rejectedCount.get());
+        "Failed to delete tablets accepted:%s != %s rejected:%s", acceptedCount.get(), submitted,
+        rejectedCount.get());
   }
 
   private void addFilesToLastTablet(ServerContext context, KeyExtent lastExtent,

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/MergeTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/MergeTablets.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.manager.tableOps.merge;
 
+import static org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.DIR;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.ECOMP;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.FILES;
@@ -33,28 +34,39 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiConsumer;
 
 import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.admin.TabletHostingGoal;
+import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.fate.FateTxId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.gc.ReferenceFile;
+import org.apache.accumulo.core.metadata.MetadataTable;
+import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.metadata.schema.MetadataTime;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletOperationId;
 import org.apache.accumulo.core.metadata.schema.TabletOperationType;
+import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.gc.AllVolumesDirectory;
 import org.apache.accumulo.server.tablets.TabletTime;
 import org.apache.hadoop.io.Text;
@@ -94,6 +106,8 @@ public class MergeTablets extends ManagerRepo {
     TabletMetadata firstTabletMeta = null;
     TabletMetadata lastTabletMeta = null;
 
+    KeyExtent lastExtent = getHighTablet(manager.getContext(), range);
+
     try (var tabletsMetadata = manager.getContext().getAmple().readTablets()
         .forTable(range.tableId()).overlapping(range.prevEndRow(), range.endRow())
         .fetch(OPID, LOCATION, HOSTING_GOAL, FILES, TIME, DIR, ECOMP, PREV_ROW, LOGS).build()) {
@@ -120,6 +134,8 @@ public class MergeTablets extends ManagerRepo {
         boolean isLastTablet = (range.endRow() == null && tabletMeta.getExtent().endRow() == null)
             || (range.endRow() != null && tabletMeta.getExtent().contains(range.endRow()));
         if (isLastTablet) {
+          Preconditions.checkState(tabletMeta.getExtent().equals(lastExtent),
+              "Last extents not equals %s != %s", tabletMeta.getExtent(), lastExtent);
           lastTabletMeta = tabletMeta;
         } else {
           // files for the last tablet need to specially handled, so only add other tablets files
@@ -128,8 +144,22 @@ public class MergeTablets extends ManagerRepo {
             newFiles.put(fenceFile(tabletMeta.getExtent(), file), dfv);
           });
 
+          // Avoid buffering too many files in memory
+          if (newFiles.size() > 1000) {
+            // Do not want to make an updates when there is only a single tablet, however should not
+            // get to this code of there is a single tablet.
+            Preconditions.checkState(tabletsSeen > 1);
+            addFilesToLastTablet(manager.getContext(), lastExtent, newFiles, opid, fateStr);
+            newFiles.clear();
+          }
+
           // queue all tablets dirs except the last tablets to be added as GC candidates
           dirs.add(new AllVolumesDirectory(range.tableId(), tabletMeta.getDirName()));
+          if (dirs.size() > 1000) {
+            Preconditions.checkState(tabletsSeen > 1);
+            manager.getContext().getAmple().putGcFileAndDirCandidates(range.tableId(), dirs);
+            dirs.clear();
+          }
         }
       }
 
@@ -156,7 +186,6 @@ public class MergeTablets extends ManagerRepo {
         < 0) {
       // update the last tablet
       try (var tabletsMutator = manager.getContext().getAmple().conditionallyMutateTablets()) {
-        var lastExtent = lastTabletMeta.getExtent();
         var tabletMutator =
             tabletsMutator.mutateTablet(lastExtent).requireOperation(opid).requireAbsentLocation();
 
@@ -190,12 +219,26 @@ public class MergeTablets extends ManagerRepo {
     // Accumulo GC will delete the dir
     manager.getContext().getAmple().putGcFileAndDirCandidates(range.tableId(), dirs);
 
+    AtomicLong acceptedCount = new AtomicLong();
+    AtomicLong rejectedCount = new AtomicLong();
     // delete tablets
+    BiConsumer<KeyExtent,Ample.ConditionalResult> resultConsumer = (extent, result) -> {
+      if (result.getStatus() == Ample.ConditionalResult.Status.ACCEPTED) {
+        acceptedCount.incrementAndGet();
+      } else {
+        log.error("{} failed to update {}", fateStr, extent);
+        rejectedCount.incrementAndGet();
+      }
+    };
+
+    long submitted = 0;
+
     try (
         var tabletsMetadata =
             manager.getContext().getAmple().readTablets().forTable(range.tableId())
                 .overlapping(range.prevEndRow(), range.endRow()).saveKeyValues().build();
-        var tabletsMutator = manager.getContext().getAmple().conditionallyMutateTablets()) {
+        var tabletsMutator =
+            manager.getContext().getAmple().conditionallyMutateTablets(resultConsumer)) {
 
       for (var tabletMeta : tabletsMetadata) {
         validateTablet(tabletMeta, fateStr, opid, data.tableId);
@@ -209,15 +252,52 @@ public class MergeTablets extends ManagerRepo {
             .requireOperation(opid).requireAbsentLocation();
 
         tabletMeta.getKeyValues().keySet().forEach(key -> {
-          log.debug("{} deleting {}", fateStr, key);
+          log.trace("{} deleting {}", fateStr, key);
         });
 
         tabletMutator.deleteAll(tabletMeta.getKeyValues().keySet());
         // if the tablet no longer exists, then it was successful
         tabletMutator.submit(Ample.RejectionHandler.acceptAbsentTablet());
+        submitted++;
       }
+    }
 
+    Preconditions.checkState(acceptedCount.get() == submitted && rejectedCount.get() == 0,
+            "Failed to delete tablets accepted:%s != %s rejected:%s", acceptedCount.get(), submitted,
+            rejectedCount.get());
+  }
+
+  private void addFilesToLastTablet(ServerContext context, KeyExtent lastExtent,
+      Map<StoredTabletFile,DataFileValue> newFiles, TabletOperationId opid, String fateStr) {
+
+    try (var tabletsMutator = context.getAmple().conditionallyMutateTablets()) {
+      var tabletMutator =
+          tabletsMutator.mutateTablet(lastExtent).requireOperation(opid).requireAbsentLocation();
+      newFiles.forEach(tabletMutator::putFile);
+      tabletMutator.submit(tm -> tm.getFiles().containsAll(newFiles.keySet()));
       verifyAccepted(tabletsMutator.process(), fateStr);
+    }
+  }
+
+  private KeyExtent getHighTablet(ServerContext context, KeyExtent range) throws AccumuloException {
+    try (Scanner scanner = context.createScanner(
+        range.isMeta() ? RootTable.NAME : MetadataTable.NAME, Authorizations.EMPTY)) {
+      PREV_ROW_COLUMN.fetch(scanner);
+      var metaRow = MetadataSchema.TabletsSection.encodeRow(range.tableId(), range.endRow());
+      scanner.setRange(new Range(metaRow, null));
+      Iterator<Map.Entry<Key,Value>> iterator = scanner.iterator();
+      if (!iterator.hasNext()) {
+        throw new AccumuloException("No last tablet for a merge " + range);
+      }
+      Map.Entry<Key,Value> entry = iterator.next();
+      KeyExtent highTablet = KeyExtent.fromMetaPrevRow(entry);
+      if (!highTablet.tableId().equals(range.tableId())) {
+        throw new AccumuloException("No last tablet for merge " + range + " " + highTablet);
+      }
+      return highTablet;
+    } catch (Exception ex) {
+      throw new AccumuloException("Unexpected failure finding the last tablet for a merge " + range,
+          ex);
     }
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/ReserveTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/ReserveTablets.java
@@ -79,7 +79,6 @@ public class ReserveTablets extends ManagerRepo {
             env.getContext().getAmple().conditionallyMutateTablets(resultConsumer)) {
 
       for (var tabletMeta : tablets) {
-
         if (tabletMeta.getOperationId() == null) {
           tabletsMutator.mutateTablet(tabletMeta.getExtent()).requireAbsentOperation()
               .putOperation(opid).submit(tm -> opid.equals(tm.getOperationId()));
@@ -129,10 +128,6 @@ public class ReserveTablets extends ManagerRepo {
 
   @Override
   public Repo<Manager> call(long tid, Manager environment) throws Exception {
-    if (data.op == MergeInfo.Operation.MERGE) {
-      return new MergeTablets(data);
-    } else {
-      return new DeleteRows(data);
-    }
+    return new CountFiles(data);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/ReserveTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/ReserveTablets.java
@@ -23,8 +23,13 @@ import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.OPID;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.PREV_ROW;
 
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiConsumer;
+
+import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.fate.FateTxId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.Ample.ConditionalResult.Status;
 import org.apache.accumulo.core.metadata.schema.TabletOperationId;
 import org.apache.accumulo.core.metadata.schema.TabletOperationType;
@@ -53,17 +58,25 @@ public class ReserveTablets extends ManagerRepo {
     log.debug("{} reserving tablets in range {}", FateTxId.formatTid(tid), range);
     var opid = TabletOperationId.from(TabletOperationType.MERGING, tid);
 
+    AtomicLong opsAccepted = new AtomicLong(0);
+    BiConsumer<KeyExtent,Ample.ConditionalResult> resultConsumer = (extent, result) -> {
+      if (result.getStatus() == Status.ACCEPTED) {
+        opsAccepted.incrementAndGet();
+      }
+    };
+
+    int count = 0;
+    int otherOps = 0;
+    int opsSet = 0;
+    int locations = 0;
+    int wals = 0;
+
     try (
         var tablets = env.getContext().getAmple().readTablets().forTable(data.tableId)
             .overlapping(range.prevEndRow(), range.endRow()).fetch(PREV_ROW, LOCATION, LOGS, OPID)
             .checkConsistency().build();
-        var tabletsMutator = env.getContext().getAmple().conditionallyMutateTablets();) {
-
-      int count = 0;
-      int otherOps = 0;
-      int opsSet = 0;
-      int locations = 0;
-      int wals = 0;
+        var tabletsMutator =
+            env.getContext().getAmple().conditionallyMutateTablets(resultConsumer)) {
 
       for (var tabletMeta : tablets) {
 
@@ -83,38 +96,35 @@ public class ReserveTablets extends ManagerRepo {
 
         count++;
       }
-
-      var opsAccepted = tabletsMutator.process().values().stream()
-          .filter(conditionalResult -> conditionalResult.getStatus() == Status.ACCEPTED).count();
-
-      log.debug(
-          "{} reserve tablets op:{} count:{} other opids:{} opids set:{} locations:{} accepted:{} wals:{}",
-          FateTxId.formatTid(tid), data.op, count, otherOps, opsSet, locations, opsAccepted, wals);
-
-      // while there are table lock a tablet can be concurrently deleted, so should always see
-      // tablets
-      Preconditions.checkState(count > 0);
-
-      if (locations > 0 && opsAccepted > 0) {
-        // operation ids were set and tablets have locations, so lets send a signal to get them
-        // unassigned
-        env.getEventCoordinator().event(range, "Tablets %d were reserved for merge %s", opsAccepted,
-            FateTxId.formatTid(tid));
-      }
-
-      if (locations > 0 || otherOps > 0 || wals > 0) {
-        // need to wait on these tablets
-        return Math.max(1000, count);
-      }
-
-      if (opsSet != opsAccepted) {
-        // not all operation ids were set
-        return Math.max(1000, count);
-      }
-
-      // operations ids were set on all tablets and no tablets have locations, so ready
-      return 0;
     }
+
+    log.debug(
+        "{} reserve tablets op:{} count:{} other opids:{} opids set:{} locations:{} accepted:{} wals:{}",
+        FateTxId.formatTid(tid), data.op, count, otherOps, opsSet, locations, opsAccepted, wals);
+
+    // while there are table lock a tablet can be concurrently deleted, so should always see
+    // tablets
+    Preconditions.checkState(count > 0);
+
+    if (locations > 0 && opsAccepted.get() > 0) {
+      // operation ids were set and tablets have locations, so lets send a signal to get them
+      // unassigned
+      env.getEventCoordinator().event(range, "Tablets %d were reserved for merge %s",
+          opsAccepted.get(), FateTxId.formatTid(tid));
+    }
+
+    if (locations > 0 || otherOps > 0 || wals > 0) {
+      // need to wait on these tablets
+      return Math.min(Math.max(1000, count), 60000);
+    }
+
+    if (opsSet != opsAccepted.get()) {
+      // not all operation ids were set
+      return Math.min(Math.max(1000, count), 60000);
+    }
+
+    // operations ids were set on all tablets and no tablets have locations, so ready
+    return 0;
   }
 
   @Override

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/UnreserveAndError.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/UnreserveAndError.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.manager.tableOps.merge;
+
+import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
+import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
+import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
+import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.manager.Manager;
+import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class UnreserveAndError extends ManagerRepo {
+  private static final long serialVersionUID = 1L;
+  private static final Logger log = LoggerFactory.getLogger(UnreserveAndError.class);
+  private final MergeInfo mergeInfo;
+  private final long totalFiles;
+  private final long maxFiles;
+
+  public UnreserveAndError(MergeInfo mergeInfo, long totalFiles, long maxFiles) {
+    this.mergeInfo = mergeInfo;
+    this.totalFiles = totalFiles;
+    this.maxFiles = maxFiles;
+  }
+
+  @Override
+  public Repo<Manager> call(long tid, Manager environment) throws Exception {
+    FinishTableRangeOp.removeOperationIds(log, mergeInfo, tid, environment);
+    throw new AcceptableThriftTableOperationException(mergeInfo.tableId.toString(), null,
+        mergeInfo.op == MergeInfo.Operation.MERGE ? TableOperation.MERGE
+            : TableOperation.DELETE_RANGE,
+        TableOperationExceptionType.OTHER,
+        "Aborted merge because it would produce a tablets with more files than the configured limit of "
+            + maxFiles + ". Observed " + totalFiles + " files in the merge range.");
+  }
+}

--- a/test/src/main/java/org/apache/accumulo/test/functional/DeleteRowsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/DeleteRowsIT.java
@@ -20,28 +20,38 @@ package org.apache.accumulo.test.functional;
 
 import static org.apache.accumulo.test.util.FileMetadataUtil.printAndVerifyFileMetadata;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
+import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.metadata.StoredTabletFile;
+import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
+import org.apache.accumulo.test.util.Wait;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -67,6 +77,86 @@ public class DeleteRowsIT extends AccumuloClusterHarness {
   @Override
   protected Duration defaultTimeout() {
     return Duration.ofMinutes(5);
+  }
+
+  @Test
+  public void tooManyFilesDeleteRowsTest() throws Exception {
+    try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
+      String tableName = getUniqueNames(1)[0];
+      c.tableOperations().create(tableName,
+          new NewTableConfiguration().setProperties(Map.of(Property.TABLE_MAJC_RATIO.getKey(),
+              "20000", Property.TABLE_MERGE_FILE_MAX.getKey(), "500")));
+
+      c.tableOperations().addSplits(tableName,
+          IntStream.range(1, 100).map(i -> i * 100).mapToObj(i -> String.format("%06d", i))
+              .map(Text::new).collect(Collectors.toCollection(TreeSet::new)));
+
+      // add two bogus files to each tablet, creating 40K file entries
+      c.tableOperations().offline(tableName, true);
+      try (
+          var tablets = getServerContext().getAmple().readTablets()
+              .forTable(getServerContext().getTableId(tableName)).build();
+          var tabletsMutator = getServerContext().getAmple().mutateTablets()) {
+        int fc = 0;
+        for (var tabletMeta : tablets) {
+          // add 500 files to each tablet
+          var tabletMutator = tabletsMutator.mutateTablet(tabletMeta.getExtent());
+          for (int i = 0; i < 500; i++) {
+            StoredTabletFile f1 = StoredTabletFile.of(new Path(
+                "file:///accumulo/tables/1/" + tabletMeta.getDirName() + "/F" + fc++ + ".rf"));
+            DataFileValue dfv1 = new DataFileValue(4200, 42);
+            tabletMutator.putFile(f1, dfv1);
+          }
+
+          tabletMutator.mutate();
+        }
+      }
+      c.tableOperations().online(tableName, true);
+
+      // table should now have 50000 files total
+      try (var tablets = getServerContext().getAmple().readTablets()
+          .forTable(getServerContext().getTableId(tableName)).build()) {
+        assertEquals(50000,
+            tablets.stream().mapToInt(tabletMetadata -> tabletMetadata.getFiles().size()).sum());
+      }
+
+      // should fail to merge because there are too many files in the merge range
+      var exception =
+          assertThrows(AccumuloException.class, () -> c.tableOperations().deleteRows(tableName,
+              new Text(String.format("%06d", 55)), new Text(String.format("%06d", 9907))));
+      // message should contain the observed number of files that would be merged. Some tablets
+      // would be completely merged away so their files are not counted.
+      assertTrue(exception.getMessage().contains("1000"));
+      // message should contain the max files limit it saw
+      assertTrue(exception.getMessage().contains("500"));
+
+      assertEquals(99, c.tableOperations().listSplits(tableName).size());
+
+      c.tableOperations().setProperty(tableName, Property.TABLE_MERGE_FILE_MAX.getKey(), "2000");
+
+      // with the higher merge file setting, the delete should be able to go through. The table has
+      // a total of 50K files, however only 1000 files should end up in the merged tablet because
+      // most tablets fall completely within the delete range.
+      Wait.waitFor(() -> {
+        try {
+          c.tableOperations().deleteRows(tableName, new Text(String.format("%06d", 55)),
+              new Text(String.format("%06d", 9907)));
+          return true;
+        } catch (AccumuloException e) {
+          // The property value has not updated in the manager yet.
+          assertTrue(e.getMessage().contains("500"));
+          return false;
+        }
+      });
+
+      assertEquals(1, c.tableOperations().listSplits(tableName).size());
+      // table should now have 1000 files total
+      try (var tablets = getServerContext().getAmple().readTablets()
+          .forTable(getServerContext().getTableId(tableName)).build()) {
+        assertEquals(1000,
+            tablets.stream().mapToInt(tabletMetadata -> tabletMetadata.getFiles().size()).sum());
+      }
+    }
   }
 
   @Test

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitMillionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitMillionIT.java
@@ -107,7 +107,8 @@ public class SplitMillionIT extends AccumuloClusterHarness {
       assertEquals(1_000_000, count);
       log.info("Time to scan all tablets : {}ms", t2 - t1);
 
-      // clone the table to test cloning with lots of tablets and also to give merge its own table to work on
+      // clone the table to test cloning with lots of tablets and also to give merge its own table
+      // to work on
       var cloneName = tableName + "_clone";
       t1 = System.currentTimeMillis();
       c.tableOperations().clone(tableName, cloneName, CloneConfiguration.builder().build());

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitMillionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitMillionIT.java
@@ -29,6 +29,7 @@ import java.util.stream.IntStream;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.admin.CloneConfiguration;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
@@ -95,14 +96,7 @@ public class SplitMillionIT extends AccumuloClusterHarness {
         }
 
         long t3 = System.currentTimeMillis();
-
-        try (var scanner = c.createScanner(tableName)) {
-          scanner.setRange(new Range(row));
-          Map<String,String> coords = scanner.stream().collect(Collectors.toMap(
-              e -> e.getKey().getColumnQualifier().toString(), e -> e.getValue().toString()));
-          assertEquals(Map.of("x", "200", "y", "900", "z", "300"), coords);
-        }
-
+        verifyRow(c, tableName, row);
         long t4 = System.currentTimeMillis();
         log.info("Row: {} scan1: {}ms write: {}ms scan2: {}ms", row, t2 - t1, t3 - t2, t4 - t3);
       }
@@ -113,11 +107,38 @@ public class SplitMillionIT extends AccumuloClusterHarness {
       assertEquals(1_000_000, count);
       log.info("Time to scan all tablets : {}ms", t2 - t1);
 
+      // clone the table to test cloning with lots of tablets and also to give merge its own table to work on
+      var cloneName = tableName + "_clone";
+      t1 = System.currentTimeMillis();
+      c.tableOperations().clone(tableName, cloneName, CloneConfiguration.builder().build());
+      t2 = System.currentTimeMillis();
+      log.info("Time to clone table : {}ms", t2 - t1);
+
+      // merge the clone, so that delete table can run later on tablet with lots and lots of tablets
+      t1 = System.currentTimeMillis();
+      c.tableOperations().merge(cloneName, null, null);
+      t2 = System.currentTimeMillis();
+      log.info("Time to merge all tablets : {}ms", t2 - t1);
+
+      // verify data after merge
+      for (var rowInt : rows) {
+        var row = String.format("%010d", rowInt);
+        verifyRow(c, cloneName, row);
+      }
+
       t1 = System.currentTimeMillis();
       c.tableOperations().delete(tableName);
       t2 = System.currentTimeMillis();
       log.info("Time to delete table : {}ms", t2 - t1);
+    }
+  }
 
+  private void verifyRow(AccumuloClient c, String tableName, String row) throws Exception {
+    try (var scanner = c.createScanner(tableName)) {
+      scanner.setRange(new Range(row));
+      Map<String,String> coords = scanner.stream().collect(Collectors
+          .toMap(e -> e.getKey().getColumnQualifier().toString(), e -> e.getValue().toString()));
+      assertEquals(Map.of("x", "200", "y", "900", "z", "300"), coords);
     }
   }
 


### PR DESCRIPTION
Using the conditional writer changes from https://github.com/apache/accumulo/pull/3929 this commit updates the
merge code to support merging more tablets than will fit in memory. Also
adds merge and clone operations to the SplitMillionIT and merges a table
with one million tablets in the test.  Without the changes in this
commit that test would cause the manager to die with an out of memory
error.