### PR TITLE
Validate recovered lock type

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
@@ -175,14 +175,9 @@ public class Utils {
       boolean isWriteLock = lock instanceof WriteLock;
       if ((writeLock && !isWriteLock) || (!writeLock && isWriteLock)) {
         // Lock type does not match the expected type
-        throw new IllegalStateException("Unexpected lock type recovered. " + "Expected "
+        throw new IllegalStateException("Unexpected lock type recovered. Expected "
             + (writeLock ? "write" : "read") + " lock, but recovered "
-            + (isWriteLock ? "write" : "read") + " lock. Lock ID: " + Arrays.toString(lockData)); // <--
-                                                                                                  // Replace
-                                                                                                  // this
-                                                                                                  // line
-        // with the following line:
-        // + Arrays.toString(lockData));
+            + (isWriteLock ? "write" : "read") + " lock. Lock ID: " + Arrays.toString(lockData));
       }
     } else {
       DistributedReadWriteLock locker = new DistributedReadWriteLock(qlock, lockData);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
@@ -175,8 +175,8 @@ public class Utils {
       boolean isWriteLock = lock.getType() == LockType.WRITE;
       if (writeLock != isWriteLock) {
         throw new IllegalStateException("Unexpected lock type " + lock.getType()
-            + " recovered for transaction " + tid + " on object " + id + ". Expected "
-            + (writeLock ? LockType.WRITE : LockType.READ) + " lock instead.");
+            + " recovered for transaction " + FateTxId.formatTid(tid) + " on object " + id
+            + ". Expected " + (writeLock ? LockType.WRITE : LockType.READ) + " lock instead.");
       }
     } else {
       DistributedReadWriteLock locker = new DistributedReadWriteLock(qlock, lockData);


### PR DESCRIPTION
Validate recovered lock type against expected type (read or write) and throw IllegalStateException with detailed information on mismatch. If lock is not recovered, create a new lock as usual. Fixes issue #4066 