### PR TITLE
Fixes compaction property log message bug

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionServicesConfig.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionServicesConfig.java
@@ -133,13 +133,11 @@ public class CompactionServicesConfig {
           if (eprop == null || aconf.isPropertySet(eprop)) {
             rateLimits.put(tokens[0], ConfigurationTypeHelper.getFixedMemoryAsBytes(val));
           }
-        } else if (!(tokens.length == 2 && tokens[1].equals("planner"))) {
+        } else if (tokens.length == 2 && tokens[1].equals("planner")) {
+          return; // moves to next opt
+        } else {
           throw new IllegalArgumentException(
               "Malformed compaction service property " + prefix + prop);
-        } else {
-          log.warn(
-              "Ignoring compaction property {} as does not match the prefix used by the referenced planner definition",
-              prop);
         }
       });
     });


### PR DESCRIPTION
Fixes an incorrect logging statement from appearing during normal startup conditions when processing `service.<service>.planner` compaction properties.
Bug was introduced in #3915. 

Log message: 
```
[main] WARN  org.apache.accumulo.core.util.compaction.CompactionServicesConfig [] - Ignoring compaction property default.planner as does not match the prefix used by the referenced planner definition
```

Steps to replicate bug:
1. git checkout `main`
2. Run any of the tests in `CompactionServicesConfigTest`
3. See the log message in the output.