### PR TITLE
Return non-merged view of System config

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/admin/InstanceOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/InstanceOperations.java
@@ -172,6 +172,7 @@ public interface InstanceOperations {
    * {@link #getSystemConfiguration} for a merged view.
    *
    * @return A map of the system properties set in Zookeeper only.
+   * @since 3.1
    */
   Map<String,String> getSystemProperties() throws AccumuloException, AccumuloSecurityException;
 

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/InstanceOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/InstanceOperations.java
@@ -167,6 +167,15 @@ public interface InstanceOperations {
   Map<String,String> getSiteConfiguration() throws AccumuloException, AccumuloSecurityException;
 
   /**
+   * Retrieve a map of the system properties set in Zookeeper. Note that this does not return a
+   * merged view of the properties from its parent configuration. See
+   * {@link #getSystemConfiguration} for a merged view.
+   *
+   * @return A map of the system properties set in Zookeeper only.
+   */
+  Map<String,String> getSystemProperties() throws AccumuloException, AccumuloSecurityException;
+
+  /**
    * Returns the location(s) of the accumulo manager and any redundant servers.
    *
    * @return a list of locations in <code>hostname:port</code> form.

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
@@ -207,6 +207,13 @@ public class InstanceOperationsImpl implements InstanceOperations {
   }
 
   @Override
+  public Map<String,String> getSystemProperties()
+      throws AccumuloException, AccumuloSecurityException {
+    return ThriftClientTypes.CLIENT.execute(context,
+        client -> client.getSystemProperties(TraceUtil.traceInfo(), context.rpcCreds()));
+  }
+
+  @Override
   public List<String> getManagerLocations() {
     return context.getManagerLocations();
   }

--- a/test/src/main/java/org/apache/accumulo/test/conf/PropStoreConfigIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/conf/PropStoreConfigIT.java
@@ -345,19 +345,21 @@ public class PropStoreConfigIT extends SharedMiniClusterBase {
       Map<String,String> sysProps = client.instanceOperations().getSystemProperties();
       // merged view
       Map<String,String> sysConfig = client.instanceOperations().getSystemConfiguration();
-      assertEquals(0, sysProps.size());
+      // sysProps is non-merged view, so should be empty at this point
+      assertTrue(sysProps.isEmpty());
+      // sysConfig is merged view, so will have props set already
       assertFalse(sysConfig.isEmpty());
       client.instanceOperations().setProperty(customPropKey1, customPropVal1);
       client.instanceOperations().setProperty(customPropKey2, customPropVal2);
+      Wait.waitFor(() -> client.instanceOperations().getSystemConfiguration().get(customPropKey1)
+          .equals(customPropVal1), 5000, 500);
+      Wait.waitFor(() -> client.instanceOperations().getSystemConfiguration().get(customPropKey2)
+          .equals(customPropVal2), 5000, 500);
       sysProps = client.instanceOperations().getSystemProperties();
-      sysConfig = client.instanceOperations().getSystemConfiguration();
-      // The props should be present in the merged and non-merged view
+      // The props should be present (and the only props) in the non-merged view
       assertEquals(2, sysProps.size());
       assertEquals(customPropVal1, sysProps.get(customPropKey1));
       assertEquals(customPropVal2, sysProps.get(customPropKey2));
-      assertTrue(sysConfig.size() > 2);
-      assertEquals(customPropVal1, sysConfig.get(customPropKey1));
-      assertEquals(customPropVal2, sysConfig.get(customPropKey2));
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/conf/PropStoreConfigIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/conf/PropStoreConfigIT.java
@@ -333,8 +333,10 @@ public class PropStoreConfigIT extends SharedMiniClusterBase {
   @Test
   public void getSystemPropertiesTest() throws Exception {
 
-    // Tests that getSystemProperties() does not return a merged view from its parent configuration
-    // (only returns those set at the system level)
+    // Tests that getSystemProperties() does not return a merged view (only returns props set at the
+    // system level).
+    // Compares this with getSystemConfiguration() which does return a merged view (system + site +
+    // default).
 
     String customPropKey1 = "table.custom.prop1";
     String customPropKey2 = "table.custom.prop2";
@@ -345,9 +347,10 @@ public class PropStoreConfigIT extends SharedMiniClusterBase {
       Map<String,String> sysProps = client.instanceOperations().getSystemProperties();
       // merged view
       Map<String,String> sysConfig = client.instanceOperations().getSystemConfiguration();
-      // sysProps is non-merged view, so should be empty at this point
+      // sysProps is non-merged view, so should be empty at this point (no system props set yet)
       assertTrue(sysProps.isEmpty());
-      // sysConfig is merged view, so will have props set already
+      // sysConfig is merged view, so will have some props already (default properties and those
+      // inherited from site config)
       assertFalse(sysConfig.isEmpty());
       client.instanceOperations().setProperty(customPropKey1, customPropVal1);
       client.instanceOperations().setProperty(customPropKey2, customPropVal2);
@@ -356,10 +359,15 @@ public class PropStoreConfigIT extends SharedMiniClusterBase {
       Wait.waitFor(() -> client.instanceOperations().getSystemConfiguration().get(customPropKey2)
           .equals(customPropVal2), 5000, 500);
       sysProps = client.instanceOperations().getSystemProperties();
-      // The props should be present (and the only props) in the non-merged view
+      // The custom props should be present (and the only props) in the non-merged view
       assertEquals(2, sysProps.size());
       assertEquals(customPropVal1, sysProps.get(customPropKey1));
       assertEquals(customPropVal2, sysProps.get(customPropKey2));
+      sysConfig = client.instanceOperations().getSystemConfiguration();
+      // The custom props should be present in the merged view
+      assertTrue(sysConfig.size() > 2);
+      assertEquals(customPropVal1, sysConfig.get(customPropKey1));
+      assertEquals(customPropVal2, sysConfig.get(customPropKey2));
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/apache/accumulo/issues/4095
- Added getSystemProperties() to InstanceOperations which functions similary to getTableProperties() and getNamespaceProperties() from TableOperations and NamespaceOperations.
- Added its implementation in InstanceOperationsImpl.
- Added a test getSystemPropertiesTest() to PropStoreConfigIT to test that the new method functions as intended.