### PR TITLE
Remove redundant LogEntry value (#3997)

### DIFF
--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
@@ -59,7 +59,6 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.Cu
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.FutureLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LastLocationColumnFamily;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LogColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ScanFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.SuspendLocationColumn;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
@@ -104,11 +103,9 @@ public class TabletMetadataTest {
     mutation.at().family(LastLocationColumnFamily.NAME).qualifier("s000").put("server2:8555");
 
     LogEntry le1 = new LogEntry("localhost:8020/" + UUID.randomUUID());
-    mutation.at().family(LogColumnFamily.NAME).qualifier(le1.getColumnQualifier())
-        .put(le1.getValue());
+    le1.addToMutation(mutation);
     LogEntry le2 = new LogEntry("localhost:8020/" + UUID.randomUUID());
-    mutation.at().family(LogColumnFamily.NAME).qualifier(le2.getColumnQualifier())
-        .put(le2.getValue());
+    le2.addToMutation(mutation);
 
     StoredTabletFile sf1 = StoredTabletFile.of(new Path("hdfs://nn1/acc/tables/1/t-0001/sf1.rf"));
     StoredTabletFile sf2 = StoredTabletFile.of(new Path("hdfs://nn1/acc/tables/1/t-0001/sf2.rf"));
@@ -140,8 +137,8 @@ public class TabletMetadataTest {
     assertEquals(HostAndPort.fromParts("server2", 8555), tm.getLast().getHostAndPort());
     assertEquals("s000", tm.getLast().getSession());
     assertEquals(LocationType.LAST, tm.getLast().getType());
-    assertEquals(Set.of(le1.getValue(), le2.getValue()),
-        tm.getLogs().stream().map(LogEntry::getValue).collect(toSet()));
+    assertEquals(Set.of(le1.getColumnQualifier(), le2.getColumnQualifier()),
+        tm.getLogs().stream().map(LogEntry::getColumnQualifier).collect(toSet()));
     assertEquals(extent.prevEndRow(), tm.getPrevEndRow());
     assertEquals(extent.tableId(), tm.getTableId());
     assertTrue(tm.sawPrevEndRow());

--- a/core/src/test/java/org/apache/accumulo/core/tabletserver/log/LogEntryTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/tabletserver/log/LogEntryTest.java
@@ -55,17 +55,15 @@ public class LogEntryTest {
     assertEquals(validFilename, one.getFilePath());
     assertEquals(new Text("-/" + validFilename), one.getColumnQualifier());
     assertEquals(validUUID.toString(), one.getUniqueID());
-    assertEquals(new Value(validFilename), one.getValue());
 
     // test from metadata entry
     LogEntry two = LogEntry.fromMetaWalEntry(new AbstractMap.SimpleImmutableEntry<>(
-        new Key(new Text("1<"), new Text("log"), one.getColumnQualifier()), one.getValue()));
+        new Key(new Text("1<"), new Text("log"), one.getColumnQualifier()), new Value("unused")));
     assertNotSame(one, two);
     assertEquals(one.toString(), two.toString());
     assertEquals(one.getFilePath(), two.getFilePath());
     assertEquals(one.getColumnQualifier(), two.getColumnQualifier());
     assertEquals(one.getUniqueID(), two.getUniqueID());
-    assertEquals(one.getValue(), two.getValue());
     assertEquals(one, two);
   }
 
@@ -79,7 +77,6 @@ public class LogEntryTest {
     assertEquals(one.getFilePath(), two.getFilePath());
     assertEquals(one.getColumnQualifier(), two.getColumnQualifier());
     assertEquals(one.getUniqueID(), two.getUniqueID());
-    assertEquals(one.getValue(), two.getValue());
     assertEquals(one, two);
 
     assertEquals(one, one);

--- a/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
@@ -213,7 +213,8 @@ public class MetadataConstraints implements Constraint {
         continue;
       }
 
-      if (columnUpdate.getValue().length == 0 && !columnFamily.equals(ScanFileColumnFamily.NAME)) {
+      if (columnUpdate.getValue().length == 0 && !(columnFamily.equals(ScanFileColumnFamily.NAME)
+          || columnFamily.equals(LogColumnFamily.NAME))) {
         violations = addViolation(violations, 6);
       }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeUtil.java
@@ -103,7 +103,7 @@ public class VolumeUtil {
       return null;
     }
 
-    LogEntry newLogEntry = le.switchFile(switchedString);
+    LogEntry newLogEntry = new LogEntry(switchedString);
 
     log.trace("Switched {} to {}", le, newLogEntry);
 

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorBase.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorBase.java
@@ -175,7 +175,7 @@ public abstract class TabletMutatorBase implements Ample.TabletMutator {
   @Override
   public Ample.TabletMutator putWal(LogEntry logEntry) {
     Preconditions.checkState(updatesEnabled, "Cannot make updates after calling mutate.");
-    mutation.put(LogColumnFamily.NAME, logEntry.getColumnQualifier(), logEntry.getValue());
+    logEntry.addToMutation(mutation);
     return this;
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/MissingWalHeaderCompletesRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MissingWalHeaderCompletesRecoveryIT.java
@@ -146,8 +146,7 @@ public class MissingWalHeaderCompletesRecoveryIT extends ConfigurableMacBase {
 
       Text row = TabletsSection.encodeRow(tableId, null);
       Mutation m = new Mutation(row);
-      m.put(TabletsSection.LogColumnFamily.NAME, logEntry.getColumnQualifier(),
-          logEntry.getValue());
+      logEntry.addToMutation(m);
 
       try (BatchWriter bw = client.createBatchWriter(MetadataTable.NAME)) {
         bw.addMutation(m);
@@ -205,8 +204,7 @@ public class MissingWalHeaderCompletesRecoveryIT extends ConfigurableMacBase {
 
       Text row = TabletsSection.encodeRow(tableId, null);
       Mutation m = new Mutation(row);
-      m.put(TabletsSection.LogColumnFamily.NAME, logEntry.getColumnQualifier(),
-          logEntry.getValue());
+      logEntry.addToMutation(m);
 
       try (BatchWriter bw = client.createBatchWriter(MetadataTable.NAME)) {
         bw.addMutation(m);

--- a/test/src/main/java/org/apache/accumulo/test/manager/MergeStateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/manager/MergeStateIT.java
@@ -204,8 +204,7 @@ public class MergeStateIT extends ConfigurableMacBase {
       KeyExtent ke = new KeyExtent(tableId, new Text("t"), new Text("p"));
       m = new Mutation(ke.toMetaRow());
       LogEntry logEntry = new LogEntry("localhost:1234/" + UUID.randomUUID());
-      m.at().family(LogColumnFamily.NAME).qualifier(logEntry.getColumnQualifier())
-          .put(logEntry.getValue());
+      logEntry.addToMutation(m);
       update(accumuloClient, m);
 
       // Verify state is still WAITING_FOR_OFFLINE


### PR DESCRIPTION
Remove the `LogEntry.getValue()` method and use the column qualifier for the file path, without the redundant storage in the Value

* Remove `getValue()` method and use empty `new Value()`
* Create addToMutation method to remove boilerplate for storing the LogEntry in the metadata
* Strictly validate the metadata log entries' column qualifier

This re-applies the reverted change for this ticket, 0cdf6dd2de0ca382c3881169bfe90c3bbd4367b3, but without the renaming of filePath to logReference, since with further analysis of the schema, it was discovered that these are, in fact, file paths, and not just generic references to log IDs.

This re-application also removes the metadata constraint that expected the value to be non-empty, which was overlooked on the first attempt.

---------