### PR TITLE
Restores column family validation in TabletMetadata

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -572,9 +572,12 @@ public class TabletMetadata {
               te.onDemandHostingRequested = true;
               break;
             default:
-              throw new IllegalStateException("Unexpected family " + fam);
+              throw new IllegalStateException("Unexpected qualifier " + fam);
           }
           break;
+        default:
+          throw new IllegalStateException("Unexpected family " + fam);
+
       }
     }
 

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
@@ -303,6 +303,17 @@ public class TabletMetadataTest {
     assertThrows(IllegalStateException.class, tm::hasMerged);
   }
 
+  @Test
+  public void testUnkownColFamily() {
+    KeyExtent extent = new KeyExtent(TableId.of("5"), new Text("df"), new Text("da"));
+    Mutation mutation = TabletColumnFamily.createPrevRowMutation(extent);
+
+    mutation.put("1234567890abcdefg", "xyz", "v1");
+    assertThrows(IllegalStateException.class,
+        () -> TabletMetadata.convertRow(toRowMap(mutation).entrySet().iterator(),
+            EnumSet.of(ColumnType.MERGED), true, false));
+  }
+
   private SortedMap<Key,Value> toRowMap(Mutation mutation) {
     SortedMap<Key,Value> rowMap = new TreeMap<>();
     mutation.getUpdates().forEach(cu -> {


### PR DESCRIPTION
Validation for unknown column families in TabletMetadata was dropped. Restored the validation and added a test.