### PR TITLE
clean up some AddressUtil usages

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/util/AddressUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/AddressUtil.java
@@ -32,7 +32,7 @@ public class AddressUtil {
   private static final Logger log = LoggerFactory.getLogger(AddressUtil.class);
 
   public static HostAndPort parseAddress(final String address) throws NumberFormatException {
-    String normalized = normalizePortSeparator(address);
+    String normalized = fromDfsFileFormat(address);
     HostAndPort hap = HostAndPort.fromString(normalized);
     if (!hap.hasPort()) {
       throw new IllegalArgumentException(
@@ -43,12 +43,31 @@ public class AddressUtil {
   }
 
   public static HostAndPort parseAddress(final String address, final int defaultPort) {
-    String normalized = normalizePortSeparator(address);
+    String normalized = fromDfsFileFormat(address);
     return HostAndPort.fromString(normalized).withDefaultPort(defaultPort);
   }
 
-  private static String normalizePortSeparator(final String address) {
+  /**
+   * Converts address string into as standard format of host:port string. The port separator
+   * character ':' is illegal in a dfs file path. In places where host:port are stored as a path the
+   * ':' character is replaced with '+'. This method reverses the '+' substitution if present
+   *
+   * @param address An host / port pair as either host:port or host+port.
+   * @return a standardize host:port pair string.
+   */
+  private static String fromDfsFileFormat(final String address) {
     return address.replace('+', ':');
+  }
+
+  /**
+   * Encodes a host:port pair into host+port that can be used as a dfs file path. See
+   * {@link #fromDfsFileFormat(String)}
+   *
+   * @param address An host / port pair as either host:port or host+port.
+   * @return the host and port as host+port for using it in a dfs path
+   */
+  public static String toDfsFileFormat(final String address) {
+    return address.replace(':', '+');
   }
 
   /**

--- a/core/src/test/java/org/apache/accumulo/core/tabletserver/log/LogEntryTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/tabletserver/log/LogEntryTest.java
@@ -30,10 +30,9 @@ import java.util.stream.Stream;
 
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LogColumnFamily;
+import org.apache.accumulo.core.util.AddressUtil;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.Test;
-
-import com.google.common.net.HostAndPort;
 
 public class LogEntryTest {
 
@@ -64,7 +63,7 @@ public class LogEntryTest {
   private void verifyLogEntry(LogEntry logEntry, Text expectedColumnQualifier) {
     assertEquals(validPath, logEntry.toString());
     assertEquals(validPath, logEntry.getPath());
-    assertEquals(HostAndPort.fromString(validHost.replace('+', ':')), logEntry.getTServer());
+    assertEquals(AddressUtil.parseAddress(validHost), logEntry.getTServer());
     assertEquals(expectedColumnQualifier, logEntry.getColumnQualifier());
     assertEquals(validUUID, logEntry.getUniqueID());
   }

--- a/test/src/main/java/org/apache/accumulo/test/MissingWalHeaderCompletesRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MissingWalHeaderCompletesRecoveryIT.java
@@ -40,6 +40,7 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
+import org.apache.accumulo.core.util.AddressUtil;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.test.functional.ConfigurableMacBase;
@@ -121,7 +122,7 @@ public class MissingWalHeaderCompletesRecoveryIT extends ConfigurableMacBase {
       String fakeServer = "127.0.0.1:12345";
 
       File walogs = new File(cluster.getConfig().getAccumuloDir(), Constants.WAL_DIR);
-      File walogServerDir = new File(walogs, fakeServer.replace(':', '+'));
+      File walogServerDir = new File(walogs, AddressUtil.toDfsFileFormat(fakeServer));
       File emptyWalog = new File(walogServerDir, UUID.randomUUID().toString());
 
       log.info("Created empty WAL at {}", emptyWalog.toURI());
@@ -176,7 +177,7 @@ public class MissingWalHeaderCompletesRecoveryIT extends ConfigurableMacBase {
       String fakeServer = "127.0.0.1:12345";
 
       File walogs = new File(cluster.getConfig().getAccumuloDir(), Constants.WAL_DIR);
-      File walogServerDir = new File(walogs, fakeServer.replace(':', '+'));
+      File walogServerDir = new File(walogs, AddressUtil.toDfsFileFormat(fakeServer));
       File partialHeaderWalog = new File(walogServerDir, UUID.randomUUID().toString());
 
       log.info("Created WAL with malformed header at {}", partialHeaderWalog.toURI());


### PR DESCRIPTION
This is a follow-on to suggestion made in PR #4185.

 - names methods fromDfsFileFormat and toDfsFileFormat with documentation.
 - replaces calls that where using string.replace with appropriate method.

The replace calls were easy to find, but the are likely other places where the ':' to '+' substitutions are occurring and they can be fixed later.
