### PR TITLE
Fix CompactionIT after changes in #4127

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
@@ -327,6 +327,7 @@ public class CompactionIT extends AccumuloClusterHarness {
     final String table1 = this.getUniqueNames(1)[0];
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
       client.tableOperations().create(table1);
+      client.tableOperations().setProperty(table1, Property.TABLE_FILE_MAX.getKey(), "1001");
       client.tableOperations().setProperty(table1, Property.TABLE_MAJC_RATIO.getKey(), "51");
       TableId tid = TableId.of(client.tableOperations().tableIdMap().get(table1));
 
@@ -581,6 +582,7 @@ public class CompactionIT extends AccumuloClusterHarness {
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
       final String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
+      c.tableOperations().setProperty(tableName, Property.TABLE_FILE_MAX.getKey(), "1001");
       c.tableOperations().setProperty(tableName, Property.TABLE_MAJC_RATIO.getKey(), "100.0");
 
       var beforeCount = countFiles(c);


### PR DESCRIPTION
This increases the value of table.file.max.prop to 1001, which is the value already used by testErrorDuringUserCompaction, so that the tests get the expected values