### PR TITLE
Add a merge column marker to make merge idempotent

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataSchema.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataSchema.java
@@ -325,6 +325,16 @@ public class MetadataSchema {
       public static final String STR_NAME = "ecomp";
       public static final Text NAME = new Text(STR_NAME);
     }
+
+    /**
+     * Column family for indicating that the files in a tablet contain fenced files that have been
+     * merged from other tablets
+     */
+    public static class MergedColumnFamily {
+      public static final String STR_NAME = "merged";
+      public static final Text NAME = new Text(STR_NAME);
+      public static final ColumnFQ MERGED_COLUMN = new ColumnFQ(NAME, new Text(STR_NAME));
+    }
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataSchema.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataSchema.java
@@ -328,12 +328,22 @@ public class MetadataSchema {
 
     /**
      * Column family for indicating that the files in a tablet contain fenced files that have been
-     * merged from other tablets
+     * merged from other tablets during a merge operation. This is used to support resuming a failed
+     * merge operation. The value is a boolean to indicate of a prev row column was read during the
+     * merge.
      */
     public static class MergedColumnFamily {
       public static final String STR_NAME = "merged";
       public static final Text NAME = new Text(STR_NAME);
       public static final ColumnFQ MERGED_COLUMN = new ColumnFQ(NAME, new Text(STR_NAME));
+
+      public static Value encodeHasPrevRowColumn(boolean hasPrevRowColumn) {
+        return new Value(hasPrevRowColumn ? new byte[] {1} : new byte[] {0});
+      }
+
+      public static boolean decodeHasPrevRowColumn(Value hasPrevRowColumn) {
+        return hasPrevRowColumn != null && hasPrevRowColumn.contentEquals(new byte[] {1});
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataSchema.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataSchema.java
@@ -329,21 +329,13 @@ public class MetadataSchema {
     /**
      * Column family for indicating that the files in a tablet contain fenced files that have been
      * merged from other tablets during a merge operation. This is used to support resuming a failed
-     * merge operation. The value is a boolean to indicate of a prev row column was read during the
-     * merge.
+     * merge operation.
      */
     public static class MergedColumnFamily {
       public static final String STR_NAME = "merged";
       public static final Text NAME = new Text(STR_NAME);
       public static final ColumnFQ MERGED_COLUMN = new ColumnFQ(NAME, new Text(STR_NAME));
-
-      public static Value encodeHasPrevRowColumn(boolean hasPrevRowColumn) {
-        return new Value(hasPrevRowColumn ? new byte[] {1} : new byte[] {0});
-      }
-
-      public static boolean decodeHasPrevRowColumn(Value hasPrevRowColumn) {
-        return hasPrevRowColumn != null && hasPrevRowColumn.contentEquals(new byte[] {1});
-      }
+      public static final Value MERGED_VALUE = new Value("merged");
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -105,7 +105,7 @@ public class TabletMetadata {
   private OptionalLong compact = OptionalLong.empty();
   private Double splitRatio = null;
   private Map<ExternalCompactionId,ExternalCompactionMetadata> extCompactions;
-  private boolean merged = false;
+  private Boolean mergedPrevRowColumn;
 
   public enum LocationType {
     CURRENT, FUTURE, LAST
@@ -350,7 +350,12 @@ public class TabletMetadata {
 
   public boolean hasMerged() {
     ensureFetched(ColumnType.MERGED);
-    return merged;
+    return mergedPrevRowColumn != null;
+  }
+
+  public Boolean getMergedPrevRowColumn() {
+    ensureFetched(ColumnType.MERGED);
+    return mergedPrevRowColumn;
   }
 
   public SortedMap<Key,Value> getKeyValues() {
@@ -488,7 +493,7 @@ public class TabletMetadata {
               ExternalCompactionMetadata.fromJson(val));
           break;
         case MergedColumnFamily.STR_NAME:
-          te.merged = true;
+          te.mergedPrevRowColumn = MergedColumnFamily.decodeHasPrevRowColumn(kv.getValue());
           break;
         default:
           throw new IllegalStateException("Unexpected family " + fam);

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -62,6 +62,7 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.Ex
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.FutureLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LastLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LogColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.MergedColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ScanFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.SuspendLocationColumn;
@@ -104,6 +105,7 @@ public class TabletMetadata {
   private OptionalLong compact = OptionalLong.empty();
   private Double splitRatio = null;
   private Map<ExternalCompactionId,ExternalCompactionMetadata> extCompactions;
+  private boolean merged = false;
 
   public enum LocationType {
     CURRENT, FUTURE, LAST
@@ -125,7 +127,8 @@ public class TabletMetadata {
     COMPACT_ID,
     SPLIT_RATIO,
     SUSPEND,
-    ECOMP
+    ECOMP,
+    MERGED
   }
 
   public static class Location {
@@ -345,6 +348,11 @@ public class TabletMetadata {
     return splitRatio;
   }
 
+  public boolean hasMerged() {
+    ensureFetched(ColumnType.MERGED);
+    return merged;
+  }
+
   public SortedMap<Key,Value> getKeyValues() {
     Preconditions.checkState(keyValues != null, "Requested key values when it was not saved");
     return keyValues;
@@ -478,6 +486,9 @@ public class TabletMetadata {
         case ExternalCompactionColumnFamily.STR_NAME:
           extCompBuilder.put(ExternalCompactionId.of(qual),
               ExternalCompactionMetadata.fromJson(val));
+          break;
+        case MergedColumnFamily.STR_NAME:
+          te.merged = true;
           break;
         default:
           throw new IllegalStateException("Unexpected family " + fam);

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -105,7 +105,7 @@ public class TabletMetadata {
   private OptionalLong compact = OptionalLong.empty();
   private Double splitRatio = null;
   private Map<ExternalCompactionId,ExternalCompactionMetadata> extCompactions;
-  private Boolean mergedPrevRowColumn;
+  private boolean merged;
 
   public enum LocationType {
     CURRENT, FUTURE, LAST
@@ -350,12 +350,7 @@ public class TabletMetadata {
 
   public boolean hasMerged() {
     ensureFetched(ColumnType.MERGED);
-    return mergedPrevRowColumn != null;
-  }
-
-  public Boolean getMergedPrevRowColumn() {
-    ensureFetched(ColumnType.MERGED);
-    return mergedPrevRowColumn;
+    return merged;
   }
 
   public SortedMap<Key,Value> getKeyValues() {
@@ -493,7 +488,7 @@ public class TabletMetadata {
               ExternalCompactionMetadata.fromJson(val));
           break;
         case MergedColumnFamily.STR_NAME:
-          te.mergedPrevRowColumn = MergedColumnFamily.decodeHasPrevRowColumn(kv.getValue());
+          te.merged = true;
           break;
         default:
           throw new IllegalStateException("Unexpected family " + fam);

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
@@ -76,6 +76,7 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.Ex
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.FutureLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LastLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LogColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.MergedColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ScanFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.SuspendLocationColumn;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
@@ -335,6 +336,9 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
             break;
           case ECOMP:
             families.add(ExternalCompactionColumnFamily.NAME);
+            break;
+          case MERGED:
+            families.add(MergedColumnFamily.NAME);
             break;
           default:
             throw new IllegalArgumentException("Unknown col type " + colToFetch);

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/MetadataSchemaTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/MetadataSchemaTest.java
@@ -19,8 +19,12 @@
 package org.apache.accumulo.core.metadata.schema;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.MergedColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.Test;
@@ -38,4 +42,13 @@ public class MetadataSchemaTest {
     assertEquals(ab, TabletColumnFamily.decodePrevEndRow(TabletColumnFamily.encodePrevEndRow(ab)));
   }
 
+  @Test
+  public void testMergedEncodeDecode() {
+    assertEquals(new Value(new byte[] {1}), MergedColumnFamily.encodeHasPrevRowColumn(true));
+    assertEquals(new Value(new byte[] {0}), MergedColumnFamily.encodeHasPrevRowColumn(false));
+
+    assertTrue(MergedColumnFamily.decodeHasPrevRowColumn(new Value(new byte[] {1})));
+    assertFalse(MergedColumnFamily.decodeHasPrevRowColumn(new Value(new byte[] {0})));
+    assertFalse(MergedColumnFamily.decodeHasPrevRowColumn(null));
+  }
 }

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/MetadataSchemaTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/MetadataSchemaTest.java
@@ -19,12 +19,8 @@
 package org.apache.accumulo.core.metadata.schema;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.MergedColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.Test;
@@ -42,13 +38,4 @@ public class MetadataSchemaTest {
     assertEquals(ab, TabletColumnFamily.decodePrevEndRow(TabletColumnFamily.encodePrevEndRow(ab)));
   }
 
-  @Test
-  public void testMergedEncodeDecode() {
-    assertEquals(new Value(new byte[] {1}), MergedColumnFamily.encodeHasPrevRowColumn(true));
-    assertEquals(new Value(new byte[] {0}), MergedColumnFamily.encodeHasPrevRowColumn(false));
-
-    assertTrue(MergedColumnFamily.decodeHasPrevRowColumn(new Value(new byte[] {1})));
-    assertFalse(MergedColumnFamily.decodeHasPrevRowColumn(new Value(new byte[] {0})));
-    assertFalse(MergedColumnFamily.decodeHasPrevRowColumn(null));
-  }
 }

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.core.metadata.schema;
 
 import static java.util.stream.Collectors.toSet;
 import static org.apache.accumulo.core.metadata.StoredTabletFile.serialize;
+import static org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.MergedColumnFamily.MERGED_COLUMN;
 import static org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily.COMPACT_COLUMN;
 import static org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN;
 import static org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily.FLUSH_COLUMN;
@@ -58,6 +59,7 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.Da
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.FutureLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LastLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LogColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.MergedColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ScanFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.SuspendLocationColumn;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
@@ -113,6 +115,8 @@ public class TabletMetadataTest {
     mutation.at().family(ScanFileColumnFamily.NAME).qualifier(sf1.getMetadata()).put("");
     mutation.at().family(ScanFileColumnFamily.NAME).qualifier(sf2.getMetadata()).put("");
 
+    MERGED_COLUMN.put(mutation, MergedColumnFamily.encodeHasPrevRowColumn(true));
+
     SortedMap<Key,Value> rowMap = toRowMap(mutation);
 
     TabletMetadata tm = TabletMetadata.convertRow(rowMap.entrySet().iterator(),
@@ -143,6 +147,7 @@ public class TabletMetadataTest {
     assertTrue(tm.sawPrevEndRow());
     assertEquals("M123456789", tm.getTime().encode());
     assertEquals(Set.of(sf1, sf2), Set.copyOf(tm.getScans()));
+    assertTrue(tm.getMergedPrevRowColumn());
   }
 
   @Test
@@ -256,6 +261,41 @@ public class TabletMetadataTest {
     assertEquals(ser2.getHostAndPort(), tm.getSuspend().server);
     assertNull(tm.getLocation());
     assertFalse(tm.hasCurrent());
+  }
+
+  @Test
+  public void testMergedColumn() {
+    KeyExtent extent = new KeyExtent(TableId.of("5"), new Text("df"), new Text("da"));
+
+    // Test merged prev column value set to true
+    Mutation mutation = TabletColumnFamily.createPrevRowMutation(extent);
+    MERGED_COLUMN.put(mutation, MergedColumnFamily.encodeHasPrevRowColumn(true));
+    TabletMetadata tm = TabletMetadata.convertRow(toRowMap(mutation).entrySet().iterator(),
+        EnumSet.of(ColumnType.MERGED), true);
+    assertTrue(tm.hasMerged());
+    assertTrue(tm.getMergedPrevRowColumn());
+
+    // Test merged prev column value set to false
+    mutation = TabletColumnFamily.createPrevRowMutation(extent);
+    MERGED_COLUMN.put(mutation, MergedColumnFamily.encodeHasPrevRowColumn(false));
+    tm = TabletMetadata.convertRow(toRowMap(mutation).entrySet().iterator(),
+        EnumSet.of(ColumnType.MERGED), true);
+    assertTrue(tm.hasMerged());
+    assertFalse(tm.getMergedPrevRowColumn());
+
+    // Column not set
+    mutation = TabletColumnFamily.createPrevRowMutation(extent);
+    tm = TabletMetadata.convertRow(toRowMap(mutation).entrySet().iterator(),
+        EnumSet.of(ColumnType.MERGED), true);
+    assertFalse(tm.hasMerged());
+    assertNull(tm.getMergedPrevRowColumn());
+
+    // MERGED Column not fetched
+    mutation = TabletColumnFamily.createPrevRowMutation(extent);
+    tm = TabletMetadata.convertRow(toRowMap(mutation).entrySet().iterator(),
+        EnumSet.of(ColumnType.PREV_ROW), true);
+    assertThrows(IllegalStateException.class, tm::hasMerged);
+    assertThrows(IllegalStateException.class, tm::getMergedPrevRowColumn);
   }
 
   private SortedMap<Key,Value> toRowMap(Mutation mutation) {

--- a/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
@@ -47,6 +47,7 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.Ex
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.FutureLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LastLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LogColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.MergedColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ScanFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.SuspendLocationColumn;
@@ -98,7 +99,8 @@ public class MetadataConstraints implements Constraint {
           FutureLocationColumnFamily.NAME,
           ClonedColumnFamily.NAME,
           ExternalCompactionColumnFamily.NAME,
-          UpgraderDeprecatedConstants.ChoppedColumnFamily.NAME
+          UpgraderDeprecatedConstants.ChoppedColumnFamily.NAME,
+          MergedColumnFamily.NAME
       );
   // @formatter:on
 

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/MergeState.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/MergeState.java
@@ -37,6 +37,9 @@ public enum MergeState {
    * metadata updates
    */
   MERGING,
+
+  MERGED,
+
   /**
    * merge is complete, the resulting tablet can be brought online, remove the marker in zookeeper
    */

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/MergeState.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/MergeState.java
@@ -33,15 +33,17 @@ public enum MergeState {
    */
   WAITING_FOR_OFFLINE,
   /**
-   * when the number of chopped, offline tablets equals the number of merge tablets, begin the
-   * metadata updates
+   * when the number of offline tablets equals the number of merge tablets, begin the metadata
+   * updates
    */
   MERGING,
-
-  MERGED,
-
   /**
-   * merge is complete, the resulting tablet can be brought online, remove the marker in zookeeper
+   * when the merge operation has finished fencing and/or deleting tablets in the merge/delete range
+   */
+  MERGED,
+  /**
+   * merge is complete, clean up the merged marker in the resulting tablet and the tablet can be
+   * brought online, remove the marker in zookeeper
    */
   COMPLETE
 

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/MergeState.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/MergeState.java
@@ -38,12 +38,13 @@ public enum MergeState {
    */
   MERGING,
   /**
-   * when the merge operation has finished fencing and/or deleting tablets in the merge/delete range
+   * when the operation has finished metadata updates for merge/delete. For delete the tablets will
+   * already have been deleted but for merge we can now remove the merged tablets and clear the
+   * MERGED marker.
    */
   MERGED,
   /**
-   * merge is complete, clean up the merged marker in the resulting tablet and the tablet can be
-   * brought online, remove the marker in zookeeper
+   * merge is complete, the resulting tablet can be brought online, remove the marker in zookeeper
    */
   COMPLETE
 

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/MergeState.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/MergeState.java
@@ -38,9 +38,8 @@ public enum MergeState {
    */
   MERGING,
   /**
-   * when the operation has finished metadata updates for merge/delete. For delete the tablets will
-   * already have been deleted but for merge we can now remove the merged tablets and clear the
-   * MERGED marker.
+   * when the operation has finished metadata updates for merge. We can now remove the merged
+   * tablets and clear the MERGED marker. Not used for delete
    */
   MERGED,
   /**

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -657,6 +657,7 @@ public class Manager extends AbstractServer
                 return TabletGoalState.UNASSIGNED;
               }
             case MERGING:
+            case MERGED:
               return TabletGoalState.UNASSIGNED;
           }
         } else {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
@@ -616,10 +616,9 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
   }
 
   // Remove the merged marker from the last tablet in the merge range
-  private void clearMerged(MergeInfo mergeInfo, BatchWriter bw) throws AccumuloException {
-    HighTablet highTablet = getHighTablet(mergeInfo.getExtent());
+  private void clearMerged(MergeInfo mergeInfo, BatchWriter bw, HighTablet highTablet)
+      throws AccumuloException {
     Manager.log.debug("Clearing MERGED marker for {}", mergeInfo.getExtent());
-
     var m = new Mutation(highTablet.getExtent().toMetaRow());
     MergedColumnFamily.MERGED_COLUMN.putDelete(m);
     bw.addMutation(m);
@@ -1042,7 +1041,7 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
       deleteTablets(info, scanRange, bw, client);
 
       // Clear the merged marker after we finish deleting tablets
-      clearMerged(info, bw);
+      clearMerged(info, bw, highTablet);
     } catch (Exception ex) {
       throw new AccumuloException(ex);
     }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/state/MergeStats.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/state/MergeStats.java
@@ -124,7 +124,7 @@ public class MergeStats {
             info.getExtent());
       }
     }
-    if (state == MergeState.MERGING) {
+    if (state == MergeState.MERGING || state == MergeState.MERGED) {
       if (hosted != 0) {
         // Shouldn't happen
         log.error("Unexpected state: hosted tablets should be zero {} merge {}", hosted,

--- a/server/manager/src/test/java/org/apache/accumulo/manager/TabletGroupWatcherTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/TabletGroupWatcherTest.java
@@ -75,27 +75,13 @@ public class TabletGroupWatcherTest {
   @Test
   public void testHighTablet() {
     HighTablet mergedTruePrevRowFalse =
-        new HighTablet(new KeyExtent(MetadataTable.ID, new Text("end"), null), true, false);
+        new HighTablet(new KeyExtent(MetadataTable.ID, new Text("end"), null), true);
     assertNotNull(mergedTruePrevRowFalse.getExtent());
     assertTrue(mergedTruePrevRowFalse.isMerged());
-    assertFalse(mergedTruePrevRowFalse.hasPrevRowColumn());
 
     HighTablet mergedFalsePrevRowFalse =
-        new HighTablet(new KeyExtent(MetadataTable.ID, new Text("end"), null), false, false);
+        new HighTablet(new KeyExtent(MetadataTable.ID, new Text("end"), null), false);
     assertNotNull(mergedFalsePrevRowFalse.getExtent());
     assertFalse(mergedFalsePrevRowFalse.isMerged());
-    assertFalse(mergedFalsePrevRowFalse.hasPrevRowColumn());
-
-    HighTablet mergedTruePrevRowTrue =
-        new HighTablet(new KeyExtent(MetadataTable.ID, new Text("end"), null), true, true);
-    assertNotNull(mergedTruePrevRowTrue.getExtent());
-    assertTrue(mergedTruePrevRowTrue.isMerged());
-    assertTrue(mergedTruePrevRowTrue.hasPrevRowColumn());
-
-    HighTablet mergedFalsePrevRowTrue =
-        new HighTablet(new KeyExtent(MetadataTable.ID, new Text("end"), null), false, true);
-    assertNotNull(mergedFalsePrevRowTrue.getExtent());
-    assertFalse(mergedFalsePrevRowTrue.isMerged());
-    assertTrue(mergedFalsePrevRowTrue.hasPrevRowColumn());
   }
 }

--- a/server/manager/src/test/java/org/apache/accumulo/manager/TabletGroupWatcherTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/TabletGroupWatcherTest.java
@@ -20,15 +20,12 @@ package org.apache.accumulo.manager;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.manager.TabletGroupWatcher.HighTablet;
 import org.apache.hadoop.io.Text;
@@ -77,30 +74,28 @@ public class TabletGroupWatcherTest {
 
   @Test
   public void testHighTablet() {
-    HighTablet nullFirstPrevRow =
-        new HighTablet(new KeyExtent(MetadataTable.ID, new Text("end"), null), true, null);
-    assertTrue(nullFirstPrevRow.isMerged());
-    assertFalse(nullFirstPrevRow.hasFirstPrevRowValue());
-    assertEquals(HighTablet.EMPTY_VALUE, nullFirstPrevRow.getFirstPrevRowValue());
+    HighTablet mergedTruePrevRowFalse =
+        new HighTablet(new KeyExtent(MetadataTable.ID, new Text("end"), null), true, false);
+    assertNotNull(mergedTruePrevRowFalse.getExtent());
+    assertTrue(mergedTruePrevRowFalse.isMerged());
+    assertFalse(mergedTruePrevRowFalse.hasPrevRowColumn());
 
-    HighTablet emptyFirstPrevRow =
-        new HighTablet(new KeyExtent(MetadataTable.ID, new Text("end"), null), true, new Value());
-    assertTrue(emptyFirstPrevRow.isMerged());
-    assertFalse(emptyFirstPrevRow.hasFirstPrevRowValue());
-    assertEquals(HighTablet.EMPTY_VALUE, emptyFirstPrevRow.getFirstPrevRowValue());
+    HighTablet mergedFalsePrevRowFalse =
+        new HighTablet(new KeyExtent(MetadataTable.ID, new Text("end"), null), false, false);
+    assertNotNull(mergedFalsePrevRowFalse.getExtent());
+    assertFalse(mergedFalsePrevRowFalse.isMerged());
+    assertFalse(mergedFalsePrevRowFalse.hasPrevRowColumn());
 
-    HighTablet nullTextFirstPrevRow =
-        new HighTablet(new KeyExtent(MetadataTable.ID, new Text("end"), null), true,
-            TabletColumnFamily.encodePrevEndRow(null));
-    assertTrue(nullTextFirstPrevRow.hasFirstPrevRowValue());
-    assertNotEquals(HighTablet.EMPTY_VALUE, nullTextFirstPrevRow.getFirstPrevRowValue());
-    assertNull(TabletColumnFamily.decodePrevEndRow(nullTextFirstPrevRow.getFirstPrevRowValue()));
+    HighTablet mergedTruePrevRowTrue =
+        new HighTablet(new KeyExtent(MetadataTable.ID, new Text("end"), null), true, true);
+    assertNotNull(mergedTruePrevRowTrue.getExtent());
+    assertTrue(mergedTruePrevRowTrue.isMerged());
+    assertTrue(mergedTruePrevRowTrue.hasPrevRowColumn());
 
-    HighTablet prevFirstPrevRow =
-        new HighTablet(new KeyExtent(MetadataTable.ID, new Text("end"), null), true,
-            TabletColumnFamily.encodePrevEndRow(new Text("prevEnd")));
-    assertTrue(prevFirstPrevRow.hasFirstPrevRowValue());
-    assertEquals(new Text("prevEnd"),
-        TabletColumnFamily.decodePrevEndRow(prevFirstPrevRow.getFirstPrevRowValue()));
+    HighTablet mergedFalsePrevRowTrue =
+        new HighTablet(new KeyExtent(MetadataTable.ID, new Text("end"), null), false, true);
+    assertNotNull(mergedFalsePrevRowTrue.getExtent());
+    assertFalse(mergedFalsePrevRowTrue.isMerged());
+    assertTrue(mergedFalsePrevRowTrue.hasPrevRowColumn());
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/MetaSplitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MetaSplitIT.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.test;
 
 import static org.apache.accumulo.test.util.FileMetadataUtil.countFencedFiles;
+import static org.apache.accumulo.test.util.FileMetadataUtil.verifyMergedMarkerCleared;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -145,21 +146,29 @@ public class MetaSplitIT extends AccumuloClusterHarness {
         // Merging tablets should produce fenced files because of no-chop merge
         assertTrue(countFencedFiles(getServerContext(), MetadataTable.NAME) > 0);
         verifyMetadataTableScan(client);
+        // Verify that the MERGED marker was cleared and doesn't exist on any tablet
+        verifyMergedMarkerCleared(getServerContext(), MetadataTable.ID);
 
         addSplits(opts, "44 55 66 77 88".split(" "));
         checkMetadataSplits(9, opts);
         assertTrue(countFencedFiles(getServerContext(), MetadataTable.NAME) > 0);
         verifyMetadataTableScan(client);
+        // Verify that the MERGED marker was cleared and doesn't exist on any tablet
+        verifyMergedMarkerCleared(getServerContext(), MetadataTable.ID);
 
         opts.merge(MetadataTable.NAME, new Text("5"), new Text("7"));
         checkMetadataSplits(6, opts);
         assertTrue(countFencedFiles(getServerContext(), MetadataTable.NAME) > 0);
         verifyMetadataTableScan(client);
+        // Verify that the MERGED marker was cleared and doesn't exist on any tablet
+        verifyMergedMarkerCleared(getServerContext(), MetadataTable.ID);
 
         opts.merge(MetadataTable.NAME, null, null);
         checkMetadataSplits(0, opts);
         assertTrue(countFencedFiles(getServerContext(), MetadataTable.NAME) > 0);
         verifyMetadataTableScan(client);
+        // Verify that the MERGED marker was cleared and doesn't exist on any tablet
+        verifyMergedMarkerCleared(getServerContext(), MetadataTable.ID);
 
         opts.compact(MetadataTable.NAME, new CompactionConfig());
         // Should be no more fenced files after compaction

--- a/test/src/main/java/org/apache/accumulo/test/util/FileMetadataUtil.java
+++ b/test/src/main/java/org/apache/accumulo/test/util/FileMetadataUtil.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.test.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -167,6 +168,14 @@ public class FileMetadataUtil {
 
     // Bring back online after metadata updates
     ctx.tableOperations().online(tableName, true);
+  }
+
+  // Verifies that the MERGED marker was cleared and doesn't exist on any tablet
+  public static void verifyMergedMarkerCleared(final ServerContext ctx, TableId tableId) {
+    try (var tabletsMetadata =
+        ctx.getAmple().readTablets().forTable(tableId).fetch(ColumnType.MERGED).build()) {
+      assertTrue(tabletsMetadata.stream().noneMatch(TabletMetadata::hasMerged));
+    }
   }
 
   public interface FileMutator {


### PR DESCRIPTION
This PR fixes no-chop merge so that it is idempotent and will no longer fail on recovery if the last tablet in the merge range was already fenced. Previously on resume if it tried to fence the files again there would be disjoint files seen from previously copied files during the merge. See #3938 for more details.

**This PR makes the following changes:**

1. A new `MERGED` column marker is inserted into the last tablet as part of the mutation that contains all the fenced file metadata update so the marker is flushed and atomic with the metadata updates. If a failure occurs after this point and before completion on resume this marker can be read to know that fencing was already completed so we can skip this operation and continue to tablet deletion. Note that this marker is only set for merge and not for deletion as it isn't needed when deleting.
2. The value of the column doesn't matter as just the existing of the marker is needed to know whether or not the files were already fenced..
3. A new state called `MERGED` has also been added to `MergeState`. This new state is necessary so we can clear the marker. After the merge is completed the state is set to MERGED which allows the MERGED marker to be cleared from the last table if it was set (merge only and not delete).
4. The update of the prev row on the last tablet has been moved to the same mutation as the metadata updates so that the operation is atomic.

**Testing notes:**

Trying to test a failure with an IT is not really possible due to how TGW is constructed so I did a lot of manual testing with throwing exceptions and recovery to make sure things worked properly. I also added whatever tests to this PR I could. I added unit tests to verify the new `MERGED` marker is properly encoded/decoded into the metadata table and I also updated the ITs to verify that the `MERGED` marker is cleared correctly.

This closes #3938