### PR TITLE
Pre-release build quality updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/post_vote_checklist.md
+++ b/.github/ISSUE_TEMPLATE/post_vote_checklist.md
@@ -32,7 +32,8 @@ assignees: ''
   - [ ] Downloads page
   - [ ] If LTM release, update previous LTM release entry on downloads page and release notes with an EOL date 1 year from the current release date
   - [ ] DOAP file
-  - [ ] Add manual/examples/javadoc (build javadoc from tag with `mvn clean package -DskipTests javadoc:aggregate -Paggregate-javadocs` using at least JDK 17)
+  - [ ] Add manual/examples/javadoc (build javadoc from tag with `mvn clean package -DskipTests javadoc:aggregate -Paggregate-javadocs`)
+  - [ ] Add updated properties documentation (see [the website README](https://github.com/apache/accumulo-website#updating-property-documentation-for-releases))
   - [ ] Jekyll config
   - [ ] Grep for, and update any links to previous version to now point to the new version
   - [ ] Update any older release notes front-matter to indicate they are either `archived: true` or `archived_critical: true`
@@ -43,7 +44,4 @@ assignees: ''
   - [ ] Close this issue
   - [ ] Create a new "Automated Kanban" [project](https://github.com/apache/accumulo/projects) for the next version (if necessary) and move any open issues not completed in this release to that project
   - [ ] Close the project that corresponds to this release
-- Twitter
-  - [ ] [Tweet it](https://tweetdeck.twitter.com)
-  - [ ] [Confirm the tweet](https://twitter.com/ApacheAccumulo)
 

--- a/.github/workflows/maven-full-its.yaml
+++ b/.github/workflows/maven-full-its.yaml
@@ -45,14 +45,14 @@ jobs:
   fastbuild:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.inputs.buildRef }}
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
       with:
         distribution: adopt
-        java-version: 11
+        java-version: 17
     - name: Cache local maven repository
       uses: actions/cache@v3
       with:
@@ -75,7 +75,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.CUSTOM_MATRIX }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.inputs.buildRef }}
     - id: set-matrix
@@ -89,14 +89,14 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.inputs.buildRef }}
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
       with:
         distribution: adopt
-        java-version: 11
+        java-version: 17
     - name: Cache local maven repository
       uses: actions/cache@v3
       with:

--- a/.github/workflows/maven-on-demand.yaml
+++ b/.github/workflows/maven-on-demand.yaml
@@ -62,14 +62,14 @@ jobs:
     name: mvn (triggered by ${{ github.event.sender.login }})
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.inputs.buildRef }}
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
       with:
         distribution: adopt
-        java-version: 11
+        java-version: 17
     - name: Cache local maven repository
       uses: actions/cache@v3
       with:

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -37,12 +37,12 @@ jobs:
   fastbuild:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
       with:
         distribution: adopt
-        java-version: 11
+        java-version: 17
     - name: Cache local maven repository
       uses: actions/cache@v3
       with:
@@ -68,17 +68,16 @@ jobs:
     strategy:
       matrix:
         profile:
-          - {name: 'unit-tests',    javaver: 11, args: 'verify -PskipQA -DskipTests=false'}
-          - {name: 'qa-checks',     javaver: 11, args: 'verify javadoc:jar -Psec-bugs -DskipTests -Dspotbugs.timeout=3600000'}
-          - {name: 'compat',        javaver: 11, args: 'package -DskipTests -Dversion.hadoop=3.0.3 -Dversion.zookeeper=3.5.10'}
-          - {name: 'errorprone',    javaver: 11, args: 'verify -Perrorprone,skipQA'}
-          - {name: 'jdk17',         javaver: 17, args: 'verify -DskipITs'}
+          - {name: 'unit-tests',    javaver: 17, args: 'verify -PskipQA -DskipTests=false'}
+          - {name: 'qa-checks',     javaver: 17, args: 'verify javadoc:jar -Psec-bugs -DskipTests -Dspotbugs.timeout=3600000'}
+          - {name: 'compat',        javaver: 17, args: 'package -DskipTests -Dversion.hadoop=3.0.3 -Dversion.zookeeper=3.5.10'}
+          - {name: 'errorprone',    javaver: 17, args: 'verify -Perrorprone,skipQA'}
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up JDK ${{ matrix.profile.javaver }}
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: adopt
         java-version: ${{ matrix.profile.javaver }}

--- a/.github/workflows/scripts.yaml
+++ b/.github/workflows/scripts.yaml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 3
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Show the first log message
       run: git log -n1
     - name: Install shfmt
@@ -51,7 +51,7 @@ jobs:
     timeout-minutes: 3
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Show the first log message
       run: git log -n1
     - name: Install shfmt
@@ -64,7 +64,7 @@ jobs:
     timeout-minutes: 3
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Show the first log message
       run: git log -n1
     - name: Update package repository

