### PR TITLE
Fix fateRefs init check when setting the manager state

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -334,7 +334,7 @@ public class Manager extends AbstractServer
     }
 
     if (oldState != newState && (newState == ManagerState.NORMAL)) {
-      if (!getFateRefs().isEmpty()) {
+      if (fateRefs.get() != null) {
         throw new IllegalStateException("Access to Fate should not have been"
             + " initialized prior to the Manager finishing upgrades. Please save"
             + " all logs and file a bug.");


### PR DESCRIPTION
As part of #4133 the null check for fateRef inside of setManagerState() method in the Manager was inadvertently [changed](https://github.com/apache/accumulo/pull/4133/files#diff-07984c23da1745b22dd4fde5c4b8877dfb190ea19e5e60ab79d8a93e752031c7R339) to check if the map size was non empty but the actual check should be that it's null which means not initialized. The map will never be non empty if it is set.

This restores the previous check that used to check for a null ref