### PR TITLE
Adjusts compactor error logging because of race

### DIFF
--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -699,7 +699,7 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
                 }
               }
             } else {
-              LOG.error("Waiting on compaction thread to finish, but no RUNNING compaction");
+              LOG.debug("Waiting on compaction thread to finish, but no RUNNING compaction");
             }
           }
           compactionThread.join();


### PR DESCRIPTION
Noticed error logging from the compactor process and found it was caused by a race condition.  The logging indicated a compaction was not running when it was expected to, but the compaction started shortly after.  The background thread had not yet populated a set that the foreground thread was examining.  Adjusted the error logging to debug since it can happen spuriously.