### PR TITLE
Update isPropertySet to check parent config

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/ConfigurationCopy.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ConfigurationCopy.java
@@ -138,6 +138,10 @@ public class ConfigurationCopy extends AccumuloConfiguration {
 
   @Override
   public boolean isPropertySet(Property prop) {
-    return copy.containsKey(prop.getKey());
+    if (parent != null) {
+      return copy.containsKey(prop.getKey()) || parent.isPropertySet(prop);
+    } else {
+      return copy.containsKey(prop.getKey());
+    }
   }
 }


### PR DESCRIPTION
Modifies `isPropertySet` to also check the parent config if it exists.
