### PR TITLE
validate system config on server startup

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/conf/ServerConfigurationFactory.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/ServerConfigurationFactory.java
@@ -77,8 +77,12 @@ public class ServerConfigurationFactory extends ServerConfiguration {
   public ServerConfigurationFactory(ServerContext context, SiteConfiguration siteConfig) {
     this.context = context;
     this.siteConfig = siteConfig;
-    this.systemConfig = memoize(() -> new SystemConfiguration(context,
-        SystemPropKey.of(context.getInstanceID()), siteConfig));
+    this.systemConfig = memoize(() -> {
+      var sysConf =
+          new SystemConfiguration(context, SystemPropKey.of(context.getInstanceID()), siteConfig);
+      ConfigCheckUtil.validate(sysConf);
+      return sysConf;
+    });
     tableParentConfigs =
         Caffeine.newBuilder().expireAfterAccess(CACHE_EXPIRATION_HRS, TimeUnit.HOURS).build();
     tableConfigs =


### PR DESCRIPTION
Noticed that site, namespaces, and table configuration were being validated in servers the first time used.  System configuration did not seem the be validated though.  Added validation of system config.  Have not test this yet.