### PR TITLE
Update serialVersionUID in ImportedTableInfo since a new field was added

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportedTableInfo.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportedTableInfo.java
@@ -26,7 +26,7 @@ import org.apache.accumulo.core.data.TableId;
 
 class ImportedTableInfo implements Serializable {
 
-  private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 2L;
 
   public String user;
   public String tableName;


### PR DESCRIPTION
#4122 added a new field, `exportedVersion` so the `serialVersionUID` should be incremented.