### PR TITLE
Add filtering to Ample

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/HasWalsFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/HasWalsFilter.java
@@ -18,24 +18,18 @@
  */
 package org.apache.accumulo.core.iterators.user;
 
-import java.io.IOException;
 import java.util.EnumSet;
 
-import org.apache.accumulo.core.data.Key;
-import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.iterators.IteratorAdapter;
-import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 
-public abstract class TabletMetadataFilter extends RowFilter {
+public class HasWalsFilter extends TabletMetadataFilter {
   @Override
-  public boolean acceptRow(SortedKeyValueIterator<Key,Value> rowIterator) throws IOException {
-    TabletMetadata tm =
-        TabletMetadata.convertRow(new IteratorAdapter(rowIterator), getColumns(), true, false);
-    return acceptTablet(tm);
+  public EnumSet<TabletMetadata.ColumnType> getColumns() {
+    return EnumSet.of(TabletMetadata.ColumnType.LOGS);
   }
 
-  public abstract EnumSet<TabletMetadata.ColumnType> getColumns();
-
-  public abstract boolean acceptTablet(TabletMetadata tabletMetadata);
+  @Override
+  public boolean acceptTablet(TabletMetadata tabletMetadata) {
+    return !tabletMetadata.getLogs().isEmpty();
+  }
 }

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/TabletMetadataFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/TabletMetadataFilter.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.iterators.user;
+
+import java.io.IOException;
+import java.util.EnumSet;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.IteratorAdapter;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+
+public abstract class TabletMetadataFilter extends RowFilter {
+  @Override
+  public boolean acceptRow(SortedKeyValueIterator<Key,Value> rowIterator) throws IOException {
+    TabletMetadata tm =
+        TabletMetadata.convertRow(new IteratorAdapter(rowIterator), getColumns(), false, false);
+    return acceptTablet(tm);
+  }
+
+  public abstract EnumSet<TabletMetadata.ColumnType> getColumns();
+
+  public abstract boolean acceptTablet(TabletMetadata tabletMetadata);
+}

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/WalFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/WalFilter.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.iterators.user;
+
+import java.util.EnumSet;
+
+import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+
+public class WalFilter extends TabletMetadataFilter {
+  @Override
+  public EnumSet<TabletMetadata.ColumnType> getColumns() {
+    return EnumSet.of(TabletMetadata.ColumnType.LOGS);
+  }
+
+  @Override
+  public boolean acceptTablet(TabletMetadata tabletMetadata) {
+    return !tabletMetadata.getLogs().isEmpty();
+  }
+}

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
@@ -246,6 +246,11 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
         configureColumns(scanner);
         Range range1 = scanner.getRange();
 
+        if (tableMetadataFilter != null) {
+          IteratorSetting iterSetting = new IteratorSetting(100, tableMetadataFilter.getClass());
+          scanner.addScanIterator(iterSetting);
+        }
+
         Function<Range,Iterator<TabletMetadata>> iterFactory = r -> {
           synchronized (scanner) {
             scanner.setRange(r);

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
@@ -37,6 +37,7 @@ import java.util.UUID;
 
 import org.apache.accumulo.core.gc.thrift.GCStatus;
 import org.apache.accumulo.core.gc.thrift.GcCycleStats;
+import org.apache.accumulo.core.iterators.user.HasWalsFilter;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.TabletState;
 import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
@@ -83,11 +84,11 @@ public class GarbageCollectWriteAheadLogs {
     this.liveServers = liveServers;
     this.walMarker = new WalStateManager(context);
     this.store = () -> Iterators.concat(
-        context.getAmple().readTablets().forLevel(DataLevel.ROOT)
+        context.getAmple().readTablets().forLevel(DataLevel.ROOT).filter(new HasWalsFilter())
             .fetch(LOCATION, LAST, LOGS, PREV_ROW, SUSPEND).checkConsistency().build().iterator(),
-        context.getAmple().readTablets().forLevel(DataLevel.METADATA)
+        context.getAmple().readTablets().forLevel(DataLevel.METADATA).filter(new HasWalsFilter())
             .fetch(LOCATION, LAST, LOGS, PREV_ROW, SUSPEND).checkConsistency().build().iterator(),
-        context.getAmple().readTablets().forLevel(DataLevel.USER)
+        context.getAmple().readTablets().forLevel(DataLevel.USER).filter(new HasWalsFilter())
             .fetch(LOCATION, LAST, LOGS, PREV_ROW, SUSPEND).checkConsistency().build().iterator());
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/TestTabletMetadataFilter.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TestTabletMetadataFilter.java
@@ -16,20 +16,30 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.core.iterators.user;
+package org.apache.accumulo.test.functional;
 
 import java.util.EnumSet;
+import java.util.OptionalLong;
 
+import org.apache.accumulo.core.iterators.user.TabletMetadataFilter;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 
-public class WalFilter extends TabletMetadataFilter {
+/**
+ * A filter constructed to test filtering in ample. This filter only allows tablets with compacted
+ * and with a flush ID.
+ */
+public class TestTabletMetadataFilter extends TabletMetadataFilter {
+
+  public static final long VALID_FLUSH_ID = 44L;
+
   @Override
   public EnumSet<TabletMetadata.ColumnType> getColumns() {
-    return EnumSet.of(TabletMetadata.ColumnType.LOGS);
+    return EnumSet.of(TabletMetadata.ColumnType.COMPACTED, TabletMetadata.ColumnType.FLUSH_ID);
   }
 
   @Override
   public boolean acceptTablet(TabletMetadata tabletMetadata) {
-    return !tabletMetadata.getLogs().isEmpty();
+    return !tabletMetadata.getCompacted().isEmpty()
+        && tabletMetadata.getFlushId().equals(OptionalLong.of(VALID_FLUSH_ID));
   }
 }


### PR DESCRIPTION
closes #3933

This PR adds a new class, `TabletMetadataFilter` that can be extended to provide custom filtering to ample calls.