### PR TITLE
Handle exception when compaction queue is empty

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/queue/CompactionJobPriorityQueue.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/queue/CompactionJobPriorityQueue.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -159,11 +158,10 @@ public class CompactionJobPriorityQueue {
   }
 
   public synchronized long getLowestPriority() {
-    CompactionJobPriorityQueue.CjpqKey highestJob = null;
-    try {
-      highestJob = jobQueue.lastKey();
-    } catch (NoSuchElementException e) {}
-    return highestJob == null ? 0 : highestJob.job.getPriority();
+    if (jobQueue.isEmpty()) {
+      return 0;
+    }
+    return jobQueue.lastKey().job.getPriority();
   }
 
   public synchronized CompactionJobQueues.MetaJob poll() {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/queue/CompactionJobPriorityQueue.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/queue/CompactionJobPriorityQueue.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -158,7 +159,11 @@ public class CompactionJobPriorityQueue {
   }
 
   public synchronized long getLowestPriority() {
-    return jobQueue.lastKey().job.getPriority();
+    CompactionJobPriorityQueue.CjpqKey highestJob = null;
+    try {
+      highestJob = jobQueue.lastKey();
+    } catch (NoSuchElementException e) {}
+    return highestJob == null ? 0 : highestJob.job.getPriority();
   }
 
   public synchronized CompactionJobQueues.MetaJob poll() {


### PR DESCRIPTION
Handles a `NullElementException` that is thrown if `getLowestPriority` is called on an empty compaction priority queue.

This is expected to fix the flaky MetricsIT test as the metric `METRICS_COMPACTOR_JOB_PRIORITY_QUEUE_JOBS_PRIORITY` will always return a value for a given queue.

@keith-turner If a queue is empty, what should the queue priority return? Right now it's `0` but I'm not sure if that's the correct "empty"  value we want to set.