### PR TITLE
Moves Compaction Properties to accumulo.properties file

### DIFF
--- a/assemble/conf/accumulo.properties
+++ b/assemble/conf/accumulo.properties
@@ -34,16 +34,16 @@ tserver.memory.maps.native.enabled=true
 
 ## Set compaction settings
 ### Default Compactor
-tserver.compaction.major.service.default.planner=org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner
-tserver.compaction.major.service.default.planner.opts.maxOpen=10
-tserver.compaction.major.service.default.planner.opts.executors="[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'medium','type':'internal','maxSize':'128M','numThreads':2},{'name':'large','type':'internal','numThreads':2}]"
+compaction.service.default.planner=org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner
+compaction.service.default.planner.opts.maxOpen=10
+compaction.service.default.planner.opts.executors="[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'medium','type':'internal','maxSize':'128M','numThreads':2},{'name':'large','type':'internal','numThreads':2}]"
 
 ### Meta Compactor
-tserver.compaction.major.service.meta.planner=org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner
-tserver.compaction.major.service.meta.planner.opts.maxOpen=30
-tserver.compaction.major.service.meta.planner.opts.executors="[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'huge','type':'internal','numThreads':2}]"
+compaction.service.meta.planner=org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner
+compaction.service.meta.planner.opts.maxOpen=30
+compaction.service.meta.planner.opts.executors="[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'huge','type':'internal','numThreads':2}]"
 
 ### Root Compactor
-tserver.compaction.major.service.root.planner=org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner
-tserver.compaction.major.service.root.planner.opts.maxOpen=30
-tserver.compaction.major.service.root.planner.opts.executors="[{'name':'small','type':'internal','maxSize':'32M','numThreads':1},{'name':'huge','type':'internal','numThreads':1}]"
+compaction.service.root.planner=org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner
+compaction.service.root.planner.opts.maxOpen=30
+compaction.service.root.planner.opts.executors="[{'name':'small','type':'internal','maxSize':'32M','numThreads':1},{'name':'huge','type':'internal','numThreads':1}]"

--- a/assemble/conf/accumulo.properties
+++ b/assemble/conf/accumulo.properties
@@ -31,3 +31,19 @@ instance.secret=DEFAULT
 
 ## Set to false if 'accumulo-util build-native' fails
 tserver.memory.maps.native.enabled=true
+
+## Set compaction settings
+### Default Compactor
+tserver.compaction.major.service.default.planner=org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner
+tserver.compaction.major.service.default.planner.opts.maxOpen=10
+tserver.compaction.major.service.default.planner.opts.executors="[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'medium','type':'internal','maxSize':'128M','numThreads':2},{'name':'large','type':'internal','numThreads':2}]"
+
+### Meta Compactor
+tserver.compaction.major.service.meta.planner=org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner
+tserver.compaction.major.service.meta.planner.opts.maxOpen=30
+tserver.compaction.major.service.meta.planner.opts.executors="[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'huge','type':'internal','numThreads':2}]"
+
+### Root Compactor
+tserver.compaction.major.service.root.planner=org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner
+tserver.compaction.major.service.root.planner.opts.maxOpen=30
+tserver.compaction.major.service.root.planner.opts.executors="[{'name':'small','type':'internal','maxSize':'32M','numThreads':1},{'name':'huge','type':'internal','numThreads':1}]"

--- a/core/src/main/java/org/apache/accumulo/core/conf/ConfigurationDocGen.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ConfigurationDocGen.java
@@ -97,6 +97,8 @@ public class ConfigurationDocGen {
         "<a name=\"" + prop.getKey().replace(".", "_") + "\" class=\"prop\"></a> " + prop.getKey(),
         depr);
     String description = prop.isExperimental() ? "**Experimental**<br>" : "";
