### PR TITLE
Fix paste invocation to work with Mac OS X

### DIFF
--- a/assemble/conf/accumulo-env.sh
+++ b/assemble/conf/accumulo-env.sh
@@ -61,7 +61,7 @@ if [[ -n $CLASSPATH ]]; then
 else
   CLASSPATH="${conf}"
 fi
-ZK_JARS=$(find "$ZOOKEEPER_HOME/lib/" -maxdepth 1 -name '*.jar' -not -name '*slf4j*' -not -name '*log4j*' | paste -sd:)
+ZK_JARS=$(find "$ZOOKEEPER_HOME/lib/" -maxdepth 1 -name '*.jar' -not -name '*slf4j*' -not -name '*log4j*' | paste -sd: -)
 # lib is set by calling script that sources this env file
 #shellcheck disable=SC2154
 CLASSPATH="${CLASSPATH}:${lib}/*:${HADOOP_CONF_DIR}:${ZOOKEEPER_HOME}/*:${ZK_JARS}:${HADOOP_HOME}/share/hadoop/client/*"


### PR DESCRIPTION
Mac's version of paste (and other BSD systems, for that matter) require a filename or "-".  Linux's does not.  With this change, I can use Accumulo (via fluo-uno) on Mac OS X.