### PR TITLE
Remove active FateTx constraint for bulk import

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/MutationsRejectedException.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/MutationsRejectedException.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.client.security.SecurityErrorCode;
 import org.apache.accumulo.core.clientImpl.ClientContext;
@@ -59,8 +60,11 @@ public class MutationsRejectedException extends AccumuloException {
       Map<TabletId,Set<SecurityErrorCode>> hashMap, Collection<String> serverSideErrors,
       int unknownErrors, Throwable cause) {
     super(
-        "# constraint violations : " + cvsList.size() + "  security codes: " + hashMap.toString()
-            + "  # server errors " + serverSideErrors.size() + " # exceptions " + unknownErrors,
+        "# constraint violations : "
+            + cvsList.stream().map(ConstraintViolationSummary::getViolationCode)
+                .collect(Collectors.toSet())
+            + "  security codes: " + hashMap.toString() + "  # server errors "
+            + serverSideErrors.size() + " # exceptions " + unknownErrors,
         cause);
     this.cvsl.addAll(cvsList);
     this.af.putAll(hashMap);
@@ -82,9 +86,13 @@ public class MutationsRejectedException extends AccumuloException {
   public MutationsRejectedException(AccumuloClient client, List<ConstraintViolationSummary> cvsList,
       Map<TabletId,Set<SecurityErrorCode>> hashMap, Collection<String> serverSideErrors,
       int unknownErrors, Throwable cause) {
-    super("# constraint violations : " + cvsList.size() + "  security codes: "
-        + format(hashMap, (ClientContext) client) + "  # server errors " + serverSideErrors.size()
-        + " # exceptions " + unknownErrors, cause);
+    super(
+        "# constraint violations : "
+            + cvsList.stream().map(ConstraintViolationSummary::getViolationCode).collect(
+                Collectors.toSet())
+            + "  security codes: " + format(hashMap, (ClientContext) client) + "  # server errors "
+            + serverSideErrors.size() + " # exceptions " + unknownErrors,
+        cause);
     this.cvsl.addAll(cvsList);
     this.af.putAll(hashMap);
     this.es.addAll(serverSideErrors);

--- a/core/src/main/java/org/apache/accumulo/core/client/MutationsRejectedException.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/MutationsRejectedException.java
@@ -60,7 +60,7 @@ public class MutationsRejectedException extends AccumuloException {
       Map<TabletId,Set<SecurityErrorCode>> hashMap, Collection<String> serverSideErrors,
       int unknownErrors, Throwable cause) {
     super(
-        "# constraint violations : "
+        "constraint violation codes : "
             + cvsList.stream().map(ConstraintViolationSummary::getViolationCode)
                 .collect(Collectors.toSet())
             + "  security codes: " + hashMap.toString() + "  # server errors "
@@ -87,7 +87,7 @@ public class MutationsRejectedException extends AccumuloException {
       Map<TabletId,Set<SecurityErrorCode>> hashMap, Collection<String> serverSideErrors,
       int unknownErrors, Throwable cause) {
     super(
-        "# constraint violations : "
+        "constraint violation codes : "
             + cvsList.stream().map(ConstraintViolationSummary::getViolationCode).collect(
                 Collectors.toSet())
             + "  security codes: " + format(hashMap, (ClientContext) client) + "  # server errors "


### PR DESCRIPTION
Removes the active FateTx ID constraint for metadata mutations when creating bulk import file markers.

Also changes the MutationsRejectedException to return the violation type code.
closes #4047 