--- a/assemble/pom.xml
+++ b/assemble/pom.xml
@@ -147,11 +147,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>io.opentelemetry</groupId>
-      <artifactId>opentelemetry-semconv</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>jakarta.activation</groupId>
       <artifactId>jakarta.activation-api</artifactId>
       <optional>true</optional>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -86,10 +86,6 @@
       <artifactId>opentelemetry-context</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.opentelemetry</groupId>
-      <artifactId>opentelemetry-semconv</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.accumulo</groupId>
       <artifactId>accumulo-start</artifactId>
     </dependency>

--- a/core/src/main/java/org/apache/accumulo/core/trace/TraceUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/trace/TraceUtil.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
@@ -43,7 +44,6 @@ import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.TextMapGetter;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 
 public class TraceUtil {
 
@@ -124,9 +124,9 @@ public class TraceUtil {
     if (enabled) {
       span.setStatus(StatusCode.ERROR);
       span.recordException(e,
-          Attributes.builder().put(SemanticAttributes.EXCEPTION_TYPE, e.getClass().getName())
-              .put(SemanticAttributes.EXCEPTION_MESSAGE, e.getMessage())
-              .put(SemanticAttributes.EXCEPTION_ESCAPED, rethrown).build());
+          Attributes.builder().put(AttributeKey.stringKey("exception.type"), e.getClass().getName())
+              .put(AttributeKey.stringKey("exception.message"), e.getMessage())
+              .put(AttributeKey.booleanKey("exception.escaped"), rethrown).build());
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
     <version.curator>5.5.0</version.curator>
     <version.errorprone>2.23.0</version.errorprone>
     <version.hadoop>3.3.6</version.hadoop>
-    <version.opentelemetry>1.32.0</version.opentelemetry>
+    <version.opentelemetry>1.33.0</version.opentelemetry>
     <version.powermock>2.0.9</version.powermock>
     <version.slf4j>2.0.9</version.slf4j>
     <version.thrift>0.17.0</version.thrift>
@@ -169,7 +169,7 @@
       <dependency>
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-bom</artifactId>
-        <version>1.12.0</version>
+        <version>1.12.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -177,7 +177,7 @@
         <!-- for dependency convergence between Micrometer and ZooKeeper -->
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
-        <version>4.1.94.Final</version>
+        <version>4.1.104.Final</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -205,21 +205,21 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-bom</artifactId>
-        <version>11.0.18</version>
+        <version>11.0.19</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-bom</artifactId>
-        <version>3.0.4</version>
+        <version>3.0.5</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jaxb</groupId>
         <artifactId>jaxb-bom</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -246,17 +246,17 @@
       <dependency>
         <groupId>com.fasterxml</groupId>
         <artifactId>classmate</artifactId>
-        <version>1.5.1</version>
+        <version>1.6.0</version>
       </dependency>
       <dependency>
         <groupId>com.github.ben-manes.caffeine</groupId>
         <artifactId>caffeine</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.8</version>
       </dependency>
       <dependency>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-annotations</artifactId>
-        <version>4.7.3</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>com.google.auto.service</groupId>
@@ -288,7 +288,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>32.1.3-jre</version>
+        <version>33.0.0-jre</version>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>
@@ -298,7 +298,7 @@
       <dependency>
         <groupId>com.lmax</groupId>
         <artifactId>disruptor</artifactId>
-        <version>3.4.4</version>
+        <version>4.0.0</version>
       </dependency>
       <dependency>
         <groupId>commons-cli</groupId>
@@ -571,7 +571,7 @@
       <dependency>
         <groupId>org.checkerframework</groupId>
         <artifactId>checker-qual</artifactId>
-        <version>3.35.0</version>
+        <version>3.42.0</version>
       </dependency>
       <dependency>
         <groupId>org.easymock</groupId>
@@ -601,12 +601,12 @@
       <dependency>
         <groupId>org.javassist</groupId>
         <artifactId>javassist</artifactId>
-        <version>3.29.2-GA</version>
+        <version>3.30.1-GA</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.logging</groupId>
         <artifactId>jboss-logging</artifactId>
-        <version>3.5.1.Final</version>
+        <version>3.5.3.Final</version>
       </dependency>
       <dependency>
         <!-- force convergence of transitive dependency of hibernate-validator -->
@@ -623,7 +623,7 @@
       <dependency>
         <groupId>org.jline</groupId>
         <artifactId>jline</artifactId>
-        <version>3.24.0</version>
+        <version>3.24.1</version>
       </dependency>
       <dependency>
         <groupId>org.latencyutils</groupId>
@@ -676,7 +676,7 @@
       <dependency>
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
-        <version>2.0</version>
+        <version>2.2</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -985,6 +985,8 @@
                 <unused>org.apache.logging.log4j:log4j-1.2-api:jar:*</unused>
                 <unused>org.apache.logging.log4j:log4j-slf4j2-impl:jar:*</unused>
                 <unused>org.apache.logging.log4j:log4j-web:jar:*</unused>
+                <!-- ignore log4j dep used for annotations and needed for compile time linting -->
+                <unused>biz.aQute.bnd:biz.aQute.bnd.annotation:jar:*</unused>
                 <!-- This should be removed upon completion of migrating junit 4 to 5 -->
                 <unused>org.junit.vintage:junit-vintage-engine:jar:*</unused>
                 <unused>org.junit.jupiter:junit-jupiter-engine:jar:*</unused>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>30</version>
+    <version>31</version>
   </parent>
   <groupId>org.apache.accumulo</groupId>
   <artifactId>accumulo-project</artifactId>
@@ -116,7 +116,7 @@
     <accumulo.release.version>${project.version}</accumulo.release.version>
     <!-- avoid error shutting down built-in ForkJoinPool.commonPool() during exec:java tasks -->
     <exec.cleanupDaemonThreads>false</exec.cleanupDaemonThreads>
-    <extraTestArgs />
+    <extraTestArgs>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.management/java.lang.management=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens java.base/java.time=ALL-UNNAMED</extraTestArgs>
     <failsafe.excludedGroups />
     <failsafe.failIfNoSpecifiedTests>false</failsafe.failIfNoSpecifiedTests>
     <failsafe.forkCount>1</failsafe.forkCount>
@@ -134,8 +134,7 @@
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <!-- versions-maven-plugin ignore patterns for snapshots, alpha, beta, milestones, and release candidates -->
     <maven.version.ignore>.+-SNAPSHOT,(?i).*(alpha|beta)[0-9.-]*,(?i).*[.-](m|rc)[0-9]+</maven.version.ignore>
-    <minimalJavaBuildVersion>11</minimalJavaBuildVersion>
-    <minimalMavenBuildVersion>3.6.0</minimalMavenBuildVersion>
+    <minimalJavaBuildVersion>17</minimalJavaBuildVersion>
     <!-- timestamp for reproducible outputs, updated on release by the release plugin -->
     <project.build.outputTimestamp>2023-08-14T08:01:47Z</project.build.outputTimestamp>
     <rat.consoleOutput>true</rat.consoleOutput>
@@ -148,29 +147,29 @@
     <unitTestMemSize>-Xmx1G</unitTestMemSize>
     <!-- dependency and plugin versions managed with properties -->
     <version.auto-service>1.1.1</version.auto-service>
-    <version.bouncycastle>1.76</version.bouncycastle>
+    <version.bouncycastle>1.77</version.bouncycastle>
     <version.curator>5.5.0</version.curator>
     <version.errorprone>2.23.0</version.errorprone>
     <version.hadoop>3.3.6</version.hadoop>
-    <version.opentelemetry>1.27.0</version.opentelemetry>
+    <version.opentelemetry>1.32.0</version.opentelemetry>
     <version.powermock>2.0.9</version.powermock>
-    <version.slf4j>2.0.7</version.slf4j>
+    <version.slf4j>2.0.9</version.slf4j>
     <version.thrift>0.17.0</version.thrift>
-    <version.zookeeper>3.8.3</version.zookeeper>
+    <version.zookeeper>3.9.1</version.zookeeper>
   </properties>
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
-        <version>2.15.2</version>
+        <version>2.16.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-bom</artifactId>
-        <version>1.11.1</version>
+        <version>1.12.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -190,13 +189,6 @@
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>io.opentelemetry</groupId>
-        <artifactId>opentelemetry-bom-alpha</artifactId>
-        <version>${version.opentelemetry}-alpha</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>jakarta.platform</groupId>
         <artifactId>jakarta.jakartaee-bom</artifactId>
         <version>9.1.0</version>
@@ -206,14 +198,14 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.20.0</version>
+        <version>2.22.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-bom</artifactId>
-        <version>11.0.15</version>
+        <version>11.0.18</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -242,7 +234,7 @@
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>5.9.3</version>
+        <version>5.10.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -291,12 +283,12 @@
         <!-- this is a runtime dependency of guava, no longer included with guava as of 27.1 -->
         <groupId>com.google.guava</groupId>
         <artifactId>failureaccess</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>32.0.1-jre</version>
+        <version>32.1.3-jre</version>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>
@@ -584,7 +576,7 @@
       <dependency>
         <groupId>org.easymock</groupId>
         <artifactId>easymock</artifactId>
-        <version>5.1.0</version>
+        <version>5.2.0</version>
       </dependency>
       <dependency>
         <groupId>org.freemarker</groupId>
@@ -679,7 +671,7 @@
         <!-- version specified to converge transitive dependency of hadoop and curator -->
         <groupId>org.xerial.snappy</groupId>
         <artifactId>snappy-java</artifactId>
-        <version>1.1.10.4</version>
+        <version>1.1.10.5</version>
       </dependency>
       <dependency>
         <groupId>org.yaml</groupId>
@@ -702,12 +694,12 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
-          <version>2.16.0</version>
+          <version>2.16.2</version>
         </plugin>
         <plugin>
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>
-          <version>4.2</version>
+          <version>4.3</version>
           <configuration>
             <licenseSets>
               <licenseSet>
@@ -736,7 +728,7 @@
         <plugin>
           <groupId>org.gaul</groupId>
           <artifactId>modernizer-maven-plugin</artifactId>
-          <version>2.6.0</version>
+          <version>2.7.0</version>
           <configuration>
             <javaVersion>${maven.compiler.target}</javaVersion>
           </configuration>
@@ -744,7 +736,7 @@
         <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>4.7.3.5</version>
+          <version>4.7.3.6</version>
           <configuration>
             <xmlOutput>true</xmlOutput>
             <effort>Max</effort>
@@ -760,11 +752,6 @@
               </plugin>
             </plugins>
           </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>3.3.0</version>
         </plugin>
         <plugin>
           <groupId>com.github.ekryd.sortpom</groupId>
@@ -887,12 +874,12 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>3.4.0</version>
+          <version>3.5.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.1.1</version>
         </plugin>
         <plugin>
           <groupId>net.revelc.code</groupId>
@@ -1179,7 +1166,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>10.12.2</version>
+            <version>10.12.6</version>
           </dependency>
         </dependencies>
         <executions>
@@ -1549,10 +1536,6 @@
     <profile>
       <!-- mvn clean package javadoc:aggregate -DskipTests -Paggregate-javadocs -->
       <id>aggregate-javadocs</id>
-      <properties>
-        <!-- use at least 17 to avoid patching for JDK-8227487 JDK-8214856 and JDK-8215291 -->
-        <minimalJavaBuildVersion>17</minimalJavaBuildVersion>
-      </properties>
       <build>
         <pluginManagement>
           <plugins>
@@ -1718,15 +1701,6 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
-    <profile>
-      <id>jdk16</id>
-      <activation>
-        <jdk>[16,)</jdk>
-      </activation>
-      <properties>
-        <extraTestArgs>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.management/java.lang.management=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens java.base/java.time=ALL-UNNAMED</extraTestArgs>
-      </properties>
     </profile>
   </profiles>
 </project>

--- a/server/base/src/main/java/org/apache/accumulo/server/util/RestoreZookeeper.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/RestoreZookeeper.java
@@ -23,7 +23,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.Base64;
-import java.util.Stack;
+import java.util.Deque;
+import java.util.LinkedList;
 
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
@@ -41,7 +42,7 @@ public class RestoreZookeeper {
 
   private static class Restore extends DefaultHandler {
     ZooReaderWriter zk = null;
-    Stack<String> cwd = new Stack<>();
+    Deque<String> cwd = new LinkedList<>();
     boolean overwrite = false;
 
     Restore(ZooReaderWriter zk, boolean overwrite) {
@@ -61,7 +62,7 @@ public class RestoreZookeeper {
         if (value == null) {
           value = "";
         }
-        String path = cwd.lastElement() + "/" + child;
+        String path = cwd.element() + "/" + child;
         create(path, value, encoding);
         cwd.push(path);
       } else if ("dump".equals(name)) {

--- a/server/monitor/pom.xml
+++ b/server/monitor/pom.xml
@@ -145,6 +145,12 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
+      <!-- used by log4j; needed here for compile time linting only; we don't actually use it -->
+      <groupId>biz.aQute.bnd</groupId>
+      <artifactId>biz.aQute.bnd.annotation</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client-runtime</artifactId>
       <scope>runtime</scope>


### PR DESCRIPTION
In preparation for 2.1.3 release, update some of the build tools and dependencies to enhance the quality of the next release.

* Update post-release checklist template
* Update GitHub Actions workflows
* Require JDK 17 for the build, for build consistency/reproducibility (still target Java 11 for runtime)
* Update the parent POM version to 31
* Update opentelemetry version and drop the semantic conventions jar as a dependency, which is no longer available (and not really needed)
* Update bouncycastle, slf4j, zookeeper, jackson, micrometer, log4j, jetty, junit, guava, easymock, and snappy dependencies
* Update plugin versions (leave spotbugs back at an earlier version for now, because of some overly aggressive and spammy checks in the latest version that disallows exceptions being thrown in constructors for non-final classes
* Address modernizer issue to use LinkedList as a Deque instead of Stack, which is a recommendation in Java's own code as well