### PR TITLE
Remove direct use of System.out in shell

### DIFF
--- a/shell/src/main/java/org/apache/accumulo/shell/ShellOptionsJC.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/ShellOptionsJC.java
@@ -201,7 +201,7 @@ public class ShellOptionsJC {
         File file = new File(path);
         if (file.isFile() && file.canRead()) {
           clientConfigFile = file.getAbsolutePath();
-          System.out.println("Loading configuration from " + clientConfigFile);
+          Shell.log.info("Loading configuration from {}", clientConfigFile);
           break;
         }
       }

--- a/shell/src/test/java/org/apache/accumulo/shell/commands/FateCommandTest.java
+++ b/shell/src/test/java/org/apache/accumulo/shell/commands/FateCommandTest.java
@@ -33,6 +33,7 @@ import java.io.FileDescriptor;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -96,15 +97,15 @@ public class FateCommandTest {
     }
 
     @Override
-    protected boolean deleteTx(AdminUtil<FateCommand> admin, ZooStore<FateCommand> zs,
-        ZooReaderWriter zk, ServiceLockPath zLockManagerPath, String[] args)
-        throws InterruptedException, KeeperException {
+    protected boolean deleteTx(PrintWriter out, AdminUtil<FateCommand> admin,
+        ZooStore<FateCommand> zs, ZooReaderWriter zk, ServiceLockPath zLockManagerPath,
+        String[] args) throws InterruptedException, KeeperException {
       deleteCalled = true;
       return true;
     }
 
     @Override
-    public boolean failTx(AdminUtil<FateCommand> admin, ZooStore<FateCommand> zs,
+    public boolean failTx(PrintWriter out, AdminUtil<FateCommand> admin, ZooStore<FateCommand> zs,
         ZooReaderWriter zk, ServiceLockPath managerLockPath, String[] args) {
       failCalled = true;
       return true;
@@ -154,9 +155,10 @@ public class FateCommandTest {
 
     FateCommand cmd = new FateCommand();
     // require number for Tx
-    assertFalse(cmd.failTx(helper, zs, zk, managerLockPath, new String[] {"fail", "tx1"}));
+    var out = new PrintWriter(System.out);
+    assertFalse(cmd.failTx(out, helper, zs, zk, managerLockPath, new String[] {"fail", "tx1"}));
     // fail the long configured above
-    assertTrue(cmd.failTx(helper, zs, zk, managerLockPath, new String[] {"fail", "12345"}));
+    assertTrue(cmd.failTx(out, helper, zs, zk, managerLockPath, new String[] {"fail", "12345"}));
 
     verify(zs);
   }


### PR DESCRIPTION
* Show shell config load info as a log message, so it can be suppressed from output more easily (depending on logging config)
* Throw command line parse exception when an invalid shell option is used in FateCommand, instead of merely printing to System.out and returning
* Use shellState.getWriter() for command-output messages instead of hard-coded System.out (use System.out for related unit tests)