### PR TITLE
Add IllegalStateException in TabletMedata class

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -459,6 +459,8 @@ public class TabletMetadata {
             case REQUESTED_QUAL:
               te.onDemandHostingRequested = true;
               break;
+            default:
+              throw new IllegalStateException("Unexpected TabletColumnFamily qualifier: " + qual);
           }
           break;
         case ServerColumnFamily.STR_NAME:


### PR DESCRIPTION
Add an `IllegalStateException` to the `TabletMetadata` class in instances where an unexpected `TabletColumnFamily` qualifier is used.