### PR TITLE
Enables more tests in CompactionExecutorIT

### DIFF
--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterControl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterControl.java
@@ -264,7 +264,7 @@ public class MiniAccumuloClusterControl implements ClusterControl {
         try {
           cluster.stopProcessWithTimeout(process, 30, TimeUnit.SECONDS);
         } catch (ExecutionException | TimeoutException e) {
-          log.warn("TabletServer did not fully stop after 30 seconds", e);
+          log.warn("Compactor did not fully stop after 30 seconds", e);
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
         }

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterControl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterControl.java
@@ -254,7 +254,7 @@ public class MiniAccumuloClusterControl implements ClusterControl {
     stop(server, null);
   }
 
-  public void stopCompactorGroup(String compactorResourceGroup) throws IOException {
+  public void stopCompactorGroup(String compactorResourceGroup) {
     synchronized (compactorProcesses) {
       var group = compactorProcesses.get(compactorResourceGroup);
       if (group == null) {
@@ -265,6 +265,7 @@ public class MiniAccumuloClusterControl implements ClusterControl {
           cluster.stopProcessWithTimeout(process, 30, TimeUnit.SECONDS);
         } catch (ExecutionException | TimeoutException e) {
           log.warn("Compactor did not fully stop after 30 seconds", e);
+          throw new RuntimeException(e);
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
         }

--- a/test/src/main/java/org/apache/accumulo/test/compaction/CompactionExecutorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/CompactionExecutorIT.java
@@ -80,7 +80,6 @@ import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.google.gson.JsonArray;
@@ -400,28 +399,17 @@ public class CompactionExecutorIT extends SharedMiniClusterBase {
 
   }
 
-  // ELASTICITY_TODO: Summarizer does not seem to be triggering compaction changes.
   @Test
-  @Disabled
   public void testTooManyDeletes() throws Exception {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-      Map<String,
-          String> props = Map.of(Property.TABLE_COMPACTION_SELECTOR.getKey(),
-              TooManyDeletesSelector.class.getName(),
-              Property.TABLE_COMPACTION_SELECTOR_OPTS.getKey() + "threshold", ".4");
       var deleteSummarizerCfg =
           SummarizerConfiguration.builder(DeletesSummarizer.class.getName()).build();
-      client.tableOperations().create("tmd_selector", new NewTableConfiguration()
-          .setProperties(props).enableSummarization(deleteSummarizerCfg));
       client.tableOperations().create("tmd_control1",
           new NewTableConfiguration().enableSummarization(deleteSummarizerCfg));
       client.tableOperations().create("tmd_control2",
           new NewTableConfiguration().enableSummarization(deleteSummarizerCfg));
       client.tableOperations().create("tmd_control3",
           new NewTableConfiguration().enableSummarization(deleteSummarizerCfg));
-
-      addFile(client, "tmd_selector", 1, 1000, false);
-      addFile(client, "tmd_selector", 1, 1000, true);
 
       addFile(client, "tmd_control1", 1, 1000, false);
       addFile(client, "tmd_control1", 1, 1000, true);
@@ -435,10 +423,6 @@ public class CompactionExecutorIT extends SharedMiniClusterBase {
       assertEquals(2, getFiles(client, "tmd_control1").size());
       assertEquals(2, getFiles(client, "tmd_control2").size());
       assertEquals(2, getFiles(client, "tmd_control3").size());
-
-      while (getFiles(client, "tmd_selector").size() != 0) {
-        Thread.sleep(100);
-      }
 
       assertEquals(2, getFiles(client, "tmd_control1").size());
       assertEquals(2, getFiles(client, "tmd_control2").size());

--- a/test/src/main/java/org/apache/accumulo/test/compaction/CompactionExecutorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/CompactionExecutorIT.java
@@ -81,18 +81,19 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 
 public class CompactionExecutorIT extends SharedMiniClusterBase {
   public static final List<String> compactionGroups = new LinkedList<>();
+  public static final Logger log = LoggerFactory.getLogger(CompactionExecutorIT.class);
 
   public static class TestPlanner implements CompactionPlanner {
 
     private static class ExecutorConfig {
-      String name;
-      String type;
       String group;
     }
 
@@ -219,7 +220,7 @@ public class CompactionExecutorIT extends SharedMiniClusterBase {
       try {
         getCluster().getClusterControl().stopCompactorGroup(group);
       } catch (Exception e) {
-        // Exception is encountered but ignored.
+        log.warn("Compaction group: {} failed to fully stop", group, e);
       } finally {
         iter.remove();
       }


### PR DESCRIPTION
Gets all tests working in CompactionExecutorIT. 
Adds additional method to stop compactors by resource group names.

Compaction groups are now created on an as needed basis for each test and cleaned up afterwards without affecting compactions for the root or metadata tables. 