### PR TITLE
Add waitFor method in core. Relocate UtilWaitThread.sleep

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
@@ -44,7 +44,7 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.fate.ReadOnlyTStore.TStatus;
 import org.apache.accumulo.core.logging.FateLogger;
 import org.apache.accumulo.core.util.ShutdownUtil;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.thrift.TApplicationException;
 import org.slf4j.Logger;
@@ -328,7 +328,7 @@ public class Fate<T> {
         }
       } else {
         // reserved, lets retry.
-        UtilWaitThread.sleep(500);
+        WaitFor.sleep(500);
       }
     }
     log.info("Unable to reserve transaction {} to cancel it", tid);

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/DistributedReadWriteLock.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/DistributedReadWriteLock.java
@@ -30,7 +30,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -181,7 +181,7 @@ public class DistributedReadWriteLock implements java.util.concurrent.locks.Read
           return true;
         }
         // TODO: do something better than poll - ACCUMULO-1310
-        UtilWaitThread.sleep(100);
+        WaitFor.sleep(100);
         now = System.currentTimeMillis();
       }
       return false;

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooSession.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooSession.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import org.apache.accumulo.core.singletons.SingletonManager;
 import org.apache.accumulo.core.singletons.SingletonService;
 import org.apache.accumulo.core.util.AddressUtil;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.Watcher.Event.KeeperState;
@@ -126,7 +126,7 @@ public class ZooSession {
             }
             tryAgain = false;
           } else {
-            UtilWaitThread.sleep(TIME_BETWEEN_CONNECT_CHECKS_MS);
+            WaitFor.sleep(TIME_BETWEEN_CONNECT_CHECKS_MS);
           }
         }
 
@@ -167,7 +167,7 @@ public class ZooSession {
           connectTimeWait -= sleepTime;
           sleepTime = 0;
         }
-        UtilWaitThread.sleep(sleepTime);
+        WaitFor.sleep(sleepTime);
         if (sleepTime < 10000) {
           sleepTime = sleepTime + (long) (sleepTime * RANDOM.get().nextDouble());
         }

--- a/core/src/main/java/org/apache/accumulo/core/util/WaitFor.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/WaitFor.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.util;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.util.concurrent.TimeUnit;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provides a generic capability to sleep until a condition is true. The maximum time to wait for
+ * the condition, the delay between checking the condition as well as progress and error messages
+ * can be provided. All are optional.
+ * <p>
+ * If the timeout is reached, an interrupt occurs, or if an Exception is thrown checking the
+ * condition an IllegalStateException is thrown.
+ * <p>
+ * Note: Integration tests should use the @{code Wait.waitFor(...) methods in the test module that
+ * allow the delays to be scaled using a timeout factor to allow for variations in test
+ * environments.}
+ */
+public class WaitFor {
+  private static final Logger LOG = LoggerFactory.getLogger(WaitFor.class);
+  private static final long MAX_DURATION_SEC = 30;
+  private static final long MAX_SLEEP_SEC = 1;
+
+  /**
+   * Convenience method that sleeps for the specified time (in milliseconds) where callers do not
+   * need to catch / handle the InterruptedException. If an interrupt occurs, the interrupt is
+   * reasserted so the caller has the option to test if an interrupt occurred and can take
+   * appropriate action.
+   * <p>
+   * Using this method should be discouraged in favor of the caller properly catching and taking
+   * appropriate action. At a minimum, callers should test for the interrupt status on return and
+   * take action if an interrupt occurred.
+   *
+   * @param millis the sleep time.
+   */
+  public static void sleep(long millis) {
+    try {
+      Thread.sleep(millis);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LOG.error("{}", e.getMessage(), e);
+    }
+  }
+
+  public interface Condition {
+    boolean isSatisfied() throws Exception;
+  }
+
+  private long duration = SECONDS.toMillis(MAX_DURATION_SEC);
+  private long sleepMillis = SECONDS.toMillis(MAX_SLEEP_SEC);
+
+  private String progressMsg = "";
+  private String failMessage = "";
+
+  private Condition condition = null;
+
+  /**
+   * Use a {@link #builder(Condition)} to create an instance;
+   */
+  private WaitFor() {}
+
+  /**
+   * Set the condition required to be true before the {@link #waitFor()} will continue, This creates
+   * a fluent-style object to allow for setting optional parameters before calling
+   * {@link #waitFor()}.
+   *
+   * @param condition when condition evaluates true, return from waiting
+   * @return return a fluent-style object to configure optional parameters.
+   */
+  public static WaitFor builder(@NonNull final Condition condition) {
+    WaitFor waiter = new WaitFor();
+    waiter.condition = condition;
+    return waiter;
+  }
+
+  /**
+   * Set the approximate maximum time the waitFor will wait for the condition to be satisfied. If
+   * the condition is not satisfied by this time, an IllegalStateException will be thrown. The
+   * absolute max time for the wait also depends on the delay time and could be up to (duration +
+   * delay). If not set, the default value is {@value #MAX_DURATION_SEC} seconds.
+   *
+   * @param duration the approximate max wait time for the condition to be true.
+   * @param units the time units of the duration.
+   * @return return a fluent-style object to configure other optional parameters.
+   */
+  public WaitFor upTo(final long duration, TimeUnit units) {
+    if (duration <= 0) {
+      LOG.info("Invalid wait duration {} millis, using default of {} millis",
+          units.toMillis(duration), this.duration);
+    } else {
+      this.duration = units.toMillis(duration);
+    }
+    return this;
+  }
+
+  /**
+   * Set the delay time between checking the condition to continue. If not set, the default value of
+   * {@value #MAX_SLEEP_SEC} second(s) is used.
+   *
+   * @param sleep the time to sleep between checks.
+   * @param units the time units of the duration.
+   * @return return a fluent-style object to configure other optional parameters.
+   */
+  public WaitFor withDelay(final long sleep, TimeUnit units) {
+    if (sleep <= 0) {
+      LOG.info("Invalid sleep {} millis, using default of {} millis", units.toMillis(sleep),
+          sleepMillis);
+    } else {
+      this.sleepMillis = units.toMillis(sleep);
+    }
+    return this;
+  }
+
+  /**
+   * Add optional text that will be included in a debug level message when the condition is false
+   * and the wait will enter a sleep. The sleep time is appended to this text. If the progress
+   * message is not provided, no logging will occur.
+   *
+   * @param msg text to be included with the debug level log statement.
+   * @return return a fluent-style object to configure other optional parameters.
+   */
+  public WaitFor withProgressMsg(final String msg) {
+    this.progressMsg = msg;
+    return this;
+  }
+
+  /**
+   * Add optional text that will be included in the IllegalStateException if an Exception occurs
+   * checking the condition or if the maximum duration time is reached without the condition being
+   * satisfied.
+   *
+   * @param msg text to be included in the IllegalStateException message
+   * @return return a fluent-style object to configure other optional parameters.
+   */
+  public WaitFor withFailMsg(final String msg) {
+    this.failMessage = msg;
+    return this;
+  }
+
+  /**
+   * Start the wait and hold until condition is satisfied or the timeout is reached.
+   */
+  public void waitFor() {
+    final long durationNanos = MILLISECONDS.toNanos(duration);
+
+    final long startNanos = System.nanoTime();
+    boolean success;
+    try {
+      success = condition.isSatisfied();
+      while (!success && System.nanoTime() - startNanos < durationNanos) {
+        if (!progressMsg.isEmpty()) {
+          LOG.debug("{}, pausing for {} mills", progressMsg, sleepMillis);
+        }
+        MILLISECONDS.sleep(sleepMillis);
+        success = condition.isSatisfied();
+      }
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("Interrupted during wait");
+    } catch (Exception ex) {
+      throw new IllegalStateException(failMessage + ". Failed because of exception in condition",
+          ex);
+    }
+    if (!success) {
+      throw new IllegalStateException(failMessage + ". Timeout exceeded");
+    }
+  }
+}

