### PR TITLE
fixes bug with compaction preemption

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
@@ -81,6 +81,7 @@ import org.apache.zookeeper.KeeperException.NoNodeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.Collections2;
@@ -231,6 +232,11 @@ public class CompactableImpl implements Compactable {
       return selectKind;
     }
 
+    @VisibleForTesting
+    Set<StoredTabletFile> getSelectedFiles() {
+      return Set.copyOf(selectedFiles);
+    }
+
     SelectedInfo getReservedInfo() {
       Preconditions.checkState(selectStatus == FileSelectionStatus.RESERVED);
       return new SelectedInfo(initiallySelectedAll, selectedFiles, selectKind);
@@ -245,7 +251,8 @@ public class CompactableImpl implements Compactable {
       Preconditions.checkArgument(kind == CompactionKind.SELECTOR || kind == CompactionKind.USER);
 
       if (selectStatus == FileSelectionStatus.NOT_ACTIVE || (kind == CompactionKind.USER
-          && selectKind == CompactionKind.SELECTOR && noneRunning(CompactionKind.SELECTOR))) {
+          && selectKind == CompactionKind.SELECTOR && noneRunning(CompactionKind.SELECTOR)
+          && selectStatus != FileSelectionStatus.SELECTING)) {
         selectStatus = FileSelectionStatus.NEW;
         selectKind = kind;
         selectedFiles.clear();
@@ -1065,7 +1072,6 @@ public class CompactableImpl implements Compactable {
 
         manager.compactableChanged(this);
       }
-
     } catch (Exception e) {
       log.error("Failed to select user compaction files {}", getExtent(), e);
     } finally {
@@ -1075,7 +1081,6 @@ public class CompactableImpl implements Compactable {
         }
       }
     }
-
   }
 
   static Collection<String> asFileNames(Set<StoredTabletFile> files) {

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/CompactableImplFileManagerTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/CompactableImplFileManagerTest.java
@@ -289,6 +289,40 @@ public class CompactableImplFileManagerTest {
   }
 
   @Test
+  public void testUserCompactionPreemptsSelectorCompaction() {
+    TestFileManager fileMgr = new TestFileManager();
+
+    assertTrue(fileMgr.initiateSelection(SELECTOR));
+    assertEquals(SELECTOR, fileMgr.getSelectionKind());
+    assertTrue(fileMgr.beginSelection());
+    // USER compaction should not be able to preempt while in the middle of selecting files
+    assertFalse(fileMgr.initiateSelection(USER));
+    assertEquals(SELECTOR, fileMgr.getSelectionKind());
+    fileMgr.finishSelection(newFiles("F00000.rf", "F00001.rf", "F00002.rf"), false);
+    // check state is as expected after finishing selection
+    assertEquals(SELECTOR, fileMgr.getSelectionKind());
+    assertEquals(FileSelectionStatus.SELECTED, fileMgr.getSelectionStatus());
+    assertFalse(fileMgr.getSelectedFiles().isEmpty());
+
+    // USER compaction should not be able to preempt when there are running compactions.
+    fileMgr.running.add(SELECTOR);
+    assertFalse(fileMgr.initiateSelection(USER));
+    // check state is as expected
+    assertEquals(SELECTOR, fileMgr.getSelectionKind());
+    assertEquals(FileSelectionStatus.SELECTED, fileMgr.getSelectionStatus());
+    assertFalse(fileMgr.getSelectedFiles().isEmpty());
+
+    // after file selection is complete and there are no running compactions, should be able to
+    // preempt
+    fileMgr.running.clear();
+    assertTrue(fileMgr.initiateSelection(USER));
+    // check that things were properly reset
+    assertEquals(USER, fileMgr.getSelectionKind());
+    assertEquals(FileSelectionStatus.NEW, fileMgr.getSelectionStatus());
+    assertTrue(fileMgr.getSelectedFiles().isEmpty());
+  }
+
+  @Test
   public void testUserCompactionCanceled() {
     TestFileManager fileMgr = new TestFileManager();
     var tabletFiles = newFiles("F00000.rf", "F00001.rf", "F00002.rf", "F00003.rf", "F00004.rf");


### PR DESCRIPTION
User compactions can preempt selector compaction under certain conditions.  There was a bug in the code where a user compaction could preempt a selector compaction that was in the middle of selecting its files.  The way the code is structured doing this causes an exception. This change makes the preemption wait until file selection is complete.