### PR TITLE
removes consitency check in GC wal scan

### DIFF
--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
@@ -85,11 +85,11 @@ public class GarbageCollectWriteAheadLogs {
     this.walMarker = new WalStateManager(context);
     this.store = () -> Iterators.concat(
         context.getAmple().readTablets().forLevel(DataLevel.ROOT).filter(new HasWalsFilter())
-            .fetch(LOCATION, LAST, LOGS, PREV_ROW, SUSPEND).checkConsistency().build().iterator(),
+            .fetch(LOCATION, LAST, LOGS, PREV_ROW, SUSPEND).build().iterator(),
         context.getAmple().readTablets().forLevel(DataLevel.METADATA).filter(new HasWalsFilter())
-            .fetch(LOCATION, LAST, LOGS, PREV_ROW, SUSPEND).checkConsistency().build().iterator(),
+            .fetch(LOCATION, LAST, LOGS, PREV_ROW, SUSPEND).build().iterator(),
         context.getAmple().readTablets().forLevel(DataLevel.USER).filter(new HasWalsFilter())
-            .fetch(LOCATION, LAST, LOGS, PREV_ROW, SUSPEND).checkConsistency().build().iterator());
+            .fetch(LOCATION, LAST, LOGS, PREV_ROW, SUSPEND).build().iterator());
   }
 
   /**

--- a/test/src/main/java/org/apache/accumulo/test/VolumeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/VolumeIT.java
@@ -69,6 +69,7 @@ import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.TablePermission;
+import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.init.Initialize;
@@ -333,6 +334,7 @@ public class VolumeIT extends ConfigurableMacBase {
               }
             }
             log.warn("Unexpected volume " + entry.getKey() + " (" + entry.getValue() + ")");
+            UtilWaitThread.sleep(100);
             continue retry;
           }
         } catch (WalMarkerException e) {


### PR DESCRIPTION
The GC Wal scan was doing consitency checking and filtering which caused a runtime excecption that prevented wal GC.  Consistency checking is not needed becasue a tablet with a wal will not split or merge. Prior to the change in 5c454e12a144e3543175d2cbc0b54bc0900749b1 consistency checking was not done.  It was added w/o a specific reason so removing the consistency check instead of removing filtering. Fixing GC for wals fixes VolumeIT which was failing because no GC was happening.