### PR TITLE
Fix ImportConfiguration.builder().setKeepOffline()

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
@@ -607,10 +607,9 @@ class FateServiceHandler implements FateService.Iface {
 
         goalMessage += "Import table with new name: " + tableName + " from " + exportDirs;
         manager.fate()
-            .seedTransaction(
-                op.toString(), opid, new TraceRepo<>(new ImportTable(c.getPrincipal(), tableName,
-                    exportDirs, namespaceId, keepMappings, !keepOffline)),
-                autoCleanup, goalMessage);
+            .seedTransaction(op.toString(), opid, new TraceRepo<>(new ImportTable(c.getPrincipal(),
+                tableName, exportDirs, namespaceId, keepMappings, keepOffline)), autoCleanup,
+                goalMessage);
         break;
       }
       case TABLE_EXPORT: {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/FinishImportTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/FinishImportTable.java
@@ -52,9 +52,8 @@ class FinishImportTable extends ManagerRepo {
       }
     }
 
-    if (tableInfo.onlineTable) {
-      env.getTableManager().transitionTableState(tableInfo.tableId, TableState.ONLINE);
-    }
+    final TableState newState = tableInfo.keepOffline ? TableState.OFFLINE : TableState.ONLINE;
+    env.getTableManager().transitionTableState(tableInfo.tableId, newState);
 
     Utils.unreserveNamespace(env, tableInfo.namespaceId, tid, false);
     Utils.unreserveTable(env, tableInfo.tableId, tid, true);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportTable.java
@@ -62,14 +62,14 @@ public class ImportTable extends ManagerRepo {
   private final ImportedTableInfo tableInfo;
 
   public ImportTable(String user, String tableName, Set<String> exportDirs, NamespaceId namespaceId,
-      boolean keepMappings, boolean onlineTable) {
+      boolean keepMappings, boolean keepOffline) {
     tableInfo = new ImportedTableInfo();
     tableInfo.tableName = tableName;
     tableInfo.user = user;
     tableInfo.namespaceId = namespaceId;
     tableInfo.directories = parseExportDir(exportDirs);
     tableInfo.keepMappings = keepMappings;
-    tableInfo.onlineTable = onlineTable;
+    tableInfo.keepOffline = keepOffline;
   }
 
   @Override

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportedTableInfo.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportedTableInfo.java
@@ -35,7 +35,7 @@ class ImportedTableInfo implements Serializable {
   public List<DirectoryMapping> directories;
   public String exportFile;
   public boolean keepMappings;
-  public boolean onlineTable;
+  public boolean keepOffline;
 
   static class DirectoryMapping implements Serializable {
     private static final long serialVersionUID = 1L;

--- a/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
@@ -47,6 +47,7 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
@@ -294,6 +295,7 @@ public class ImportExportIT extends AccumuloClusterHarness {
 
       // verify the new table is offline
       assertFalse(client.tableOperations().isOnline(destTable), "Table should have been offline.");
+      assertEquals(getServerContext().getTableState(TableId.of(tableId)), TableState.OFFLINE);
       client.tableOperations().online(destTable, true);
 
       // Get all `file` colfams from the metadata table for the new table


### PR DESCRIPTION
Fixes #4045 

This PR adds logic to properly transition the state of a new table created via `importTable()` to offline (or online) depending on the value supplied via the `ImportConfiguration`.

This was corrected by the change in `FinishImportTable` where the table was never transitioned from the NEW to OFFLINE table state when the (then `onlineTable`) param was set.

Other changes:
* added a check in the IT to make sure the new table is in the OFFLINE state instead of just "not online"
* renamed the member variable from `onlineTable` to `keepOffline` for clarity and consistency