### PR TITLE
Cleanup failed compaction tmp files

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -1100,7 +1100,8 @@ public enum Property {
   COMPACTOR_CANCEL_CHECK_INTERVAL("compactor.cancel.check.interval", "5m",
       PropertyType.TIMEDURATION,
       "Interval at which Compactors will check to see if the currently executing compaction"
-          + " should be cancelled.",
+          + " should be cancelled. This checks for situations like was the tablet deleted (split "
+          + " and merge do this), was the table deleted, was a user compaction canceled, etc.",
       "4.0.0"),
   @Experimental
   COMPACTOR_PORTSEARCH("compactor.port.search", "true", PropertyType.BOOLEAN,

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -1097,6 +1097,11 @@ public enum Property {
   @Experimental
   COMPACTOR_PREFIX("compactor.", null, PropertyType.PREFIX,
       "Properties in this category affect the behavior of the accumulo compactor server.", "2.1.0"),
+  COMPACTOR_CANCEL_CHECK_INTERVAL("compactor.cancel.check.interval", "5m",
+      PropertyType.TIMEDURATION,
+      "Interval at which Compactors will check to see if the currently executing compaction"
+          + " should be cancelled.",
+      "4.0.0"),
   @Experimental
   COMPACTOR_PORTSEARCH("compactor.port.search", "true", PropertyType.BOOLEAN,
       "If the compactor.port.client is in use, search higher ports until one is available.",

--- a/core/src/main/java/org/apache/accumulo/core/metadata/ReferencedTabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/ReferencedTabletFile.java
@@ -97,6 +97,8 @@ public class ReferencedTabletFile extends AbstractTabletFile<ReferencedTabletFil
   public static FileParts parsePath(Path filePath) {
     // File name construct: <volume>/<tablePath>/<tableId>/<tablet>/<file>
     // Example: hdfs://namenode:9020/accumulo/tables/1/default_tablet/F00001.rf
+    // Example compaction tmp file:
+    // hdfs://namenode:9020/accumulo/tables/1/default_tablet/F00001.rf_tmp_ECID%3A<uuid>
     final URI uri = filePath.toUri();
 
     // validate that this is a fully qualified uri

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/ExternalCompactionId.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/ExternalCompactionId.java
@@ -26,7 +26,7 @@ public class ExternalCompactionId extends AbstractId<ExternalCompactionId> {
 
   // A common prefix is nice when grepping logs for external compaction ids. The prefix also serves
   // as a nice sanity check on data coming in over the network and from persistent storage.
-  private static final String PREFIX = "ECID-";
+  public static final String PREFIX = "ECID-";
 
   private ExternalCompactionId(UUID uuid) {
     super(PREFIX + uuid);

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/ExternalCompactionId.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/ExternalCompactionId.java
@@ -26,7 +26,7 @@ public class ExternalCompactionId extends AbstractId<ExternalCompactionId> {
 
   // A common prefix is nice when grepping logs for external compaction ids. The prefix also serves
   // as a nice sanity check on data coming in over the network and from persistent storage.
-  private static final String PREFIX = "ECID:";
+  private static final String PREFIX = "ECID-";
 
   private ExternalCompactionId(UUID uuid) {
     super(PREFIX + uuid);
@@ -66,11 +66,4 @@ public class ExternalCompactionId extends AbstractId<ExternalCompactionId> {
     }
     return of(ecid);
   }
-
-  public String encodeForFileName() {
-    // A colon in the file name causes issues in HDFS. Use a different character
-    // that will not be URLEncoded
-    return canonical().replace(':', '-');
-  }
-
 }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/ExternalCompactionId.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/ExternalCompactionId.java
@@ -67,4 +67,10 @@ public class ExternalCompactionId extends AbstractId<ExternalCompactionId> {
     return of(ecid);
   }
 
+  public String encodeForFileName() {
+    // A colon in the file name causes issues in HDFS. Use a different character
+    // that will not be URLEncoded
+    return canonical().replace(':', '-');
+  }
+
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/tablets/TabletNameGenerator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tablets/TabletNameGenerator.java
@@ -25,6 +25,7 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FilePrefix;
 import org.apache.accumulo.core.metadata.ReferencedTabletFile;
+import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.spi.fs.VolumeChooserEnvironment;
@@ -67,11 +68,12 @@ public class TabletNameGenerator {
   }
 
   public static ReferencedTabletFile getNextDataFilenameForMajc(boolean propagateDeletes,
-      ServerContext context, TabletMetadata tabletMetadata, Consumer<String> dirCreator) {
+      ServerContext context, TabletMetadata tabletMetadata, Consumer<String> dirCreator,
+      ExternalCompactionId ecid) {
     String tmpFileName = getNextDataFilename(
         !propagateDeletes ? FilePrefix.MAJOR_COMPACTION_ALL_FILES : FilePrefix.MAJOR_COMPACTION,
-        context, tabletMetadata.getExtent(), tabletMetadata.getDirName(), dirName -> {}).insert()
-        .getMetadataPath() + "_tmp";
+        context, tabletMetadata.getExtent(), tabletMetadata.getDirName(), dirCreator).insert()
+        .getMetadataPath() + "_tmp_" + ecid.encodeForFileName();
     return new ReferencedTabletFile(new Path(tmpFileName));
   }
 
@@ -82,7 +84,7 @@ public class TabletNameGenerator {
       newFilePath = newFilePath.substring(0, idx);
     } else {
       throw new IllegalArgumentException("Expected compaction tmp file "
-          + tmpFile.getNormalizedPathStr() + " to have suffix '_tmp'");
+          + tmpFile.getNormalizedPathStr() + " to have suffix starting with '_tmp'");
     }
     return new ReferencedTabletFile(new Path(newFilePath));
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/tablets/TabletNameGenerator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tablets/TabletNameGenerator.java
@@ -73,7 +73,7 @@ public class TabletNameGenerator {
     String tmpFileName = getNextDataFilename(
         !propagateDeletes ? FilePrefix.MAJOR_COMPACTION_ALL_FILES : FilePrefix.MAJOR_COMPACTION,
         context, tabletMetadata.getExtent(), tabletMetadata.getDirName(), dirCreator).insert()
-        .getMetadataPath() + "_tmp_" + ecid.encodeForFileName();
+        .getMetadataPath() + "_tmp_" + ecid.canonical();
     return new ReferencedTabletFile(new Path(tmpFileName));
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FindCompactionTmpFiles.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FindCompactionTmpFiles.java
@@ -106,22 +106,13 @@ public class FindCompactionTmpFiles {
     // Remove paths of all active external compaction output files from the set of
     // tmp files found on the filesystem. This must be done *after* gathering the
     // matches on the filesystem.
-    context.getAmple().readTablets().forLevel(DataLevel.ROOT).fetch(ColumnType.ECOMP).build()
-        .forEach(tm -> {
-          tm.getExternalCompactions().values()
-              .forEach(ecm -> matches.remove(ecm.getCompactTmpName().getPath()));
-        });
-    context.getAmple().readTablets().forLevel(DataLevel.METADATA).fetch(ColumnType.ECOMP).build()
-        .forEach(tm -> {
-          tm.getExternalCompactions().values()
-              .forEach(ecm -> matches.remove(ecm.getCompactTmpName().getPath()));
-        });
-    context.getAmple().readTablets().forLevel(DataLevel.USER).fetch(ColumnType.ECOMP).build()
-        .forEach(tm -> {
-          tm.getExternalCompactions().values()
-              .forEach(ecm -> matches.remove(ecm.getCompactTmpName().getPath()));
-        });
-
+    for (DataLevel level : DataLevel.values()) {
+      context.getAmple().readTablets().forLevel(level).fetch(ColumnType.ECOMP).build()
+          .forEach(tm -> {
+            tm.getExternalCompactions().values()
+                .forEach(ecm -> matches.remove(ecm.getCompactTmpName().getPath()));
+          });
+    }
     LOG.debug("Final set of compaction tmp files after removing active compactions: {}", matches);
     return matches;
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FindCompactionTmpFiles.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FindCompactionTmpFiles.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.util;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.clientImpl.ClientContext;
+import org.apache.accumulo.core.fate.zookeeper.ZooReader;
+import org.apache.accumulo.core.trace.TraceUtil;
+import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.volume.Volume;
+import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.cli.ServerUtilOpts;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.KeeperException.NoNodeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.beust.jcommander.Parameter;
+import com.google.common.net.HostAndPort;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Scope;
+
+public class FindCompactionTmpFiles {
+
+  private static final Logger LOG = LoggerFactory.getLogger(FindCompactionTmpFiles.class);
+
+  static class Opts extends ServerUtilOpts {
+    @Parameter(names = "--delete")
+    boolean delete = false;
+  }
+
+  private static boolean allCompactorsDown(ClientContext context) {
+    // This is a copy of ExternalCompactionUtil.getCompactorAddrs that returns
+    // false if any compactor address is found. If there are no compactor addresses
+    // in any of the groups, then it returns true.
+    try {
+      final Map<String,List<HostAndPort>> groupsAndAddresses = new HashMap<>();
+      final String compactorGroupsPath = context.getZooKeeperRoot() + Constants.ZCOMPACTORS;
+      ZooReader zooReader = context.getZooReader();
+      List<String> groups = zooReader.getChildren(compactorGroupsPath);
+      for (String group : groups) {
+        groupsAndAddresses.putIfAbsent(group, new ArrayList<>());
+        try {
+          List<String> compactors = zooReader.getChildren(compactorGroupsPath + "/" + group);
+          for (String compactor : compactors) {
+            // compactor is the address, we are checking to see if there is a child node which
+            // represents the compactor's lock as a check that it's alive.
+            List<String> children =
+                zooReader.getChildren(compactorGroupsPath + "/" + group + "/" + compactor);
+            if (!children.isEmpty()) {
+              LOG.trace("Found live compactor {} ", compactor);
+              return false;
+            }
+          }
+        } catch (NoNodeException e) {
+          LOG.trace("Ignoring node that went missing", e);
+        }
+      }
+      return true;
+    } catch (KeeperException e) {
+      throw new IllegalStateException(e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException(e);
+    }
+  }
+
+  public static List<Path> findTempFiles(ServerContext context) throws InterruptedException {
+    final String pattern = "/tables/*/*/*";
+    final Collection<Volume> vols = context.getVolumeManager().getVolumes();
+    final ExecutorService svc = Executors.newFixedThreadPool(vols.size());
+    final List<Path> matches = new ArrayList<>(1024);
+    final List<Future<Void>> futures = new ArrayList<>(vols.size());
+    for (Volume vol : vols) {
+      final Path volPattern = new Path(vol.getBasePath() + pattern);
+      LOG.info("Looking for tmp files in volume: {} that match pattern: {}", vol, volPattern);
+      futures.add(svc.submit(() -> {
+        try {
+          FileStatus[] files =
+              vol.getFileSystem().globStatus(volPattern, (p) -> p.getName().contains("_tmp_ECID-"));
+          System.out.println(Arrays.toString(files));
+          Arrays.stream(files).forEach(fs -> matches.add(fs.getPath()));
+        } catch (IOException e) {
+          LOG.error("Error looking for tmp files in volume: {}", vol, e);
+        }
+        return null;
+      }));
+    }
+    svc.shutdown();
+
+    while (futures.size() > 0) {
+      UtilWaitThread.sleep(10_000);
+      Iterator<Future<Void>> iter = futures.iterator();
+      while (iter.hasNext()) {
+        Future<Void> future = iter.next();
+        if (future.isDone()) {
+          iter.remove();
+          try {
+            future.get();
+          } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException("Error getting list of tmp files", e);
+          }
+        }
+      }
+    }
+    svc.awaitTermination(10, TimeUnit.MINUTES);
+    return matches;
+  }
+
+  public static class DeleteStats {
+    public int success = 0;
+    public int failure = 0;
+    public int error = 0;
+  }
+
+  public static DeleteStats deleteTempFiles(ServerContext context, List<Path> filesToDelete)
+      throws InterruptedException {
+
+    final ExecutorService delSvc = Executors.newFixedThreadPool(8);
+    final List<Future<Boolean>> futures = new ArrayList<>(filesToDelete.size());
+    final DeleteStats stats = new DeleteStats();
+
+    filesToDelete.forEach(p -> {
+      futures.add(delSvc.submit(() -> context.getVolumeManager().delete(p)));
+    });
+    delSvc.shutdown();
+
+    int expectedResponses = filesToDelete.size();
+    while (expectedResponses > 0) {
+      UtilWaitThread.sleep(10_000);
+      Iterator<Future<Boolean>> iter = futures.iterator();
+      while (iter.hasNext()) {
+        Future<Boolean> future = iter.next();
+        if (future.isDone()) {
+          expectedResponses--;
+          iter.remove();
+          try {
+            if (future.get()) {
+              stats.success++;
+            } else {
+              stats.failure++;
+            }
+          } catch (ExecutionException e) {
+            stats.error++;
+            LOG.error("Error deleting a compaction tmp file", e);
+          }
+        }
+      }
+      LOG.debug("Waiting on {} responses", expectedResponses);
+    }
+    delSvc.awaitTermination(10, TimeUnit.MINUTES);
+    return stats;
+  }
+
+  public static void main(String[] args) throws Exception {
+    Opts opts = new Opts();
+    opts.parseArgs(FindCompactionTmpFiles.class.getName(), args);
+    LOG.info("Deleting compaction tmp files: {}", opts.delete);
+    Span span = TraceUtil.startSpan(FindCompactionTmpFiles.class, "main");
+    try (Scope scope = span.makeCurrent()) {
+      ServerContext context = opts.getServerContext();
+      if (!allCompactorsDown(context)) {
+        LOG.warn("Compactor addresses found in ZooKeeper. Unable to run this utility.");
+      }
+
+      final List<Path> matches = findTempFiles(context);
+      LOG.info("Found the following compaction tmp files:");
+      matches.forEach(p -> LOG.info("{}", p));
+
+      if (opts.delete) {
+        LOG.info("Deleting compaction tmp files...");
+        DeleteStats stats = deleteTempFiles(context, matches);
+        LOG.info("Deletion complete. Success:{}, Failure:{}, Error:{}", stats.success,
+            stats.failure, stats.error);
+      }
+
+    } finally {
+      span.end();
+    }
+  }
+
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FindCompactionTmpFiles.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FindCompactionTmpFiles.java
@@ -88,7 +88,6 @@ public class FindCompactionTmpFiles {
     svc.shutdown();
 
     while (futures.size() > 0) {
-      UtilWaitThread.sleep(10_000);
       Iterator<Future<Void>> iter = futures.iterator();
       while (iter.hasNext()) {
         Future<Void> future = iter.next();
@@ -100,6 +99,9 @@ public class FindCompactionTmpFiles {
             throw new RuntimeException("Error getting list of tmp files", e);
           }
         }
+      }
+      if (futures.size() > 0) {
+        UtilWaitThread.sleep(3_000);
       }
     }
     svc.awaitTermination(10, TimeUnit.MINUTES);
@@ -144,7 +146,6 @@ public class FindCompactionTmpFiles {
 
     int expectedResponses = filesToDelete.size();
     while (expectedResponses > 0) {
-      UtilWaitThread.sleep(10_000);
       Iterator<Future<Boolean>> iter = futures.iterator();
       while (iter.hasNext()) {
         Future<Boolean> future = iter.next();
@@ -163,7 +164,10 @@ public class FindCompactionTmpFiles {
           }
         }
       }
-      LOG.debug("Waiting on {} responses", expectedResponses);
+      LOG.debug("Waiting on {} background delete operations", expectedResponses);
+      if (expectedResponses > 0) {
+        UtilWaitThread.sleep(3_000);
+      }
     }
     delSvc.awaitTermination(10, TimeUnit.MINUTES);
     return stats;

--- a/server/base/src/test/java/org/apache/accumulo/server/tablets/TabletNameGeneratorTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/tablets/TabletNameGeneratorTest.java
@@ -85,7 +85,7 @@ public class TabletNameGeneratorTest {
 
     ReferencedTabletFile rtf =
         TabletNameGenerator.getNextDataFilenameForMajc(false, context, tm1, dirCreator, ecid);
-    assertEquals("ANextFileName.rf_tmp_" + ecid.encodeForFileName(), rtf.getFileName());
+    assertEquals("ANextFileName.rf_tmp_" + ecid.canonical(), rtf.getFileName());
 
     EasyMock.verify(tableConf, vm, allocator, context, tm1);
 

--- a/server/base/src/test/java/org/apache/accumulo/server/tablets/TabletNameGeneratorTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/tablets/TabletNameGeneratorTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.tablets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import org.apache.accumulo.core.conf.ConfigurationCopy;
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.InstanceId;
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.core.metadata.ReferencedTabletFile;
+import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.util.cache.Caches;
+import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.conf.TableConfiguration;
+import org.apache.accumulo.server.fs.VolumeChooserEnvironmentImpl;
+import org.apache.accumulo.server.fs.VolumeManager;
+import org.apache.hadoop.io.Text;
+import org.easymock.EasyMock;
+import org.junit.jupiter.api.Test;
+
+public class TabletNameGeneratorTest {
+
+  @Test
+  public void testGetNextDataFilenameForMajc() {
+
+    String instanceId = UUID.randomUUID().toString();
+    String baseUri = "hdfs://localhost:8000/accumulo/" + instanceId;
+    TableId tid = TableId.of("1");
+    KeyExtent ke1 = new KeyExtent(tid, new Text("b"), new Text("a"));
+    String dirName = "t-000001";
+
+    ConfigurationCopy conf = new ConfigurationCopy();
+
+    TableConfiguration tableConf = EasyMock.createMock(TableConfiguration.class);
+    EasyMock.expect(tableConf.get(Property.TABLE_FILE_TYPE)).andReturn("rf");
+
+    VolumeManager vm = EasyMock.createMock(VolumeManager.class);
+    EasyMock.expect(
+        vm.choose(EasyMock.isA(VolumeChooserEnvironmentImpl.class), EasyMock.eq(Set.of(baseUri))))
+        .andReturn(baseUri);
+
+    UniqueNameAllocator allocator = EasyMock.createMock(UniqueNameAllocator.class);
+    EasyMock.expect(allocator.getNextName()).andReturn("NextFileName");
+
+    ServerContext context = EasyMock.createMock(ServerContext.class);
+    EasyMock.expect(context.getInstanceID()).andReturn(InstanceId.of(instanceId)).anyTimes();
+    EasyMock.expect(context.getConfiguration()).andReturn(conf);
+    EasyMock.expect(context.getTableConfiguration(tid)).andReturn(tableConf);
+    EasyMock.expect(context.getCaches()).andReturn(Caches.getInstance());
+    EasyMock.expect(context.getVolumeManager()).andReturn(vm);
+    EasyMock.expect(context.getBaseUris()).andReturn(Set.of(baseUri));
+    EasyMock.expect(context.getUniqueNameAllocator()).andReturn(allocator);
+
+    TabletMetadata tm1 = EasyMock.createMock(TabletMetadata.class);
+    EasyMock.expect(tm1.getExtent()).andReturn(ke1);
+    EasyMock.expect(tm1.getDirName()).andReturn(dirName);
+
+    Consumer<String> dirCreator = (dir) -> {};
+    ExternalCompactionId ecid = ExternalCompactionId.generate(UUID.randomUUID());
+
+    EasyMock.replay(tableConf, vm, allocator, context, tm1);
+
+    ReferencedTabletFile rtf =
+        TabletNameGenerator.getNextDataFilenameForMajc(false, context, tm1, dirCreator, ecid);
+    assertEquals("ANextFileName.rf_tmp_" + ecid.encodeForFileName(), rtf.getFileName());
+
+    EasyMock.verify(tableConf, vm, allocator, context, tm1);
+
+  }
+}

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -19,7 +19,6 @@
 package org.apache.accumulo.compactor;
 
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
-import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.io.IOException;
@@ -125,7 +124,6 @@ import io.micrometer.core.instrument.MeterRegistry;
 public class Compactor extends AbstractServer implements MetricsProducer, CompactorService.Iface {
 
   private static final Logger LOG = LoggerFactory.getLogger(Compactor.class);
-  private static final long TIME_BETWEEN_CANCEL_CHECKS = MINUTES.toMillis(5);
 
   private static final long TEN_MEGABYTES = 10485760;
 
@@ -158,7 +156,8 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
     watcher = new CompactionWatcher(aconf);
     var schedExecutor =
         ThreadPools.getServerThreadPools().createGeneralScheduledExecutorService(aconf);
-    startCancelChecker(schedExecutor, TIME_BETWEEN_CANCEL_CHECKS);
+    startCancelChecker(schedExecutor,
+        aconf.getTimeInMillis(Property.COMPACTOR_CANCEL_CHECK_INTERVAL));
     printStartupMsg();
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/DeadCompactionDetector.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/DeadCompactionDetector.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.manager.compaction.coordinator;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -29,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
@@ -36,6 +38,9 @@ import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.accumulo.core.util.compaction.ExternalCompactionUtil;
 import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.util.FindCompactionTmpFiles;
+import org.apache.accumulo.server.util.FindCompactionTmpFiles.DeleteStats;
+import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,6 +52,7 @@ public class DeadCompactionDetector {
   private final CompactionCoordinator coordinator;
   private final ScheduledThreadPoolExecutor schedExecutor;
   private final ConcurrentHashMap<ExternalCompactionId,Long> deadCompactions;
+  private final Set<TableId> tablesWithUnreferencedTmpFiles = new HashSet<>();
 
   public DeadCompactionDetector(ServerContext context, CompactionCoordinator coordinator,
       ScheduledThreadPoolExecutor stpe) {
@@ -54,6 +60,12 @@ public class DeadCompactionDetector {
     this.coordinator = coordinator;
     this.schedExecutor = stpe;
     this.deadCompactions = new ConcurrentHashMap<>();
+  }
+
+  public void addTableId(TableId tableWithUnreferencedTmpFiles) {
+    synchronized (tablesWithUnreferencedTmpFiles) {
+      tablesWithUnreferencedTmpFiles.add(tableWithUnreferencedTmpFiles);
+    }
   }
 
   private void detectDeadCompactions() {
@@ -77,51 +89,82 @@ public class DeadCompactionDetector {
       log.trace("Clearing the dead compaction map, no tablets have compactions running");
       this.deadCompactions.clear();
       // no need to look for dead compactions when tablets don't have anything recorded as running
-      return;
+    } else {
+      if (log.isTraceEnabled()) {
+        tabletCompactions.forEach((ecid, extent) -> log.trace("Saw {} for {}", ecid, extent));
+      }
+
+      // Remove from the dead map any compactions that the Tablet's
+      // do not think are running any more.
+      this.deadCompactions.keySet().retainAll(tabletCompactions.keySet());
+
+      // Determine what compactions are currently running and remove those.
+      //
+      // In order for this overall algorithm to be correct and avoid race conditions, the compactor
+      // must return ids covering the time period from before reservation until after commit. If the
+      // ids do not cover this time period then legitimate running compactions could be canceled.
+      Collection<ExternalCompactionId> running =
+          ExternalCompactionUtil.getCompactionIdsRunningOnCompactors(context);
+
+      running.forEach((ecid) -> {
+        if (tabletCompactions.remove(ecid) != null) {
+          log.debug("Ignoring compaction {} that is running on a compactor", ecid);
+        }
+        if (this.deadCompactions.remove(ecid) != null) {
+          log.debug("Removed {} from the dead compaction map, it's running on a compactor", ecid);
+        }
+      });
+
+      tabletCompactions.forEach((ecid, extent) -> {
+        log.info("Possible dead compaction detected {} {}", ecid, extent);
+        this.deadCompactions.merge(ecid, 1L, Long::sum);
+      });
+
+      // Everything left in tabletCompactions is no longer running anywhere and should be failed.
+      // Its possible that a compaction committed while going through the steps above, if so then
+      // that is ok and marking it failed will end up being a no-op.
+      Set<ExternalCompactionId> toFail =
+          this.deadCompactions.entrySet().stream().filter(e -> e.getValue() > 2)
+              .map(e -> e.getKey()).collect(Collectors.toCollection(TreeSet::new));
+      tabletCompactions.keySet().retainAll(toFail);
+      tabletCompactions.forEach((eci, v) -> {
+        log.warn("Compaction {} believed to be dead, failing it.", eci);
+      });
+      coordinator.compactionFailed(tabletCompactions);
+      this.deadCompactions.keySet().removeAll(toFail);
     }
 
-    if (log.isTraceEnabled()) {
-      tabletCompactions.forEach((ecid, extent) -> log.trace("Saw {} for {}", ecid, extent));
+    // Find and delete any known tables that have unreferenced
+    // compaction tmp files.
+    if (!tablesWithUnreferencedTmpFiles.isEmpty()) {
+
+      Set<TableId> copy = new HashSet<>();
+      synchronized (tablesWithUnreferencedTmpFiles) {
+        copy.addAll(tablesWithUnreferencedTmpFiles);
+        tablesWithUnreferencedTmpFiles.clear();
+      }
+
+      log.debug("Tables that may have unreferenced compaction tmp files: {}", copy);
+      for (TableId tid : copy) {
+        try {
+          final Set<Path> matches = FindCompactionTmpFiles.findTempFiles(context, tid.canonical());
+          log.debug("Found the following compaction tmp files for table {}:", tid);
+          matches.forEach(p -> log.debug("{}", p));
+
+          if (!matches.isEmpty()) {
+            log.debug("Deleting compaction tmp files for table {}...", tid);
+            DeleteStats stats = FindCompactionTmpFiles.deleteTempFiles(context, matches);
+            log.debug(
+                "Deletion of compaction tmp files for table {} complete. Success:{}, Failure:{}, Error:{}",
+                tid, stats.success, stats.failure, stats.error);
+          }
+        } catch (InterruptedException e) {
+          log.error("Interrupted while finding compaction tmp files for table: {}", tid.canonical(),
+              e);
+        }
+      }
     }
 
-    // Remove from the dead map any compactions that the Tablet's
-    // do not think are running any more.
-    this.deadCompactions.keySet().retainAll(tabletCompactions.keySet());
-
-    // Determine what compactions are currently running and remove those.
-    //
-    // In order for this overall algorithm to be correct and avoid race conditions, the compactor
-    // must return ids covering the time period from before reservation until after commit. If the
-    // ids do not cover this time period then legitimate running compactions could be canceled.
-    Collection<ExternalCompactionId> running =
-        ExternalCompactionUtil.getCompactionIdsRunningOnCompactors(context);
-
-    running.forEach((ecid) -> {
-      if (tabletCompactions.remove(ecid) != null) {
-        log.debug("Ignoring compaction {} that is running on a compactor", ecid);
-      }
-      if (this.deadCompactions.remove(ecid) != null) {
-        log.debug("Removed {} from the dead compaction map, it's running on a compactor", ecid);
-      }
-    });
-
-    tabletCompactions.forEach((ecid, extent) -> {
-      log.info("Possible dead compaction detected {} {}", ecid, extent);
-      this.deadCompactions.merge(ecid, 1L, Long::sum);
-    });
-
-    // Everything left in tabletCompactions is no longer running anywhere and should be failed.
-    // Its possible that a compaction committed while going through the steps above, if so then
-    // that is ok and marking it failed will end up being a no-op.
-    Set<ExternalCompactionId> toFail =
-        this.deadCompactions.entrySet().stream().filter(e -> e.getValue() > 2).map(e -> e.getKey())
-            .collect(Collectors.toCollection(TreeSet::new));
-    tabletCompactions.keySet().retainAll(toFail);
-    tabletCompactions.forEach((eci, v) -> {
-      log.warn("Compaction {} believed to be dead, failing it.", eci);
-    });
-    coordinator.compactionFailed(tabletCompactions);
-    this.deadCompactions.keySet().removeAll(toFail);
   }
 
   public void start() {

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionTestUtils.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionTestUtils.java
@@ -230,6 +230,7 @@ public class ExternalCompactionTestUtils {
     cfg.setProperty(Property.COMPACTION_COORDINATOR_FINALIZER_COMPLETION_CHECK_INTERVAL, "5s");
     cfg.setProperty(Property.COMPACTION_COORDINATOR_DEAD_COMPACTOR_CHECK_INTERVAL, "5s");
     cfg.setProperty(Property.COMPACTION_COORDINATOR_TSERVER_COMPACTION_CHECK_INTERVAL, "3s");
+    cfg.setProperty(Property.COMPACTOR_CANCEL_CHECK_INTERVAL, "5s");
     cfg.setProperty(Property.COMPACTOR_PORTSEARCH, "true");
     cfg.setProperty(Property.COMPACTOR_MIN_JOB_WAIT_TIME, "100ms");
     cfg.setProperty(Property.COMPACTOR_MAX_JOB_WAIT_TIME, "1s");

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_2_IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_2_IT.java
@@ -139,7 +139,7 @@ public class ExternalCompaction_2_IT extends SharedMiniClusterBase {
 
       // Verify that the tmp file are cleaned up
       Wait.waitFor(() -> FindCompactionTmpFiles
-          .findTempFiles(getCluster().getServerContext(), tid.canonical()).size() == 1);
+          .findTempFiles(getCluster().getServerContext(), tid.canonical()).size() == 0, 60_000);
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_2_IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_2_IT.java
@@ -62,6 +62,8 @@ import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.util.FindCompactionTmpFiles;
+import org.apache.accumulo.test.util.Wait;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.BeforeAll;
@@ -106,6 +108,10 @@ public class ExternalCompaction_2_IT extends SharedMiniClusterBase {
           .confirmCompactionRunning(getCluster().getServerContext(), ecids);
       assertTrue(matches > 0);
 
+      // Verify that a tmp file is created
+      Wait.waitFor(() -> FindCompactionTmpFiles
+          .findTempFiles(getCluster().getServerContext(), tid.canonical()).size() == 1);
+
       // ExternalDoNothingCompactor will not compact, it will wait, split the table.
       SortedSet<Text> splits = new TreeSet<>();
       int jump = MAX_DATA / 5;
@@ -130,6 +136,10 @@ public class ExternalCompaction_2_IT extends SharedMiniClusterBase {
       // compaction above in the test. Even though the external compaction was cancelled
       // because we split the table, FaTE will continue to queue up a compaction
       client.tableOperations().cancelCompaction(table1);
+
+      // Verify that the tmp file are cleaned up
+      Wait.waitFor(() -> FindCompactionTmpFiles
+          .findTempFiles(getCluster().getServerContext(), tid.canonical()).size() == 1);
     }
   }
 
@@ -163,6 +173,10 @@ public class ExternalCompaction_2_IT extends SharedMiniClusterBase {
           .confirmCompactionRunning(getCluster().getServerContext(), ecids);
       assertTrue(matches > 0);
 
+      // Verify that a tmp file is created
+      Wait.waitFor(() -> FindCompactionTmpFiles
+          .findTempFiles(getCluster().getServerContext(), tid.canonical()).size() == 1);
+
       // when the compaction starts it will create a selected files column in the tablet, wait for
       // that to happen
       while (countTablets(getCluster().getServerContext(), table1,
@@ -185,6 +199,10 @@ public class ExternalCompaction_2_IT extends SharedMiniClusterBase {
           tm -> tm.getSelectedFiles() != null || !tm.getCompacted().isEmpty()) > 0) {
         Thread.sleep(1000);
       }
+
+      // Verify that the tmp file are cleaned up
+      Wait.waitFor(() -> FindCompactionTmpFiles
+          .findTempFiles(getCluster().getServerContext(), tid.canonical()).size() == 0);
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_3_IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_3_IT.java
@@ -113,7 +113,7 @@ public class ExternalCompaction_3_IT extends SharedMiniClusterBase {
 
       // Verify that a tmp file is created
       Wait.waitFor(() -> FindCompactionTmpFiles
-          .findTempFiles(getCluster().getServerContext(), tid.canonical()).size() == 0);
+          .findTempFiles(getCluster().getServerContext(), tid.canonical()).size() == 1);
 
       // Merge - blocking operation
       Text start = md.get(0).getPrevEndRow();

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_3_IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_3_IT.java
@@ -53,6 +53,8 @@ import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.util.FindCompactionTmpFiles;
+import org.apache.accumulo.test.util.Wait;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
 import org.apache.thrift.TException;
@@ -109,6 +111,10 @@ public class ExternalCompaction_3_IT extends SharedMiniClusterBase {
         assertEquals(2, md.size());
       }
 
+      // Verify that a tmp file is created
+      Wait.waitFor(() -> FindCompactionTmpFiles
+          .findTempFiles(getCluster().getServerContext(), tid.canonical()).size() == 0);
+
       // Merge - blocking operation
       Text start = md.get(0).getPrevEndRow();
       Text end = md.get(1).getEndRow();
@@ -133,6 +139,10 @@ public class ExternalCompaction_3_IT extends SharedMiniClusterBase {
       // compaction above in the test. Even though the external compaction was cancelled
       // because we split the table, FaTE will continue to queue up a compaction
       client.tableOperations().delete(table1);
+
+      // Verify that the tmp file are cleaned up
+      Wait.waitFor(() -> FindCompactionTmpFiles
+          .findTempFiles(getCluster().getServerContext(), tid.canonical()).size() == 0);
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/FindCompactionTmpFilesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FindCompactionTmpFilesIT.java
@@ -105,7 +105,7 @@ public class FindCompactionTmpFilesIT extends SharedMiniClusterBase {
         System.out.println(p);
       }
 
-      List<Path> foundPaths = FindCompactionTmpFiles.findTempFiles(ctx, tid.canonical());
+      Set<Path> foundPaths = FindCompactionTmpFiles.findTempFiles(ctx, tid.canonical());
       assertEquals(100, foundPaths.size());
       assertEquals(foundPaths, generatedPaths);
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/FindCompactionTmpFilesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FindCompactionTmpFilesIT.java
@@ -94,7 +94,7 @@ public class FindCompactionTmpFilesIT extends SharedMiniClusterBase {
       Path defaultTabletPath = new Path(tdir);
       assertTrue(fs.exists(defaultTabletPath));
 
-      assertEquals(0, FindCompactionTmpFiles.findTempFiles(ctx).size());
+      assertEquals(0, FindCompactionTmpFiles.findTempFiles(ctx, tid.canonical()).size());
 
       List<Path> generatedPaths = generateTmpFilePaths(ctx, tid, defaultTabletPath, 100);
 
@@ -105,7 +105,7 @@ public class FindCompactionTmpFilesIT extends SharedMiniClusterBase {
         System.out.println(p);
       }
 
-      List<Path> foundPaths = FindCompactionTmpFiles.findTempFiles(ctx);
+      List<Path> foundPaths = FindCompactionTmpFiles.findTempFiles(ctx, tid.canonical());
       assertEquals(100, foundPaths.size());
       assertEquals(foundPaths, generatedPaths);
 
@@ -114,7 +114,7 @@ public class FindCompactionTmpFilesIT extends SharedMiniClusterBase {
       assertEquals(0, stats.failure);
       assertEquals(0, stats.error);
 
-      foundPaths = FindCompactionTmpFiles.findTempFiles(ctx);
+      foundPaths = FindCompactionTmpFiles.findTempFiles(ctx, tid.canonical());
       assertEquals(0, foundPaths.size());
 
     }

--- a/test/src/main/java/org/apache/accumulo/test/functional/FindCompactionTmpFilesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FindCompactionTmpFilesIT.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test.functional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import org.apache.accumulo.core.client.Accumulo;
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.metadata.ReferencedTabletFile;
+import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
+import org.apache.accumulo.harness.SharedMiniClusterBase;
+import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.tablets.TabletNameGenerator;
+import org.apache.accumulo.server.util.FindCompactionTmpFiles;
+import org.apache.accumulo.server.util.FindCompactionTmpFiles.DeleteStats;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class FindCompactionTmpFilesIT extends SharedMiniClusterBase {
+
+  @BeforeAll
+  public static void before() throws Exception {
+    startMiniCluster();
+  }
+
+  @AfterAll
+  public static void after() throws Exception {
+    stopMiniCluster();
+  }
+
+  private List<Path> generateTmpFilePaths(ServerContext context, TableId tid, Path tabletDir,
+      int numFiles) {
+    final List<Path> paths = new ArrayList<>(numFiles);
+    final TabletsMetadata tms = context.getAmple().readTablets().forTable(tid).build();
+    final TabletMetadata tm = tms.iterator().next();
+
+    for (int i = 0; i < numFiles; i++) {
+      ReferencedTabletFile rtf = TabletNameGenerator.getNextDataFilenameForMajc(false, context, tm,
+          (s) -> {}, ExternalCompactionId.generate(UUID.randomUUID()));
+      paths.add(rtf.getPath());
+    }
+    return paths;
+  }
+
+  @Test
+  public void testFindCompactionTmpFiles() throws Exception {
+
+    try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
+
+      String tableName = getUniqueNames(1)[0];
+      c.tableOperations().create(tableName);
+      ReadWriteIT.ingest(c, 100, 1, 1, 0, tableName);
+      c.tableOperations().flush(tableName);
+
+      String tableId = c.tableOperations().tableIdMap().get(tableName);
+      TableId tid = TableId.of(tableId);
+
+      ServerContext ctx = getCluster().getServerContext();
+      FileSystem fs = getCluster().getFileSystem();
+
+      Set<String> tablesDirs = ctx.getTablesDirs();
+      assertEquals(1, tablesDirs.size());
+
+      String tdir = tablesDirs.iterator().next() + "/" + tid.canonical() + "/default_tablet";
+      Path defaultTabletPath = new Path(tdir);
+      assertTrue(fs.exists(defaultTabletPath));
+
+      assertEquals(0, FindCompactionTmpFiles.findTempFiles(ctx).size());
+
+      List<Path> generatedPaths = generateTmpFilePaths(ctx, tid, defaultTabletPath, 100);
+
+      for (Path p : generatedPaths) {
+        assertFalse(fs.exists(p));
+        assertTrue(fs.createNewFile(p));
+        assertTrue(fs.exists(p));
+        System.out.println(p);
+      }
+
+      List<Path> foundPaths = FindCompactionTmpFiles.findTempFiles(ctx);
+      assertEquals(100, foundPaths.size());
+      assertEquals(foundPaths, generatedPaths);
+
+      DeleteStats stats = FindCompactionTmpFiles.deleteTempFiles(ctx, foundPaths);
+      assertEquals(100, stats.success);
+      assertEquals(0, stats.failure);
+      assertEquals(0, stats.error);
+
+      foundPaths = FindCompactionTmpFiles.findTempFiles(ctx);
+      assertEquals(0, foundPaths.size());
+
+    }
+  }
+
+}

--- a/test/src/main/java/org/apache/accumulo/test/functional/FindCompactionTmpFilesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FindCompactionTmpFilesIT.java
@@ -22,8 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
@@ -57,9 +56,9 @@ public class FindCompactionTmpFilesIT extends SharedMiniClusterBase {
     stopMiniCluster();
   }
 
-  private List<Path> generateTmpFilePaths(ServerContext context, TableId tid, Path tabletDir,
+  private Set<Path> generateTmpFilePaths(ServerContext context, TableId tid, Path tabletDir,
       int numFiles) {
-    final List<Path> paths = new ArrayList<>(numFiles);
+    final Set<Path> paths = new HashSet<>(numFiles);
     final TabletsMetadata tms = context.getAmple().readTablets().forTable(tid).build();
     final TabletMetadata tm = tms.iterator().next();
 
@@ -96,7 +95,7 @@ public class FindCompactionTmpFilesIT extends SharedMiniClusterBase {
 
       assertEquals(0, FindCompactionTmpFiles.findTempFiles(ctx, tid.canonical()).size());
 
-      List<Path> generatedPaths = generateTmpFilePaths(ctx, tid, defaultTabletPath, 100);
+      Set<Path> generatedPaths = generateTmpFilePaths(ctx, tid, defaultTabletPath, 100);
 
       for (Path p : generatedPaths) {
         assertFalse(fs.exists(p));


### PR DESCRIPTION
Modified TabletNameGenerator.getNextDataFilenameForMajc to add the external compaction id to the filename. When a compaction fails, or the DeadCompactionDetector notices a Compactor is down, CompactionCoordinator.compactionFailed is called to remove the external compaction id from the tablet metadata. Modified this method to also remove corresponding tmp files from the tablet directory when the external compaction id is successfully removed from the tablet metadata. Created the FindCompactionTmpFiles utility to find, and optionally delete, compaction tmp files at a system level. This utility requires that no Compactors are running to avoid any collisions.

Fixes #3577