### PR TITLE
rename DataLevel tableId() to metaTableId(), doc updates

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
@@ -98,7 +98,7 @@ public interface Ample {
     /**
      * @return The Id of the Accumulo table in which this data level stores its metadata.
      */
-    public TableId tableId() {
+    public TableId metaTableId() {
       if (id == null) {
         throw new UnsupportedOperationException();
       }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
@@ -320,9 +320,10 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
     }
 
     /**
-     * Set the range to the table range that stores the provided level's metadata. For example
-     * {@link DataLevel#USER} will set the range to the metadata table. {@link DataLevel#METADATA}
-     * will set the range to the root table.
+     * For a given data level, read all of its tablets metadata. For {@link DataLevel#USER} this
+     * will read tablet metadata from the accumulo.metadata table for all user tables. For
+     * {@link DataLevel#METADATA} this will read tablet metadata from the accumulo.root table. For
+     * {@link DataLevel#ROOT} this will read tablet metadata from Zookeeper.
      */
     @Override
     public Options forLevel(DataLevel level) {
@@ -332,10 +333,11 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
     }
 
     /**
-     * Set the range to the data level that contains the metadata references for the provided
-     * TableId. For example, if the TableId is the metadata table id, then the table range will be
-     * root metadata that points to the metadata. Likewise, if the TableId is a user table, then the
-     * table range will be the metadata table range that points to the user table.
+     * For a given table read all of its tablet metadata. If the table id is for a user table, then
+     * its metadata will be read from its section in the accumulo.metadata table. If the table id is
+     * for the accumulo.metadata table, then its metadata will be read from the accumulo.root table.
+     * If the table id is for the accumulo.root table, then its metadata will be read from
+     * zookeeper.
      */
     @Override
     public TableRangeOptions forTable(TableId tableId) {

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
@@ -319,6 +319,11 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
       return this;
     }
 
+    /**
+     * Set the range to the table range that stores the provided level's metadata. For example
+     * {@link DataLevel#USER} will set the range to the metadata table. {@link DataLevel#METADATA}
+     * will set the range to the root table.
+     */
     @Override
     public Options forLevel(DataLevel level) {
       this.level = level;
@@ -326,6 +331,12 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
       return this;
     }
 
+    /**
+     * Set the range to the data level that contains the metadata references for the provided
+     * TableId. For example, if the TableId is the metadata table id, then the table range will be
+     * root metadata that points to the metadata. Likewise, if the TableId is a user table, then the
+     * table range will be the metadata table range that points to the user table.
+     */
     @Override
     public TableRangeOptions forTable(TableId tableId) {
       this.level = DataLevel.of(tableId);

--- a/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorIT.java
@@ -291,7 +291,7 @@ public class GarbageCollectorIT extends ConfigurableMacBase {
   @Test
   public void testMetadataUniqueMutationDelete() throws Exception {
     killMacGc();
-    TableId tableId = DataLevel.USER.tableId();
+    TableId tableId = DataLevel.USER.metaTableId();
     log.info("Metadata GcCandidate Deletion test");
     log.info("GcCandidates will be added/removed from table: {}", DataLevel.METADATA.metaTable());
     createAndDeleteUniqueMutation(tableId, Ample.GcCandidateType.INUSE);
@@ -306,7 +306,7 @@ public class GarbageCollectorIT extends ConfigurableMacBase {
   @Test
   public void testRootUniqueMutationDelete() throws Exception {
     killMacGc();
-    TableId tableId = DataLevel.METADATA.tableId();
+    TableId tableId = DataLevel.METADATA.metaTableId();
     log.info("Root GcCandidate Deletion test");
     log.info("GcCandidates will be added but not removed from Zookeeper");
 


### PR DESCRIPTION
Renames the DataLevel method tableId to metaTableId to help clarify that the id returned is the reference to the meta data that contain information for that level (USER points to metadata table, METADATA points to ROOT and ROOT point to ZooKeeper)

Also adds some javadoc to emphasize the level, meta data relationship for forLevel and forTable in TabletsMetadata