### PR TITLE
Avoids reading all fate ids into memory.

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/AbstractFateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/AbstractFateStore.java
@@ -27,17 +27,17 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.io.UncheckedIOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongConsumer;
+import java.util.stream.Stream;
 
 import org.apache.accumulo.core.fate.Fate.TxInfo;
 import org.slf4j.Logger;
@@ -124,37 +124,34 @@ public abstract class AbstractFateStore<T> implements FateStore<T> {
   }
 
   @Override
-  public Iterator<Long> runnable(AtomicBoolean keepWaiting) {
+  public void runnable(AtomicBoolean keepWaiting, LongConsumer idConsumer) {
 
-    while (keepWaiting.get()) {
-      ArrayList<Long> runnableTids = new ArrayList<>();
+    AtomicLong seen = new AtomicLong(0);
 
+    while (keepWaiting.get() && seen.get() == 0) {
       final long beforeCount = unreservedRunnableCount.getCount();
 
-      List<String> transactions = getTransactions();
-      for (String txidStr : transactions) {
-        long txid = parseTid(txidStr);
-        if (isRunnable(_getStatus(txid))) {
-          runnableTids.add(txid);
-        }
+      try (Stream<FateIdStatus> transactions = getTransactions()) {
+        transactions.filter(fateIdStatus -> isRunnable(fateIdStatus.getStatus()))
+            .mapToLong(FateIdStatus::getTxid).filter(txid -> {
+              synchronized (AbstractFateStore.this) {
+                var deferredTime = deferred.get(txid);
+                if (deferredTime != null) {
+                  if (deferredTime >= System.currentTimeMillis()) {
+                    return false;
+                  } else {
+                    deferred.remove(txid);
+                  }
+                }
+                return !reserved.contains(txid);
+              }
+            }).forEach(txid -> {
+              seen.incrementAndGet();
+              idConsumer.accept(txid);
+            });
       }
 
-      synchronized (this) {
-        runnableTids.removeIf(txid -> {
-          var deferredTime = deferred.get(txid);
-          if (deferredTime != null) {
-            if (deferredTime >= System.currentTimeMillis()) {
-              return true;
-            } else {
-              deferred.remove(txid);
-            }
-          }
-
-          return reserved.contains(txid);
-        });
-      }
-
-      if (runnableTids.isEmpty()) {
+      if (seen.get() == 0) {
         if (beforeCount == unreservedRunnableCount.getCount()) {
           long waitTime = 5000;
           if (!deferred.isEmpty()) {
@@ -167,23 +164,13 @@ public abstract class AbstractFateStore<T> implements FateStore<T> {
                 keepWaiting::get);
           }
         }
-      } else {
-        return runnableTids.iterator();
       }
-
     }
-
-    return Collections.emptyIterator();
   }
 
   @Override
-  public List<Long> list() {
-    ArrayList<Long> l = new ArrayList<>();
-    List<String> transactions = getTransactions();
-    for (String txid : transactions) {
-      l.add(parseTid(txid));
-    }
-    return l;
+  public Stream<Long> list() {
+    return getTransactions().map(fateIdStatus -> fateIdStatus.txid);
   }
 
   @Override
@@ -200,7 +187,21 @@ public abstract class AbstractFateStore<T> implements FateStore<T> {
     return Long.parseLong(txdir.split("_")[1], 16);
   }
 
-  protected abstract List<String> getTransactions();
+  public static abstract class FateIdStatus {
+    private final long txid;
+
+    public FateIdStatus(long txid) {
+      this.txid = txid;
+    }
+
+    public long getTxid() {
+      return txid;
+    }
+
+    public abstract TStatus getStatus();
+  }
+
+  protected abstract Stream<FateIdStatus> getTransactions();
 
   protected abstract TStatus _getStatus(long tid);
 

--- a/core/src/main/java/org/apache/accumulo/core/fate/AdminUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/AdminUtil.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.apache.accumulo.core.fate.FateStore.FateTxStore;
 import org.apache.accumulo.core.fate.ReadOnlyFateStore.ReadOnlyFateTxStore;
@@ -338,44 +339,45 @@ public class AdminUtil<T> {
       EnumSet<TStatus> filterStatus, Map<Long,List<String>> heldLocks,
       Map<Long,List<String>> waitingLocks) {
 
-    List<Long> transactions = zs.list();
-    List<TransactionStatus> statuses = new ArrayList<>(transactions.size());
+    try (Stream<Long> tids = zs.list()) {
+      List<TransactionStatus> statuses = new ArrayList<>();
 
-    for (Long tid : transactions) {
+      tids.forEach(tid -> {
 
-      ReadOnlyFateTxStore<T> txStore = zs.read(tid);
+        ReadOnlyFateTxStore<T> txStore = zs.read(tid);
 
-      String txName = (String) txStore.getTransactionInfo(Fate.TxInfo.TX_NAME);
+        String txName = (String) txStore.getTransactionInfo(Fate.TxInfo.TX_NAME);
 
-      List<String> hlocks = heldLocks.remove(tid);
+        List<String> hlocks = heldLocks.remove(tid);
 
-      if (hlocks == null) {
-        hlocks = Collections.emptyList();
-      }
+        if (hlocks == null) {
+          hlocks = Collections.emptyList();
+        }
 
-      List<String> wlocks = waitingLocks.remove(tid);
+        List<String> wlocks = waitingLocks.remove(tid);
 
-      if (wlocks == null) {
-        wlocks = Collections.emptyList();
-      }
+        if (wlocks == null) {
+          wlocks = Collections.emptyList();
+        }
 
-      String top = null;
-      ReadOnlyRepo<T> repo = txStore.top();
-      if (repo != null) {
-        top = repo.getName();
-      }
+        String top = null;
+        ReadOnlyRepo<T> repo = txStore.top();
+        if (repo != null) {
+          top = repo.getName();
+        }
 
-      TStatus status = txStore.getStatus();
+        TStatus status = txStore.getStatus();
 
-      long timeCreated = txStore.timeCreated();
+        long timeCreated = txStore.timeCreated();
 
-      if (includeByStatus(status, filterStatus) && includeByTxid(tid, filterTxid)) {
-        statuses.add(new TransactionStatus(tid, status, txName, hlocks, wlocks, top, timeCreated));
-      }
+        if (includeByStatus(status, filterStatus) && includeByTxid(tid, filterTxid)) {
+          statuses
+              .add(new TransactionStatus(tid, status, txName, hlocks, wlocks, top, timeCreated));
+        }
+      });
+
+      return new FateStatus(statuses, heldLocks, waitingLocks);
     }
-
-    return new FateStatus(statuses, heldLocks, waitingLocks);
-
   }
 
   private boolean includeByStatus(TStatus status, EnumSet<TStatus> filterStatus) {

--- a/core/src/main/java/org/apache/accumulo/core/fate/AgeOffStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/AgeOffStore.java
@@ -20,12 +20,14 @@ package org.apache.accumulo.core.fate;
 
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.LongConsumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -124,7 +126,9 @@ public class AgeOffStore<T> implements FateStore<T> {
 
     minTime = Long.MAX_VALUE;
 
-    List<Long> txids = store.list();
+    // ELASTICITY_TODO need to rework how this class works so that it does not buffer everything in
+    // memory.
+    List<Long> txids = store.list().collect(Collectors.toList());
     for (Long txid : txids) {
       FateTxStore<T> txStore = store.reserve(txid);
       try {
@@ -198,12 +202,12 @@ public class AgeOffStore<T> implements FateStore<T> {
   }
 
   @Override
-  public List<Long> list() {
+  public Stream<Long> list() {
     return store.list();
   }
 
   @Override
-  public Iterator<Long> runnable(AtomicBoolean keepWaiting) {
-    return store.runnable(keepWaiting);
+  public void runnable(AtomicBoolean keepWaiting, LongConsumer idConsumer) {
+    store.runnable(keepWaiting, idConsumer);
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
@@ -89,12 +89,9 @@ public class Fate<T> {
     public void run() {
       while (keepRunning.get()) {
         try {
-          var iter = store.runnable(keepRunning);
-
-          while (iter.hasNext() && keepRunning.get()) {
-            Long txid = iter.next();
-            try {
-              while (keepRunning.get()) {
+          store.runnable(keepRunning, txid -> {
+            while (keepRunning.get()) {
+              try {
                 // The reason for calling transfer instead of queueing is avoid rescanning the
                 // storage layer and adding the same thing over and over. For example if all threads
                 // were busy, the queue size was 100, and there are three runnable things in the
@@ -103,12 +100,12 @@ public class Fate<T> {
                 if (workQueue.tryTransfer(txid, 100, MILLISECONDS)) {
                   break;
                 }
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException(e);
               }
-            } catch (InterruptedException e) {
-              Thread.currentThread().interrupt();
-              throw new IllegalStateException(e);
             }
-          }
+          });
         } catch (Exception e) {
           if (keepRunning.get()) {
             log.warn("Failure while attempting to find work for fate", e);

--- a/core/src/main/java/org/apache/accumulo/core/fate/FateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/FateStore.java
@@ -85,7 +85,8 @@ public interface FateStore<T> extends ReadOnlyFateStore<T> {
      * longer interact with it.
      *
      * @param deferTime time in millis to keep this transaction from being returned by
-     *        {@link #runnable(java.util.concurrent.atomic.AtomicBoolean)}. Must be non-negative.
+     *        {@link #runnable(java.util.concurrent.atomic.AtomicBoolean, java.util.function.LongConsumer)}.
+     *        Must be non-negative.
      */
     void unreserve(long deferTime);
   }

--- a/core/src/main/java/org/apache/accumulo/core/fate/ReadOnlyFateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/ReadOnlyFateStore.java
@@ -20,9 +20,10 @@ package org.apache.accumulo.core.fate;
 
 import java.io.Serializable;
 import java.util.EnumSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.LongConsumer;
+import java.util.stream.Stream;
 
 /**
  * Read only access to a Transaction Store.
@@ -122,12 +123,13 @@ public interface ReadOnlyFateStore<T> {
    *
    * @return all outstanding transactions, including those reserved by others.
    */
-  List<Long> list();
+  Stream<Long> list();
 
   /**
-   * @return an iterator over fate op ids that are (IN_PROGRESS or FAILED_IN_PROGRESS) and
-   *         unreserved. This method will block until it finds something that is runnable or until
-   *         the keepWaiting parameter is false.
+   * Finds all fate ops that are (IN_PROGRESS, SUBMITTED, or FAILED_IN_PROGRESS) and unreserved. Ids
+   * that are found are passed to the consumer. This method will block until at least one runnable
+   * is found or until the keepWaiting parameter is false. It will return once all runnable ids
+   * found were passed to the consumer.
    */
-  Iterator<Long> runnable(AtomicBoolean keepWaiting);
+  void runnable(AtomicBoolean keepWaiting, LongConsumer idConsumer);
 }

--- a/core/src/main/java/org/apache/accumulo/core/logging/FateLogger.java
+++ b/core/src/main/java/org/apache/accumulo/core/logging/FateLogger.java
@@ -21,11 +21,11 @@ package org.apache.accumulo.core.logging;
 import static org.apache.accumulo.core.fate.FateTxId.formatTid;
 
 import java.io.Serializable;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
+import java.util.function.LongConsumer;
+import java.util.stream.Stream;
 
 import org.apache.accumulo.core.fate.Fate;
 import org.apache.accumulo.core.fate.FateStore;
@@ -115,13 +115,13 @@ public class FateLogger {
       }
 
       @Override
-      public List<Long> list() {
+      public Stream<Long> list() {
         return store.list();
       }
 
       @Override
-      public Iterator<Long> runnable(AtomicBoolean keepWaiting) {
-        return store.runnable(keepWaiting);
+      public void runnable(AtomicBoolean keepWaiting, LongConsumer idConsumer) {
+        store.runnable(keepWaiting, idConsumer);
       }
 
       @Override

--- a/core/src/test/java/org/apache/accumulo/core/fate/AgeOffStoreTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/fate/AgeOffStoreTest.java
@@ -18,9 +18,9 @@
  */
 package org.apache.accumulo.core.fate;
 
+import static java.util.stream.Collectors.toSet;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.accumulo.core.fate.AgeOffStore.TimeSource;
@@ -74,22 +74,19 @@ public class AgeOffStoreTest {
 
     aoStore.ageOff();
 
-    assertEquals(Set.of(txid1, txid2, txid3, txid4), new HashSet<>(aoStore.list()));
-    assertEquals(4, new HashSet<>(aoStore.list()).size());
+    assertEquals(Set.of(txid1, txid2, txid3, txid4), aoStore.list().collect(toSet()));
 
     tts.time = 15;
 
     aoStore.ageOff();
 
-    assertEquals(Set.of(txid1, txid3, txid4), new HashSet<>(aoStore.list()));
-    assertEquals(3, new HashSet<>(aoStore.list()).size());
+    assertEquals(Set.of(txid1, txid3, txid4), aoStore.list().collect(toSet()));
 
     tts.time = 30;
 
     aoStore.ageOff();
 
-    assertEquals(Set.of(txid1), new HashSet<>(aoStore.list()));
-    assertEquals(1, Set.of(aoStore.list()).size());
+    assertEquals(Set.of(txid1), aoStore.list().collect(toSet()));
   }
 
   @Test
@@ -119,20 +116,17 @@ public class AgeOffStoreTest {
 
     AgeOffStore<String> aoStore = new AgeOffStore<>(testStore, 10, tts);
 
-    assertEquals(Set.of(txid1, txid2, txid3, txid4), new HashSet<>(aoStore.list()));
-    assertEquals(4, new HashSet<>(aoStore.list()).size());
+    assertEquals(Set.of(txid1, txid2, txid3, txid4), aoStore.list().collect(toSet()));
 
     aoStore.ageOff();
 
-    assertEquals(Set.of(txid1, txid2, txid3, txid4), new HashSet<>(aoStore.list()));
-    assertEquals(4, new HashSet<>(aoStore.list()).size());
+    assertEquals(Set.of(txid1, txid2, txid3, txid4), aoStore.list().collect(toSet()));
 
     tts.time = 15;
 
     aoStore.ageOff();
 
-    assertEquals(Set.of(txid1), new HashSet<>(aoStore.list()));
-    assertEquals(1, new HashSet<>(aoStore.list()).size());
+    assertEquals(Set.of(txid1), aoStore.list().collect(toSet()));
 
     txStore1 = aoStore.reserve(txid1);
     txStore1.setStatus(TStatus.FAILED_IN_PROGRESS);
@@ -142,8 +136,7 @@ public class AgeOffStoreTest {
 
     aoStore.ageOff();
 
-    assertEquals(Set.of(txid1), new HashSet<>(aoStore.list()));
-    assertEquals(1, new HashSet<>(aoStore.list()).size());
+    assertEquals(Set.of(txid1), aoStore.list().collect(toSet()));
 
     txStore1 = aoStore.reserve(txid1);
     txStore1.setStatus(TStatus.FAILED);
@@ -151,13 +144,12 @@ public class AgeOffStoreTest {
 
     aoStore.ageOff();
 
-    assertEquals(Set.of(txid1), new HashSet<>(aoStore.list()));
-    assertEquals(1, new HashSet<>(aoStore.list()).size());
+    assertEquals(Set.of(txid1), aoStore.list().collect(toSet()));
 
     tts.time = 42;
 
     aoStore.ageOff();
 
-    assertEquals(0, new HashSet<>(aoStore.list()).size());
+    assertEquals(0, aoStore.list().count());
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/fate/TestStore.java
+++ b/core/src/test/java/org/apache/accumulo/core/fate/TestStore.java
@@ -23,12 +23,13 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.LongConsumer;
+import java.util.stream.Stream;
 
 /**
  * Transient in memory store for transactions.
@@ -165,12 +166,12 @@ public class TestStore implements FateStore<String> {
   }
 
   @Override
-  public List<Long> list() {
-    return new ArrayList<>(statuses.keySet());
+  public Stream<Long> list() {
+    return new ArrayList<>(statuses.keySet()).stream();
   }
 
   @Override
-  public Iterator<Long> runnable(AtomicBoolean keepWaiting) {
+  public void runnable(AtomicBoolean keepWaiting, LongConsumer idConsumer) {
     throw new UnsupportedOperationException();
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeCoordinator.java
@@ -274,13 +274,15 @@ public class UpgradeCoordinator {
     try {
       final ReadOnlyFateStore<UpgradeCoordinator> fate = new ZooStore<>(
           context.getZooKeeperRoot() + Constants.ZFATE, context.getZooReaderWriter());
-      if (!fate.list().isEmpty()) {
-        throw new AccumuloException("Aborting upgrade because there are"
-            + " outstanding FATE transactions from a previous Accumulo version."
-            + " You can start the tservers and then use the shell to delete completed "
-            + " transactions. If there are incomplete transactions, you will need to roll"
-            + " back and fix those issues. Please see the following page for more information: "
-            + " https://accumulo.apache.org/docs/2.x/troubleshooting/advanced#upgrade-issues");
+      try (var idStream = fate.list()) {
+        if (idStream.findFirst().isPresent()) {
+          throw new AccumuloException("Aborting upgrade because there are"
+              + " outstanding FATE transactions from a previous Accumulo version."
+              + " You can start the tservers and then use the shell to delete completed "
+              + " transactions. If there are incomplete transactions, you will need to roll"
+              + " back and fix those issues. Please see the following page for more information: "
+              + " https://accumulo.apache.org/docs/2.x/troubleshooting/advanced#upgrade-issues");
+        }
       }
     } catch (Exception exception) {
       log.error("Problem verifying Fate readiness", exception);

--- a/test/src/main/java/org/apache/accumulo/test/fate/accumulo/AccumuloFateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/accumulo/AccumuloFateIT.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.test.fate.accumulo;
 
-import java.util.NoSuchElementException;
 import java.util.stream.StreamSupport;
 
 import org.apache.accumulo.core.client.Accumulo;
@@ -69,20 +68,10 @@ public class AccumuloFateIT extends FateIT {
       scanner.setRange(getRow(txid));
       TxColumnFamily.STATUS_COLUMN.fetch(scanner);
       return StreamSupport.stream(scanner.spliterator(), false)
-          .map(e -> TStatus.valueOf(e.getValue().toString())).findFirst().orElseThrow();
+          .map(e -> TStatus.valueOf(e.getValue().toString())).findFirst().orElse(TStatus.UNKNOWN);
     } catch (TableNotFoundException e) {
       throw new IllegalStateException(table + " not found!", e);
     }
-  }
-
-  @Override
-  protected boolean verifyRemoved(ServerContext sctx, long txid) {
-    try {
-      getTxStatus(sctx, txid);
-    } catch (NoSuchElementException e) {
-      return true;
-    }
-    return false;
   }
 
   private static Range getRow(long tid) {

--- a/test/src/main/java/org/apache/accumulo/test/fate/accumulo/AccumuloStoreReadWriteIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/accumulo/AccumuloStoreReadWriteIT.java
@@ -66,13 +66,13 @@ public class AccumuloStoreReadWriteIT extends SharedMiniClusterBase {
 
       AccumuloStore<TestEnv> store = new AccumuloStore<>(client, table);
       // Verify no transactions
-      assertEquals(0, store.list().size());
+      assertEquals(0, store.list().count());
 
       // Create a new transaction and get the store for it
       long tid = store.create();
       FateTxStore<TestEnv> txStore = store.reserve(tid);
       assertTrue(txStore.timeCreated() > 0);
-      assertEquals(1, store.list().size());
+      assertEquals(1, store.list().count());
 
       // Push a test FATE op and verify we can read it back
       txStore.push(new TestRepo("testOp"));
@@ -109,13 +109,13 @@ public class AccumuloStoreReadWriteIT extends SharedMiniClusterBase {
 
       // create second
       FateTxStore<TestEnv> txStore2 = store.reserve(store.create());
-      assertEquals(2, store.list().size());
+      assertEquals(2, store.list().count());
 
       // test delete
       txStore.delete();
-      assertEquals(1, store.list().size());
+      assertEquals(1, store.list().count());
       txStore2.delete();
-      assertEquals(0, store.list().size());
+      assertEquals(0, store.list().count());
     }
   }
 


### PR DESCRIPTION
As we change Accumulo to use FATE for per tablet operations its important to avoid reading all FATEs persisted data into memory. This commit modifies FATE to use Streams internally instead of Collections. For the Accumulo implemention of FATE storage this makes it possible to have java stream backed by a scanner which avoids reading all of the FATE ids into memory.  The Zookeeper storage implementation will still read everything into memory.

Another change that was made in the PR was optimizing the Accumulo storage layer to read the status while reading the id.  Before this change ids were read from scanner, then for each id a scanner was created to read the status. Now the status and id are read in stream from the same scanner which should be much faster.  This change was not possible for Zookeeper, it will still make an RPC to get each status. Its ok that Zookeeper store is less efficient as the Accumulo store will likely store orders of magnitude more data.  Its probably not possible to make the same optimizations for speed and memory in the zookeeper store.

A bug in the Fate integration test was fixed by using the Unknown status which represents the status for transaction that does not exists in the persisted store.  Ran into this bug while testing these changes.