### PR TITLE
Fix 4100 - move header length check to test

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
@@ -180,9 +180,8 @@ public final class DfsLogger implements Comparable<DfsLogger> {
         }
         long duration = System.currentTimeMillis() - start;
         if (duration > slowFlushMillis) {
-          String msg = new StringBuilder(128).append("Slow sync cost: ").append(duration)
-              .append(" ms, current pipeline: ").append(Arrays.toString(getPipeLine())).toString();
-          log.info(msg);
+          log.info("Slow sync cost: {} ms, current pipeline: {}", duration,
+              Arrays.toString(getPipeLine()));
           if (expectedReplication > 0) {
             int current = expectedReplication;
             try {
@@ -333,11 +332,6 @@ public final class DfsLogger implements Comparable<DfsLogger> {
     byte[] magic4 = DfsLogger.LOG_FILE_HEADER_V4.getBytes(UTF_8);
     byte[] magic3 = DfsLogger.LOG_FILE_HEADER_V3.getBytes(UTF_8);
 
-    if (magic4.length != magic3.length) {
-      throw new AssertionError("Always expect log file headers to be same length : " + magic4.length
-          + " != " + magic3.length);
-    }
-
     byte[] magicBuffer = new byte[magic4.length];
     try {
       input.readFully(magicBuffer);
@@ -392,7 +386,7 @@ public final class DfsLogger implements Comparable<DfsLogger> {
         + Constants.WAL_DIR + Path.SEPARATOR + logger + Path.SEPARATOR + filename;
     this.logEntry = LogEntry.fromPath(logPath);
 
-    LoggerOperation op = null;
+    LoggerOperation op;
     var serverConf = context.getConfiguration();
     try {
       Path logfilePath = new Path(logPath);
@@ -433,11 +427,11 @@ public final class DfsLogger implements Comparable<DfsLogger> {
       byte[] cryptoParams = encrypter.getDecryptionParameters();
       CryptoUtils.writeParams(cryptoParams, logFile);
 
-      /**
-       * Always wrap the WAL in a NoFlushOutputStream to prevent extra flushing to HDFS. The
-       * {@link #write(LogFileKey, LogFileValue)} method will flush crypto data or do nothing when
-       * crypto is not enabled.
-       **/
+      /*
+       * Always wrap the WAL in a NoFlushOutputStream to prevent extra flushing to HDFS. The {@link
+       * #write(LogFileKey, LogFileValue)} method will flush crypto data or do nothing when crypto
+       * is not enabled.
+       */
       OutputStream encryptedStream = encrypter.encryptStream(new NoFlushOutputStream(logFile));
       if (encryptedStream instanceof NoFlushOutputStream) {
         encryptingLogFile = (NoFlushOutputStream) encryptedStream;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
@@ -428,9 +428,9 @@ public final class DfsLogger implements Comparable<DfsLogger> {
       CryptoUtils.writeParams(cryptoParams, logFile);
 
       /*
-       * Always wrap the WAL in a NoFlushOutputStream to prevent extra flushing to HDFS. The {@link
-       * #write(LogFileKey, LogFileValue)} method will flush crypto data or do nothing when crypto
-       * is not enabled.
+       * Always wrap the WAL in a NoFlushOutputStream to prevent extra flushing to HDFS. The method
+       * write(LogFileKey, LogFileValue) will flush crypto data or do nothing when crypto is not
+       * enabled.
        */
       OutputStream encryptedStream = encrypter.encryptStream(new NoFlushOutputStream(logFile));
       if (encryptedStream instanceof NoFlushOutputStream) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogReader.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogReader.java
@@ -191,11 +191,6 @@ public class LogReader implements KeywordExecutable {
     byte[] magic3 = DfsLogger.LOG_FILE_HEADER_V3.getBytes(UTF_8);
     byte[] noCryptoBytes = new NoFileEncrypter().getDecryptionParameters();
 
-    if (magic4.length != magic3.length) {
-      throw new AssertionError("Always expect log file headers to be same length : " + magic4.length
-          + " != " + magic3.length);
-    }
-
     byte[] magicBuffer = new byte[magic4.length];
     try {
       input.readFully(magicBuffer);

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/DfsLoggerTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/DfsLoggerTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.tserver.log;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
@@ -66,6 +67,14 @@ public class DfsLoggerTest {
         new TabletMutations(commitSession, Collections.emptyList(), Durability.FLUSH);
     lst.add(m7);
     assertEquals(Durability.SYNC, chooseDurabilityForGroupCommit(lst));
+  }
+
+  @Test
+  public void headerLengthTest() {
+    byte[] magic4 = DfsLogger.LOG_FILE_HEADER_V4.getBytes(UTF_8);
+    byte[] magic3 = DfsLogger.LOG_FILE_HEADER_V3.getBytes(UTF_8);
+
+    assertEquals(magic3.length, magic4.length, "Always expect log file headers to be same length");
   }
 
   static Durability chooseDurabilityForGroupCommit(Collection<TabletMutations> mutations) {


### PR DESCRIPTION
- Move the assert check to a unit test and deletes redundant check
- simple IDE suggested QA checks.

Fixes #4100 