### PR TITLE
Fixes Queue Metric Tag format

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/QueueMetrics.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/QueueMetrics.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.manager.compaction.coordinator;
 
+import static org.apache.accumulo.core.metrics.MetricsUtil.formatString;
 import static org.apache.accumulo.core.metrics.MetricsUtil.getCommonTags;
 
 import java.util.HashMap;
@@ -51,40 +52,37 @@ public class QueueMetrics implements MetricsProducer {
     private final Gauge jobsRejected;
     private final Gauge jobsLowestPriority;
 
-    public QueueMeters(MeterRegistry meterRegistry, CompactorGroupId queueId,
+    public QueueMeters(MeterRegistry meterRegistry, CompactorGroupId cgid,
         CompactionJobPriorityQueue queue) {
+      var queueId = formatString(cgid.canonical());
+
       length =
           Gauge.builder(METRICS_COMPACTOR_JOB_PRIORITY_QUEUE_LENGTH, queue, q -> q.getMaxSize())
               .description("Length of priority queues")
-              .tags(Tags.concat(getCommonTags(), "queue.id", queueId.canonical()))
-              .register(meterRegistry);
+              .tags(Tags.concat(getCommonTags(), "queue.id", queueId)).register(meterRegistry);
 
       jobsQueued = Gauge
           .builder(METRICS_COMPACTOR_JOB_PRIORITY_QUEUE_JOBS_QUEUED, queue, q -> q.getQueuedJobs())
           .description("Count of queued jobs")
-          .tags(Tags.concat(getCommonTags(), "queue.id", queueId.canonical()))
-          .register(meterRegistry);
+          .tags(Tags.concat(getCommonTags(), "queue.id", queueId)).register(meterRegistry);
 
       jobsDequeued = Gauge
           .builder(METRICS_COMPACTOR_JOB_PRIORITY_QUEUE_JOBS_DEQUEUED, queue,
               q -> q.getDequeuedJobs())
           .description("Count of jobs dequeued")
-          .tags(Tags.concat(getCommonTags(), "queue.id", queueId.canonical()))
-          .register(meterRegistry);
+          .tags(Tags.concat(getCommonTags(), "queue.id", queueId)).register(meterRegistry);
 
       jobsRejected = Gauge
           .builder(METRICS_COMPACTOR_JOB_PRIORITY_QUEUE_JOBS_REJECTED, queue,
               q -> q.getRejectedJobs())
           .description("Count of rejected jobs")
-          .tags(Tags.concat(getCommonTags(), "queue.id", queueId.canonical()))
-          .register(meterRegistry);
+          .tags(Tags.concat(getCommonTags(), "queue.id", queueId)).register(meterRegistry);
 
       jobsLowestPriority = Gauge
           .builder(METRICS_COMPACTOR_JOB_PRIORITY_QUEUE_JOBS_PRIORITY, queue,
               q -> q.getLowestPriority())
           .description("Lowest priority queued job")
-          .tags(Tags.concat(getCommonTags(), "queue.id", queueId.canonical()))
-          .register(meterRegistry);
+          .tags(Tags.concat(getCommonTags(), "queue.id", queueId)).register(meterRegistry);
     }
 
     private void removeMeters(MeterRegistry registry) {

--- a/test/src/main/java/org/apache/accumulo/test/compaction/CompactionPriorityQueueMetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/CompactionPriorityQueueMetricsIT.java
@@ -56,10 +56,12 @@ import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.core.metrics.MetricsProducer;
 import org.apache.accumulo.core.metrics.MetricsUtil;
 import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.spi.compaction.CompactionKind;
 import org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner;
 import org.apache.accumulo.core.spi.compaction.SimpleCompactionDispatcher;
 import org.apache.accumulo.core.spi.crypto.NoCryptoServiceFactory;
 import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.accumulo.core.util.compaction.CompactionJobPrioritizer;
 import org.apache.accumulo.core.util.threads.Threads;
 import org.apache.accumulo.harness.MiniClusterConfigurationCallback;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
@@ -97,7 +99,7 @@ public class CompactionPriorityQueueMetricsIT extends SharedMiniClusterBase {
   private String rootPath;
 
   public static final String QUEUE1 = "METRICSQ1";
-  public static final String QUEUE1_METRIC_LABEL = "e." + MetricsUtil.formatString(QUEUE1);
+  public static final String QUEUE1_METRIC_LABEL = MetricsUtil.formatString(QUEUE1);
   public static final String QUEUE1_SERVICE = "Q1";
   public static final int QUEUE1_SIZE = 6;
 
@@ -153,9 +155,10 @@ public class CompactionPriorityQueueMetricsIT extends SharedMiniClusterBase {
       cfg.getClusterServerConfiguration().setNumDefaultCompactors(0);
 
       // Create a new queue with zero compactors.
-      cfg.setProperty("tserver.compaction.major.service." + QUEUE1_SERVICE + ".planner",
+      cfg.setProperty(Property.COMPACTION_SERVICE_PREFIX.getKey() + QUEUE1_SERVICE + ".planner",
           DefaultCompactionPlanner.class.getName());
-      cfg.setProperty("tserver.compaction.major.service." + QUEUE1_SERVICE + ".planner.opts.groups",
+      cfg.setProperty(
+          Property.COMPACTION_SERVICE_PREFIX.getKey() + QUEUE1_SERVICE + ".planner.opts.groups",
           "[{'name':'" + QUEUE1 + "'}]");
 
       cfg.setProperty(Property.MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_SIZE, "6");
@@ -359,7 +362,11 @@ public class CompactionPriorityQueueMetricsIT extends SharedMiniClusterBase {
     // Priority is the file counts + number of compactions for that tablet.
     // The lowestPriority job in the queue should have been
     // at least 1 count higher than the highest file count.
-    assertTrue(lowestPriority > highestFileCount);
+    short highestFileCountPrio = CompactionJobPrioritizer.createPriority(
+        getCluster().getServerContext().getTableId(tableName), CompactionKind.USER,
+        (int) highestFileCount, 0);
+    assertTrue(lowestPriority > highestFileCountPrio,
+        lowestPriority + " " + highestFileCount + " " + highestFileCountPrio);
 
     // Multiple Queues have been created
     assertTrue(sawQueues);

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionMetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionMetricsIT.java
@@ -194,7 +194,7 @@ public class ExternalCompactionMetricsIT extends SharedMiniClusterBase {
   private static boolean match(Metric input, String queue, String value) {
     if (input.getTags() != null) {
       String id = input.getTags().get("queue.id");
-      if (id != null && id.equals("e." + queue) && input.getValue().equals(value)) {
+      if (id != null && id.equals(queue) && input.getValue().equals(value)) {
         return true;
       }
     }


### PR DESCRIPTION
Adds back in the use of the MetricsUtil.formatString method when creating metric tags
Removes missed "e." external queue name prefixes