### PR TITLE
Avoid DfsLogger unencrypted WAL special case

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
@@ -56,7 +56,6 @@ import org.apache.accumulo.core.spi.crypto.CryptoEnvironment.Scope;
 import org.apache.accumulo.core.spi.crypto.CryptoService;
 import org.apache.accumulo.core.spi.crypto.FileDecrypter;
 import org.apache.accumulo.core.spi.crypto.FileEncrypter;
-import org.apache.accumulo.core.spi.crypto.NoCryptoService;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.core.util.threads.Threads;
 import org.apache.accumulo.server.ServerContext;
@@ -362,8 +361,9 @@ public class DfsLogger implements Comparable<DfsLogger> {
         FileDecrypter decrypter =
             CryptoUtils.getFileDecrypter(cryptoService, Scope.WAL, null, input);
         log.debug("Using {} for decrypting WAL", cryptoService.getClass().getSimpleName());
-        decryptingInput = cryptoService instanceof NoCryptoService ? input
-            : new DataInputStream(decrypter.decryptStream(input));
+        var stream = decrypter.decryptStream(input);
+        decryptingInput = stream instanceof DataInputStream ? (DataInputStream) stream
+            : new DataInputStream(stream);
       } else if (Arrays.equals(magicBuffer, magic3)) {
         // Read logs files from Accumulo 1.9 and throw an error if they are encrypted
         String cryptoModuleClassname = input.readUTF();


### PR DESCRIPTION
Although the NoCryptoService's decrypter returns the same stream that it was given in the current implementation, that behavior is not guaranteed in the future. So, instead of relying on that insider knowledge about the NoCryptoService implementation, ask the decrypter for the stream like normal, and then check if it's already a DataInputStream before re-wrapping it, since that's the condition we actually should check in order to avoid rewrapping. This allows us to avoid duplicate wrapping of other implementations as well, instead of treating NoCryptoService as a special case.