### PR TITLE
Fix ManagerRepairsDualAssignmentIT

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
@@ -677,14 +677,12 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
           // Create an event at the store level, this will force the next scan to be a full scan
           manager.nextEvent.event(store.getLevel(), "Set of tablet servers changed");
         }
+      } catch (BadLocationStateException e) {
+        Manager.log.error("{}, attempting to repair", e.getMessage());
+        repairMetadata(e.getEncodedEndRow());
       } catch (Exception ex) {
         Manager.log.error("Error processing table state for store " + store.name(), ex);
-        if (ex.getCause() != null && ex.getCause() instanceof BadLocationStateException) {
-          // ELASTICITY_TODO review this function
-          repairMetadata(((BadLocationStateException) ex.getCause()).getEncodedEndRow());
-        } else {
-          sleepUninterruptibly(Manager.WAIT_BETWEEN_ERRORS, TimeUnit.MILLISECONDS);
-        }
+        sleepUninterruptibly(Manager.WAIT_BETWEEN_ERRORS, TimeUnit.MILLISECONDS);
       } finally {
         if (iter != null) {
           try {

--- a/test/src/main/java/org/apache/accumulo/test/ManagerRepairsDualAssignmentIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ManagerRepairsDualAssignmentIT.java
@@ -48,10 +48,8 @@ import org.apache.accumulo.test.functional.ConfigurableMacBase;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.RawLocalFileSystem;
 import org.apache.hadoop.io.Text;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-@Disabled // ELASTICITY_TODO
 public class ManagerRepairsDualAssignmentIT extends ConfigurableMacBase {
 
   @Override


### PR DESCRIPTION
The exception handling for the BadLocationStateException in the TabletGroupWatcher was not correct, so the repairMetadata method was not being called.