### PR TITLE
modifies FATE to use a single thread to find work

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/AgeOffStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/AgeOffStore.java
@@ -20,10 +20,12 @@ package org.apache.accumulo.core.fate;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -149,11 +151,6 @@ public class AgeOffStore<T> implements FateStore<T> {
   }
 
   @Override
-  public FateTxStore<T> reserve() {
-    return new AgeOffFateTxStore(store.reserve());
-  }
-
-  @Override
   public FateTxStore<T> reserve(long tid) {
     return new AgeOffFateTxStore(store.reserve(tid));
   }
@@ -203,5 +200,10 @@ public class AgeOffStore<T> implements FateStore<T> {
   @Override
   public List<Long> list() {
     return store.list();
+  }
+
+  @Override
+  public Iterator<Long> runnable(AtomicBoolean keepWaiting) {
+    return store.runnable(keepWaiting);
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
@@ -73,7 +73,6 @@ public class Fate<T> {
 
   private final AtomicBoolean keepRunning = new AtomicBoolean(true);
   private final TransferQueue<Long> workQueue;
-  private final SignalCount idleWorkerCount = new SignalCount();
   private final Thread workFinder;
 
   public enum TxInfo {

--- a/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
@@ -95,6 +95,11 @@ public class Fate<T> {
             Long txid = iter.next();
             try {
               while (keepRunning.get()) {
+                // The reason for calling transfer instead of queueing is avoid rescanning the
+                // storage layer and adding the same thing over and over. For example if all threads
+                // were busy, the queue size was 100, and there are three runnable things in the
+                // store. Do not want to keep scanning the store adding those same 3 runnable things
+                // until the queue is full.
                 if (workQueue.tryTransfer(txid, 100, MILLISECONDS)) {
                   break;
                 }

--- a/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
@@ -88,10 +88,8 @@ public class Fate<T> {
 
     @Override
     public void run() {
-
-      try {
-
-        while (keepRunning.get()) {
+      while (keepRunning.get()) {
+        try {
           var iter = store.runnable(keepRunning);
 
           while (iter.hasNext() && keepRunning.get()) {
@@ -107,15 +105,15 @@ public class Fate<T> {
               throw new IllegalStateException(e);
             }
           }
-        }
-      } catch (Exception e) {
-        if (keepRunning.get()) {
-          log.warn("Failure while attempting to find work for fate", e);
-        } else {
-          log.debug("Failure while attempting to find work for fate", e);
-        }
+        } catch (Exception e) {
+          if (keepRunning.get()) {
+            log.warn("Failure while attempting to find work for fate", e);
+          } else {
+            log.debug("Failure while attempting to find work for fate", e);
+          }
 
-        workQueue.clear();
+          workQueue.clear();
+        }
       }
     }
   }

--- a/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
@@ -75,14 +75,14 @@ public class Fate<T> {
 
   private final AtomicBoolean keepRunning = new AtomicBoolean(true);
   private final BlockingQueue<Long> workQueue;
-  private final SingalCount idleWorkerCount = new SingalCount();
+  private final SignalCount idleWorkerCount = new SignalCount();
   private final Thread workFinder;
 
   public enum TxInfo {
     TX_NAME, AUTO_CLEAN, EXCEPTION, RETURN_VALUE
   }
 
-  private class SingalCount {
+  private class SignalCount {
     long count;
 
     synchronized void increment() {

--- a/core/src/main/java/org/apache/accumulo/core/fate/FateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/FateStore.java
@@ -38,6 +38,9 @@ public interface FateStore<T> extends ReadOnlyFateStore<T> {
    */
   long create();
 
+  /**
+   * An interface that allows read/write access to the data related to a single fate operation.
+   */
   interface FateTxStore<T> extends ReadOnlyFateTxStore<T> {
     @Override
     Repo<T> top();
@@ -81,8 +84,8 @@ public interface FateStore<T> extends ReadOnlyFateStore<T> {
      * upon successful return the store now controls the referenced transaction id. caller should no
      * longer interact with it.
      *
-     * @param deferTime time in millis to keep this transaction out of the pool used in the
-     *        {@link #reserve() reserve} method. must be non-negative.
+     * @param deferTime time in millis to keep this transaction from being returned by
+     *        {@link #runnable()}. Must be non-negative.
      */
     void unreserve(long deferTime);
   }
@@ -103,15 +106,5 @@ public interface FateStore<T> extends ReadOnlyFateStore<T> {
    *
    */
   FateTxStore<T> reserve(long tid);
-
-  /**
-   * Reserve a transaction that is IN_PROGRESS or FAILED_IN_PROGRESS.
-   *
-   * Reserving a transaction id ensures that nothing else in-process interacting via the same
-   * instance will be operating on that transaction id.
-   *
-   * @return a transaction id that is safe to interact with, chosen by the store.
-   */
-  FateTxStore<T> reserve();
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/fate/FateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/FateStore.java
@@ -85,7 +85,7 @@ public interface FateStore<T> extends ReadOnlyFateStore<T> {
      * longer interact with it.
      *
      * @param deferTime time in millis to keep this transaction from being returned by
-     *        {@link #runnable()}. Must be non-negative.
+     *        {@link #runnable(java.util.concurrent.atomic.AtomicBoolean)}. Must be non-negative.
      */
     void unreserve(long deferTime);
   }

--- a/core/src/main/java/org/apache/accumulo/core/fate/ReadOnlyFateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/ReadOnlyFateStore.java
@@ -20,7 +20,9 @@ package org.apache.accumulo.core.fate;
 
 import java.io.Serializable;
 import java.util.EnumSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Read only access to a Transaction Store.
@@ -121,4 +123,11 @@ public interface ReadOnlyFateStore<T> {
    * @return all outstanding transactions, including those reserved by others.
    */
   List<Long> list();
+
+  /**
+   * @return an iterator over fate op ids that are (IN_PROGRESS or FAILED_IN_PROGRESS) and
+   *         unreserved. This method will block until it finds something that is runnable or until
+   *         the keepWaiting parameter is false.
+   */
+  Iterator<Long> runnable(AtomicBoolean keepWaiting);
 }

--- a/core/src/main/java/org/apache/accumulo/core/fate/SignalCount.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/SignalCount.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.fate;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+import java.util.function.LongPredicate;
+
+import com.google.common.base.Preconditions;
+
+class SignalCount {
+  private long count = 0;
+
+  synchronized void increment() {
+    count++;
+    this.notifyAll();
+  }
+
+  synchronized void decrement() {
+    Preconditions.checkState(count > 0);
+    count--;
+    this.notifyAll();
+  }
+
+  synchronized long getCount() {
+    return count;
+  }
+
+  synchronized boolean waitFor(LongPredicate predicate, BooleanSupplier keepWaiting) {
+    return waitFor(predicate, Long.MAX_VALUE, keepWaiting);
+  }
+
+  synchronized boolean waitFor(LongPredicate predicate, long maxWait, BooleanSupplier keepWaiting) {
+    Preconditions.checkArgument(maxWait >= 0);
+
+    if (maxWait == 0) {
+      return predicate.test(count);
+    }
+
+    long start = System.nanoTime();
+
+    while (!predicate.test(count) && keepWaiting.getAsBoolean()
+        && TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start) < maxWait) {
+      try {
+        wait(100);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IllegalStateException(e);
+      }
+    }
+
+    return predicate.test(count);
+  }
+}

--- a/core/src/main/java/org/apache/accumulo/core/fate/ZooStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/ZooStore.java
@@ -333,7 +333,7 @@ public class ZooStore<T> implements FateStore<T> {
           return status;
         }
 
-        waitForChange(tid, 5000);
+        waitForChange(tid, 1000);
       }
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/logging/FateLogger.java
+++ b/core/src/main/java/org/apache/accumulo/core/logging/FateLogger.java
@@ -21,8 +21,10 @@ package org.apache.accumulo.core.logging;
 import static org.apache.accumulo.core.fate.FateTxId.formatTid;
 
 import java.io.Serializable;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
 import org.apache.accumulo.core.fate.Fate;
@@ -98,11 +100,6 @@ public class FateLogger {
     return new FateStore<>() {
 
       @Override
-      public FateTxStore<T> reserve() {
-        return new LoggingFateTxStore<>(store.reserve(), toLogString);
-      }
-
-      @Override
       public FateTxStore<T> reserve(long tid) {
         return new LoggingFateTxStore<>(store.reserve(tid), toLogString);
       }
@@ -120,6 +117,11 @@ public class FateLogger {
       @Override
       public List<Long> list() {
         return store.list();
+      }
+
+      @Override
+      public Iterator<Long> runnable(AtomicBoolean keepWaiting) {
+        return store.runnable(keepWaiting);
       }
 
       @Override

--- a/core/src/test/java/org/apache/accumulo/core/fate/TestStore.java
+++ b/core/src/test/java/org/apache/accumulo/core/fate/TestStore.java
@@ -23,10 +23,12 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Transient in memory store for transactions.
@@ -51,11 +53,6 @@ public class TestStore implements FateStore<String> {
     // twice... if test change, then change this
     reserved.add(tid);
     return new TestFateTxStore(tid);
-  }
-
-  @Override
-  public FateTxStore<String> reserve() {
-    throw new UnsupportedOperationException();
   }
 
   @Override
@@ -170,6 +167,11 @@ public class TestStore implements FateStore<String> {
   @Override
   public List<Long> list() {
     return new ArrayList<>(statuses.keySet());
+  }
+
+  @Override
+  public Iterator<Long> runnable(AtomicBoolean keepWaiting) {
+    throw new UnsupportedOperationException();
   }
 
 }

--- a/test/src/main/java/org/apache/accumulo/test/ComprehensiveIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ComprehensiveIT.java
@@ -148,7 +148,10 @@ public class ComprehensiveIT extends SharedMiniClusterBase {
   public void testMergeAndSplit() throws Exception {
     String table = getUniqueNames(1)[0];
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
+      long t1 = System.currentTimeMillis();
       client.tableOperations().create(table);
+      long t2 = System.currentTimeMillis();
+      System.out.println("create time " + (t2 - t1));
 
       final SortedMap<Key,Value> expectedData = generateKeys(0, 300);
 
@@ -158,23 +161,35 @@ public class ComprehensiveIT extends SharedMiniClusterBase {
 
       // test adding splits to a table
       var splits = new TreeSet<>(List.of(new Text(row(75)), new Text(row(150))));
+      t1 = System.currentTimeMillis();
       client.tableOperations().addSplits(table, splits);
+      t2 = System.currentTimeMillis();
+      System.out.println("split time " + (t2 - t1));
       assertEquals(splits, new TreeSet<>(client.tableOperations().listSplits(table)));
       // adding splits should not change data
       verifyData(client, table, AUTHORIZATIONS, expectedData);
 
+      t1 = System.currentTimeMillis();
       // test merging splits away
       client.tableOperations().merge(table, null, null);
+      t2 = System.currentTimeMillis();
+      System.out.println("merge time " + (t2 - t1));
       assertEquals(Set.of(), new TreeSet<>(client.tableOperations().listSplits(table)));
       // merging should not change data
       verifyData(client, table, AUTHORIZATIONS, expectedData);
 
       splits = new TreeSet<>(List.of(new Text(row(33)), new Text(row(66))));
+      t1 = System.currentTimeMillis();
       client.tableOperations().addSplits(table, splits);
+      t2 = System.currentTimeMillis();
+      System.out.println("split time " + (t2 - t1));
       assertEquals(splits, new TreeSet<>(client.tableOperations().listSplits(table)));
       verifyData(client, table, AUTHORIZATIONS, expectedData);
 
+      t1 = System.currentTimeMillis();
       client.tableOperations().merge(table, null, null);
+      t2 = System.currentTimeMillis();
+      System.out.println("merge time " + (t2 - t1));
       assertEquals(Set.of(), new TreeSet<>(client.tableOperations().listSplits(table)));
       verifyData(client, table, AUTHORIZATIONS, expectedData);
     }

--- a/test/src/main/java/org/apache/accumulo/test/ComprehensiveIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ComprehensiveIT.java
@@ -148,10 +148,7 @@ public class ComprehensiveIT extends SharedMiniClusterBase {
   public void testMergeAndSplit() throws Exception {
     String table = getUniqueNames(1)[0];
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-      long t1 = System.currentTimeMillis();
       client.tableOperations().create(table);
-      long t2 = System.currentTimeMillis();
-      System.out.println("create time " + (t2 - t1));
 
       final SortedMap<Key,Value> expectedData = generateKeys(0, 300);
 
@@ -161,35 +158,23 @@ public class ComprehensiveIT extends SharedMiniClusterBase {
 
       // test adding splits to a table
       var splits = new TreeSet<>(List.of(new Text(row(75)), new Text(row(150))));
-      t1 = System.currentTimeMillis();
       client.tableOperations().addSplits(table, splits);
-      t2 = System.currentTimeMillis();
-      System.out.println("split time " + (t2 - t1));
       assertEquals(splits, new TreeSet<>(client.tableOperations().listSplits(table)));
       // adding splits should not change data
       verifyData(client, table, AUTHORIZATIONS, expectedData);
 
-      t1 = System.currentTimeMillis();
       // test merging splits away
       client.tableOperations().merge(table, null, null);
-      t2 = System.currentTimeMillis();
-      System.out.println("merge time " + (t2 - t1));
       assertEquals(Set.of(), new TreeSet<>(client.tableOperations().listSplits(table)));
       // merging should not change data
       verifyData(client, table, AUTHORIZATIONS, expectedData);
 
       splits = new TreeSet<>(List.of(new Text(row(33)), new Text(row(66))));
-      t1 = System.currentTimeMillis();
       client.tableOperations().addSplits(table, splits);
-      t2 = System.currentTimeMillis();
-      System.out.println("split time " + (t2 - t1));
       assertEquals(splits, new TreeSet<>(client.tableOperations().listSplits(table)));
       verifyData(client, table, AUTHORIZATIONS, expectedData);
 
-      t1 = System.currentTimeMillis();
       client.tableOperations().merge(table, null, null);
-      t2 = System.currentTimeMillis();
-      System.out.println("merge time " + (t2 - t1));
       assertEquals(Set.of(), new TreeSet<>(client.tableOperations().listSplits(table)));
       verifyData(client, table, AUTHORIZATIONS, expectedData);
     }


### PR DESCRIPTION
This change modifies FATE to use singe thread to find work.  It also cleans up some of the signaling between threads in FATE and fixes a synchronization bug in FATE that was introduced in #4017.  The bug introduced in #4017 is that somethings are syncronizing on the wrong object because a new inner class was introduced.

These changes were pulled from #3964 and cleaned up and improved.