### PR TITLE
Fix TServerClient.getThriftServerConnection for compactor queue names

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/rpc/clients/TServerClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/clients/TServerClient.java
@@ -72,14 +72,7 @@ public interface TServerClient<C extends TServiceClient> {
     }
     ZooCache zc = context.getZooCache();
     for (String serverPath : serverPaths) {
-      if (!serverPath.endsWith(Constants.ZCOMPACTORS)) {
-        for (String server : zc.getChildren(serverPath)) {
-          var zLocPath = ServiceLock.path(serverPath + "/" + server);
-          zc.getLockData(zLocPath).map(sld -> sld.getAddress(service))
-              .map(address -> new ThriftTransportKey(address, rpcTimeout, context))
-              .ifPresent(servers::add);
-        }
-      } else {
+      if (serverPath.endsWith(Constants.ZCOMPACTORS)) {
         // Compactor path has another subdirectory, the group / queue name
         for (String groupName : zc.getChildren(serverPath)) {
           for (String server : zc.getChildren(serverPath + "/" + groupName)) {
@@ -88,6 +81,13 @@ public interface TServerClient<C extends TServiceClient> {
                 .map(address -> new ThriftTransportKey(address, rpcTimeout, context))
                 .ifPresent(servers::add);
           }
+        }
+      } else {
+        for (String server : zc.getChildren(serverPath)) {
+          var zLocPath = ServiceLock.path(serverPath + "/" + server);
+          zc.getLockData(zLocPath).map(sld -> sld.getAddress(service))
+              .map(address -> new ThriftTransportKey(address, rpcTimeout, context))
+              .ifPresent(servers::add);
         }
       }
     }

--- a/core/src/main/java/org/apache/accumulo/core/rpc/clients/TServerClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/clients/TServerClient.java
@@ -72,11 +72,23 @@ public interface TServerClient<C extends TServiceClient> {
     }
     ZooCache zc = context.getZooCache();
     for (String serverPath : serverPaths) {
-      for (String server : zc.getChildren(serverPath)) {
-        var zLocPath = ServiceLock.path(serverPath + "/" + server);
-        zc.getLockData(zLocPath).map(sld -> sld.getAddress(service))
-            .map(address -> new ThriftTransportKey(address, rpcTimeout, context))
-            .ifPresent(servers::add);
+      if (!serverPath.endsWith(Constants.ZCOMPACTORS)) {
+        for (String server : zc.getChildren(serverPath)) {
+          var zLocPath = ServiceLock.path(serverPath + "/" + server);
+          zc.getLockData(zLocPath).map(sld -> sld.getAddress(service))
+              .map(address -> new ThriftTransportKey(address, rpcTimeout, context))
+              .ifPresent(servers::add);
+        }
+      } else {
+        // Compactor path has another subdirectory, the group / queue name
+        for (String groupName : zc.getChildren(serverPath)) {
+          for (String server : zc.getChildren(serverPath + "/" + groupName)) {
+            var zLocPath = ServiceLock.path(serverPath + "/" + groupName + "/" + server);
+            zc.getLockData(zLocPath).map(sld -> sld.getAddress(service))
+                .map(address -> new ThriftTransportKey(address, rpcTimeout, context))
+                .ifPresent(servers::add);
+          }
+        }
       }
     }
 


### PR DESCRIPTION
This fixes an issue introducted in #3951 where the Compactor and ScanServer now expose the ClientService. The issue fixed here is that #3951 did not account for the extra part in the compactor path in ZooKeeper that is used for the queue name.