### PR TITLE
Use a Map for volume replacements

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
@@ -32,7 +32,6 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.UnknownHostException;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -58,7 +57,6 @@ import org.apache.accumulo.core.rpc.SslConnectionParams;
 import org.apache.accumulo.core.singletons.SingletonReservation;
 import org.apache.accumulo.core.spi.crypto.CryptoServiceFactory;
 import org.apache.accumulo.core.util.AddressUtil;
-import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.core.util.threads.Threads;
 import org.apache.accumulo.server.conf.NamespaceConfiguration;
@@ -286,7 +284,7 @@ public class ServerContext extends ClientContext {
     return serverDirs.getBaseUris();
   }
 
-  public List<Pair<Path,Path>> getVolumeReplacements() {
+  public Map<Path,Path> getVolumeReplacements() {
     return serverDirs.getVolumeReplacements();
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerDirs.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerDirs.java
@@ -22,11 +22,11 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -35,7 +35,6 @@ import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.InstanceId;
-import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.core.volume.Volume;
 import org.apache.accumulo.core.volume.VolumeConfiguration;
 import org.apache.accumulo.server.fs.VolumeManager;
@@ -55,14 +54,14 @@ public class ServerDirs {
   private Set<String> tablesDirs;
   private Set<String> recoveryDirs;
 
-  private final List<Pair<Path,Path>> replacementsList;
+  private final Map<Path,Path> replacements;
   private final AccumuloConfiguration conf;
   private final Configuration hadoopConf;
 
   public ServerDirs(AccumuloConfiguration conf, Configuration hadoopConf) {
     this.conf = Objects.requireNonNull(conf, "Configuration cannot be null");
     this.hadoopConf = Objects.requireNonNull(hadoopConf, "Hadoop configuration cannot be null");
-    this.replacementsList = loadVolumeReplacements();
+    this.replacements = loadVolumeReplacements();
   }
 
   public Set<String> getBaseUris() {
@@ -143,18 +142,18 @@ public class ServerDirs {
     return recoveryDirs;
   }
 
-  private List<Pair<Path,Path>> loadVolumeReplacements() {
+  private Map<Path,Path> loadVolumeReplacements() {
 
-    List<Pair<Path,Path>> replacementsList;
+    Map<Path,Path> replacementsList;
     String replacements = conf.get(Property.INSTANCE_VOLUMES_REPLACEMENTS);
 
     if (replacements == null || replacements.trim().isEmpty()) {
-      return Collections.emptyList();
+      return Collections.emptyMap();
     }
     replacements = replacements.trim();
 
     String[] pairs = replacements.split(",");
-    List<Pair<Path,Path>> ret = new ArrayList<>();
+    Map<Path,Path> ret = new LinkedHashMap<>();
 
     for (String pair : pairs) {
 
@@ -188,7 +187,7 @@ public class ServerDirs {
             + " contains " + uris[1] + " which has a syntax error", e);
       }
 
-      ret.add(new Pair<>(p1, p2));
+      ret.put(p1, p2);
     }
 
     HashSet<Path> baseDirs = new HashSet<>();
@@ -197,10 +196,10 @@ public class ServerDirs {
       baseDirs.add(new Path(baseDir));
     }
 
-    for (Pair<Path,Path> pair : ret) {
-      if (!baseDirs.contains(pair.getSecond())) {
+    for (Path replacement : ret.values()) {
+      if (!baseDirs.contains(replacement)) {
         throw new IllegalArgumentException(Property.INSTANCE_VOLUMES_REPLACEMENTS.getKey()
-            + " contains " + pair.getSecond() + " which is not a configured volume");
+            + " contains " + replacement + " which is not a configured volume");
       }
     }
 
@@ -210,8 +209,8 @@ public class ServerDirs {
     return replacementsList;
   }
 
-  public List<Pair<Path,Path>> getVolumeReplacements() {
-    return this.replacementsList;
+  public Map<Path,Path> getVolumeReplacements() {
+    return this.replacements;
   }
 
   public Path getDataVersionLocation(Volume v) {

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeUtil.java
@@ -18,10 +18,12 @@
  */
 package org.apache.accumulo.server.fs;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
@@ -31,7 +33,6 @@ import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
-import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.fs.VolumeManager.FileType;
 import org.apache.accumulo.server.util.MetadataTableUtil;
@@ -54,49 +55,34 @@ public class VolumeUtil {
   }
 
   public static Path removeTrailingSlash(Path path) {
-    String pathStr = Objects.requireNonNull(path).toString();
+    String pathStr = requireNonNull(path).toString();
     if (pathStr.endsWith("/")) {
       return new Path(removeTrailingSlash(pathStr));
     }
     return path;
   }
 
-  public static Path switchVolume(Path path, FileType ft, List<Pair<Path,Path>> replacements) {
-    if (replacements.isEmpty()) {
-      log.trace("Not switching volume because there are no replacements");
-      return null;
+  public static Path switchVolume(Path path, FileType ft, Map<Path,Path> replacements) {
+    Path replacement = null;
+    if (!replacements.isEmpty()) {
+      // removing trailing slash for exact match comparison on the volume itself
+      Path volume = removeTrailingSlash(ft.getVolume(requireNonNull(path)));
+      replacement = replacements.entrySet().stream()
+          .filter(entry -> removeTrailingSlash(entry.getKey()).equals(volume))
+          .map(entry -> new Path(entry.getValue(), requireNonNull(ft.removeVolume(path))))
+          .findFirst().orElse(null);
     }
-
-    // removing slash because new Path("hdfs://nn1").equals(new Path("hdfs://nn1/")) evaluates to
-    // false
-    Path volume = removeTrailingSlash(ft.getVolume(Objects.requireNonNull(path)));
-
-    for (Pair<Path,Path> pair : replacements) {
-      Path key = removeTrailingSlash(pair.getFirst());
-
-      if (key.equals(volume)) {
-        Path replacement =
-            new Path(pair.getSecond(), Objects.requireNonNull(ft.removeVolume(path)));
-        log.trace("Replacing {} with {}", path, replacement);
-        return replacement;
-      }
+    if (replacement != null) {
+      log.trace("Replacing {} with {} for {}", path, replacement, ft);
+      return replacement;
     }
-
-    log.trace("Could not find replacement for {} at {}", ft, path);
-
+    log.trace("No replacement available for {} at {}", ft, path);
     return null;
   }
 
-  public static LogEntry switchVolumes(LogEntry le, List<Pair<Path,Path>> replacements) {
+  public static LogEntry switchVolume(LogEntry le, Map<Path,Path> replacements) {
     Path switchedPath = switchVolume(new Path(le.getPath()), FileType.WAL, replacements);
-    if (switchedPath == null) {
-      log.trace("Did not switch {}", le);
-      return null;
-    }
-
-    LogEntry newLogEntry = LogEntry.fromPath(switchedPath.toString());
-    log.trace("Switched {} to {}", le, newLogEntry);
-    return newLogEntry;
+    return switchedPath == null ? null : LogEntry.fromPath(switchedPath.toString());
   }
 
   public static class TabletFiles {
@@ -124,7 +110,7 @@ public class VolumeUtil {
    */
   public static TabletFiles updateTabletVolumes(ServerContext context, ServiceLock zooLock,
       KeyExtent extent, TabletFiles tabletFiles) {
-    List<Pair<Path,Path>> replacements = context.getVolumeReplacements();
+    Map<Path,Path> replacements = context.getVolumeReplacements();
     if (replacements.isEmpty()) {
       return tabletFiles;
     }
@@ -139,7 +125,7 @@ public class VolumeUtil {
     TabletFiles ret = new TabletFiles();
 
     for (LogEntry logEntry : tabletFiles.logEntries) {
-      LogEntry switchedLogEntry = switchVolumes(logEntry, replacements);
+      LogEntry switchedLogEntry = switchVolume(logEntry, replacements);
       if (switchedLogEntry != null) {
         logsToRemove.add(logEntry);
         logsToAdd.add(switchedLogEntry);

--- a/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
@@ -45,7 +45,6 @@ import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.singletons.SingletonManager;
 import org.apache.accumulo.core.singletons.SingletonManager.Mode;
 import org.apache.accumulo.core.spi.fs.VolumeChooserEnvironment.Scope;
-import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.core.volume.VolumeConfiguration;
 import org.apache.accumulo.server.AccumuloDataVersion;
 import org.apache.accumulo.server.ServerContext;
@@ -453,8 +452,8 @@ public class Initialize implements KeywordExecutable {
     Path versionPath = new Path(aBasePath, Constants.VERSION_DIR);
 
     InstanceId instanceId = VolumeManager.getInstanceIDFromHdfs(iidPath, hadoopConf);
-    for (Pair<Path,Path> replacementVolume : serverDirs.getVolumeReplacements()) {
-      if (aBasePath.equals(replacementVolume.getFirst())) {
+    for (Path replacedVolume : serverDirs.getVolumeReplacements().keySet()) {
+      if (aBasePath.equals(replacedVolume)) {
         log.error(
             "{} is set to be replaced in {} and should not appear in {}."
                 + " It is highly recommended that this property be removed as data"

--- a/server/base/src/test/java/org/apache/accumulo/server/fs/VolumeUtilTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/fs/VolumeUtilTest.java
@@ -21,12 +21,11 @@ package org.apache.accumulo.server.fs;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
-import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.server.fs.VolumeManager.FileType;
 import org.apache.hadoop.fs.Path;
 import org.junit.jupiter.api.Test;
@@ -38,11 +37,10 @@ public class VolumeUtilTest {
 
   @Test
   public void testSwitchVolume() {
-    List<Pair<Path,Path>> replacements = new ArrayList<>();
-    replacements.add(new Pair<>(new Path("hdfs://nn1/accumulo"), new Path("viewfs:/a/accumulo")));
-    replacements
-        .add(new Pair<>(new Path("hdfs://nn1:9000/accumulo"), new Path("viewfs:/a/accumulo")));
-    replacements.add(new Pair<>(new Path("hdfs://nn2/accumulo"), new Path("viewfs:/b/accumulo")));
+    Map<Path,Path> replacements = new LinkedHashMap<>();
+    replacements.put(new Path("hdfs://nn1/accumulo"), new Path("viewfs:/a/accumulo"));
+    replacements.put(new Path("hdfs://nn1:9000/accumulo"), new Path("viewfs:/a/accumulo"));
+    replacements.put(new Path("hdfs://nn2/accumulo"), new Path("viewfs:/b/accumulo"));
 
     assertEquals(new Path("viewfs:/a/accumulo/tables/t-00000/C000.rf"), VolumeUtil.switchVolume(
         new Path("hdfs://nn1/accumulo/tables/t-00000/C000.rf"), FileType.TABLE, replacements));
@@ -56,12 +54,9 @@ public class VolumeUtilTest {
         FileType.TABLE, replacements));
 
     replacements.clear();
-    replacements
-        .add(new Pair<>(new Path("hdfs://nn1/d1/accumulo"), new Path("viewfs:/a/accumulo")));
-    replacements
-        .add(new Pair<>(new Path("hdfs://nn1:9000/d1/accumulo"), new Path("viewfs:/a/accumulo")));
-    replacements
-        .add(new Pair<>(new Path("hdfs://nn2/d2/accumulo"), new Path("viewfs:/b/accumulo")));
+    replacements.put(new Path("hdfs://nn1/d1/accumulo"), new Path("viewfs:/a/accumulo"));
+    replacements.put(new Path("hdfs://nn1:9000/d1/accumulo"), new Path("viewfs:/a/accumulo"));
+    replacements.put(new Path("hdfs://nn2/d2/accumulo"), new Path("viewfs:/b/accumulo"));
 
     assertEquals(new Path("viewfs:/a/accumulo/tables/t-00000/C000.rf"), VolumeUtil.switchVolume(
         new Path("hdfs://nn1/d1/accumulo/tables/t-00000/C000.rf"), FileType.TABLE, replacements));
@@ -80,10 +75,10 @@ public class VolumeUtilTest {
 
   @Test
   public void testSwitchVolumesDifferentSourceDepths() {
-    List<Pair<Path,Path>> replacements = new ArrayList<>();
-    replacements.add(new Pair<>(new Path("hdfs://nn1/accumulo"), new Path("viewfs:/a")));
-    replacements.add(new Pair<>(new Path("hdfs://nn1:9000/accumulo"), new Path("viewfs:/a")));
-    replacements.add(new Pair<>(new Path("hdfs://nn2/accumulo"), new Path("viewfs:/b")));
+    Map<Path,Path> replacements = new LinkedHashMap<>();
+    replacements.put(new Path("hdfs://nn1/accumulo"), new Path("viewfs:/a"));
+    replacements.put(new Path("hdfs://nn1:9000/accumulo"), new Path("viewfs:/a"));
+    replacements.put(new Path("hdfs://nn2/accumulo"), new Path("viewfs:/b"));
 
     assertEquals(new Path("viewfs:/a/tables/t-00000/C000.rf"), VolumeUtil.switchVolume(
         new Path("hdfs://nn1/accumulo/tables/t-00000/C000.rf"), FileType.TABLE, replacements));
@@ -97,9 +92,9 @@ public class VolumeUtilTest {
         FileType.TABLE, replacements));
 
     replacements.clear();
-    replacements.add(new Pair<>(new Path("hdfs://nn1/d1/accumulo"), new Path("viewfs:/a")));
-    replacements.add(new Pair<>(new Path("hdfs://nn1:9000/d1/accumulo"), new Path("viewfs:/a")));
-    replacements.add(new Pair<>(new Path("hdfs://nn2/d2/accumulo"), new Path("viewfs:/b")));
+    replacements.put(new Path("hdfs://nn1/d1/accumulo"), new Path("viewfs:/a"));
+    replacements.put(new Path("hdfs://nn1:9000/d1/accumulo"), new Path("viewfs:/a"));
+    replacements.put(new Path("hdfs://nn2/d2/accumulo"), new Path("viewfs:/b"));
 
     assertEquals(new Path("viewfs:/a/tables/t-00000/C000.rf"), VolumeUtil.switchVolume(
         new Path("hdfs://nn1/d1/accumulo/tables/t-00000/C000.rf"), FileType.TABLE, replacements));
@@ -118,11 +113,10 @@ public class VolumeUtilTest {
 
   @Test
   public void testSwitchVolumesDifferentTargetDepths() {
-    List<Pair<Path,Path>> replacements = new ArrayList<>();
-    replacements.add(new Pair<>(new Path("hdfs://nn1/accumulo"), new Path("viewfs:/path1/path2")));
-    replacements
-        .add(new Pair<>(new Path("hdfs://nn1:9000/accumulo"), new Path("viewfs:/path1/path2")));
-    replacements.add(new Pair<>(new Path("hdfs://nn2/accumulo"), new Path("viewfs:/path3")));
+    Map<Path,Path> replacements = new LinkedHashMap<>();
+    replacements.put(new Path("hdfs://nn1/accumulo"), new Path("viewfs:/path1/path2"));
+    replacements.put(new Path("hdfs://nn1:9000/accumulo"), new Path("viewfs:/path1/path2"));
+    replacements.put(new Path("hdfs://nn2/accumulo"), new Path("viewfs:/path3"));
 
     assertEquals(new Path("viewfs:/path1/path2/tables/t-00000/C000.rf"), VolumeUtil.switchVolume(
         new Path("hdfs://nn1/accumulo/tables/t-00000/C000.rf"), FileType.TABLE, replacements));
@@ -136,11 +130,9 @@ public class VolumeUtilTest {
         FileType.TABLE, replacements));
 
     replacements.clear();
-    replacements
-        .add(new Pair<>(new Path("hdfs://nn1/d1/accumulo"), new Path("viewfs:/path1/path2")));
-    replacements
-        .add(new Pair<>(new Path("hdfs://nn1:9000/d1/accumulo"), new Path("viewfs:/path1/path2")));
-    replacements.add(new Pair<>(new Path("hdfs://nn2/d2/accumulo"), new Path("viewfs:/path3")));
+    replacements.put(new Path("hdfs://nn1/d1/accumulo"), new Path("viewfs:/path1/path2"));
+    replacements.put(new Path("hdfs://nn1:9000/d1/accumulo"), new Path("viewfs:/path1/path2"));
+    replacements.put(new Path("hdfs://nn2/d2/accumulo"), new Path("viewfs:/path3"));
 
     assertEquals(new Path("viewfs:/path1/path2/tables/t-00000/C000.rf"), VolumeUtil.switchVolume(
         new Path("hdfs://nn1/d1/accumulo/tables/t-00000/C000.rf"), FileType.TABLE, replacements));
@@ -159,9 +151,9 @@ public class VolumeUtilTest {
 
   @Test
   public void testRootTableReplacement() {
-    List<Pair<Path,Path>> replacements = new ArrayList<>();
-    replacements.add(new Pair<>(new Path("file:/foo/v1"), new Path("file:/foo/v8")));
-    replacements.add(new Pair<>(new Path("file:/foo/v2"), new Path("file:/foo/v9")));
+    Map<Path,Path> replacements = new LinkedHashMap<>();
+    replacements.put(new Path("file:/foo/v1"), new Path("file:/foo/v8"));
+    replacements.put(new Path("file:/foo/v2"), new Path("file:/foo/v9"));
 
     FileType ft = FileType.TABLE;
 
@@ -171,26 +163,25 @@ public class VolumeUtilTest {
 
   @Test
   public void testWalVolumeReplacment() {
-    List<Pair<Path,Path>> replacements = new ArrayList<>();
-    replacements.add(new Pair<>(new Path("hdfs://nn1/accumulo"), new Path("viewfs:/a/accumulo")));
-    replacements
-        .add(new Pair<>(new Path("hdfs://nn1:9000/accumulo"), new Path("viewfs:/a/accumulo")));
-    replacements.add(new Pair<>(new Path("hdfs://nn2/accumulo"), new Path("viewfs:/b/accumulo")));
+    Map<Path,Path> replacements = new LinkedHashMap<>();
+    replacements.put(new Path("hdfs://nn1/accumulo"), new Path("viewfs:/a/accumulo"));
+    replacements.put(new Path("hdfs://nn1:9000/accumulo"), new Path("viewfs:/a/accumulo"));
+    replacements.put(new Path("hdfs://nn2/accumulo"), new Path("viewfs:/b/accumulo"));
 
     String walUUID = UUID.randomUUID().toString();
     String fileName = "hdfs://nn1/accumulo/wal/localhost+9997/" + walUUID;
     LogEntry le = LogEntry.fromPath(fileName);
-    LogEntry fixedVolume = VolumeUtil.switchVolumes(le, replacements);
+    LogEntry fixedVolume = VolumeUtil.switchVolume(le, replacements);
     assertEquals("viewfs:/a/accumulo/wal/localhost+9997/" + walUUID, fixedVolume.getPath());
 
     fileName = "hdfs://nn1:9000/accumulo/wal/localhost+9997/" + walUUID;
     le = LogEntry.fromPath(fileName);
-    fixedVolume = VolumeUtil.switchVolumes(le, replacements);
+    fixedVolume = VolumeUtil.switchVolume(le, replacements);
     assertEquals("viewfs:/a/accumulo/wal/localhost+9997/" + walUUID, fixedVolume.getPath());
 
     fileName = "hdfs://nn2/accumulo/wal/localhost+9997/" + walUUID;
     le = LogEntry.fromPath(fileName);
-    fixedVolume = VolumeUtil.switchVolumes(le, replacements);
+    fixedVolume = VolumeUtil.switchVolume(le, replacements);
     assertEquals("viewfs:/b/accumulo/wal/localhost+9997/" + walUUID, fixedVolume.getPath());
   }
 }

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
@@ -64,7 +64,6 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.core.volume.Volume;
 import org.apache.accumulo.server.ServerContext;
@@ -287,7 +286,7 @@ public class GCRun implements GarbageCollectionEnvironment {
     ExecutorService deleteThreadPool = ThreadPools.getServerThreadPools()
         .createExecutorService(config, Property.GC_DELETE_THREADS, false);
 
-    final List<Pair<Path,Path>> replacements = context.getVolumeReplacements();
+    final Map<Path,Path> replacements = context.getVolumeReplacements();
 
     for (final GcCandidate delete : confirmedDeletes.values()) {
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/recovery/RecoveryManager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/recovery/RecoveryManager.java
@@ -162,7 +162,7 @@ public class RecoveryManager {
     for (LogEntry walog : walogs) {
 
       LogEntry switchedWalog =
-          VolumeUtil.switchVolumes(walog, manager.getContext().getVolumeReplacements());
+          VolumeUtil.switchVolume(walog, manager.getContext().getVolumeReplacements());
       if (switchedWalog != null) {
         // replaces the volume used for sorting, but do not change entry in metadata table. When
         // the tablet loads it will change the metadata table entry. If


### PR DESCRIPTION
* Use LinkedHashMap for order-preserved mapping of volume replacements instead of a List of Pairs
* Use this to simplify VolumeUtil.switchVolume
* Rename VolumeUtil.switchVolumes to switchVolume so it's actually an overloaded method for LogEntry, rather than merely having a similar name
* Also remove redundant trace logging for switching volumes for LogEntry, say "No replacement available" instead of the more concerning-sounding "Could not find replacement" (which implies there's supposed to be one, when it's fine if there isn't), and include the FileType in the trace log when the replacement is found