### PR TITLE
More Detailed Compaction Errors

### DIFF
--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
@@ -537,7 +537,8 @@ public class CompactionCoordinator extends AbstractServer
       throw new AccumuloSecurityException(credentials.getPrincipal(),
           SecurityErrorCode.PERMISSION_DENIED).asThriftException();
     }
-    LOG.info("Compaction failed, id: {}", externalCompactionId);
+    KeyExtent fromThriftExtent = KeyExtent.fromThrift(extent);
+    LOG.info("Compaction failed: id: {}, extent: {}", externalCompactionId, fromThriftExtent);
     final var ecid = ExternalCompactionId.of(externalCompactionId);
     compactionFailed(Map.of(ecid, KeyExtent.fromThrift(extent)));
   }

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionFinalizer.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionFinalizer.java
@@ -128,7 +128,8 @@ public class CompactionFinalizer {
             ecfs.getExternalCompactionId().canonical(), ecfs.getExtent().toThrift(),
             ecfs.getFileSize(), ecfs.getEntries());
       } else if (ecfs.getFinalState() == FinalState.FAILED) {
-        LOG.debug("Notifying tserver {} that compaction {} has failed.", loc, ecfs);
+        LOG.debug("Notifying tserver {} that compaction {} with {} has failed.", loc, ecfs,
+            ecfs.getExternalCompactionId());
         client.compactionJobFailed(TraceUtil.traceInfo(), context.rpcCreds(),
             ecfs.getExternalCompactionId().canonical(), ecfs.getExtent().toThrift());
       } else {

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionFinalizer.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionFinalizer.java
@@ -128,8 +128,8 @@ public class CompactionFinalizer {
             ecfs.getExternalCompactionId().canonical(), ecfs.getExtent().toThrift(),
             ecfs.getFileSize(), ecfs.getEntries());
       } else if (ecfs.getFinalState() == FinalState.FAILED) {
-        LOG.debug("Notifying tserver {} that compaction {} with {} has failed.", loc, ecfs,
-            ecfs.getExternalCompactionId());
+        LOG.debug("Notifying tserver {} that compaction {} with {} has failed.", loc,
+            ecfs.getExternalCompactionId(), ecfs);
         client.compactionJobFailed(TraceUtil.traceInfo(), context.rpcCreds(),
             ecfs.getExternalCompactionId().canonical(), ecfs.getExtent().toThrift());
       } else {

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/DeadCompactionDetector.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/DeadCompactionDetector.java
@@ -128,8 +128,8 @@ public class DeadCompactionDetector {
         this.deadCompactions.entrySet().stream().filter(e -> e.getValue() > 2).map(e -> e.getKey())
             .collect(Collectors.toCollection(TreeSet::new));
     tabletCompactions.keySet().retainAll(toFail);
-    tabletCompactions.forEach((eci, v) -> {
-      log.warn("Compaction {} believed to be dead, failing it.", eci);
+    tabletCompactions.forEach((ecid, extent) -> {
+      log.warn("Compaction believed to be dead, failing it: id: {}, extent: {}", ecid, extent);
     });
     coordinator.compactionFailed(tabletCompactions);
     this.deadCompactions.keySet().removeAll(toFail);

--- a/server/compactor/src/test/java/org/apache/accumulo/compactor/CompactorTest.java
+++ b/server/compactor/src/test/java/org/apache/accumulo/compactor/CompactorTest.java
@@ -39,6 +39,8 @@ import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.dataImpl.thrift.TKeyExtent;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
@@ -367,8 +369,7 @@ public class CompactorTest {
     expect(client.getAddress()).andReturn(address);
 
     TExternalCompactionJob job = PowerMock.createNiceMock(TExternalCompactionJob.class);
-    TKeyExtent extent = PowerMock.createNiceMock(TKeyExtent.class);
-    expect(extent.getTable()).andReturn("testTable".getBytes()).anyTimes();
+    TKeyExtent extent = new KeyExtent(TableId.of("testTable"), null, null).toThrift();
 
     expect(job.isSetExternalCompactionId()).andReturn(true).anyTimes();
     expect(job.getExternalCompactionId()).andReturn(eci.toString()).anyTimes();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
@@ -1408,7 +1408,8 @@ public class CompactableImpl implements Compactable {
           successful = true;
         } catch (Exception e) {
           metaFile = Optional.empty();
-          log.error("Error committing external compaction {}", extCompactionId, e);
+          log.error("Error committing external compaction: id: {}, extent: {}", extCompactionId,
+              getExtent(), e);
           throw new RuntimeException(e);
         } finally {
           completeCompaction(ecInfo.job, ecInfo.meta.getJobFiles(), metaFile, successful);
@@ -1450,7 +1451,7 @@ public class CompactableImpl implements Compactable {
             .mutate();
         completeCompaction(ecInfo.job, ecInfo.meta.getJobFiles(), Optional.empty(), false);
         externalCompactions.remove(ecid);
-        log.debug("Processed external compaction failure {}", ecid);
+        log.debug("Processed external compaction failure: id: {}, extent: {}", ecid, getExtent());
       } else {
         log.debug("Ignoring request to fail external compaction that is unknown {}", ecid);
       }

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalDoNothingCompactor.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalDoNothingCompactor.java
@@ -29,6 +29,7 @@ import org.apache.accumulo.compactor.Compactor;
 import org.apache.accumulo.core.compaction.thrift.CompactorService.Iface;
 import org.apache.accumulo.core.compaction.thrift.TCompactionState;
 import org.apache.accumulo.core.compaction.thrift.TCompactionStatusUpdate;
+import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.tabletserver.thrift.TExternalCompactionJob;
 import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.server.compaction.FileCompactor.CompactionCanceledException;
@@ -77,7 +78,9 @@ public class ExternalDoNothingCompactor extends Compactor implements Iface {
         throw new CompactionCanceledException();
 
       } catch (Exception e) {
-        LOG.error("Compaction failed", e);
+        KeyExtent fromThriftExtent = KeyExtent.fromThrift(job.getExtent());
+        LOG.error("Compaction failed: id: {}, extent: {}", job.getExternalCompactionId(),
+            fromThriftExtent, e);
         err.set(e);
       } finally {
         stopped.countDown();


### PR DESCRIPTION
Closes #4075
Changes:
- CompactionFinalizer
	- Added compactionId to log of compaction failure (tableId is already included from 'ecfs')
- CompactionCoordinator
	- Added extent/tableId to log of compaction failure (compactionId already included)
- CompactableImpl
	- Added extent/tableId to two logs of compaction failure (compactionId already included)
- Compactor
	- Added extent/tableId and compactionId to three of the logs
- ExternalDoNothingCompactor
	- Added extent/tableId and compactionId to log of compaction failure
- DeadCompactionDetector
	- Added extent/tableId to log (compactionId already included)
- FileCompactor
	- Added extent/tableId, input files, output file, iterators, and thread start time to log when error occurs

Potentially still left TODO:
- Any more logs that need to be changed?
- Any of the logs I changed that shouldn't have been?
- Other requested changes?