### PR TITLE
Compaction Failed Logging in TabletLogger

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/logging/TabletLogger.java
+++ b/core/src/main/java/org/apache/accumulo/core/logging/TabletLogger.java
@@ -33,6 +33,7 @@ import org.apache.accumulo.core.metadata.CompactableFileImpl;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.TabletFile;
+import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
 import org.apache.accumulo.core.spi.compaction.CompactionJob;
 import org.apache.accumulo.core.spi.compaction.CompactionKind;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
@@ -146,6 +147,18 @@ public class TabletLogger {
   public static void compacted(KeyExtent extent, CompactionJob job, StoredTabletFile output) {
     fileLog.debug("Compacted {} for {} created {} from {}", extent, job.getKind(), output,
         asMinimalString(job.getFiles()));
+  }
+
+  public static void compactionFailed(KeyExtent extent, CompactionJob job,
+      CompactionConfig config) {
+    fileLog.debug("Failed to compact: extent: {}, input files: {}, iterators: {}", extent,
+        asMinimalString(job.getFiles()), config.getIterators());
+  }
+
+  public static void externalCompactionFailed(KeyExtent extent, ExternalCompactionId id,
+      CompactionJob job, CompactionConfig config) {
+    fileLog.debug("Failed to compact: id: {}, extent: {}, input files: {}, iterators: {}", id,
+        extent, asMinimalString(job.getFiles()), config.getIterators());
   }
 
   public static void flushed(KeyExtent extent, Optional<StoredTabletFile> newDatafile) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
@@ -1108,10 +1108,11 @@ public class CompactableImpl implements Compactable {
       log.debug("Compaction canceled {} ", getExtent());
     } catch (Exception e) {
       newFile = Optional.empty();
+      TabletLogger.compactionFailed(getExtent(), job, cInfo.localCompactionCfg);
       throw new RuntimeException(e);
     } finally {
       completeCompaction(job, cInfo.jobFiles, newFile, successful);
-      tablet.updateTimer(MAJOR, queuedTime, startTime, stats.getEntriesRead(), newFile == null);
+      tablet.updateTimer(MAJOR, queuedTime, startTime, stats.getEntriesRead(), newFile.isEmpty());
     }
   }
 
@@ -1161,6 +1162,8 @@ public class CompactableImpl implements Compactable {
 
     } catch (Exception e) {
       externalCompactions.remove(externalCompactionId);
+      TabletLogger.externalCompactionFailed(getExtent(), externalCompactionId, job,
+          cInfo.localCompactionCfg);
       completeCompaction(job, cInfo.jobFiles, Optional.empty(), false);
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
Closes #4139
Related to [pull/4148](https://github.com/apache/accumulo/pull/4148) / [issue/4075](https://github.com/apache/accumulo/issues/4075)
Changes:
- Methods compactionFailed() and externalCompactionFailed() in TabletLogger
- Small change to arg passed to updateTimer()
- Calls to compactionFailed() and externalCompactionFailed() in CompactableImpl