### PR TITLE
update cache workflow action to v4, replaces node 16 with node 20

### DIFF
--- a/.github/workflows/maven-full-its.yaml
+++ b/.github/workflows/maven-full-its.yaml
@@ -54,7 +54,7 @@ jobs:
         distribution: adopt
         java-version: 17
     - name: Cache local maven repository
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.m2/repository/
@@ -98,7 +98,7 @@ jobs:
         distribution: adopt
         java-version: 17
     - name: Cache local maven repository
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.m2/repository/

--- a/.github/workflows/maven-on-demand.yaml
+++ b/.github/workflows/maven-on-demand.yaml
@@ -71,7 +71,7 @@ jobs:
         distribution: adopt
         java-version: 17
     - name: Cache local maven repository
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.m2/repository/

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -44,7 +44,7 @@ jobs:
         distribution: adopt
         java-version: 17
     - name: Cache local maven repository
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.m2/repository/
@@ -82,7 +82,7 @@ jobs:
         distribution: adopt
         java-version: ${{ matrix.profile.javaver }}
     - name: Cache local maven repository
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.m2/repository/


### PR DESCRIPTION
Updated GitHub action cache@v3 to v4.  Node 16 has been deprecated in GitHub actions and v4 was updated to use node 20.  

This eliminates warnings in the GitHub action runner, for example:

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```
