### PR TITLE
Update javadoc to indicate composite view returned or not

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/admin/NamespaceOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/NamespaceOperations.java
@@ -184,8 +184,8 @@ public interface NamespaceOperations {
       throws AccumuloException, AccumuloSecurityException, NamespaceNotFoundException;
 
   /**
-   * Gets properties of a namespace, which are inherited by tables in this namespace. Note that
-   * recently changed properties may not be available immediately. Method calls
+   * Gets a merged view of the properties of a namespace, which are inherited by tables in this
+   * namespace. Note that recently changed properties may not be available immediately. Method calls
    * {@link #getConfiguration(String)} and then calls .entrySet() on the map.
    *
    * @param namespace the name of the namespace
@@ -202,9 +202,9 @@ public interface NamespaceOperations {
   }
 
   /**
-   * Gets properties of a namespace, which are inherited by tables in this namespace. Note that
-   * recently changed properties may not be available immediately. This new method returns a Map
-   * instead of an Iterable.
+   * Gets a merged view of the properties of a namespace, which are inherited by tables in this
+   * namespace. Note that recently changed properties may not be available immediately. This new
+   * method returns a Map instead of an Iterable.
    *
    * @param namespace the name of the namespace
    * @return all properties visible by this namespace (system and per-table properties). Note that
@@ -218,8 +218,9 @@ public interface NamespaceOperations {
       throws AccumuloException, AccumuloSecurityException, NamespaceNotFoundException;
 
   /**
-   * Gets properties specific to this namespace. Note that recently changed properties may not be
-   * available immediately. This new method returns a Map instead of an Iterable.
+   * Gets properties specific to this namespace. Note that this does not return a merged view of the
+   * properties. Also note that recently changed properties may not be available immediately. This
+   * new method returns a Map instead of an Iterable.
    *
    * @param namespace the name of the namespace
    * @return per-table properties specific to this namespace. Note that recently changed properties

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/NamespaceOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/NamespaceOperations.java
@@ -205,7 +205,7 @@ public interface NamespaceOperations {
   /**
    * Gets a merged view of the properties of a namespace from its parent configuration. These
    * properties are inherited by tables in this namespace. Note that recently changed properties may
-   * not be available immediately. This new method returns a Map instead of an Iterable.
+   * not be available immediately. This method returns a Map instead of an Iterable.
    *
    * @param namespace the name of the namespace
    * @return all properties visible by this namespace (system and per-table properties). Note that
@@ -221,7 +221,7 @@ public interface NamespaceOperations {
   /**
    * Gets properties specific to this namespace. Note that this does not return a merged view of the
    * properties from its parent configuration. Also note that recently changed properties may not be
-   * available immediately. This new method returns a Map instead of an Iterable.
+   * available immediately. This method returns a Map instead of an Iterable.
    *
    * @param namespace the name of the namespace
    * @return per-table properties specific to this namespace. Note that recently changed properties

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/NamespaceOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/NamespaceOperations.java
@@ -184,9 +184,10 @@ public interface NamespaceOperations {
       throws AccumuloException, AccumuloSecurityException, NamespaceNotFoundException;
 
   /**
-   * Gets a merged view of the properties of a namespace, which are inherited by tables in this
-   * namespace. Note that recently changed properties may not be available immediately. Method calls
-   * {@link #getConfiguration(String)} and then calls .entrySet() on the map.
+   * Gets a merged view of the properties of a namespace from its parent configuration. These
+   * properties are inherited by tables in this namespace. Note that recently changed properties may
+   * not be available immediately. Method calls {@link #getConfiguration(String)} and then calls
+   * .entrySet() on the map.
    *
    * @param namespace the name of the namespace
    * @return all properties visible by this namespace (system and per-table properties). Note that
@@ -202,9 +203,9 @@ public interface NamespaceOperations {
   }
 
   /**
-   * Gets a merged view of the properties of a namespace, which are inherited by tables in this
-   * namespace. Note that recently changed properties may not be available immediately. This new
-   * method returns a Map instead of an Iterable.
+   * Gets a merged view of the properties of a namespace from its parent configuration. These
+   * properties are inherited by tables in this namespace. Note that recently changed properties may
+   * not be available immediately. This new method returns a Map instead of an Iterable.
    *
    * @param namespace the name of the namespace
    * @return all properties visible by this namespace (system and per-table properties). Note that
@@ -219,8 +220,8 @@ public interface NamespaceOperations {
 
   /**
    * Gets properties specific to this namespace. Note that this does not return a merged view of the
-   * properties. Also note that recently changed properties may not be available immediately. This
-   * new method returns a Map instead of an Iterable.
+   * properties from its parent configuration. Also note that recently changed properties may not be
+   * available immediately. This new method returns a Map instead of an Iterable.
    *
    * @param namespace the name of the namespace
    * @return per-table properties specific to this namespace. Note that recently changed properties

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/NamespaceOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/NamespaceOperations.java
@@ -184,7 +184,7 @@ public interface NamespaceOperations {
       throws AccumuloException, AccumuloSecurityException, NamespaceNotFoundException;
 
   /**
-   * Gets a merged view of the properties of a namespace from its parent configuration. These
+   * Gets a merged view of the properties of a namespace with its parent configuration. These
    * properties are inherited by tables in this namespace. Note that recently changed properties may
    * not be available immediately. Method calls {@link #getConfiguration(String)} and then calls
    * .entrySet() on the map.
@@ -203,7 +203,7 @@ public interface NamespaceOperations {
   }
 
   /**
-   * Gets a merged view of the properties of a namespace from its parent configuration. These
+   * Gets a merged view of the properties of a namespace with its parent configuration. These
    * properties are inherited by tables in this namespace. Note that recently changed properties may
    * not be available immediately. This method returns a Map instead of an Iterable.
    *
@@ -220,7 +220,7 @@ public interface NamespaceOperations {
 
   /**
    * Gets properties specific to this namespace. Note that this does not return a merged view of the
-   * properties from its parent configuration. Also note that recently changed properties may not be
+   * properties with its parent configuration. Also note that recently changed properties may not be
    * available immediately. This method returns a Map instead of an Iterable.
    *
    * @param namespace the name of the namespace

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
@@ -553,11 +553,11 @@ public interface TableOperations {
       throws AccumuloException, AccumuloSecurityException;
 
   /**
-   * Gets properties of a table. This operation is asynchronous and eventually consistent. It is not
-   * guaranteed that all tablets in a table will return the same values. Within a few seconds
-   * without another change, all tablets in a table should be consistent. The clone table feature
-   * can be used if consistency is required. Method calls {@link #getConfiguration(String)} and then
-   * calls .entrySet() on the map.
+   * Gets a merged view of the properties of a table. This operation is asynchronous and eventually
+   * consistent. It is not guaranteed that all tablets in a table will return the same values.
+   * Within a few seconds without another change, all tablets in a table should be consistent. The
+   * clone table feature can be used if consistency is required. Method calls
+   * {@link #getConfiguration(String)} and then calls .entrySet() on the map.
    *
    * @param tableName the name of the table
    * @return all properties visible by this table (system and per-table properties). Note that
@@ -571,10 +571,11 @@ public interface TableOperations {
   }
 
   /**
-   * Gets properties of a table. This operation is asynchronous and eventually consistent. It is not
-   * guaranteed that all tablets in a table will return the same values. Within a few seconds
-   * without another change, all tablets in a table should be consistent. The clone table feature
-   * can be used if consistency is required. This new method returns a Map instead of an Iterable.
+   * Gets a merged view of the properties of a table. This operation is asynchronous and eventually
+   * consistent. It is not guaranteed that all tablets in a table will return the same values.
+   * Within a few seconds without another change, all tablets in a table should be consistent. The
+   * clone table feature can be used if consistency is required. This new method returns a Map
+   * instead of an Iterable.
    *
    * @param tableName the name of the table
    * @return all properties visible by this table (system and per-table properties). Note that
@@ -586,10 +587,11 @@ public interface TableOperations {
       throws AccumuloException, TableNotFoundException;
 
   /**
-   * Gets per-table properties of a table. This operation is asynchronous and eventually consistent.
-   * It is not guaranteed that all tablets in a table will return the same values. Within a few
-   * seconds without another change, all tablets in a table should be consistent. The clone table
-   * feature can be used if consistency is required.
+   * Gets per-table properties of a table. Note that this does not return a merged view of the
+   * properties. This operation is asynchronous and eventually consistent. It is not guaranteed that
+   * all tablets in a table will return the same values. Within a few seconds without another
+   * change, all tablets in a table should be consistent. The clone table feature can be used if
+   * consistency is required.
    *
    * @param tableName the name of the table
    * @return per-table properties visible by this table. Note that recently changed properties may

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
@@ -553,7 +553,7 @@ public interface TableOperations {
       throws AccumuloException, AccumuloSecurityException;
 
   /**
-   * Gets a merged view of the properties of a table from its parent configuration. This operation
+   * Gets a merged view of the properties of a table with its parent configuration. This operation
    * is asynchronous and eventually consistent. It is not guaranteed that all tablets in a table
    * will return the same values. Within a few seconds without another change, all tablets in a
    * table should be consistent. The clone table feature can be used if consistency is required.
@@ -571,7 +571,7 @@ public interface TableOperations {
   }
 
   /**
-   * Gets a merged view of the properties of a table from its parent configuration. This operation
+   * Gets a merged view of the properties of a table with its parent configuration. This operation
    * is asynchronous and eventually consistent. It is not guaranteed that all tablets in a table
    * will return the same values. Within a few seconds without another change, all tablets in a
    * table should be consistent. The clone table feature can be used if consistency is required.
@@ -588,7 +588,7 @@ public interface TableOperations {
 
   /**
    * Gets per-table properties of a table. Note that this does not return a merged view of the
-   * properties from its parent configuration. This operation is asynchronous and eventually
+   * properties with its parent configuration. This operation is asynchronous and eventually
    * consistent. It is not guaranteed that all tablets in a table will return the same values.
    * Within a few seconds without another change, all tablets in a table should be consistent. The
    * clone table feature can be used if consistency is required.

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
@@ -553,11 +553,11 @@ public interface TableOperations {
       throws AccumuloException, AccumuloSecurityException;
 
   /**
-   * Gets a merged view of the properties of a table. This operation is asynchronous and eventually
-   * consistent. It is not guaranteed that all tablets in a table will return the same values.
-   * Within a few seconds without another change, all tablets in a table should be consistent. The
-   * clone table feature can be used if consistency is required. Method calls
-   * {@link #getConfiguration(String)} and then calls .entrySet() on the map.
+   * Gets a merged view of the properties of a table from its parent configuration. This operation
+   * is asynchronous and eventually consistent. It is not guaranteed that all tablets in a table
+   * will return the same values. Within a few seconds without another change, all tablets in a
+   * table should be consistent. The clone table feature can be used if consistency is required.
+   * Method calls {@link #getConfiguration(String)} and then calls .entrySet() on the map.
    *
    * @param tableName the name of the table
    * @return all properties visible by this table (system and per-table properties). Note that
@@ -571,11 +571,11 @@ public interface TableOperations {
   }
 
   /**
-   * Gets a merged view of the properties of a table. This operation is asynchronous and eventually
-   * consistent. It is not guaranteed that all tablets in a table will return the same values.
-   * Within a few seconds without another change, all tablets in a table should be consistent. The
-   * clone table feature can be used if consistency is required. This new method returns a Map
-   * instead of an Iterable.
+   * Gets a merged view of the properties of a table from its parent configuration. This operation
+   * is asynchronous and eventually consistent. It is not guaranteed that all tablets in a table
+   * will return the same values. Within a few seconds without another change, all tablets in a
+   * table should be consistent. The clone table feature can be used if consistency is required.
+   * This new method returns a Map instead of an Iterable.
    *
    * @param tableName the name of the table
    * @return all properties visible by this table (system and per-table properties). Note that
@@ -588,10 +588,10 @@ public interface TableOperations {
 
   /**
    * Gets per-table properties of a table. Note that this does not return a merged view of the
-   * properties. This operation is asynchronous and eventually consistent. It is not guaranteed that
-   * all tablets in a table will return the same values. Within a few seconds without another
-   * change, all tablets in a table should be consistent. The clone table feature can be used if
-   * consistency is required.
+   * properties from its parent configuration. This operation is asynchronous and eventually
+   * consistent. It is not guaranteed that all tablets in a table will return the same values.
+   * Within a few seconds without another change, all tablets in a table should be consistent. The
+   * clone table feature can be used if consistency is required.
    *
    * @param tableName the name of the table
    * @return per-table properties visible by this table. Note that recently changed properties may

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
@@ -575,7 +575,7 @@ public interface TableOperations {
    * is asynchronous and eventually consistent. It is not guaranteed that all tablets in a table
    * will return the same values. Within a few seconds without another change, all tablets in a
    * table should be consistent. The clone table feature can be used if consistency is required.
-   * This new method returns a Map instead of an Iterable.
+   * This method returns a Map instead of an Iterable.
    *
    * @param tableName the name of the table
    * @return all properties visible by this table (system and per-table properties). Note that


### PR DESCRIPTION
closes #4038 

InstanceOperations:
Did not find any changes needed to be made:
- modifyProperties() returns non-composite (System level only) view as
  stated in the javadocs
- getSystemConfiguration() returns composite view as stated in the
  javadocs
- getSiteConfiguration() returns non-composite (Site level only) view as
  stated in the javadocs

NamespaceOperations:
- modifyProperties() returns non-composite (Namespace level only) view
  as stated in the javadocs (no changes here)
- getProperties() returns a composite view. Updated javadocs.
- getConfiguration() returns a composite view. Updated javadocs.
- getNamespaceProperties() returns a non-composite (Namespace level
  only) view. Updated javadocs.

TableOperations:
- modifyProperties() returns non-composite (Table level only) view
  as stated in the javadocs (no changes here)
- getProperties() returns a composite view. Updated javadocs.
- getConfiguration() returns a composite view. Updated javadocs.
- getTableProperties() returns a non-composite (Table level
  only) view. Updated javadocs.

No other methods were applicable.