### PR TITLE
Replace UtilWaitThread.sleep() in tests.

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/GarbageCollectWALIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/GarbageCollectWALIT.java
@@ -74,7 +74,6 @@ public class GarbageCollectWALIT extends ConfigurableMacBase {
         scanner.forEach((k, v) -> {});
       }
       Wait.waitFor(() -> countWALsInFS(cluster) == 2, SECONDS.toMillis(120), SECONDS.toMillis(15));
-      assertEquals(2, countWALsInFS(cluster));
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/GarbageCollectWALIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/GarbageCollectWALIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.test;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Duration;
@@ -28,11 +29,11 @@ import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.test.functional.ConfigurableMacBase;
+import org.apache.accumulo.test.util.Wait;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
@@ -72,7 +73,7 @@ public class GarbageCollectWALIT extends ConfigurableMacBase {
       try (Scanner scanner = c.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
         scanner.forEach((k, v) -> {});
       }
-      UtilWaitThread.sleep(3 * 5_000);
+      Wait.waitFor(() -> countWALsInFS(cluster) == 2, SECONDS.toMillis(120), SECONDS.toMillis(15));
       assertEquals(2, countWALsInFS(cluster));
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/ScanFlushWithTimeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ScanFlushWithTimeIT.java
@@ -37,7 +37,6 @@ import org.apache.accumulo.core.client.ScannerBase;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.test.functional.SlowIterator;
 import org.apache.hadoop.io.Text;
@@ -69,7 +68,7 @@ public class ScanFlushWithTimeIT extends AccumuloClusterHarness {
       partitionKeys.add(new Text("5"));
       c.tableOperations().addSplits(tableName, partitionKeys);
       log.info("waiting for zookeeper propagation");
-      UtilWaitThread.sleep(5_000);
+      Thread.sleep(5_000);
       log.info("Adding a few entries");
       try (BatchWriter bw = c.createBatchWriter(tableName)) {
         for (int i = 0; i < 10; i++) {

--- a/test/src/main/java/org/apache/accumulo/test/TestMultiTableIngest.java
+++ b/test/src/main/java/org/apache/accumulo/test/TestMultiTableIngest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.test;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
@@ -31,7 +33,7 @@ import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.test.util.Wait;
 import org.apache.hadoop.io.Text;
 
 import com.beust.jcommander.Parameter;
@@ -54,9 +56,7 @@ public class TestMultiTableIngest {
     int i = 0;
     for (String table : tableNames) {
       // wait for table to exist
-      while (!client.tableOperations().exists(table)) {
-        UtilWaitThread.sleep(100);
-      }
+      Wait.waitFor(() -> client.tableOperations().exists(table), SECONDS.toMillis(30), 100);
       try (Scanner scanner = client.createScanner(table, opts.auths)) {
         int count = i;
         for (Entry<Key,Value> elt : scanner) {

--- a/test/src/main/java/org/apache/accumulo/test/WriteAfterCloseIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/WriteAfterCloseIT.java
@@ -45,7 +45,6 @@ import org.apache.accumulo.core.data.ColumnUpdate;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.data.constraints.Constraint;
-import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
@@ -86,7 +85,11 @@ public class WriteAfterCloseIT extends AccumuloClusterHarness {
 
       // the purpose of this constraint is to just randomly hold up inserts on the server side
       if (rand.nextBoolean()) {
-        UtilWaitThread.sleep(4000);
+        try {
+          Thread.sleep(4000);
+        } catch (InterruptedException ex) {
+          throw new IllegalStateException("Interrupted during sleep", ex);
+        }
       }
 
       return null;

--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
@@ -51,7 +51,6 @@ import org.apache.accumulo.core.fate.ReadOnlyTStore.TStatus;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.ZooStore;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
-import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.TraceRepo;
@@ -165,7 +164,7 @@ public class FateIT {
     try {
 
       // Wait for the transaction runner to be scheduled.
-      UtilWaitThread.sleep(3000);
+      Thread.sleep(3000);
 
       callStarted = new CountDownLatch(1);
       finishCall = new CountDownLatch(1);
@@ -225,7 +224,7 @@ public class FateIT {
     try {
 
       // Wait for the transaction runner to be scheduled.
-      UtilWaitThread.sleep(3000);
+      Thread.sleep(3000);
 
       callStarted = new CountDownLatch(1);
       finishCall = new CountDownLatch(1);
@@ -264,7 +263,7 @@ public class FateIT {
     try {
 
       // Wait for the transaction runner to be scheduled.
-      UtilWaitThread.sleep(3000);
+      Thread.sleep(3000);
 
       callStarted = new CountDownLatch(1);
       finishCall = new CountDownLatch(1);
@@ -305,7 +304,7 @@ public class FateIT {
     try {
 
       // Wait for the transaction runner to be scheduled.
-      UtilWaitThread.sleep(3000);
+      Thread.sleep(3000);
 
       callStarted = new CountDownLatch(1);
       finishCall = new CountDownLatch(1);

--- a/test/src/main/java/org/apache/accumulo/test/functional/BalanceAfterCommsFailureIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BalanceAfterCommsFailureIT.java
@@ -39,7 +39,6 @@ import org.apache.accumulo.core.manager.thrift.TabletServerStatus;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.trace.TraceUtil;
-import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.miniclusterImpl.ProcessReference;
@@ -84,7 +83,7 @@ public class BalanceAfterCommsFailureIT extends ConfigurableMacBase {
         assertEquals(0, Runtime.getRuntime()
             .exec(new String[] {"kill", "-SIGSTOP", Integer.toString(pid)}).waitFor());
       }
-      UtilWaitThread.sleep(20_000);
+      Thread.sleep(20_000);
       for (int pid : tserverPids) {
         assertEquals(0, Runtime.getRuntime()
             .exec(new String[] {"kill", "-SIGCONT", Integer.toString(pid)}).waitFor());
@@ -96,7 +95,7 @@ public class BalanceAfterCommsFailureIT extends ConfigurableMacBase {
       c.tableOperations().addSplits("test", splits);
       // Ensure all of the tablets are actually assigned
       assertEquals(0, Iterables.size(c.createScanner("test", Authorizations.EMPTY)));
-      UtilWaitThread.sleep(30_000);
+      Thread.sleep(30_000);
       checkBalance(c);
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/BalanceInPresenceOfOfflineTableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BalanceInPresenceOfOfflineTableIT.java
@@ -25,7 +25,6 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -40,12 +39,12 @@ import org.apache.accumulo.core.manager.thrift.ManagerMonitorInfo;
 import org.apache.accumulo.core.manager.thrift.TableInfo;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
 import org.apache.accumulo.core.trace.TraceUtil;
-import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.test.TestIngest;
 import org.apache.accumulo.test.VerifyIngest;
 import org.apache.accumulo.test.VerifyIngest.VerifyParams;
+import org.apache.accumulo.test.util.Wait;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
@@ -86,13 +85,10 @@ public class BalanceInPresenceOfOfflineTableIT extends AccumuloClusterHarness {
   public void setupTables() throws AccumuloException, AccumuloSecurityException,
       TableExistsException, TableNotFoundException {
     accumuloClient = Accumulo.newClient().from(getClientProps()).build();
+
     // Need at least two tservers -- wait for them to start before failing
-    for (int retries = 0; retries < 5; ++retries) {
-      if (accumuloClient.instanceOperations().getTabletServers().size() >= 2) {
-        break;
-      }
-      UtilWaitThread.sleep(TimeUnit.SECONDS.toMillis(2));
-    }
+    Wait.waitFor(() -> accumuloClient.instanceOperations().getTabletServers().size() >= 2);
+
     assumeTrue(accumuloClient.instanceOperations().getTabletServers().size() >= 2,
         "Not enough tservers to run test");
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/BloomFilterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BloomFilterIT.java
@@ -44,7 +44,6 @@ import org.apache.accumulo.core.file.keyfunctor.ColumnFamilyFunctor;
 import org.apache.accumulo.core.file.keyfunctor.ColumnQualifierFunctor;
 import org.apache.accumulo.core.file.keyfunctor.RowFunctor;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.minicluster.MemoryUnit;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
@@ -138,8 +137,8 @@ public class BloomFilterIT extends AccumuloClusterHarness {
         c.tableOperations().setProperty(tables[3], Property.TABLE_BLOOM_KEY_FUNCTOR.getKey(),
             RowFunctor.class.getName());
 
-        // ensure the updates to zookeeper propagate
-        UtilWaitThread.sleep(500);
+        // allow the updates to zookeeper propagate
+        Thread.sleep(500);
 
         c.tableOperations().compact(tables[3], null, null, false, true);
         c.tableOperations().compact(tables[0], null, null, false, true);

--- a/test/src/main/java/org/apache/accumulo/test/functional/CompactLocationModeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CompactLocationModeIT.java
@@ -35,9 +35,9 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.TabletLocationState;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
-import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.server.manager.state.MetaDataTableScanner;
+import org.apache.accumulo.test.util.Wait;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.Test;
 
@@ -65,11 +65,9 @@ public class CompactLocationModeIT extends ConfigurableMacBase {
       c.tableOperations().create(tableName);
       String tableId = c.tableOperations().tableIdMap().get(tableName);
       // wait for the table to be online
-      TabletLocationState newTablet;
-      do {
-        UtilWaitThread.sleep(250);
-        newTablet = getTabletLocationState(c, tableId);
-      } while (newTablet.current == null);
+      Wait.waitFor(() -> getTabletLocationState(c, tableId) != null);
+
+      TabletLocationState newTablet = getTabletLocationState(c, tableId);
       assertNull(newTablet.last);
       assertNull(newTablet.future);
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/DeletedTablesDontFlushIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/DeletedTablesDontFlushIT.java
@@ -28,7 +28,6 @@ import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
-import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -61,7 +60,7 @@ public class DeletedTablesDontFlushIT extends SharedMiniClusterBase {
       SlowIterator.setSleepTime(setting, 1000);
       c.tableOperations().attachIterator(tableName, setting, EnumSet.of(IteratorScope.minc));
       // let the configuration change propagate through zookeeper
-      UtilWaitThread.sleep(1000);
+      Thread.sleep(1000);
 
       Mutation m = new Mutation("xyzzy");
       for (int i = 0; i < 100; i++) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/HalfClosedTabletIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/HalfClosedTabletIT.java
@@ -40,7 +40,6 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
-import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.harness.MiniClusterConfigurationCallback;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
@@ -119,7 +118,12 @@ public class HalfClosedTabletIT extends SharedMiniClusterBase {
       Thread.sleep(3000);
 
       Thread configFixer = new Thread(() -> {
-        UtilWaitThread.sleep(3000);
+        try {
+          Thread.sleep(3000);
+        } catch (InterruptedException ex) {
+          // ignore exception
+          Thread.currentThread().interrupt();
+        }
         removeInvalidClassLoaderContextProperty(client, tableName);
       });
 
@@ -218,7 +222,7 @@ public class HalfClosedTabletIT extends SharedMiniClusterBase {
 
       c.tableOperations().flush(tableName, null, null, false);
 
-      UtilWaitThread.sleep(5000);
+      Thread.sleep(5000);
 
       // minc should fail, so there should be no files
       FunctionalTestUtils.checkRFiles(c, tableName, 1, 1, 0, 0);
@@ -229,7 +233,7 @@ public class HalfClosedTabletIT extends SharedMiniClusterBase {
       // The offine operation should not be able to complete because the tablet can not minor
       // compact, give the offline operation a bit of time to attempt to complete even though it
       // should never be able to complete.
-      UtilWaitThread.sleep(5000);
+      Thread.sleep(5000);
 
       assertTrue(countHostedTablets(c, tid) > 0);
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/ManagerAssignmentIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ManagerAssignmentIT.java
@@ -50,7 +50,6 @@ import org.apache.accumulo.core.metadata.TabletLocationState;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
 import org.apache.accumulo.core.trace.TraceUtil;
-import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterControl;
@@ -73,12 +72,11 @@ public class ManagerAssignmentIT extends AccumuloClusterHarness {
       String tableName = super.getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
       String tableId = c.tableOperations().tableIdMap().get(tableName);
+
       // wait for the table to be online
-      TabletLocationState newTablet;
-      do {
-        UtilWaitThread.sleep(250);
-        newTablet = getTabletLocationState(c, tableId);
-      } while (newTablet.current == null);
+      Wait.waitFor(() -> getTabletLocationState(c, tableId) != null, SECONDS.toMillis(60), 250);
+
+      TabletLocationState newTablet = getTabletLocationState(c, tableId);
       assertNull(newTablet.last);
       assertNull(newTablet.future);
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/ScannerContextIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ScannerContextIT.java
@@ -42,7 +42,6 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl;
 import org.apache.hadoop.fs.FileSystem;
@@ -71,7 +70,7 @@ public class ScannerContextIT extends AccumuloClusterHarness {
     fs = FileSystem.get(cluster.getServerContext().getHadoopConf());
   }
 
-  private Path copyTestIteratorsJarToTmp() throws IOException {
+  private Path copyTestIteratorsJarToTmp() throws IOException, InterruptedException {
     // Copy the test iterators jar to tmp
     Path baseDir = new Path(System.getProperty("user.dir"));
     Path targetDir = new Path(baseDir, "target");
@@ -79,7 +78,7 @@ public class ScannerContextIT extends AccumuloClusterHarness {
     Path dstPath = new Path(CONTEXT_DIR + "/Test.jar");
     fs.copyFromLocalFile(jarPath, dstPath);
     // Sleep to ensure jar change gets picked up
-    UtilWaitThread.sleep(WAIT);
+    Thread.sleep(WAIT);
     return dstPath;
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/ScannerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ScannerIT.java
@@ -34,7 +34,6 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.junit.jupiter.api.Test;
 
@@ -80,7 +79,7 @@ public class ScannerIT extends AccumuloClusterHarness {
           nanosWithWait += System.nanoTime() - startTime;
 
           // While we "do work" in the client, we should be fetching the next result
-          UtilWaitThread.sleep(100L);
+          Thread.sleep(100L);
           iterator.next();
           startTime = System.nanoTime();
         }
@@ -100,7 +99,7 @@ public class ScannerIT extends AccumuloClusterHarness {
           nanosWithNoWait += System.nanoTime() - startTime;
 
           // While we "do work" in the client, we should be fetching the next result
-          UtilWaitThread.sleep(100L);
+          Thread.sleep(100L);
           iterator.next();
           startTime = System.nanoTime();
         }

--- a/test/src/main/java/org/apache/accumulo/test/functional/SummaryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SummaryIT.java
@@ -83,7 +83,6 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.Filter;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.TablePermission;
-import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.AfterAll;
@@ -600,7 +599,7 @@ public class SummaryIT extends SharedMiniClusterBase {
             assertEquals(1L, (long) summary.getStatistics().getOrDefault("foos", 0L));
             break;
           } catch (AccumuloSecurityException ase) {
-            UtilWaitThread.sleep(500);
+            Thread.sleep(500);
             tries++;
           }
         }

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletStateChangeIteratorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletStateChangeIteratorIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.test.functional;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Duration;
@@ -60,12 +61,12 @@ import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.server.manager.state.CurrentState;
 import org.apache.accumulo.server.manager.state.MergeInfo;
 import org.apache.accumulo.server.manager.state.MetaDataTableScanner;
 import org.apache.accumulo.server.manager.state.TabletStateChangeIterator;
+import org.apache.accumulo.test.util.Wait;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -107,14 +108,11 @@ public class TabletStateChangeIteratorIT extends AccumuloClusterHarness {
       // examine a clone of the metadata table, so we can manipulate it
       copyTable(client, MetadataTable.NAME, metaCopy1);
 
-      State state = new State(client);
-      int tabletsInFlux = findTabletsNeedingAttention(client, metaCopy1, state);
-      while (tabletsInFlux > 0) {
-        log.debug("Waiting for {} tablets for {}", tabletsInFlux, metaCopy1);
-        UtilWaitThread.sleep(500);
-        copyTable(client, MetadataTable.NAME, metaCopy1);
-        tabletsInFlux = findTabletsNeedingAttention(client, metaCopy1, state);
-      }
+      log.debug("Waiting for tablets");
+      final State state = new State(client);
+      Wait.waitFor(() -> findTabletsNeedingAttention(client, metaCopy1, state) <= 0,
+          SECONDS.toMillis(30), 500);
+
       assertEquals(0, findTabletsNeedingAttention(client, metaCopy1, state),
           "No tables should need attention");
 
@@ -134,7 +132,7 @@ public class TabletStateChangeIteratorIT extends AccumuloClusterHarness {
           "Should have one tablet that needs to be unassigned");
 
       // test the cases where there is ongoing merges
-      state = new State(client) {
+      State state2 = new State(client) {
         @Override
         public Collection<MergeInfo> merges() {
           TableId tableIdToModify = TableId.of(client.tableOperations().tableIdMap().get(t3));
@@ -142,13 +140,13 @@ public class TabletStateChangeIteratorIT extends AccumuloClusterHarness {
               new MergeInfo(new KeyExtent(tableIdToModify, null, null), MergeInfo.Operation.MERGE));
         }
       };
-      assertEquals(1, findTabletsNeedingAttention(client, metaCopy2, state),
+      assertEquals(1, findTabletsNeedingAttention(client, metaCopy2, state2),
           "Should have 2 tablets that need to be chopped or unassigned");
 
       // test the bad tablet location state case (inconsistent metadata)
-      state = new State(client);
+      state2 = new State(client);
       addDuplicateLocation(client, metaCopy3, t3);
-      assertEquals(1, findTabletsNeedingAttention(client, metaCopy3, state),
+      assertEquals(1, findTabletsNeedingAttention(client, metaCopy3, state2),
           "Should have 1 tablet that needs a metadata repair");
 
       // clean up

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletStateChangeIteratorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletStateChangeIteratorIT.java
@@ -113,6 +113,9 @@ public class TabletStateChangeIteratorIT extends AccumuloClusterHarness {
       Wait.waitFor(() -> findTabletsNeedingAttention(client, metaCopy1, state) <= 0,
           SECONDS.toMillis(30), 500);
 
+      // update the clone for additional manipulations
+      copyTable(client, MetadataTable.NAME, metaCopy1);
+
       assertEquals(0, findTabletsNeedingAttention(client, metaCopy1, state),
           "No tables should need attention");
 

--- a/test/src/main/java/org/apache/accumulo/test/util/SlowOps.java
+++ b/test/src/main/java/org/apache/accumulo/test/util/SlowOps.java
@@ -45,7 +45,6 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.test.functional.SlowIterator;
 import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
@@ -86,8 +85,9 @@ public class SlowOps {
       client.instanceOperations().setProperty(
           Property.TSERV_COMPACTION_SERVICE_DEFAULT_EXECUTORS.getKey(),
           "[{'name':'any','numThreads':" + target + "}]".replaceAll("'", "\""));
-      UtilWaitThread.sleep(3_000); // give it time to propagate
-    } catch (AccumuloException | AccumuloSecurityException | NumberFormatException ex) {
+      Thread.sleep(3_000); // give it time to propagate
+    } catch (AccumuloException | AccumuloSecurityException | InterruptedException
+        | NumberFormatException ex) {
       throw new IllegalStateException("Could not set parallel compaction limit to " + target, ex);
     }
   }


### PR DESCRIPTION
Replaces the UtilWaitThread.sleep() method with Wait.waitFor or standard Thread.sleep() in tests.  Excludes changes to compaction tests for now.