### PR TITLE
Fix intermittent failure in AuthenticationTokenSecretManagerTest

### DIFF
--- a/server/base/src/test/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenSecretManagerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenSecretManagerTest.java
@@ -207,11 +207,11 @@ public class AuthenticationTokenSecretManagerTest extends WithTestNames {
     // The passwords line up against multiple calls with the same ID
     assertArrayEquals(password, secretManager.retrievePassword(id));
 
-    // Sleep 1 ms to make sure we generate another token for the test
+    // Sleep 50 ms to make sure we generate another token for the test
     // System.currentTimeMillis() is used as part of the token generation and if
     // the test runs fast enough it can return the same value that was used
     // when generating the first token and the test will fail
-    Thread.sleep(1);
+    Thread.sleep(50);
 
     // Make a second token for the same user
     Entry<Token<AuthenticationTokenIdentifier>,AuthenticationTokenIdentifier> pair2 =

--- a/server/base/src/test/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenSecretManagerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenSecretManagerTest.java
@@ -210,7 +210,7 @@ public class AuthenticationTokenSecretManagerTest extends WithTestNames {
     // Sleep 1 ms to make sure we generate another token for the test
     // System.currentTimeMillis() is used as part of the token generation and if
     // the test runs fast enough it can return the same value that was used
-    // when generation the first token and the test will fail
+    // when generating the first token and the test will fail
     Thread.sleep(1);
 
     // Make a second token for the same user

--- a/server/base/src/test/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenSecretManagerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenSecretManagerTest.java
@@ -207,6 +207,12 @@ public class AuthenticationTokenSecretManagerTest extends WithTestNames {
     // The passwords line up against multiple calls with the same ID
     assertArrayEquals(password, secretManager.retrievePassword(id));
 
+    // Sleep 1 ms to make sure we generate another token for the test
+    // System.currentTimeMillis() is used as part of the token generation and if
+    // the test runs fast enough it can return the same value that was used
+    // when generation the first token and the test will fail
+    Thread.sleep(1);
+
     // Make a second token for the same user
     Entry<Token<AuthenticationTokenIdentifier>,AuthenticationTokenIdentifier> pair2 =
         secretManager.generateToken(principal, cfg);


### PR DESCRIPTION
There fixes a test race condition in the `AuthenticationTokenSecretManager#testVerifyPassword` test that could occasionally cause the test to fail if it ran too quickly. Token generation uses System.currentTimeMillis() so the test previously would fail when trying to generate a new token if the timestamp didn't update as the same token would be returned. This commit adds a short sleep of 1 ms to guarantee that the test won't fail.

Before this fix when running that test in a loop in my IDE it would typically fail within 3-5 iterations. With this change I was able to run 10k iterations in a loop without failure.