### PR TITLE
fixes validation in MetaSplitIT

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/MetaSplitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MetaSplitIT.java
@@ -189,8 +189,9 @@ public class MetaSplitIT extends AccumuloClusterHarness {
     try (var tablets = ample.readTablets().forLevel(Ample.DataLevel.USER).build()) {
       for (var tablet : tablets) {
         assertTrue(expectedExtents.remove(tablet.getExtent()));
+        // check a few fields that should always be present in tablet metadata
         assertNotNull(tablet.getDirName());
-        assertNotNull(tablet.getLocation());
+        assertNotNull(tablet.getTime());
       }
     }
 


### PR DESCRIPTION
As part of validating the metadata table MetaSplitIT was requiring tablets to have a location.  However locations may be temproarily absent and that is ok.  Changed the test to validate the time field was present as it should always be there.