### PR TITLE
fixes CompactionPriorityQueueMetricsIT

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/compaction/CompactionPriorityQueueMetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/CompactionPriorityQueueMetricsIT.java
@@ -393,6 +393,14 @@ public class CompactionPriorityQueueMetricsIT extends SharedMiniClusterBase {
             emptyQueue = true;
           }
         }
+
+        // Check if the total number of queues is zero, if so then will not see metrics for the
+        // above queue.
+        if (metric.getName().equals(MetricsProducer.METRICS_COMPACTOR_JOB_PRIORITY_QUEUES)) {
+          if (Integer.parseInt(metric.getValue()) == 0) {
+            emptyQueue = true;
+          }
+        }
       }
       UtilWaitThread.sleep(3500);
     }


### PR DESCRIPTION
CompactionPriorityQueueMetricsIT was waiting for a queue to report zero size.  However when the queue is empty it may be removed and then no reports are generated for it.  Added an additional check for zero total queues to the test.