### PR TITLE
Add Volume replacement test for logs

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeUtil.java
@@ -89,7 +89,7 @@ public class VolumeUtil {
     return null;
   }
 
-  private static LogEntry switchVolumes(LogEntry le, List<Pair<Path,Path>> replacements) {
+  public static LogEntry switchVolumes(LogEntry le, List<Pair<Path,Path>> replacements) {
     Path switchedPath = switchVolume(le.filename, FileType.WAL, replacements);
     String switchedString;
     int numSwitched = 0;

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeUtil.java
@@ -89,7 +89,7 @@ public class VolumeUtil {
     return null;
   }
 
-  public static LogEntry switchVolumes(LogEntry le, List<Pair<Path,Path>> replacements) {
+  protected static LogEntry switchVolumes(LogEntry le, List<Pair<Path,Path>> replacements) {
     Path switchedPath = switchVolume(le.filename, FileType.WAL, replacements);
     String switchedString;
     int numSwitched = 0;


### PR DESCRIPTION
VolumeUtil.switchVolumes is used to perform
volume replacement on LogEntry objects. However,
there was no test for it.

Related to #4004