### PR TITLE
Add retry and logging to CloseScannerIT

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/CloseScannerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/CloseScannerIT.java
@@ -18,21 +18,28 @@
  */
 package org.apache.accumulo.test;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.IsolatedScanner;
 import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.admin.ActiveScan;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.test.functional.ReadWriteIT;
+import org.apache.accumulo.test.util.Wait;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CloseScannerIT extends AccumuloClusterHarness {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CloseScannerIT.class);
 
   static final int ROWS = 1000;
   static final int COLS = 1000;
@@ -61,14 +68,26 @@ public class CloseScannerIT extends AccumuloClusterHarness {
         } // when the scanner is closed, all open sessions should be closed
       }
 
-      List<String> tservers = client.instanceOperations().getTabletServers();
-      int activeScans = 0;
-      for (String tserver : tservers) {
-        activeScans += client.instanceOperations().getActiveScans(tserver).size();
-      }
-
-      assertTrue(activeScans < 3);
+      Wait.waitFor(() -> {
+        final List<ActiveScan> activeScans = getAllActiveScans(client);
+        if (activeScans.size() < 3) {
+          return true;
+        } else {
+          LOG.error("Saw more scans than expected. Retrying. Scans found: {}", activeScans);
+          return false;
+        }
+      }, 5000, 250, "Found too many active scans after closing all scanners.");
     }
+  }
+
+  private static List<ActiveScan> getAllActiveScans(AccumuloClient client)
+      throws AccumuloException, AccumuloSecurityException {
+    List<String> tservers = client.instanceOperations().getTabletServers();
+    List<ActiveScan> allActiveScans = new ArrayList<>();
+    for (String tserver : tservers) {
+      allActiveScans.addAll(client.instanceOperations().getActiveScans(tserver));
+    }
+    return allActiveScans;
   }
 
   private static Scanner createScanner(AccumuloClient client, String tableName, int i)

--- a/test/src/main/java/org/apache/accumulo/test/CloseScannerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/CloseScannerIT.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.test;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.accumulo.core.client.Accumulo;
@@ -27,7 +26,6 @@ import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.IsolatedScanner;
 import org.apache.accumulo.core.client.Scanner;
-import org.apache.accumulo.core.client.admin.ActiveScan;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
@@ -68,26 +66,19 @@ public class CloseScannerIT extends AccumuloClusterHarness {
         } // when the scanner is closed, all open sessions should be closed
       }
 
-      Wait.waitFor(() -> {
-        final List<ActiveScan> activeScans = getAllActiveScans(client);
-        if (activeScans.size() < 3) {
-          return true;
-        } else {
-          LOG.error("Saw more scans than expected. Retrying. Scans found: {}", activeScans);
-          return false;
-        }
-      }, 5000, 250, "Found too many active scans after closing all scanners.");
+      Wait.waitFor(() -> getActiveScansCount(client) < 1, 5000, 250,
+          "Found active scans after closing all scanners. Expected to find no scans");
     }
   }
 
-  private static List<ActiveScan> getAllActiveScans(AccumuloClient client)
+  private static int getActiveScansCount(AccumuloClient client)
       throws AccumuloException, AccumuloSecurityException {
     List<String> tservers = client.instanceOperations().getTabletServers();
-    List<ActiveScan> allActiveScans = new ArrayList<>();
+    int scanCount = 0;
     for (String tserver : tservers) {
-      allActiveScans.addAll(client.instanceOperations().getActiveScans(tserver));
+      scanCount += client.instanceOperations().getActiveScans(tserver).size();
     }
-    return allActiveScans;
+    return scanCount;
   }
 
   private static Scanner createScanner(AccumuloClient client, String tableName, int i)


### PR DESCRIPTION
This PR adds a retry to the condition we are testing for once all scanners are closed. I also added logs when the condition does not pass.

I am not sure why the condition in the test is checking that the number of scans is less than 3. If anyone has insight on this maybe we can create a variable name for this number or a comment. I tried changing the condition to check that there are 0 scans and still could not get it to fail locally.

This IT has failed twice recently:

- https://ci-builds.apache.org/job/Accumulo/job/main/org.apache.accumulo$accumulo-test/611/testReport/junit/org.apache.accumulo.test/CloseScannerIT/testManyScans/
- https://ci-builds.apache.org/job/Accumulo/job/main/org.apache.accumulo$accumulo-test/605/testReport/junit/org.apache.accumulo.test/CloseScannerIT/testManyScans/

```
Error Message
expected: <true> but was: <false>
Stacktrace
org.opentest4j.AssertionFailedError: expected: <true> but was: <false>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertTrue.failNotTrue(AssertTrue.java:63)
	at org.junit.jupiter.api.AssertTrue.assertTrue(AssertTrue.java:36)
	at org.junit.jupiter.api.AssertTrue.assertTrue(AssertTrue.java:31)
	at org.junit.jupiter.api.Assertions.assertTrue(Assertions.java:180)
	at org.apache.accumulo.test.CloseScannerIT.testManyScans(CloseScannerIT.java:70)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```