--- a/core/src/main/java/org/apache/accumulo/core/util/WaitFor.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/WaitFor.java
@@ -27,6 +27,8 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Preconditions;
+
 /**
  * Provides a generic capability to sleep until a condition is true. The maximum time to wait for
  * the condition, the delay between checking the condition as well as progress and error messages
@@ -107,12 +109,9 @@ public class WaitFor {
    * @return return a fluent-style object to configure other optional parameters.
    */
   public WaitFor upTo(final long duration, TimeUnit units) {
-    if (duration <= 0) {
-      LOG.info("Invalid wait duration {} millis, using default of {} millis",
-          units.toMillis(duration), this.duration);
-    } else {
-      this.duration = units.toMillis(duration);
-    }
+    Preconditions.checkArgument(duration > 0,
+        "when supplied, duration must be > 0. Received: " + duration);
+    this.duration = units.toMillis(duration);
     return this;
   }
 
@@ -125,12 +124,8 @@ public class WaitFor {
    * @return return a fluent-style object to configure other optional parameters.
    */
   public WaitFor withDelay(final long sleep, TimeUnit units) {
-    if (sleep <= 0) {
-      LOG.info("Invalid sleep {} millis, using default of {} millis", units.toMillis(sleep),
-          sleepMillis);
-    } else {
-      this.sleepMillis = units.toMillis(sleep);
-    }
+    Preconditions.checkArgument(sleep > 0, "when supplied, sleep must be > 0. Received: " + sleep);
+    this.sleepMillis = units.toMillis(sleep);
     return this;
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancerReconfigurationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancerReconfigurationTest.java
@@ -48,7 +48,7 @@ import org.apache.accumulo.core.spi.balancer.data.TabletServerId;
 import org.apache.accumulo.core.spi.balancer.data.TabletStatistics;
 import org.apache.accumulo.core.tabletserver.thrift.TabletStats;
 import org.apache.accumulo.core.util.ConfigurationImpl;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.junit.jupiter.api.Test;
 
 public class HostRegexTableLoadBalancerReconfigurationTest
@@ -105,7 +105,7 @@ public class HostRegexTableLoadBalancerReconfigurationTest
     List<TabletMigration> migrationsOut = new ArrayList<>();
     // Wait to trigger the out of bounds check which will call our version of
     // getOnlineTabletsForTable
-    UtilWaitThread.sleep(3000);
+    WaitFor.sleep(3000);
     this.balance(new BalanceParamsImpl(Collections.unmodifiableSortedMap(allTabletServers),
         migrations, migrationsOut));
     assertEquals(0, migrationsOut.size());
@@ -114,7 +114,7 @@ public class HostRegexTableLoadBalancerReconfigurationTest
     config.set(HostRegexTableLoadBalancer.HOST_BALANCER_PREFIX + BAR.getTableName(), "r01.*");
 
     // Wait to trigger the out of bounds check and the repool check
-    UtilWaitThread.sleep(10000);
+    WaitFor.sleep(10000);
     this.balance(new BalanceParamsImpl(Collections.unmodifiableSortedMap(allTabletServers),
         migrations, migrationsOut));
     assertEquals(5, migrationsOut.size());

--- a/core/src/test/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancerTest.java
@@ -54,7 +54,7 @@ import org.apache.accumulo.core.spi.balancer.data.TabletServerId;
 import org.apache.accumulo.core.spi.balancer.data.TabletStatistics;
 import org.apache.accumulo.core.tabletserver.thrift.TabletStats;
 import org.apache.accumulo.core.util.ConfigurationImpl;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.junit.jupiter.api.Test;
 
 public class HostRegexTableLoadBalancerTest extends BaseHostRegexTableLoadBalancerTest {
@@ -490,7 +490,7 @@ public class HostRegexTableLoadBalancerTest extends BaseHostRegexTableLoadBalanc
     init(DEFAULT_TABLE_PROPERTIES);
     // Wait to trigger the out of bounds check which will call our version of
     // getOnlineTabletsForTable
-    UtilWaitThread.sleep(11000);
+    WaitFor.sleep(11000);
     Set<TabletId> migrations = new HashSet<>();
     List<TabletMigration> migrationsOut = new ArrayList<>();
     this.balance(new BalanceParamsImpl(createCurrent(15), migrations, migrationsOut));

--- a/core/src/test/java/org/apache/accumulo/core/util/WaitForTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/WaitForTest.java
@@ -19,13 +19,42 @@
 package org.apache.accumulo.core.util;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class WaitForTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(WaitForTest.class);
+
+  private static class TimedCondition implements WaitFor.Condition {
+    private final long startNanos = System.nanoTime();
+
+    @Override
+    public boolean isSatisfied() throws Exception {
+      return (System.nanoTime() - startNanos) > MILLISECONDS.toNanos(1_100);
+    }
+  }
+
+  @Test
+  public void goPathTest() {
+
+    TimedCondition c1 = new TimedCondition();
+
+    long start = System.nanoTime();
+
+    WaitFor.builder(c1).upTo(5, SECONDS).withDelay(250, MILLISECONDS).waitFor();
+
+    LOG.info("Condition passed in {} mills", NANOSECONDS.toMillis(System.nanoTime() - start));
+
+    assertTrue(System.nanoTime() - start < SECONDS.toNanos(5));
+
+  }
 
   @Test
   public void pauseTest() {

--- a/core/src/test/java/org/apache/accumulo/core/util/WaitForTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/WaitForTest.java
@@ -37,4 +37,15 @@ public class WaitForTest {
     assertTrue(System.nanoTime() - start < SECONDS.toNanos(5));
   }
 
+  @Test
+  public void invalidSleepTest() {
+    assertThrows(IllegalArgumentException.class,
+        () -> WaitFor.builder(() -> false).upTo(0, SECONDS).waitFor());
+  }
+
+  @Test
+  public void invalidDurationTest() {
+    assertThrows(IllegalArgumentException.class,
+        () -> WaitFor.builder(() -> false).withDelay(-1, SECONDS).waitFor());
+  }
 }

--- a/core/src/test/java/org/apache/accumulo/core/util/WaitForTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/WaitForTest.java
@@ -18,17 +18,23 @@
  */
 package org.apache.accumulo.core.util;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class UtilWaitThread {
-  private static final Logger log = LoggerFactory.getLogger(UtilWaitThread.class);
+import org.junit.jupiter.api.Test;
 
-  public static void sleep(long millis) {
-    try {
-      Thread.sleep(millis);
-    } catch (InterruptedException e) {
-      log.error("{}", e.getMessage(), e);
-    }
+public class WaitForTest {
+
+  @Test
+  public void pauseTest() {
+    long start = System.nanoTime();
+    assertThrows(IllegalStateException.class,
+        () -> WaitFor.builder(() -> false).upTo(1, SECONDS).withDelay(250, MILLISECONDS)
+            .withProgressMsg("a message").withFailMsg("forced fail").waitFor());
+
+    assertTrue(System.nanoTime() - start < SECONDS.toNanos(5));
   }
+
 }

--- a/core/src/test/java/org/apache/accumulo/core/util/WaitForTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/WaitForTest.java
@@ -40,7 +40,7 @@ public class WaitForTest {
     WaitFor.builder(c1).upTo(5, SECONDS).withDelay(250, MILLISECONDS).waitFor();
 
     long elapsed = System.nanoTime() - start;
-    LOG.info("Condition passed in {} mills", NANOSECONDS.toMillis(elapsed - start));
+    LOG.info("Condition passed in {} mills", NANOSECONDS.toMillis(elapsed));
     assertTrue(elapsed < SECONDS.toNanos(5));
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/util/WaitForTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/WaitForTest.java
@@ -32,33 +32,22 @@ public class WaitForTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(WaitForTest.class);
 
-  private static class TimedCondition implements WaitFor.Condition {
-    private final long startNanos = System.nanoTime();
-
-    @Override
-    public boolean isSatisfied() throws Exception {
-      return (System.nanoTime() - startNanos) > MILLISECONDS.toNanos(1_100);
-    }
-  }
-
   @Test
   public void goPathTest() {
-
     TimedCondition c1 = new TimedCondition();
-
     long start = System.nanoTime();
 
     WaitFor.builder(c1).upTo(5, SECONDS).withDelay(250, MILLISECONDS).waitFor();
 
-    LOG.info("Condition passed in {} mills", NANOSECONDS.toMillis(System.nanoTime() - start));
-
-    assertTrue(System.nanoTime() - start < SECONDS.toNanos(5));
-
+    long elapsed = System.nanoTime() - start;
+    LOG.info("Condition passed in {} mills", NANOSECONDS.toMillis(elapsed - start));
+    assertTrue(elapsed < SECONDS.toNanos(5));
   }
 
   @Test
   public void pauseTest() {
     long start = System.nanoTime();
+
     assertThrows(IllegalStateException.class,
         () -> WaitFor.builder(() -> false).upTo(1, SECONDS).withDelay(250, MILLISECONDS)
             .withProgressMsg("a message").withFailMsg("forced fail").waitFor());
@@ -76,5 +65,14 @@ public class WaitForTest {
   public void invalidDurationTest() {
     assertThrows(IllegalArgumentException.class,
         () -> WaitFor.builder(() -> false).withDelay(-1, SECONDS).waitFor());
+  }
+
+  private static class TimedCondition implements WaitFor.Condition {
+    private final long startNanos = System.nanoTime();
+
+    @Override
+    public boolean isSatisfied() throws Exception {
+      return (System.nanoTime() - startNanos) > MILLISECONDS.toNanos(1_100);
+    }
   }
 }

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterControl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterControl.java
@@ -42,7 +42,7 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.rpc.ThriftUtil;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
 import org.apache.accumulo.core.trace.TraceUtil;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.accumulo.core.util.compaction.ExternalCompactionUtil;
 import org.apache.accumulo.gc.SimpleGarbageCollector;
 import org.apache.accumulo.manager.Manager;
@@ -161,7 +161,7 @@ public class MiniAccumuloClusterControl implements ClusterControl {
         } catch (TException e) {
           log.debug(
               "Error getting running compactions from coordinator, message: " + e.getMessage());
-          UtilWaitThread.sleep(250);
+          WaitFor.sleep(250);
         }
       }
     }

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
@@ -75,7 +75,7 @@ import org.apache.accumulo.core.tabletserver.thrift.TCompactionStats;
 import org.apache.accumulo.core.tabletserver.thrift.TExternalCompactionJob;
 import org.apache.accumulo.core.tabletserver.thrift.TabletServerClientService;
 import org.apache.accumulo.core.trace.TraceUtil;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.accumulo.core.util.compaction.ExternalCompactionUtil;
 import org.apache.accumulo.core.util.compaction.RunningCompaction;
 import org.apache.accumulo.core.util.threads.ThreadPools;
@@ -315,7 +315,7 @@ public class CompactionCoordinator extends AbstractServer
       long duration = (System.currentTimeMillis() - start);
       if (checkInterval - duration > 0) {
         LOG.debug("Waiting {}ms for next tserver check", (checkInterval - duration));
-        UtilWaitThread.sleep(checkInterval - duration);
+        WaitFor.sleep(checkInterval - duration);
       }
     }
 

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -89,7 +89,7 @@ import org.apache.accumulo.core.tabletserver.thrift.TCompactionStats;
 import org.apache.accumulo.core.tabletserver.thrift.TExternalCompactionJob;
 import org.apache.accumulo.core.trace.TraceUtil;
 import org.apache.accumulo.core.util.Halt;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.accumulo.core.util.compaction.ExternalCompactionUtil;
 import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.core.util.threads.Threads;
@@ -632,7 +632,7 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
           job = getNextJob(getNextId());
           if (!job.isSetExternalCompactionId()) {
             LOG.trace("No external compactions in queue {}", this.queueName);
-            UtilWaitThread.sleep(getWaitTimeBetweenCompactionChecks());
+            WaitFor.sleep(getWaitTimeBetweenCompactionChecks());
             continue;
           }
           if (!job.getExternalCompactionId().equals(currentCompactionId.get().toString())) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -87,7 +87,7 @@ import org.apache.accumulo.core.tabletscan.thrift.TooManyFilesException;
 import org.apache.accumulo.core.tabletserver.thrift.NoSuchScanIDException;
 import org.apache.accumulo.core.tabletserver.thrift.NotServingTabletException;
 import org.apache.accumulo.core.util.Halt;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.server.AbstractServer;
 import org.apache.accumulo.server.ServerContext;
@@ -385,7 +385,7 @@ public class ScanServer extends AbstractServer
 
     try {
       while (!serverStopRequested) {
-        UtilWaitThread.sleep(1000);
+        WaitFor.sleep(1000);
       }
     } finally {
       LOG.info("Stopping Thrift Servers");

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -106,7 +106,7 @@ import org.apache.accumulo.core.util.MapCounter;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.core.util.Retry;
 import org.apache.accumulo.core.util.Retry.RetryFactory;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.core.util.threads.Threads;
 import org.apache.accumulo.server.AbstractServer;
@@ -962,7 +962,7 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
         // sleep a few seconds in case this is at cluster start...give monitor
         // time to start so the warning will be more visible
         if (!warned) {
-          UtilWaitThread.sleep(5000);
+          WaitFor.sleep(5000);
           warned = true;
         }
         log.warn("WAL directory ({}) implementation does not support sync or flush."

--- a/test/src/main/java/org/apache/accumulo/test/DetectDeadTabletServersIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/DetectDeadTabletServersIT.java
@@ -32,7 +32,7 @@ import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.trace.TraceUtil;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.test.functional.ConfigurableMacBase;
 import org.apache.hadoop.conf.Configuration;
@@ -66,7 +66,7 @@ public class DetectDeadTabletServersIT extends ConfigurableMacBase {
         if (stats.tServerInfo.size() != 2) {
           break;
         }
-        UtilWaitThread.sleep(500);
+        WaitFor.sleep(500);
       }
       assertEquals(1, stats.tServerInfo.size());
       assertEquals(1, stats.badTServers.size() + stats.deadTabletServers.size());
@@ -75,7 +75,7 @@ public class DetectDeadTabletServersIT extends ConfigurableMacBase {
         if (!stats.deadTabletServers.isEmpty()) {
           break;
         }
-        UtilWaitThread.sleep(500);
+        WaitFor.sleep(500);
       }
       assertEquals(1, stats.tServerInfo.size());
       assertEquals(0, stats.badTServers.size());

--- a/test/src/main/java/org/apache/accumulo/test/GarbageCollectWALIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/GarbageCollectWALIT.java
@@ -28,7 +28,7 @@ import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
@@ -72,7 +72,7 @@ public class GarbageCollectWALIT extends ConfigurableMacBase {
       try (Scanner scanner = c.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
         scanner.forEach((k, v) -> {});
       }
-      UtilWaitThread.sleep(3 * 5_000);
+      WaitFor.sleep(3 * 5_000);
       assertEquals(2, countWALsInFS(cluster));
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/ManagerRepairsDualAssignmentIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ManagerRepairsDualAssignmentIT.java
@@ -40,7 +40,7 @@ import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
 import org.apache.accumulo.core.metadata.schema.Ample.TabletMutator;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.security.TablePermission;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.server.ServerContext;
@@ -88,7 +88,7 @@ public class ManagerRepairsDualAssignmentIT extends ConfigurableMacBase {
       Set<TabletLocationState> oldLocations = new HashSet<>();
       TabletStateStore store = TabletStateStore.getStoreForLevel(DataLevel.USER, context);
       while (states.size() < 2) {
-        UtilWaitThread.sleep(250);
+        WaitFor.sleep(250);
         oldLocations.clear();
         for (TabletLocationState tls : store) {
           if (tls.current != null) {
@@ -103,7 +103,7 @@ public class ManagerRepairsDualAssignmentIT extends ConfigurableMacBase {
           cluster.getProcesses().get(ServerType.TABLET_SERVER).iterator().next());
       // Find out which tablet server remains
       while (true) {
-        UtilWaitThread.sleep(1000);
+        WaitFor.sleep(1000);
         states.clear();
         boolean allAssigned = true;
         for (TabletLocationState tls : store) {
@@ -148,7 +148,7 @@ public class ManagerRepairsDualAssignmentIT extends ConfigurableMacBase {
         iter.forEachRemaining(t -> {});
       } catch (Exception ex) {
         System.out.println(ex);
-        UtilWaitThread.sleep(250);
+        WaitFor.sleep(250);
         continue;
       }
       break;

--- a/test/src/main/java/org/apache/accumulo/test/ScanFlushWithTimeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ScanFlushWithTimeIT.java
@@ -37,7 +37,7 @@ import org.apache.accumulo.core.client.ScannerBase;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.test.functional.SlowIterator;
 import org.apache.hadoop.io.Text;
@@ -69,7 +69,7 @@ public class ScanFlushWithTimeIT extends AccumuloClusterHarness {
       partitionKeys.add(new Text("5"));
       c.tableOperations().addSplits(tableName, partitionKeys);
       log.info("waiting for zookeeper propagation");
-      UtilWaitThread.sleep(5_000);
+      WaitFor.sleep(5_000);
       log.info("Adding a few entries");
       try (BatchWriter bw = c.createBatchWriter(tableName)) {
         for (int i = 0; i < 10; i++) {

--- a/test/src/main/java/org/apache/accumulo/test/TestMultiTableIngest.java
+++ b/test/src/main/java/org/apache/accumulo/test/TestMultiTableIngest.java
@@ -31,7 +31,7 @@ import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.hadoop.io.Text;
 
 import com.beust.jcommander.Parameter;
@@ -55,7 +55,7 @@ public class TestMultiTableIngest {
     for (String table : tableNames) {
       // wait for table to exist
       while (!client.tableOperations().exists(table)) {
-        UtilWaitThread.sleep(100);
+        WaitFor.sleep(100);
       }
       try (Scanner scanner = client.createScanner(table, opts.auths)) {
         int count = i;

--- a/test/src/main/java/org/apache/accumulo/test/WriteAfterCloseIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/WriteAfterCloseIT.java
@@ -45,7 +45,7 @@ import org.apache.accumulo.core.data.ColumnUpdate;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.data.constraints.Constraint;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
@@ -86,7 +86,7 @@ public class WriteAfterCloseIT extends AccumuloClusterHarness {
 
       // the purpose of this constraint is to just randomly hold up inserts on the server side
       if (rand.nextBoolean()) {
-        UtilWaitThread.sleep(4000);
+        WaitFor.sleep(4000);
       }
 
       return null;

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionMetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionMetricsIT.java
@@ -41,7 +41,7 @@ import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.core.metrics.MetricsProducer;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.accumulo.core.util.threads.Threads;
 import org.apache.accumulo.harness.MiniClusterConfigurationCallback;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
@@ -163,7 +163,7 @@ public class ExternalCompactionMetricsIT extends SharedMiniClusterBase {
       // Wait for all external compactions to complete
       long count;
       do {
-        UtilWaitThread.sleep(100);
+        WaitFor.sleep(100);
         try (TabletsMetadata tm = getCluster().getServerContext().getAmple().readTablets()
             .forLevel(DataLevel.USER).fetch(ColumnType.ECOMP).build()) {
           count = tm.stream().mapToLong(t -> t.getExternalCompactions().keySet().size()).sum();

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionTestUtils.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionTestUtils.java
@@ -63,7 +63,7 @@ import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
 import org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner;
 import org.apache.accumulo.core.spi.compaction.SimpleCompactionDispatcher;
 import org.apache.accumulo.core.trace.TraceUtil;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.accumulo.core.util.compaction.ExternalCompactionUtil;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.server.ServerContext;
@@ -292,7 +292,7 @@ public class ExternalCompactionTestUtils {
         tm.stream().flatMap(t -> t.getExternalCompactions().keySet().stream()).forEach(ecids::add);
       }
       if (ecids.isEmpty()) {
-        UtilWaitThread.sleep(50);
+        WaitFor.sleep(50);
       }
     } while (ecids.isEmpty());
     return ecids;
@@ -313,7 +313,7 @@ public class ExternalCompactionTestUtils {
         }
       }
       if (matches == 0) {
-        UtilWaitThread.sleep(50);
+        WaitFor.sleep(50);
       }
     }
     return matches;
@@ -326,7 +326,7 @@ public class ExternalCompactionTestUtils {
     while (running.getCompactions() != null) {
       running = ExternalCompactionTestUtils.getRunningCompactions(ctx);
       if (running.getCompactions() == null) {
-        UtilWaitThread.sleep(250);
+        WaitFor.sleep(250);
       }
     }
     // The compaction should be in the completed list with the expected state
@@ -334,7 +334,7 @@ public class ExternalCompactionTestUtils {
     while (completed.getCompactions() == null) {
       completed = ExternalCompactionTestUtils.getCompletedCompactions(ctx);
       if (completed.getCompactions() == null) {
-        UtilWaitThread.sleep(50);
+        WaitFor.sleep(50);
       }
     }
     for (ExternalCompactionId e : ecids) {

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_1_IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_1_IT.java
@@ -89,7 +89,7 @@ import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.core.spi.compaction.SimpleCompactionDispatcher;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.accumulo.harness.MiniClusterConfigurationCallback;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.minicluster.ServerType;
@@ -239,7 +239,7 @@ public class ExternalCompaction_1_IT extends SharedMiniClusterBase {
       while (count == 0) {
         count = getFinalStatesForTable(getCluster(), tid)
             .filter(state -> state.getFinalState().equals(FinalState.FAILED)).count();
-        UtilWaitThread.sleep(250);
+        WaitFor.sleep(250);
       }
 
       // We need to cancel the compaction or delete the table here because we initiate a user
@@ -404,7 +404,7 @@ public class ExternalCompaction_1_IT extends SharedMiniClusterBase {
       Stream<ExternalCompactionFinalState> fs = getFinalStatesForTable(getCluster(), tid);
       while (fs.findAny().isEmpty()) {
         LOG.info("Waiting for compaction completed marker to appear");
-        UtilWaitThread.sleep(250);
+        WaitFor.sleep(250);
         fs = getFinalStatesForTable(getCluster(), tid);
       }
 
@@ -442,7 +442,7 @@ public class ExternalCompaction_1_IT extends SharedMiniClusterBase {
       Stream<ExternalCompactionFinalState> fs2 = getFinalStatesForTable(getCluster(), tid);
       while (fs2.findAny().isPresent()) {
         LOG.info("Waiting for compaction completed marker to disappear");
-        UtilWaitThread.sleep(500);
+        WaitFor.sleep(500);
         fs2 = getFinalStatesForTable(getCluster(), tid);
       }
       verify(client, table3, 2);

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_2_IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_2_IT.java
@@ -55,7 +55,7 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.accumulo.harness.MiniClusterConfigurationCallback;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.minicluster.ServerType;
@@ -177,7 +177,7 @@ public class ExternalCompaction_2_IT extends SharedMiniClusterBase {
           while (metrics2.getCompactions() == null) {
             metrics2 = getRunningCompactions(getCluster().getServerContext());
             if (metrics2.getCompactions() == null) {
-              UtilWaitThread.sleep(50);
+              WaitFor.sleep(50);
             }
           }
           LOG.info("Taking table offline");
@@ -220,7 +220,7 @@ public class ExternalCompaction_2_IT extends SharedMiniClusterBase {
       while (finalStateCount > 0) {
         finalStateCount = getFinalStatesForTable(getCluster(), tid).count();
         if (finalStateCount > 0) {
-          UtilWaitThread.sleep(50);
+          WaitFor.sleep(50);
         }
       }
 

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_3_IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_3_IT.java
@@ -47,7 +47,7 @@ import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.accumulo.harness.MiniClusterConfigurationCallback;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.minicluster.ServerType;
@@ -126,7 +126,7 @@ public class ExternalCompaction_3_IT extends SharedMiniClusterBase {
             .flatMap(t -> t.getExternalCompactions().keySet().stream()).collect(Collectors.toSet());
         // keep checking until test times out
         while (!Collections.disjoint(ecids, ecids2)) {
-          UtilWaitThread.sleep(25);
+          WaitFor.sleep(25);
           ecids2 = tm.stream().flatMap(t -> t.getExternalCompactions().keySet().stream())
               .collect(Collectors.toSet());
         }
@@ -176,7 +176,7 @@ public class ExternalCompaction_3_IT extends SharedMiniClusterBase {
             }
           }
         }
-        UtilWaitThread.sleep(250);
+        WaitFor.sleep(250);
       }
       assertTrue(matches > 0);
 

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalDoNothingCompactor.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalDoNothingCompactor.java
@@ -31,7 +31,7 @@ import org.apache.accumulo.core.compaction.thrift.CompactorService.Iface;
 import org.apache.accumulo.core.compaction.thrift.TCompactionState;
 import org.apache.accumulo.core.compaction.thrift.TCompactionStatusUpdate;
 import org.apache.accumulo.core.tabletserver.thrift.TExternalCompactionJob;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.accumulo.server.compaction.FileCompactor.CompactionCanceledException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,7 +72,7 @@ public class ExternalDoNothingCompactor extends Compactor implements Iface {
 
         while (!JOB_HOLDER.isCancelled()) {
           LOG.info("Sleeping while job is not cancelled");
-          UtilWaitThread.sleep(1000);
+          WaitFor.sleep(1000);
         }
         // Compactor throws this exception when cancelled
         throw new CompactionCanceledException();

--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
@@ -51,7 +51,7 @@ import org.apache.accumulo.core.fate.ReadOnlyTStore.TStatus;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.ZooStore;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.TraceRepo;
@@ -165,7 +165,7 @@ public class FateIT {
     try {
 
       // Wait for the transaction runner to be scheduled.
-      UtilWaitThread.sleep(3000);
+      WaitFor.sleep(3000);
 
       callStarted = new CountDownLatch(1);
       finishCall = new CountDownLatch(1);
@@ -225,7 +225,7 @@ public class FateIT {
     try {
 
       // Wait for the transaction runner to be scheduled.
-      UtilWaitThread.sleep(3000);
+      WaitFor.sleep(3000);
 
       callStarted = new CountDownLatch(1);
       finishCall = new CountDownLatch(1);
@@ -264,7 +264,7 @@ public class FateIT {
     try {
 
       // Wait for the transaction runner to be scheduled.
-      UtilWaitThread.sleep(3000);
+      WaitFor.sleep(3000);
 
       callStarted = new CountDownLatch(1);
       finishCall = new CountDownLatch(1);
@@ -305,7 +305,7 @@ public class FateIT {
     try {
 
       // Wait for the transaction runner to be scheduled.
-      UtilWaitThread.sleep(3000);
+      WaitFor.sleep(3000);
 
       callStarted = new CountDownLatch(1);
       finishCall = new CountDownLatch(1);

--- a/test/src/main/java/org/apache/accumulo/test/functional/AssignLocationModeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/AssignLocationModeIT.java
@@ -35,7 +35,7 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.TabletLocationState;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.server.manager.state.MetaDataTableScanner;
 import org.apache.hadoop.conf.Configuration;
@@ -67,7 +67,7 @@ public class AssignLocationModeIT extends ConfigurableMacBase {
       // wait for the table to be online
       TabletLocationState newTablet;
       do {
-        UtilWaitThread.sleep(250);
+        WaitFor.sleep(250);
         newTablet = getTabletLocationState(c, tableId);
       } while (newTablet.current == null);
       // this would be null if the mode was not "assign"

--- a/test/src/main/java/org/apache/accumulo/test/functional/BalanceAfterCommsFailureIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BalanceAfterCommsFailureIT.java
@@ -39,7 +39,7 @@ import org.apache.accumulo.core.manager.thrift.TabletServerStatus;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.trace.TraceUtil;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.miniclusterImpl.ProcessReference;
@@ -84,7 +84,7 @@ public class BalanceAfterCommsFailureIT extends ConfigurableMacBase {
         assertEquals(0, Runtime.getRuntime()
             .exec(new String[] {"kill", "-SIGSTOP", Integer.toString(pid)}).waitFor());
       }
-      UtilWaitThread.sleep(20_000);
+      WaitFor.sleep(20_000);
       for (int pid : tserverPids) {
         assertEquals(0, Runtime.getRuntime()
             .exec(new String[] {"kill", "-SIGCONT", Integer.toString(pid)}).waitFor());
@@ -96,7 +96,7 @@ public class BalanceAfterCommsFailureIT extends ConfigurableMacBase {
       c.tableOperations().addSplits("test", splits);
       // Ensure all of the tablets are actually assigned
       assertEquals(0, Iterables.size(c.createScanner("test", Authorizations.EMPTY)));
-      UtilWaitThread.sleep(30_000);
+      WaitFor.sleep(30_000);
       checkBalance(c);
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/BalanceInPresenceOfOfflineTableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BalanceInPresenceOfOfflineTableIT.java
@@ -40,7 +40,7 @@ import org.apache.accumulo.core.manager.thrift.ManagerMonitorInfo;
 import org.apache.accumulo.core.manager.thrift.TableInfo;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
 import org.apache.accumulo.core.trace.TraceUtil;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.test.TestIngest;
@@ -91,7 +91,7 @@ public class BalanceInPresenceOfOfflineTableIT extends AccumuloClusterHarness {
       if (accumuloClient.instanceOperations().getTabletServers().size() >= 2) {
         break;
       }
-      UtilWaitThread.sleep(TimeUnit.SECONDS.toMillis(2));
+      WaitFor.sleep(TimeUnit.SECONDS.toMillis(2));
     }
     assumeTrue(accumuloClient.instanceOperations().getTabletServers().size() >= 2,
         "Not enough tservers to run test");

--- a/test/src/main/java/org/apache/accumulo/test/functional/BloomFilterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BloomFilterIT.java
@@ -44,7 +44,7 @@ import org.apache.accumulo.core.file.keyfunctor.ColumnFamilyFunctor;
 import org.apache.accumulo.core.file.keyfunctor.ColumnQualifierFunctor;
 import org.apache.accumulo.core.file.keyfunctor.RowFunctor;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.minicluster.MemoryUnit;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
@@ -139,7 +139,7 @@ public class BloomFilterIT extends AccumuloClusterHarness {
             RowFunctor.class.getName());
 
         // ensure the updates to zookeeper propagate
-        UtilWaitThread.sleep(500);
+        WaitFor.sleep(500);
 
         c.tableOperations().compact(tables[3], null, null, false, true);
         c.tableOperations().compact(tables[0], null, null, false, true);

--- a/test/src/main/java/org/apache/accumulo/test/functional/CompactLocationModeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CompactLocationModeIT.java
@@ -35,7 +35,7 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.TabletLocationState;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.server.manager.state.MetaDataTableScanner;
 import org.apache.hadoop.conf.Configuration;
@@ -67,7 +67,7 @@ public class CompactLocationModeIT extends ConfigurableMacBase {
       // wait for the table to be online
       TabletLocationState newTablet;
       do {
-        UtilWaitThread.sleep(250);
+        WaitFor.sleep(250);
         newTablet = getTabletLocationState(c, tableId);
       } while (newTablet.current == null);
       assertNull(newTablet.last);

--- a/test/src/main/java/org/apache/accumulo/test/functional/DeletedTablesDontFlushIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/DeletedTablesDontFlushIT.java
@@ -28,7 +28,7 @@ import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -61,7 +61,7 @@ public class DeletedTablesDontFlushIT extends SharedMiniClusterBase {
       SlowIterator.setSleepTime(setting, 1000);
       c.tableOperations().attachIterator(tableName, setting, EnumSet.of(IteratorScope.minc));
       // let the configuration change propagate through zookeeper
-      UtilWaitThread.sleep(1000);
+      WaitFor.sleep(1000);
 
       Mutation m = new Mutation("xyzzy");
       for (int i = 0; i < 100; i++) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/HalfClosedTabletIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/HalfClosedTabletIT.java
@@ -40,7 +40,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.accumulo.harness.MiniClusterConfigurationCallback;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
@@ -119,7 +119,7 @@ public class HalfClosedTabletIT extends SharedMiniClusterBase {
       Thread.sleep(3000);
 
       Thread configFixer = new Thread(() -> {
-        UtilWaitThread.sleep(3000);
+        WaitFor.sleep(3000);
         removeInvalidClassLoaderContextProperty(client, tableName);
       });
 
@@ -218,7 +218,7 @@ public class HalfClosedTabletIT extends SharedMiniClusterBase {
 
       c.tableOperations().flush(tableName, null, null, false);
 
-      UtilWaitThread.sleep(5000);
+      WaitFor.sleep(5000);
 
       // minc should fail, so there should be no files
       FunctionalTestUtils.checkRFiles(c, tableName, 1, 1, 0, 0);
@@ -229,7 +229,7 @@ public class HalfClosedTabletIT extends SharedMiniClusterBase {
       // The offine operation should not be able to complete because the tablet can not minor
       // compact, give the offline operation a bit of time to attempt to complete even though it
       // should never be able to complete.
-      UtilWaitThread.sleep(5000);
+      WaitFor.sleep(5000);
 
       assertTrue(countHostedTablets(c, tid) > 0);
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/ManagerAssignmentIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ManagerAssignmentIT.java
@@ -50,7 +50,7 @@ import org.apache.accumulo.core.metadata.TabletLocationState;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
 import org.apache.accumulo.core.trace.TraceUtil;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterControl;
@@ -76,7 +76,7 @@ public class ManagerAssignmentIT extends AccumuloClusterHarness {
       // wait for the table to be online
       TabletLocationState newTablet;
       do {
-        UtilWaitThread.sleep(250);
+        WaitFor.sleep(250);
         newTablet = getTabletLocationState(c, tableId);
       } while (newTablet.current == null);
       assertNull(newTablet.last);

--- a/test/src/main/java/org/apache/accumulo/test/functional/ScannerContextIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ScannerContextIT.java
@@ -42,7 +42,7 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl;
 import org.apache.hadoop.fs.FileSystem;
@@ -79,7 +79,7 @@ public class ScannerContextIT extends AccumuloClusterHarness {
     Path dstPath = new Path(CONTEXT_DIR + "/Test.jar");
     fs.copyFromLocalFile(jarPath, dstPath);
     // Sleep to ensure jar change gets picked up
-    UtilWaitThread.sleep(WAIT);
+    WaitFor.sleep(WAIT);
     return dstPath;
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/ScannerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ScannerIT.java
@@ -34,7 +34,7 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.junit.jupiter.api.Test;
 
@@ -80,7 +80,7 @@ public class ScannerIT extends AccumuloClusterHarness {
           nanosWithWait += System.nanoTime() - startTime;
 
           // While we "do work" in the client, we should be fetching the next result
-          UtilWaitThread.sleep(100L);
+          WaitFor.sleep(100L);
           iterator.next();
           startTime = System.nanoTime();
         }
@@ -100,7 +100,7 @@ public class ScannerIT extends AccumuloClusterHarness {
           nanosWithNoWait += System.nanoTime() - startTime;
 
           // While we "do work" in the client, we should be fetching the next result
-          UtilWaitThread.sleep(100L);
+          WaitFor.sleep(100L);
           iterator.next();
           startTime = System.nanoTime();
         }

--- a/test/src/main/java/org/apache/accumulo/test/functional/SummaryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SummaryIT.java
@@ -83,7 +83,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.Filter;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.TablePermission;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.AfterAll;
@@ -600,7 +600,7 @@ public class SummaryIT extends SharedMiniClusterBase {
             assertEquals(1L, (long) summary.getStatistics().getOrDefault("foos", 0L));
             break;
           } catch (AccumuloSecurityException ase) {
-            UtilWaitThread.sleep(500);
+            WaitFor.sleep(500);
             tries++;
           }
         }

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletStateChangeIteratorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletStateChangeIteratorIT.java
@@ -60,7 +60,7 @@ import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.server.manager.state.CurrentState;
 import org.apache.accumulo.server.manager.state.MergeInfo;
@@ -111,7 +111,7 @@ public class TabletStateChangeIteratorIT extends AccumuloClusterHarness {
       int tabletsInFlux = findTabletsNeedingAttention(client, metaCopy1, state);
       while (tabletsInFlux > 0) {
         log.debug("Waiting for {} tablets for {}", tabletsInFlux, metaCopy1);
-        UtilWaitThread.sleep(500);
+        WaitFor.sleep(500);
         copyTable(client, MetadataTable.NAME, metaCopy1);
         tabletsInFlux = findTabletsNeedingAttention(client, metaCopy1, state);
       }

--- a/test/src/main/java/org/apache/accumulo/test/util/SlowOps.java
+++ b/test/src/main/java/org/apache/accumulo/test/util/SlowOps.java
@@ -45,7 +45,7 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.WaitFor;
 import org.apache.accumulo.test.functional.SlowIterator;
 import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
@@ -86,7 +86,7 @@ public class SlowOps {
       client.instanceOperations().setProperty(
           Property.TSERV_COMPACTION_SERVICE_DEFAULT_EXECUTORS.getKey(),
           "[{'name':'any','numThreads':" + target + "}]".replaceAll("'", "\""));
-      UtilWaitThread.sleep(3_000); // give it time to propagate
+      WaitFor.sleep(3_000); // give it time to propagate
     } catch (AccumuloException | AccumuloSecurityException | NumberFormatException ex) {
       throw new IllegalStateException("Could not set parallel compaction limit to " + target, ex);
     }


### PR DESCRIPTION
The test module has a convenient Wait.waitFor that could be used generally, however, that code allows for a scaling factor to allow for variations in test environments.  This PR replicates that functionality for general use outside of the test module.

Rather that static methods, this uses fluent-style builder that can be concise while providing customization. It also has a signature different from the test waitFor methods to avoid confusion which wait is being used.

This also relocates the sleep method from UtilWaitThread and deletes that class.  The original intent of UtilWaitThread class was to hold guava sleepUninterruptibly code that had been marked as beta at one time.  Using the guava provided sleepUninterruptibly was completed in a previous PR.  The relocated sleep also reestablishes the interrupt flag that can be used by callers to determine if in interrupt occurred. 