### PR TITLE
Fix bug in compaction props (reapply #4092)

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
@@ -221,7 +221,8 @@ public class DefaultCompactionPlanner implements CompactionPlanner {
       this.maxFilesToCompact = Integer.parseInt(params.getServiceEnvironment().getConfiguration()
           .get(Property.TSERV_MAJC_THREAD_MAXOPEN.getKey()));
     } else {
-      this.maxFilesToCompact = Integer.parseInt(params.getOptions().getOrDefault("maxOpen", "10"));
+      this.maxFilesToCompact = Integer.parseInt(params.getOptions().getOrDefault("maxOpen",
+          Property.TSERV_COMPACTION_SERVICE_DEFAULT_MAX_OPEN.getDefaultValue()));
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionPlannerInitParams.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionPlannerInitParams.java
@@ -60,7 +60,7 @@ public class CompactionPlannerInitParams implements CompactionPlanner.InitParame
 
   @Override
   public String getFullyQualifiedOption(String key) {
-    return Property.TSERV_COMPACTION_SERVICE_PREFIX.getKey() + serviceId + ".opts." + key;
+    return Property.TSERV_COMPACTION_SERVICE_PREFIX.getKey() + serviceId + ".planner.opts." + key;
   }
 
   @Override


### PR DESCRIPTION
This fixes a bug in the compaction properties to ensure the replacement
property is always preferred over the deprecated open.max compaction
property when it is set.

Add tests for maxOpen to override open.max:
* Adds a test to ensure that setting the maxOpen option for a compaction
  service will override the deprecated `open.max` property if set
* Condenses helper methods in planner tests
* Uses CompactionPlannerInitParams for tests instead of custom test code
* Adds test case for default compaction service used with deprecated
  property
* Removes hardcoded maxOpen value with reference to default property
  value
* Modifies the getFullyQualifiedOption to return the correct path for
  the `<service>.planner.opts.` properties

This is a reapplication of #4092 after it was reverted, to use
SiteConfiguration for testing overrides rather than modifications to
ConfigurationCopy

Changes made by ctubbsii that diverge from #4092:
* Update commit log message to add detail and format it
* Omit changes to ConfigurationCopy, including changes in #4112, which
  is now OBE, to add a parent to preserve its role as a simple "flat"
  configuration object for testing and simple operations
* Use SiteConfiguration with overrides, instead of ConfigurationCopy
  with a parent, to test override behavior for
  DefaultCompactionPlannerTest

Co-authored-by: Christopher Tubbs <ctubbsii@apache.org>