### PR TITLE
Updates DefaultCompactionPlanner to honor table.file.max prop

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -1130,8 +1130,12 @@ public enum Property {
           + " adjusting this property you may want to consider adjusting"
           + " table.compaction.major.ratio also. Setting this property to 0 will make"
           + " it default to tserver.scan.files.open.max-1, this will prevent a tablet"
-          + " from having more RFiles than can be opened. Setting this property low may"
-          + " throttle ingest and increase query performance.",
+          + " from having more RFiles than can be opened. Prior to 2.1.0 this property"
+          + " was used to trigger merging minor compactions, but merging minor compactions"
+          + " were removed in 2.1.0. Now this property is only used by the"
+          + " DefaultCompactionStrategy and the DefaultCompactionPlanner."
+          + " The DefaultCompactionPlanner started using this property in 2.1.3, before"
+          + " that it did not use the property.",
       "1.4.0"),
   TABLE_FILE_SUMMARY_MAX_SIZE("table.file.summary.maxSize", "256k", PropertyType.BYTES,
       "The maximum size summary that will be stored. The number of RFiles that"

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
@@ -122,7 +122,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * For example, given a tablet with 20 files, and table.file.max is 15 and no compactions are
  * planned. If the compaction ratio is set to 3, then this plugin will find the largest compaction
  * ratio less than 3 that results in a compaction.
- * </p>
  *
  *
  * @since 2.1.0

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
@@ -111,13 +111,19 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  *
  * <p>
  * Starting with Accumulo 2.1.3, this plugin will use the table config option
- * {@code "table.file.max"}. When a tablet has no compactions running, its number of files exceeds
- * table.file.max, and system compactions are not finding anything to compact then this plugin will
- * try to find a lower compaction ratio that will result in a compaction. For example if the
- * compaction ratio is set to 3, a tablet has 20 files, table.file.max is 15 and no compactions are
- * planned, then this plugin will find the largest compaction ratio less than 3 that results in a
- * compaction.
+ * {@code "table.file.max"}. When the following four conditions are met, then this plugin will try
+ * to find a lower compaction ratio that will result in a compaction:
+ * <ol>
+ * <li>When a tablet has no compactions running</li>
+ * <li>Its number of files exceeds table.file.max</li>
+ * <li>System compactions are not finding anything to compact</li>
+ * <li>No files are selected for user compaction</li>
+ * </ol>
+ * For example, given a tablet with 20 files, and table.file.max is 15 and no compactions are
+ * planned. If the compaction ratio is set to 3, then this plugin will find the largest compaction
+ * ratio less than 3 that results in a compaction.
  * </p>
+ *
  *
  * @since 2.1.0
  * @see org.apache.accumulo.core.spi.compaction

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
@@ -395,10 +395,11 @@ public class DefaultCompactionPlanner implements CompactionPlanner {
           maxTabletFiles);
     }
 
-    log.trace(
-        "Found {} files to compact lowering compaction ratio from {} to {} because the tablet "
+    log.info(
+        "For {} found {} files to compact lowering compaction ratio from {} to {} because the tablet "
             + "exceeded {} files, it had {}",
-        found.size(), params.getRatio(), lowRatio, maxTabletFiles, params.getCandidates().size());
+        params.getTableId(), found.size(), params.getRatio(), lowRatio, maxTabletFiles,
+        params.getCandidates().size());
 
     return found;
   }


### PR DESCRIPTION
This change updates the DefaultCompactionPlanner to honor the table.file.max property.  When a tablet has more files than is configured in table.file.max and its not compacting, it will try to find a compaction ratio that will cause a compaction.

Using a lower compaction ratio will find files of a similar size to compact. This avoids the problem with deprecated DefautlCompactionStrategy where it may select a 1K and 1G file for compaction because it selected the N smallest files that would bring the tablet under the table.file.max limit.