### PR TITLE
clean up AddressUtil.parseAddress usage

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
@@ -352,8 +352,7 @@ public class InstanceOperationsImpl implements InstanceOperations {
 
   @Override
   public void ping(String tserver) throws AccumuloException {
-    try (
-        TTransport transport = createTransport(AddressUtil.parseAddress(tserver, false), context)) {
+    try (TTransport transport = createTransport(AddressUtil.parseAddress(tserver), context)) {
       Client client = createClient(ThriftClientTypes.TABLET_SERVER, transport);
       client.getTabletServerStatus(TraceUtil.traceInfo(), context.rpcCreds());
     } catch (TException e) {

--- a/core/src/main/java/org/apache/accumulo/core/lock/ServiceLockData.java
+++ b/core/src/main/java/org/apache/accumulo/core/lock/ServiceLockData.java
@@ -170,7 +170,7 @@ public class ServiceLockData implements Comparable<ServiceLockData> {
 
   public HostAndPort getAddress(ThriftService service) {
     String s = getAddressString(service);
-    return s == null ? null : AddressUtil.parseAddress(s, false);
+    return s == null ? null : AddressUtil.parseAddress(s);
   }
 
   public String getGroup(ThriftService service) {

--- a/core/src/main/java/org/apache/accumulo/core/metadata/TServerInstance.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/TServerInstance.java
@@ -62,11 +62,11 @@ public class TServerInstance implements Comparable<TServerInstance> {
   }
 
   public TServerInstance(String address, long session) {
-    this(AddressUtil.parseAddress(address, false), Long.toHexString(session));
+    this(AddressUtil.parseAddress(address), Long.toHexString(session));
   }
 
   public TServerInstance(Value address, Text session) {
-    this(AddressUtil.parseAddress(new String(address.get(), UTF_8), false), session.toString());
+    this(AddressUtil.parseAddress(new String(address.get(), UTF_8)), session.toString());
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/util/AddressUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/AddressUtil.java
@@ -31,11 +31,10 @@ public class AddressUtil {
 
   private static final Logger log = LoggerFactory.getLogger(AddressUtil.class);
 
-  public static HostAndPort parseAddress(String address, boolean ignoreMissingPort)
-      throws NumberFormatException {
+  public static HostAndPort parseAddress(String address) throws NumberFormatException {
     address = address.replace('+', ':');
     HostAndPort hap = HostAndPort.fromString(address);
-    if (!ignoreMissingPort && !hap.hasPort()) {
+    if (!hap.hasPort()) {
       throw new IllegalArgumentException(
           "Address was expected to contain port. address=" + address);
     }
@@ -44,7 +43,7 @@ public class AddressUtil {
   }
 
   public static HostAndPort parseAddress(String address, int defaultPort) {
-    return parseAddress(address, true).withDefaultPort(defaultPort);
+    return HostAndPort.fromString(address).withDefaultPort(defaultPort);
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/util/AddressUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/AddressUtil.java
@@ -31,9 +31,9 @@ public class AddressUtil {
 
   private static final Logger log = LoggerFactory.getLogger(AddressUtil.class);
 
-  public static HostAndPort parseAddress(String address) throws NumberFormatException {
-    address = address.replace('+', ':');
-    HostAndPort hap = HostAndPort.fromString(address);
+  public static HostAndPort parseAddress(final String address) throws NumberFormatException {
+    String normalized = normalizePortSeparator(address);
+    HostAndPort hap = HostAndPort.fromString(normalized);
     if (!hap.hasPort()) {
       throw new IllegalArgumentException(
           "Address was expected to contain port. address=" + address);
@@ -42,8 +42,13 @@ public class AddressUtil {
     return hap;
   }
 
-  public static HostAndPort parseAddress(String address, int defaultPort) {
-    return HostAndPort.fromString(address).withDefaultPort(defaultPort);
+  public static HostAndPort parseAddress(final String address, final int defaultPort) {
+    String normalized = normalizePortSeparator(address);
+    return HostAndPort.fromString(normalized).withDefaultPort(defaultPort);
+  }
+
+  private static String normalizePortSeparator(final String address) {
+    return address.replace('+', ':');
   }
 
   /**

--- a/core/src/test/java/org/apache/accumulo/core/util/AddressUtilTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/AddressUtilTest.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.net.HostAndPort;
+
 /**
  * Test the AddressUtil class.
  */
@@ -101,5 +103,29 @@ public class AddressUtilTest {
     assertThrows(IllegalArgumentException.class, () -> AddressUtil.getAddressCacheNegativeTtl(null),
         "The JVM Security settings cache DNS failures forever, this should cause an exception.");
 
+  }
+
+  @Test
+  public void normalizeAddressRequirePortTest() {
+    HostAndPort hostAndPort = AddressUtil.parseAddress("127.0.1.2+8080");
+    assertEquals("127.0.1.2", hostAndPort.getHost());
+    assertEquals(8080, hostAndPort.getPort());
+
+    HostAndPort hostAndPort2 = AddressUtil.parseAddress("127.0.1.2:9123");
+    assertEquals("127.0.1.2", hostAndPort2.getHost());
+    assertEquals(9123, hostAndPort2.getPort());
+
+    assertThrows(IllegalArgumentException.class, () -> AddressUtil.parseAddress("127.0.1.2"));
+  }
+
+  @Test
+  public void normalizeAddressWithDefaultTest() {
+    HostAndPort hostAndPort = AddressUtil.parseAddress("127.0.1.2+8080", 9123);
+    assertEquals("127.0.1.2", hostAndPort.getHost());
+    assertEquals(8080, hostAndPort.getPort());
+
+    HostAndPort hostAndPort2 = AddressUtil.parseAddress("127.0.1.2", 9123);
+    assertEquals("127.0.1.2", hostAndPort2.getHost());
+    assertEquals(9123, hostAndPort2.getPort());
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/LiveTServerSet.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/LiveTServerSet.java
@@ -398,11 +398,11 @@ public class LiveTServerSet implements Watcher {
       if (index == -1) {
         throw new IllegalArgumentException("Could not parse tabletserver '" + tabletServer + "'");
       }
-      addr = AddressUtil.parseAddress(tabletServer.substring(0, index), false);
+      addr = AddressUtil.parseAddress(tabletServer.substring(0, index));
       // Strip off the last bracket
       sessionId = tabletServer.substring(index + 1, tabletServer.length() - 1);
     } else {
-      addr = AddressUtil.parseAddress(tabletServer, false);
+      addr = AddressUtil.parseAddress(tabletServer);
     }
     for (Entry<String,TServerInfo> entry : servers.entrySet()) {
       if (entry.getValue().instance.getHostAndPort().equals(addr)) {

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletStateChangeIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletStateChangeIterator.java
@@ -135,7 +135,7 @@ public class TabletStateChangeIterator extends SkippingIterator {
         if (instance != null && instance.endsWith("]")) {
           instance = instance.substring(0, instance.length() - 1);
         }
-        result.add(new TServerInstance(AddressUtil.parseAddress(hostport, false), instance));
+        result.add(new TServerInstance(AddressUtil.parseAddress(hostport), instance));
       }
     }
     return result;

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/manager/ManagerResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/manager/ManagerResource.java
@@ -102,7 +102,7 @@ public class ManagerResource {
       List<String> managers = monitor.getContext().getManagerLocations();
 
       String manager =
-          managers.isEmpty() ? "Down" : AddressUtil.parseAddress(managers.get(0), false).getHost();
+          managers.isEmpty() ? "Down" : AddressUtil.parseAddress(managers.get(0)).getHost();
       int onlineTabletServers = mmi.tServerInfo.size();
       int totalTabletServers = tservers.size();
       int tablets = monitor.getTotalTabletCount();

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tservers/TabletServerResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tservers/TabletServerResource.java
@@ -125,7 +125,7 @@ public class TabletServerResource {
     for (TabletServerStatus server : mmi.tServerInfo) {
       if (server.logSorts != null) {
         for (RecoveryStatus recovery : server.logSorts) {
-          String serv = AddressUtil.parseAddress(server.name, false).getHost();
+          String serv = AddressUtil.parseAddress(server.name).getHost();
           String log = recovery.name;
           int time = recovery.runtime;
           double progress = recovery.progress;


### PR DESCRIPTION
The utility AddressUtil,parseAddress() had a boolean parameter to allowed addresses to be created without a port. Other than another utility method that allows setting the default port the value was always false (required port)  This PR removes the boolean from the method signature.

Discovered this while trying to use HostAndPort in favor of strings where possible.  Submitting this a separate PR because it is stand-alone change that is easier to review.