### PR TITLE
revert disruptor version to 3.4.4 for log4j compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -298,7 +298,7 @@
       <dependency>
         <groupId>com.lmax</groupId>
         <artifactId>disruptor</artifactId>
-        <version>4.0.0</version>
+        <version>3.4.4</version>
       </dependency>
       <dependency>
         <groupId>commons-cli</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -298,6 +298,7 @@
       <dependency>
         <groupId>com.lmax</groupId>
         <artifactId>disruptor</artifactId>
+        <!-- log4j doesn't support 4 yet; see https://github.com/apache/logging-log4j2/issues/1829 -->
         <version>3.4.4</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
With distruptor version 4.0.0 SequenceReportingEventHandler.class needed by log4j is missing.  This change reverts distruptor back to 3.4.4

Verified that uno will run an instance with this change (main branch), fails with version 4.0.0