### PR TITLE
Example of how to send metrics to the log.

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/metrics/LoggingMetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/metrics/LoggingMetricsIT.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test.metrics;
+
+import java.time.Duration;
+
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+public class LoggingMetricsIT extends MetricsIT {
+
+  @Override
+  protected Duration defaultTimeout() {
+    return Duration.ofMinutes(4);
+  }
+
+  @Override
+  protected void configure(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
+    cfg.setNumTservers(2);
+    cfg.setProperty(Property.GC_CYCLE_START, "1s");
+    cfg.setProperty(Property.GC_CYCLE_DELAY, "1s");
+    cfg.setProperty(Property.MANAGER_FATE_METRICS_MIN_UPDATE_INTERVAL, "1s");
+
+    // Tell the server processes to use a StatsDMeterRegistry that will be configured
+    // to push all metrics to the sink we started.
+    cfg.setProperty(Property.GENERAL_MICROMETER_ENABLED, "true");
+    cfg.setProperty(Property.GENERAL_MICROMETER_FACTORY,
+        TestLoggingRegistryFactory.class.getName());
+  }
+
+  @Test
+  @Disabled
+  @Override
+  public void confirmMetricsPublished() throws Exception {
+    // Override does nothing
+  }
+
+  @Test
+  @Disabled
+  @Override
+  public void metricTags() throws Exception {
+    // Override does nothing
+  }
+
+  @Test
+  public void doWorkToGenerateLogs() throws Exception {
+    // Metrics are pushed every 1m using a logger with the name LoggingMeterRegistry
+    // we need the test to take longer than 1m
+    for (int i = 0; i < 10; i++) {
+      doWorkToGenerateMetrics();
+      Thread.sleep(10_000);
+    }
+  }
+
+}

--- a/test/src/main/java/org/apache/accumulo/test/metrics/MetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/metrics/MetricsIT.java
@@ -132,7 +132,7 @@ public class MetricsIT extends ConfigurableMacBase implements MetricsProducer {
         "Did not see all expected metric names, missing: " + expectedMetricNames.values());
   }
 
-  private void doWorkToGenerateMetrics() throws Exception {
+  protected void doWorkToGenerateMetrics() throws Exception {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProperties()).build()) {
       String tableName = this.getClass().getSimpleName();
       client.tableOperations().create(tableName);

--- a/test/src/main/java/org/apache/accumulo/test/metrics/TestLoggingRegistryFactory.java
+++ b/test/src/main/java/org/apache/accumulo/test/metrics/TestLoggingRegistryFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test.metrics;
+
+import org.apache.accumulo.core.metrics.MeterRegistryFactory;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.logging.LoggingMeterRegistry;
+import io.micrometer.core.instrument.logging.LoggingRegistryConfig;
+
+/**
+ * Set the following properties to use this MeterRegistryFactory
+ *
+ * <p>
+ * Property.GENERAL_MICROMETER_ENABLED = true
+ * <p>
+ * Property.GENERAL_MICROMETER_FACTORY = TestLoggingRegistryFactory.class.getName()
+ */
+public class TestLoggingRegistryFactory implements MeterRegistryFactory {
+
+  @Override
+  public MeterRegistry create() {
+
+    return LoggingMeterRegistry.builder(LoggingRegistryConfig.DEFAULT).build();
+  }
+
+}

--- a/test/src/main/resources/log4j2-test.properties
+++ b/test/src/main/resources/log4j2-test.properties
@@ -152,29 +152,6 @@ logger.38.level = debug
 logger.39.name = org.apache.accumulo.manager.Manager
 logger.39.level = trace
 
-property.metricsFilename = ./target/test-metrics
-
-# appender.metrics.type = Console
-appender.metrics.type = RollingFile
-appender.metrics.name = LoggingMetricsOutput
-appender.metrics.fileName = ${metricsFilename}.metrics
-appender.metrics.filePattern = ${metricsFilename}-%d{MM-dd-yy-HH}-%i.metrics.gz
-appender.metrics.layout.type = PatternLayout
-appender.metrics.layout.pattern = METRICS: %d{ISO8601}, %m%n
-appender.metrics.policies.type = Policies
-appender.metrics.policies.time.type = TimeBasedTriggeringPolicy
-appender.metrics.policies.time.interval = 1
-appender.metrics.policies.time.modulate = true
-appender.metrics.policies.size.type = SizeBasedTriggeringPolicy
-appender.metrics.policies.size.size=100MB
-appender.metrics.strategy.type = DefaultRolloverStrategy
-appender.metrics.strategy.max = 10
-
-logger.metrics.name = org.apache.accumulo.metrics
-logger.metrics.level = info
-logger.metrics.additivity = false
-logger.metrics.appenderRef.metrics.ref = LoggingMetricsOutput
-
 rootLogger.level = debug
 rootLogger.appenderRef.console.ref = STDOUT
 


### PR DESCRIPTION
This adds an example of how to create a MeterRegistryFactory that
emits metrics to the log. In this example the metrics are emitted to
the process log every 1 minute using the logger name LoggingMeterRegistry.