### PR TITLE
Fix error in uuid validation, checkstyle fixes

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ServiceLockIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ServiceLockIT.java
@@ -44,6 +44,7 @@ import org.apache.accumulo.core.fate.zookeeper.ServiceLock.ServiceLockPath;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.fate.zookeeper.ZooSession;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
+import org.apache.accumulo.test.util.Wait;
 import org.apache.accumulo.test.zookeeper.ZooKeeperTestingServer;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
@@ -372,9 +373,7 @@ public class ServiceLockIT {
     try (ZooKeeper zk = new ZooKeeper(szk.getConn(), 30000, watcher)) {
       ZooUtil.digestAuth(zk, "secret");
 
-      while (!watcher.isConnected()) {
-        Thread.sleep(200);
-      }
+      Wait.waitFor(() -> !watcher.isConnected(), 30_000, 200);
 
       zk.create(parent.toString(), new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
 
@@ -422,13 +421,8 @@ public class ServiceLockIT {
       ZooUtil.digestAuth(zk1, "secret");
       ZooUtil.digestAuth(zk2, "secret");
 
-      while (!watcher1.isConnected()) {
-        Thread.sleep(200);
-      }
-
-      while (!watcher2.isConnected()) {
-        Thread.sleep(200);
-      }
+      Wait.waitFor(() -> !watcher1.isConnected(), 30_000, 200);
+      Wait.waitFor(() -> !watcher2.isConnected(), 30_000, 200);
 
       // Create the parent node
       zk1.createOnce(parent.toString(), new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE,
@@ -492,8 +486,6 @@ public class ServiceLockIT {
 
       assertTrue(zlw2.isLockHeld());
       zl2.unlock();
-      zk2.close();
-
     }
 
   }
@@ -533,9 +525,8 @@ public class ServiceLockIT {
         try (ZooKeeperWrapper zk = new ZooKeeperWrapper(szk.getConn(), 30000, watcher)) {
           ZooUtil.digestAuth(zk, "secret");
 
-          while (!watcher.isConnected()) {
-            Thread.sleep(50);
-          }
+          Wait.waitFor(() -> !watcher.isConnected(), 30_000, 50);
+
           ServiceLock zl = getZooLock(zk, parent, uuid);
           getLockLatch.countDown(); // signal we are done
           getLockLatch.await(); // wait for others to finish
@@ -584,9 +575,8 @@ public class ServiceLockIT {
     try (ZooKeeperWrapper zk = new ZooKeeperWrapper(szk.getConn(), 30000, watcher)) {
       ZooUtil.digestAuth(zk, "secret");
 
-      while (!watcher.isConnected()) {
-        Thread.sleep(50);
-      }
+      Wait.waitFor(() -> !watcher.isConnected(), 30_000, 50);
+
       // Create the parent node
       zk.createOnce(parent.toString(), new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE,
           CreateMode.PERSISTENT);
@@ -654,9 +644,7 @@ public class ServiceLockIT {
     try (ZooKeeper zk = new ZooKeeper(szk.getConn(), 30000, watcher)) {
       ZooUtil.digestAuth(zk, "secret");
 
-      while (!watcher.isConnected()) {
-        Thread.sleep(200);
-      }
+      Wait.waitFor(() -> !watcher.isConnected(), 30_000, 200);
 
       for (int i = 0; i < 10; i++) {
         zk.create(parent.toString(), new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE,
@@ -692,9 +680,7 @@ public class ServiceLockIT {
     try (ZooKeeper zk = new ZooKeeper(szk.getConn(), 30000, watcher)) {
       ZooUtil.digestAuth(zk, "secret");
 
-      while (!watcher.isConnected()) {
-        Thread.sleep(200);
-      }
+      Wait.waitFor(() -> !watcher.isConnected(), 30_000, 200);
 
       zk.create(parent.toString(), new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
 
@@ -709,5 +695,4 @@ public class ServiceLockIT {
       assertEquals("test2", new String(zk.getData(zl.getLockPath(), null, null)));
     }
   }
-
 }


### PR DESCRIPTION
Fixes the UUID parsing check / validation in ServiceLock. The parsing of the lock string had a logic error with the indices used to parse out the parts.  The error in the index parsing would pass not pass the complete UUID for validation.  

The uuid check would pass for things that were UUID like, but not strictly a UUID.  For example, it would accept 1-1-1-1-1 as a valid UUID string.  This also allowed the incomplete uuid that was parsed from the lock string to pass.

This was found while reducing the reported check style errors and to favor Wait instead of sleep in the tests.