### PR TITLE
Call Ample.putGCCandidates on compaction completion

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
@@ -959,11 +959,12 @@ public class CompactionCoordinator implements CompactionCoordinatorService.Iface
         var result = tabletsMutator.process().get(extent);
         if (result.getStatus() == Ample.ConditionalResult.Status.ACCEPTED) {
           // compaction was committed, mark the compaction input files for deletion
-          // ELASTICITIY_TODO in the case of process death the GC candidates would never be added like #3811.  If
-          // compaction commit were moved to FATE per #3559 then this would not be an issue.  If compaction
-          // commit is never moved to FATE, then this addition could moved to the compaction refresh
-          // process. The compaction refresh procss will go away if compaction commit is moved to FATE, so 
-          // should only do this if not moving to FATE.
+          //
+          // ELASTICITIY_TODO in the case of process death the GC candidates would never be added
+          // like #3811. If compaction commit were moved to FATE per #3559 then this would not
+          // be an issue. If compaction commit is never moved to FATE, then this addition could
+          // moved to the compaction refresh process. The compaction refresh process will go away
+          // if compaction commit is moved to FATE, so should only do this if not moving to FATE.
           ctx.getAmple().putGcCandidates(extent.tableId(), ecm.getJobFiles());
           break;
         } else {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
@@ -959,6 +959,11 @@ public class CompactionCoordinator implements CompactionCoordinatorService.Iface
         var result = tabletsMutator.process().get(extent);
         if (result.getStatus() == Ample.ConditionalResult.Status.ACCEPTED) {
           // compaction was committed, mark the compaction input files for deletion
+          // ELASTICITIY_TODO in the case of process death the GC candidates would never be added like #3811.  If
+          // compaction commit were moved to FATE per #3559 then this would not be an issue.  If compaction
+          // commit is never moved to FATE, then this addition could moved to the compaction refresh
+          // process. The compaction refresh procss will go away if compaction commit is moved to FATE, so 
+          // should only do this if not moving to FATE.
           ctx.getAmple().putGcCandidates(extent.tableId(), ecm.getJobFiles());
           break;
         } else {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
@@ -958,7 +958,8 @@ public class CompactionCoordinator implements CompactionCoordinatorService.Iface
         // ELASTICITY_TODO check return value and retry, could fail because of race conditions
         var result = tabletsMutator.process().get(extent);
         if (result.getStatus() == Ample.ConditionalResult.Status.ACCEPTED) {
-          // compaction was committed
+          // compaction was committed, mark the compaction input files for deletion
+          ctx.getAmple().putGcCandidates(extent.tableId(), ecm.getJobFiles());
           break;
         } else {
           // compaction failed to commit, maybe something changed on the tablet so lets reread the

--- a/test/src/main/java/org/apache/accumulo/test/GCRunIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/GCRunIT.java
@@ -151,7 +151,7 @@ public class GCRunIT extends SharedMiniClusterBase {
    * GCRun need to support injecting synthetic row data, or another solution is required.
    */
   @Test
-  @Disabled("deleting prev row causes scan to fail before row read validation")
+  @Disabled("disabled since test creation, deleting prev row causes scan to fail before row read validation")
   public void forceMissingPrevRowTest() {}
 
   private void scanReferences(GCRun userGC) {

--- a/test/src/main/java/org/apache/accumulo/test/GarbageCollectWALIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/GarbageCollectWALIT.java
@@ -39,10 +39,8 @@ import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RawLocalFileSystem;
 import org.apache.hadoop.fs.RemoteIterator;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-@Disabled // ELASTICITY_TODO
 public class GarbageCollectWALIT extends ConfigurableMacBase {
 
   @Override

--- a/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorIT.java
@@ -79,7 +79,6 @@ import org.apache.hadoop.fs.RawLocalFileSystem;
 import org.apache.hadoop.io.Text;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.NoNodeException;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -129,7 +128,6 @@ public class GarbageCollectorIT extends ConfigurableMacBase {
   }
 
   @Test
-  @Disabled // ELASTICITY_TODO
   public void gcTest() throws Exception {
     killMacGc();
     final String table = "test_ingest";

--- a/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorTrashDefaultIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorTrashDefaultIT.java
@@ -36,11 +36,9 @@ import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FileSystem;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 // verify trash is not used with Hadoop defaults, since Trash is not enabled by default
-@Disabled // ELASTICITY_TODO
 public class GarbageCollectorTrashDefaultIT extends GarbageCollectorTrashBase {
 
   @Override

--- a/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorTrashEnabledIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorTrashEnabledIT.java
@@ -36,11 +36,9 @@ import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FileSystem;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 // verify that trash is used if Hadoop is configured to use it
-@Disabled // ELASTICITY_TODO
 public class GarbageCollectorTrashEnabledIT extends GarbageCollectorTrashBase {
 
   @Override

--- a/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorTrashEnabledWithCustomPolicyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorTrashEnabledWithCustomPolicyIT.java
@@ -40,11 +40,9 @@ import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.TrashPolicyDefault;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 // verify that trash is used if Hadoop is configured to use it and that using a custom policy works
-@Disabled // ELASTICITY_TODO
 public class GarbageCollectorTrashEnabledWithCustomPolicyIT extends GarbageCollectorTrashBase {
 
   public static class NoFlushFilesInTrashPolicy extends TrashPolicyDefault {


### PR DESCRIPTION
The call to putGCCandidates was lost in #3604 with the removal of ManagerMetadataUtil.replaceDatafiles.