### PR TITLE
Fix ConcurrentModificationException in QueueMetrics

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactorGroupId.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactorGroupId.java
@@ -27,18 +27,11 @@ import org.apache.accumulo.core.data.AbstractId;
  * @since 3.1.0
  * @see org.apache.accumulo.core.spi.compaction
  */
-public class CompactorGroupId extends AbstractId<CompactorGroupId> implements Cloneable {
+public class CompactorGroupId extends AbstractId<CompactorGroupId> {
   // ELASTICITY_TODO make this cache ids like TableId. This will help save manager memory.
   private static final long serialVersionUID = 1L;
 
   protected CompactorGroupId(String canonical) {
     super(canonical);
   }
-
-  @Override
-  public CompactorGroupId clone() throws CloneNotSupportedException {
-    super.clone();
-    return new CompactorGroupId(this.canonical());
-  }
-
 }

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactorGroupId.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactorGroupId.java
@@ -27,11 +27,17 @@ import org.apache.accumulo.core.data.AbstractId;
  * @since 3.1.0
  * @see org.apache.accumulo.core.spi.compaction
  */
-public class CompactorGroupId extends AbstractId<CompactorGroupId> {
+public class CompactorGroupId extends AbstractId<CompactorGroupId> implements Cloneable {
   // ELASTICITY_TODO make this cache ids like TableId. This will help save manager memory.
   private static final long serialVersionUID = 1L;
 
   protected CompactorGroupId(String canonical) {
     super(canonical);
   }
+
+  @Override
+  public CompactorGroupId clone() throws CloneNotSupportedException {
+    return new CompactorGroupId(this.canonical());
+  }
+
 }

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactorGroupId.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactorGroupId.java
@@ -37,6 +37,7 @@ public class CompactorGroupId extends AbstractId<CompactorGroupId> implements Cl
 
   @Override
   public CompactorGroupId clone() throws CloneNotSupportedException {
+    super.clone();
     return new CompactorGroupId(this.canonical());
   }
 


### PR DESCRIPTION
The metricsWithoutQueues variable is a SetView
which is sensitive to changes in the underlying
sets. The loop was modifying one of the underlying objects. To prevent the CME from being raised I
copied the objects into a new set.

Closes #4144