+    description +=
+        prop.isExample() ? "**Example: property is not set in default configuration**<br>" : "";
     description += "**Available since:** ";
     if (prop.getKey().startsWith("manager.")
         && (prop.availableSince().startsWith("1.") || prop.availableSince().startsWith("2.0"))) {
@@ -115,17 +117,24 @@ public class ConfigurationDocGen {
     description += strike(sanitize(prop.getDescription()), depr) + "<br>"
         + strike("**type:** " + prop.getType().name(), depr) + ", "
         + strike("**zk mutable:** " + isZooKeeperMutable(prop), depr) + ", ";
-    String defaultValue = sanitize(prop.getDefaultValue()).trim();
-    if (defaultValue.isEmpty()) {
-      description += strike("**default value:** empty", depr);
-    } else if (defaultValue.contains("\n")) {
-      // deal with multi-line values, skip strikethrough of value
-      description += strike("**default value:** ", depr) + "\n```\n" + defaultValue + "\n```\n";
-    } else if (prop.getType() == PropertyType.CLASSNAME
-        && defaultValue.startsWith("org.apache.accumulo")) {
-      description += strike("**default value:** {% jlink -f " + defaultValue + " %}", depr);
+    String value, name;
+    if (prop.isExample()) {
+      value = sanitize(prop.getExampleValue()).trim();
+      name = "**example value:** ";
     } else {
-      description += strike("**default value:** `" + defaultValue + "`", depr);
+      value = sanitize(prop.getDefaultValue()).trim();
+      name = "**default value:** ";
+    }
+    if (value.isEmpty()) {
+      description += strike(name + "empty", depr);
+    } else if (value.contains("\n")) {
+      // deal with multi-line values, skip strikethrough of value
+      description += strike(name, depr) + "\n```\n" + value + "\n```\n";
+    } else if (prop.getType() == PropertyType.CLASSNAME
+        && value.startsWith("org.apache.accumulo")) {
+      description += strike(name + "{% jlink -f " + value + " %}", depr);
+    } else {
+      description += strike(name + "`" + value + "`", depr);
     }
     doc.println("| " + key + " | " + description + " |");
   }

--- a/core/src/main/java/org/apache/accumulo/core/conf/DefaultConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/DefaultConfiguration.java
@@ -34,8 +34,9 @@ public class DefaultConfiguration extends AccumuloConfiguration {
 
   private static final Supplier<DefaultConfiguration> instance = memoize(DefaultConfiguration::new);
 
-  private final Map<String,String> resolvedProps =
-      Arrays.stream(Property.values()).filter(p -> p.getType() != PropertyType.PREFIX)
+  private final Map<String,
+      String> resolvedProps = Arrays.stream(Property.values())
+          .filter(p -> p.getType() != PropertyType.PREFIX && !p.isExample())
           .collect(Collectors.toMap(Property::getKey, Property::getDefaultValue));
 
   private DefaultConfiguration() {}

--- a/core/src/main/java/org/apache/accumulo/core/conf/Example.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Example.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.conf;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * An annotation to denote that an {@link AccumuloConfiguration} {@link Property} key is only being
+ * referenced as an example property. This is to allow properties to exist in the {@link Property}
+ * class that are not included in the generated system properties.
+ */
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@interface Example {}

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -1142,12 +1142,15 @@ public enum Property {
 
   private final String key;
   private final String defaultValue;
+
+  private final String exampleValue;
   private final String description;
   private String deprecatedSince;
   private final String availableSince;
   private boolean annotationsComputed = false;
   private boolean isSensitive;
   private boolean isDeprecated;
+  private boolean isExample;
   private boolean isExperimental;
   private boolean isReplaced;
   private Property replacedBy = null;
@@ -1155,8 +1158,14 @@ public enum Property {
 
   Property(String name, String defaultValue, PropertyType type, String description,
       String availableSince) {
+    this(name, defaultValue, null, type, description, availableSince);
+  }
+
+  Property(String name, String defaultValue, String exampleValue, PropertyType type,
+      String description, String availableSince) {
     this.key = name;
     this.defaultValue = defaultValue;
+    this.exampleValue = exampleValue;
     this.description = description;
     this.availableSince = availableSince;
     this.type = type;
@@ -1187,6 +1196,15 @@ public enum Property {
   }
 
   /**
+   * Gets the example value for this property.
+   *
+   * @return example value
+   */
+  public String getExampleValue() {
+    return this.exampleValue;
+  }
+
+  /**
    * Gets the type of this property.
    *
    * @return property type
@@ -1202,6 +1220,17 @@ public enum Property {
    */
   public String getDescription() {
     return this.description;
+  }
+
+  /**
+   * Checks if this property is an example.
+   *
+   * @return true if this property is an example
+   */
+  public boolean isExample() {
+    Preconditions.checkState(annotationsComputed,
+        "precomputeAnnotations() must be called before calling this method");
+    return isExample;
   }
 
   /**
@@ -1298,6 +1327,7 @@ public enum Property {
     } else {
       isReplaced = false;
     }
+    isExample = hasAnnotation(Example.class) || hasPrefixWithAnnotation(getKey(), Example.class);
     annotationsComputed = true;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -82,7 +82,7 @@ public enum Property {
       COMPACTION_SERVICE_PREFIX + "default.planner.opts.groups", null,
       "[{'name':'default'},{'name':'large'}]".replaceAll("'", "\""), PropertyType.JSON,
       "The various compactor groups for this compaction service."
-          + " See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %}",
+          + " See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %}.",
       "3.1.0"),
   @Example
   @Deprecated(since = "3.1")

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -69,6 +69,31 @@ public enum Property {
           + " been deprecated in anticipation of it being removed in a future release that"
           + " removes the rate limiting feature.",
       "2.1.0"),
+  @Example
+  COMPACTION_SERVICE_DEFAULT_PLANNER(COMPACTION_SERVICE_PREFIX + "default.planner", null,
+      "org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner", PropertyType.CLASSNAME,
+      "Planner for default compaction service.", "2.1.0"),
+  @Example
+  COMPACTION_SERVICE_DEFAULT_PLANNER_MAXOPEN(
+      COMPACTION_SERVICE_PREFIX + "default.planner.opts.maxOpen", null, "10", PropertyType.STRING,
+      "The maximum number of files a compaction will open.", "2.1.0"),
+  @Example
+  COMPACTION_SERVICE_DEFAULT_PLANNER_GROUPS(
+      COMPACTION_SERVICE_PREFIX + "default.planner.opts.groups", null,
+      "[{'name':'default'},{'name':'large'}]".replaceAll("'", "\""), PropertyType.JSON,
+      "The various compactor groups for this compaction service."
+          + " See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %}",
+      "3.1.0"),
+  @Example
+  @Deprecated(since = "3.1")
+  @ReplacedBy(property = COMPACTION_SERVICE_DEFAULT_PLANNER_GROUPS)
+  COMPACTION_SERVICE_DEFAULT_PLANNER_EXECUTORS(
+      COMPACTION_SERVICE_PREFIX + "default.planner.opts.executors", null,
+      "[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'medium','type':'internal','maxSize':'128M','numThreads':2},{'name':'large','type':'internal','numThreads':2}]"
+          .replaceAll("'", "\""),
+      PropertyType.JSON,
+      "See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %}.",
+      "2.1.0"),
   COMPACTION_WARN_TIME(COMPACTION_PREFIX + "warn.time", "10m", PropertyType.TIMEDURATION,
       "When a compaction has not made progress for this time period, a warning will be logged.",
       "3.1.0"),

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
@@ -301,7 +301,7 @@ public class DefaultCompactionPlanner implements CompactionPlanner {
 
     String maxOpen = params.getOptions().get("maxOpen");
     if (maxOpen == null) {
-      maxOpen = Property.TSERV_COMPACTION_SERVICE_DEFAULT_MAX_OPEN.getDefaultValue();
+      maxOpen = Property.COMPACTION_DEFAULT_MAX_OPEN.getDefaultValue();
       log.trace("default maxOpen not set, defaulting to {}", maxOpen);
     }
     this.maxFilesToCompact = Integer.parseInt(maxOpen);

--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionServicesConfig.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionServicesConfig.java
@@ -55,7 +55,7 @@ public class CompactionServicesConfig {
   @SuppressWarnings("deprecation")
   private long getDefaultThroughput() {
     return ConfigurationTypeHelper
-        .getMemoryAsBytes(Property.TSERV_COMPACTION_SERVICE_DEFAULT_RATE_LIMIT.getDefaultValue());
+        .getMemoryAsBytes(Property.COMPACTION_DEFAULT_RATE_LIMIT.getDefaultValue());
   }
 
   private Map<String,Map<String,String>> getConfiguration(AccumuloConfiguration aconf) {

--- a/core/src/test/java/org/apache/accumulo/core/conf/PropertyTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/PropertyTest.java
@@ -61,9 +61,18 @@ public class PropertyTest {
         assertNull(prop.getDefaultValue(),
             "PREFIX property " + prop.name() + " has unexpected non-null default value.");
       } else {
-        assertTrue(Property.isValidProperty(prop.getKey(), prop.getDefaultValue()),
-            "Property " + prop + " has invalid default value " + prop.getDefaultValue()
-                + " for type " + prop.getType());
+        // Default Values aren't set for example properties, so test the example values instead.
+        if (prop.isExample()) {
+          var key = prop.getKey();
+          var value = prop.getExampleValue();
+          assertTrue(Property.isValidProperty(key, value));
+          assertTrue(prop.getDefaultValue() == null,
+              "Example property must have a default value of 'null'");
+        } else {
+          assertTrue(Property.isValidProperty(prop.getKey(), prop.getDefaultValue()),
+              "Property " + prop + " has invalid default value " + prop.getDefaultValue()
+                  + " for type " + prop.getType());
+        }
       }
 
       // make sure property has a description
@@ -140,6 +149,9 @@ public class PropertyTest {
     for (Property property : Property.values()) {
       PropertyType propertyType = property.getType();
       String invalidValue, validValue = property.getDefaultValue();
+      if (property.isExample()) {
+        validValue = property.getExampleValue();
+      }
       LOG.debug("Testing property: {} with type: {}", property.getKey(), propertyType);
 
       switch (propertyType) {

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
@@ -165,23 +165,25 @@ public class MiniAccumuloConfigImpl {
       mergePropWithRandomPort(Property.GC_PORT.getKey());
 
       // Default Compactor
-      mergeProp("tserver.compaction.major.service.default.planner",
+      mergeProp(Property.COMPACTION_SERVICE_DEFAULT_PLANNER.getKey(),
           "org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner");
-      mergeProp("tserver.compaction.major.service.default.planner.opts.maxOpen", "10");
-      mergeProp("tserver.compaction.major.service.default.planner.opts.executors",
+      mergeProp(Property.COMPACTION_SERVICE_DEFAULT_PLANNER_MAXOPEN.getKey(), "10");
+      @SuppressWarnings("deprecation")
+      String executorProp = Property.COMPACTION_SERVICE_DEFAULT_PLANNER_EXECUTORS.getKey();
+      mergeProp(executorProp,
           "[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'medium','type':'internal','maxSize':'128M','numThreads':2},{'name':'large','type':'internal','numThreads':2}]");
 
       // Meta Compactor
-      mergeProp("tserver.compaction.major.service.meta.planner",
+      mergeProp("compaction.service.meta.planner",
           "org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner");
-      mergeProp("tserver.compaction.major.service.meta.planner.opts.maxOpen", "30");
-      mergeProp("tserver.compaction.major.service.meta.planner.opts.executors",
+      mergeProp("compaction.service.meta.planner.opts.maxOpen", "30");
+      mergeProp("compaction.service.meta.planner.opts.executors",
           "[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'huge','type':'internal','numThreads':2}]");
       // Root Compactor
-      mergeProp("tserver.compaction.major.service.root.planner",
+      mergeProp("compaction.service.root.planner",
           "org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner");
-      mergeProp("tserver.compaction.major.service.root.planner.opts.maxOpen", "30");
-      mergeProp("tserver.compaction.major.service.root.planner.opts.executors",
+      mergeProp("compaction.service.root.planner.opts.maxOpen", "30");
+      mergeProp("compaction.service.root.planner.opts.executors",
           "[{'name':'small','type':'internal','maxSize':'32M','numThreads':1},{'name':'huge','type':'internal','numThreads':1}]");
 
       if (isUseCredentialProvider()) {

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
@@ -171,20 +171,23 @@ public class MiniAccumuloConfigImpl {
       @SuppressWarnings("deprecation")
       String executorProp = Property.COMPACTION_SERVICE_DEFAULT_PLANNER_EXECUTORS.getKey();
       mergeProp(executorProp,
-          "[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'medium','type':'internal','maxSize':'128M','numThreads':2},{'name':'large','type':'internal','numThreads':2}]");
+          "[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'medium','type':'internal','maxSize':'128M','numThreads':2},{'name':'large','type':'internal','numThreads':2}]"
+              .replaceAll("'", "\""));
 
       // Meta Compactor
       mergeProp("compaction.service.meta.planner",
           "org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner");
       mergeProp("compaction.service.meta.planner.opts.maxOpen", "30");
       mergeProp("compaction.service.meta.planner.opts.executors",
-          "[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'huge','type':'internal','numThreads':2}]");
+          "[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'huge','type':'internal','numThreads':2}]"
+              .replaceAll("'", "\""));
       // Root Compactor
       mergeProp("compaction.service.root.planner",
           "org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner");
       mergeProp("compaction.service.root.planner.opts.maxOpen", "30");
       mergeProp("compaction.service.root.planner.opts.executors",
-          "[{'name':'small','type':'internal','maxSize':'32M','numThreads':1},{'name':'huge','type':'internal','numThreads':1}]");
+          "[{'name':'small','type':'internal','maxSize':'32M','numThreads':1},{'name':'huge','type':'internal','numThreads':1}]"
+              .replaceAll("'", "\""));
 
       if (isUseCredentialProvider()) {
         updateConfigForCredentialProvider();

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
@@ -164,6 +164,26 @@ public class MiniAccumuloConfigImpl {
       mergePropWithRandomPort(Property.MONITOR_PORT.getKey());
       mergePropWithRandomPort(Property.GC_PORT.getKey());
 
+      // Default Compactor
+      mergeProp("tserver.compaction.major.service.default.planner",
+          "org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner");
+      mergeProp("tserver.compaction.major.service.default.planner.opts.maxOpen", "10");
+      mergeProp("tserver.compaction.major.service.default.planner.opts.executors",
+          "[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'medium','type':'internal','maxSize':'128M','numThreads':2},{'name':'large','type':'internal','numThreads':2}]");
+
+      // Meta Compactor
+      mergeProp("tserver.compaction.major.service.meta.planner",
+          "org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner");
+      mergeProp("tserver.compaction.major.service.meta.planner.opts.maxOpen", "30");
+      mergeProp("tserver.compaction.major.service.meta.planner.opts.executors",
+          "[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'huge','type':'internal','numThreads':2}]");
+      // Root Compactor
+      mergeProp("tserver.compaction.major.service.root.planner",
+          "org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner");
+      mergeProp("tserver.compaction.major.service.root.planner.opts.maxOpen", "30");
+      mergeProp("tserver.compaction.major.service.root.planner.opts.executors",
+          "[{'name':'small','type':'internal','maxSize':'32M','numThreads':1},{'name':'huge','type':'internal','numThreads':1}]");
+
       if (isUseCredentialProvider()) {
         updateConfigForCredentialProvider();
       }

--- a/test/src/main/java/org/apache/accumulo/test/compaction/CompactionRateLimitingIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/CompactionRateLimitingIT.java
@@ -42,7 +42,7 @@ public class CompactionRateLimitingIT extends ConfigurableMacBase {
 
   @SuppressWarnings("deprecation")
   protected Property getThroughputProp() {
-    return Property.TSERV_COMPACTION_SERVICE_DEFAULT_RATE_LIMIT;
+    return Property.COMPACTION_DEFAULT_RATE_LIMIT;
   }
 
   @Override

--- a/test/src/main/java/org/apache/accumulo/test/shell/ConfigSetIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ConfigSetIT.java
@@ -18,8 +18,8 @@
  */
 package org.apache.accumulo.test.shell;
 
+import static org.apache.accumulo.core.conf.Property.COMPACTION_SERVICE_PREFIX;
 import static org.apache.accumulo.core.conf.Property.MONITOR_RESOURCES_EXTERNAL;
-import static org.apache.accumulo.core.conf.Property.TSERV_COMPACTION_SERVICE_ROOT_EXECUTORS;
 import static org.apache.accumulo.harness.AccumuloITBase.MINI_CLUSTER_ONLY;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -49,7 +49,6 @@ public class ConfigSetIT extends SharedMiniClusterBase {
   private static final Logger log = LoggerFactory.getLogger(ConfigSetIT.class);
 
   @Test
-  @SuppressWarnings("deprecation")
   public void setInvalidJson() throws Exception {
     log.debug("Starting setInvalidJson test ------------------");
 
@@ -62,8 +61,8 @@ public class ConfigSetIT extends SharedMiniClusterBase {
 
     try (AccumuloClient client =
         getCluster().createAccumuloClient("root", new PasswordToken(getRootPassword()))) {
-      client.instanceOperations().setProperty(TSERV_COMPACTION_SERVICE_ROOT_EXECUTORS.getKey(),
-          validJson);
+      client.instanceOperations().setProperty(
+          COMPACTION_SERVICE_PREFIX.getKey() + "test.planner.opts.executors", validJson);
       assertThrows(AccumuloException.class, () -> client.instanceOperations()
           .setProperty(MONITOR_RESOURCES_EXTERNAL.getKey(), invalidJson));
 

--- a/test/src/main/java/org/apache/accumulo/test/shell/ConfigSetIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ConfigSetIT.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test.shell;
 
-import static org.apache.accumulo.core.conf.Property.COMPACTION_SERVICE_PREFIX;
+import static org.apache.accumulo.core.conf.Property.COMPACTION_SERVICE_DEFAULT_PLANNER_EXECUTORS;
 import static org.apache.accumulo.core.conf.Property.MONITOR_RESOURCES_EXTERNAL;
 import static org.apache.accumulo.harness.AccumuloITBase.MINI_CLUSTER_ONLY;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -49,6 +49,7 @@ public class ConfigSetIT extends SharedMiniClusterBase {
   private static final Logger log = LoggerFactory.getLogger(ConfigSetIT.class);
 
   @Test
+  @SuppressWarnings("deprecation")
   public void setInvalidJson() throws Exception {
     log.debug("Starting setInvalidJson test ------------------");
 
@@ -61,8 +62,8 @@ public class ConfigSetIT extends SharedMiniClusterBase {
 
     try (AccumuloClient client =
         getCluster().createAccumuloClient("root", new PasswordToken(getRootPassword()))) {
-      client.instanceOperations().setProperty(
-          COMPACTION_SERVICE_PREFIX.getKey() + "test.planner.opts.executors", validJson);
+      client.instanceOperations().setProperty(COMPACTION_SERVICE_DEFAULT_PLANNER_EXECUTORS.getKey(),
+          validJson);
       assertThrows(AccumuloException.class, () -> client.instanceOperations()
           .setProperty(MONITOR_RESOURCES_EXTERNAL.getKey(), invalidJson));
 

--- a/test/src/main/java/org/apache/accumulo/test/util/SlowOps.java
+++ b/test/src/main/java/org/apache/accumulo/test/util/SlowOps.java
@@ -40,7 +40,6 @@ import org.apache.accumulo.core.client.TableExistsException;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.admin.ActiveCompaction;
 import org.apache.accumulo.core.clientImpl.TableOperationsImpl;
-import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
@@ -83,7 +82,7 @@ public class SlowOps {
     final int target = numParallelExpected + 1;
     try {
       client.instanceOperations().setProperty(
-          Property.TSERV_COMPACTION_SERVICE_DEFAULT_EXECUTORS.getKey(),
+          "tserver.compaction.major.service.default.planner.opts.executors",
           "[{'name':'any','numThreads':" + target + "}]".replaceAll("'", "\""));
       Thread.sleep(3_000); // give it time to propagate
     } catch (AccumuloException | AccumuloSecurityException | InterruptedException

--- a/test/src/main/java/org/apache/accumulo/test/util/SlowOps.java
+++ b/test/src/main/java/org/apache/accumulo/test/util/SlowOps.java
@@ -40,6 +40,7 @@ import org.apache.accumulo.core.client.TableExistsException;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.admin.ActiveCompaction;
 import org.apache.accumulo.core.clientImpl.TableOperationsImpl;
+import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
@@ -82,7 +83,7 @@ public class SlowOps {
     final int target = numParallelExpected + 1;
     try {
       client.instanceOperations().setProperty(
-          "tserver.compaction.major.service.default.planner.opts.executors",
+          Property.COMPACTION_SERVICE_DEFAULT_PLANNER_EXECUTORS.getKey(),
           "[{'name':'any','numThreads':" + target + "}]".replaceAll("'", "\""));
       Thread.sleep(3_000); // give it time to propagate
     } catch (AccumuloException | AccumuloSecurityException | InterruptedException


### PR DESCRIPTION
Removes the compaction properties from the code and moves them to the accumulo.properties file to simplify the encoded accumulo configuration.

closes #3981 

Moves deprecated rate limit property under the new compaction service prefix.

Also adds the functionality of "example" properties to Property.java. This allows properties to be defined in the code, referenced by tests, included in the automated property documentation generation, while not being able to be picked up by a user and accidentally referenced in the system. 

Enabling these properties is  a two-step action to allow that property to influence the system.
The property's `@Example` annotation must be removed, and the `defaultValue` must be updated with the correct value.

Example of the property documentation changes:
![New-props-cut](https://github.com/apache/accumulo/assets/12480877/e4952b38-3081-41f7-b684-c6cf727f1073)
