### PR TITLE
allows compact column in metadata constraint

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/AbstractFateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/AbstractFateStore.java
@@ -320,6 +320,5 @@ public abstract class AbstractFateStore<T> implements FateStore<T> {
         throw new IllegalStateException("Bad node data " + txInfo);
       }
     }
-
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataSchema.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataSchema.java
@@ -436,6 +436,9 @@ public class MetadataSchema {
       public static final String SPLIT_RATIO_QUAL = "splitRatio";
       public static final ColumnFQ SPLIT_RATIO_COLUMN =
           new ColumnFQ(TabletColumnFamily.NAME, new Text(SPLIT_RATIO_QUAL));
+
+      public static final ColumnFQ COMPACT_COL =
+          new ColumnFQ(ServerColumnFamily.NAME, new Text("compact"));
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataSchema.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataSchema.java
@@ -421,7 +421,7 @@ public class MetadataSchema {
       public static final ColumnFQ REQUESTED_COLUMN = new ColumnFQ(NAME, new Text(REQUESTED_QUAL));
     }
 
-    // These can be removed when the corresponding upgrade code is removed
+    // TODO when removing the Upgrader12to13 class in the upgrade package, also remove this class.
     public static class Upgrade12to13 {
 
       /**

--- a/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
@@ -93,7 +93,8 @@ public class MetadataConstraints implements Constraint {
           ServerColumnFamily.OPID_COLUMN,
           HostingColumnFamily.GOAL_COLUMN,
           HostingColumnFamily.REQUESTED_COLUMN,
-          ServerColumnFamily.SELECTED_COLUMN);
+          ServerColumnFamily.SELECTED_COLUMN,
+              Upgrade12to13.COMPACT_COL);
 
   @SuppressWarnings("deprecation")
   private static final Text CHOPPED = ChoppedColumnFamily.NAME;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader12to13.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader12to13.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.manager.upgrade;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.core.metadata.RootTable.ZROOT_TABLET;
 import static org.apache.accumulo.core.metadata.schema.MetadataSchema.RESERVED_PREFIX;
+import static org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.Upgrade12to13.COMPACT_COL;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -47,11 +48,9 @@ import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.core.schema.Section;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.core.util.ColumnFQ;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.conf.store.TablePropKey;
 import org.apache.accumulo.server.util.PropUtil;
-import org.apache.hadoop.io.Text;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
@@ -62,9 +61,6 @@ import com.google.common.base.Preconditions;
 public class Upgrader12to13 implements Upgrader {
 
   private static final Logger LOG = LoggerFactory.getLogger(Upgrader12to13.class);
-
-  private static final ColumnFQ COMPACT_COL =
-      new ColumnFQ(MetadataSchema.TabletsSection.ServerColumnFamily.NAME, new Text("compact"));
 
   @Override
   public void upgradeZookeeper(ServerContext context) {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader12to13.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader12to13.java
@@ -58,6 +58,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 
+//TODO when removing this class, also remove MetadataSchema.Upgrader12to13
 public class Upgrader12to13 implements Upgrader {
 
   private static final Logger LOG = LoggerFactory.getLogger(Upgrader12to13.class);


### PR DESCRIPTION
The upgrade code deletes the compact column in the metadata table.  The metadata constraint would cause this to fail (confirmed w/ a manual test). This change adds the compact column to the metadata constraint so the upgrade code can delete it.