### PR TITLE
Remove mutation timestamp for valid GcCandidates

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
@@ -226,10 +226,18 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
     }
 
     try (BatchWriter writer = context.createBatchWriter(level.metaTable())) {
-      for (GcCandidate candidate : candidates) {
-        Mutation m = new Mutation(DeletesSection.encodeRow(candidate.getPath()));
-        m.putDelete(EMPTY_TEXT, EMPTY_TEXT, candidate.getUid());
-        writer.addMutation(m);
+      if (type == GcCandidateType.VALID) {
+        for (GcCandidate candidate : candidates) {
+          Mutation m = new Mutation(DeletesSection.encodeRow(candidate.getPath()));
+          m.putDelete(EMPTY_TEXT, EMPTY_TEXT);
+          writer.addMutation(m);
+        }
+      } else {
+        for (GcCandidate candidate : candidates) {
+          Mutation m = new Mutation(DeletesSection.encodeRow(candidate.getPath()));
+          m.putDelete(EMPTY_TEXT, EMPTY_TEXT, candidate.getUid());
+          writer.addMutation(m);
+        }
       }
     } catch (MutationsRejectedException | TableNotFoundException e) {
       throw new RuntimeException(e);

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
@@ -229,12 +229,14 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
       if (type == GcCandidateType.VALID) {
         for (GcCandidate candidate : candidates) {
           Mutation m = new Mutation(DeletesSection.encodeRow(candidate.getPath()));
+          // Removes all versions of the candidate to avoid reprocessing deleted file entries
           m.putDelete(EMPTY_TEXT, EMPTY_TEXT);
           writer.addMutation(m);
         }
       } else {
         for (GcCandidate candidate : candidates) {
           Mutation m = new Mutation(DeletesSection.encodeRow(candidate.getPath()));
+          // Removes this and older versions while allowing newer candidate versions to persist
           m.putDelete(EMPTY_TEXT, EMPTY_TEXT, candidate.getUid());
           writer.addMutation(m);
         }


### PR DESCRIPTION
GcCandidates are "Valid" when the filepaths they reference have been removed from HDFS.
Because the file no longer exists, the putDelete mutation should not include a timestamp to ensure no newer versions of that same GcCandidate are processed a second time. 