### PR TITLE
Fixes AccumuloClientIT.testClose

### DIFF
--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
@@ -66,15 +66,18 @@ import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.ClientProperty;
 import org.apache.accumulo.core.conf.ConfigurationCopy;
+import org.apache.accumulo.core.conf.ConfigurationTypeHelper;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.data.InstanceId;
+import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.core.manager.thrift.ManagerGoalState;
@@ -84,6 +87,7 @@ import org.apache.accumulo.core.spi.common.ServiceEnvironment;
 import org.apache.accumulo.core.spi.compaction.CompactionPlanner;
 import org.apache.accumulo.core.spi.compaction.CompactionServiceId;
 import org.apache.accumulo.core.trace.TraceUtil;
+import org.apache.accumulo.core.util.ConfigurationImpl;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.core.util.compaction.CompactionPlannerInitParams;
 import org.apache.accumulo.core.util.compaction.CompactionServicesConfig;
@@ -92,7 +96,6 @@ import org.apache.accumulo.minicluster.MiniAccumuloCluster;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.ServerDirs;
-import org.apache.accumulo.server.ServiceEnvironmentImpl;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.init.Initialize;
 import org.apache.accumulo.server.util.AccumuloStatus;
@@ -660,7 +663,37 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
     Set<String> groupNames = new HashSet<>();
     AccumuloConfiguration aconf = new ConfigurationCopy(config.getSiteConfig());
     CompactionServicesConfig csc = new CompactionServicesConfig(aconf);
-    ServiceEnvironment senv = new ServiceEnvironmentImpl(getServerContext());
+
+    ServiceEnvironment senv = new ServiceEnvironment() {
+
+      @Override
+      public String getTableName(TableId tableId) throws TableNotFoundException {
+        return null;
+      }
+
+      @Override
+      public <T> T instantiate(String className, Class<T> base)
+          throws ReflectiveOperationException {
+        return ConfigurationTypeHelper.getClassInstance(null, className, base);
+      }
+
+      @Override
+      public <T> T instantiate(TableId tableId, String className, Class<T> base)
+          throws ReflectiveOperationException {
+        return null;
+      }
+
+      @Override
+      public Configuration getConfiguration() {
+        return new ConfigurationImpl(aconf);
+      }
+
+      @Override
+      public Configuration getConfiguration(TableId tableId) {
+        return null;
+      }
+
+    };
 
     for (var entry : csc.getPlanners().entrySet()) {
       String serviceId = entry.getKey();

--- a/test/src/main/java/org/apache/accumulo/test/functional/AccumuloClientIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/AccumuloClientIT.java
@@ -44,7 +44,6 @@ import org.apache.accumulo.core.singletons.SingletonManager;
 import org.apache.accumulo.core.singletons.SingletonManager.Mode;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class AccumuloClientIT extends AccumuloClusterHarness {
@@ -141,7 +140,7 @@ public class AccumuloClientIT extends AccumuloClusterHarness {
   }
 
   @Test
-  @Disabled // ELASTICITY_TODO
+  // @Disabled // ELASTICITY_TODO
   public void testClose() throws Exception {
     String tableName = getUniqueNames(1)[0];
 


### PR DESCRIPTION
Calling getServerContext() ends up down a path where it sets the SingletonManager to SERVER mode. Modify the method in MiniAccumuloClusterImpl to create a ServiceEnvironment object that can be used to get the compactor group names with calling getServerContext()