### PR TITLE
WIP add resource groups to mini accumulo

### DIFF
--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/MiniAccumuloConfig.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/MiniAccumuloConfig.java
@@ -55,7 +55,9 @@ public class MiniAccumuloConfig {
    * Calling this method is optional. If not set, it defaults to two.
    *
    * @param numTservers the number of tablet servers that mini accumulo cluster should start
+   * @deprecated use {@link #setResourceGroups(ResourceGroups)} instead
    */
+  @Deprecated(since = "3.1.0")
   public MiniAccumuloConfig setNumTservers(int numTservers) {
     impl.setNumTservers(numTservers);
     return this;
@@ -66,10 +68,22 @@ public class MiniAccumuloConfig {
    *
    * @param numScanServers the number of scan servers that mini accumulo cluster should start
    * @since 2.1.0
+   * @deprecated use {@link #setResourceGroups(ResourceGroups)} instead
    */
+  @Deprecated(since = "3.1.0")
   public MiniAccumuloConfig setNumScanServers(int numScanServers) {
     impl.setNumScanServers(numScanServers);
     return this;
+  }
+
+  /**
+   * Sets the number of servers to starts for each resource group.
+   *
+   * @since 3.1.0
+   */
+  public MiniAccumuloConfig setResourceGroups(ResourceGroups resourceGroups) {
+    // TODO implement
+    throw new UnsupportedOperationException();
   }
 
   /**
@@ -224,6 +238,7 @@ public class MiniAccumuloConfig {
   /**
    * @return the number of tservers configured for this cluster
    */
+  @Deprecated(since = "3.1.0")
   public int getNumTservers() {
     return impl.getNumTservers();
   }

--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/ResourceGroups.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/ResourceGroups.java
@@ -1,0 +1,134 @@
+package org.apache.accumulo.minicluster;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Specified the desired numbers of servers by server type and resource group type.
+ *
+ * @since @3.1.0
+ */
+public class ResourceGroups {
+
+  public static class ResourceGroup {
+    private final ServerType serverType;
+
+    private final String resourceGroup;
+
+    public ResourceGroup(ServerType serverType, String resourceGroup) {
+      ;
+      this.serverType = Objects.requireNonNull(serverType);
+      this.resourceGroup = Objects.requireNonNull(resourceGroup);
+      // TODO is there other validation that should be done for a resource group name?
+      Preconditions.checkArgument(!resourceGroup.isBlank(),
+          "Blank resource group name is not allowed");
+
+      if (serverType == ServerType.ZOOKEEPER || serverType == ServerType.COMPACTION_COORDINATOR
+          || serverType == ServerType.MANAGER || serverType == ServerType.GARBAGE_COLLECTOR
+          || serverType == ServerType.MONITOR) {
+        // TODO use constant
+        Preconditions.checkArgument(resourceGroup.equals("default"),
+            "For server type %s can only use default resource group not : %s", serverType,
+            resourceGroup);
+      }
+    }
+
+    public ServerType getServerType() {
+      return serverType;
+    }
+
+    public String getResourceGroup() {
+      return resourceGroup;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(serverType, resourceGroup);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o instanceof ResourceGroup) {
+        var otherRG = (ResourceGroup) o;
+        return serverType.equals(otherRG.serverType) && resourceGroup.equals(otherRG.resourceGroup);
+      }
+
+      return false;
+    }
+  }
+
+  private final Map<ResourceGroup,Integer> resourceGroupSizes;
+
+  private ResourceGroups(Map<ResourceGroup,Integer> resourceGroupSizes) {
+    this.resourceGroupSizes = resourceGroupSizes;
+  }
+
+  public Map<ResourceGroup,Integer> getGroupSizes() {
+    return resourceGroupSizes;
+  }
+
+  public interface Builder {
+    /**
+     * Populates default resource group configuration. TODO document what the defaults are.
+     */
+    Builder putDefaults();
+
+    /**
+     * Sets the number of servers in the default resource group for a server type.
+     */
+    Builder put(ServerType type, int numServers);
+
+    Builder put(ServerType type, String resourceGroup, int numServers);
+
+    Builder put(Map<ResourceGroup,Integer> existingGoals);
+
+    ResourceGroups build();
+  }
+
+  public static Builder builder() {
+    var rgMap = new HashMap<ResourceGroup,Integer>();
+
+    return new Builder() {
+
+      @Override
+      public Builder putDefaults() {
+        put(ServerType.MANAGER, "default", 1);
+        put(ServerType.GARBAGE_COLLECTOR, "default", 1);
+        put(ServerType.ZOOKEEPER, "default", 1);
+        put(ServerType.TABLET_SERVER, "default", 1);
+        // TODO in elasticity will need to add compactors
+        return this;
+      }
+
+      @Override
+      public Builder put(ServerType type, int numServers) {
+        // TODO use a constatnt
+        return put(type, "default", numServers);
+      }
+
+      @Override
+      public Builder put(ServerType type, String resourceGroup, int numServers) {
+        Preconditions.checkArgument(numServers > 0, "Number of servers must be positive not : %s",
+            numServers);
+        rgMap.put(new ResourceGroup(type, resourceGroup), numServers);
+        return this;
+      }
+
+      @Override
+      public Builder put(Map<ResourceGroup,Integer> existingGoals) {
+        // not calling rgMap.putAll so that input can be verified
+        existingGoals.forEach((rg, ns) -> put(rg.getServerType(), rg.getResourceGroup(), ns));
+        return this;
+      }
+
+      @Override
+      public ResourceGroups build() {
+        // TODO need to prevent further calls to put
+        return new ResourceGroups(Map.copyOf(rgMap));
+      }
+    };
+  }
+}

--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/ServerType.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/ServerType.java
@@ -26,6 +26,7 @@ public enum ServerType {
   ZOOKEEPER("ZooKeeper"),
   TABLET_SERVER("TServer"),
   GARBAGE_COLLECTOR("GC"),
+  // TODO deprecate
   COMPACTION_COORDINATOR("CompactionCoordinator"),
   COMPACTOR("Compactor"),
   MONITOR("Monitor"),

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloResourceGroupsTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloResourceGroupsTest.java
@@ -1,0 +1,30 @@
+package org.apache.accumulo.minicluster;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+public class MiniAccumuloResourceGroupsTest {
+
+    // example of starting a mini cluster with multiple resource groups
+
+    @Test
+    public void testResourceGroups() throws Exception {
+        var builder = ResourceGroups.builder().putDefaults();
+        builder.put(ServerType.COMPACTOR, "CG1", 2);
+        builder.put(ServerType.COMPACTOR, "CG2", 2);
+        builder.put(ServerType.TABLET_SERVER, "TS1", 2);
+        builder.put(ServerType.SCAN_SERVER, "SG1", 2);
+        var resourceGroups = builder.build();
+
+        File dir  = null; //TODO
+        MiniAccumuloConfig miniCfg = new MiniAccumuloConfig(dir, "abc123");
+        miniCfg.setResourceGroups(resourceGroups);
+
+        var cluster = new MiniAccumuloCluster(miniCfg);
+        cluster.start();
+    }
+
+
+
+}

--- a/test/src/main/java/org/apache/accumulo/test/CleanWalIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/CleanWalIT.java
@@ -77,10 +77,8 @@ public class CleanWalIT extends AccumuloClusterHarness {
         m.put("cf", "cq", "value");
         bw.addMutation(m);
       }
-      getCluster().getClusterControl().stopAllServers(ServerType.TABLET_SERVER);
-      // all 3 tables should do recovery, but the bug doesn't really remove the log file references
 
-      getCluster().getClusterControl().startAllServers(ServerType.TABLET_SERVER);
+      getCluster().getClusterControl().restartGroups(rg->rg.getServerType() == ServerType.TABLET_SERVER);
 
       for (String table : new String[] {AccumuloTable.METADATA.tableName(),
           AccumuloTable.ROOT.tableName()}) {


### PR DESCRIPTION
Posting this draft PR solely for the purpose of discussion and feedback and does not actually implement anything.  The elasticity branch is heavily using the concept of servers organized into resource groups.   MiniAccumulo's public api does not support resource groups and there are comments about this in the elasticity branch [here](https://github.com/apache/accumulo/blob/5f5cbd37a8efeaab4bc129c064680bbf4aa43be8/minicluster/src/main/java/org/apache/accumulo/minicluster/MiniAccumuloConfig.java#L59). The changes in the PR were an attempt to solve the following problems.

 1. Mini Accumulo API does not support resource groups.
 2. Accumulo uses Mini Accumulo to test itself and this internal code for testing does not consistently support resource groups or making starting and stopping servers in resource groups easy.

The changes in the PR stub out external and internal API changes that attempt to address the problems above.  However there is no implementation of these stubbed out APIs.  The following is guide to the changes so far.

 * The change in the external API were made in o.a.a.minicluster.*
 * An example of code that uses the new public API is in MiniAccumuloResourceGroupsTest
 * The changes to internal API used for testing were made in ClusterControl
 * Some examples of using the new internal API can be seen in a few ITs

One thing I do not like about these change is that  there is currently a runtime exception if server processes are placed outside of the default resource group.  This seems a bit tricky, not sure how to improve it.

One thing I do like about these changes is the internal API may make it easier to start and stop processes in resource groups in a consistent way in ITs.  So the way that process would be start for a tserver RG is the same as a compactor RG.  I also like the mode of specifying a new expected state and processes being started and/or stopped based on how the current state and the new state align.

One problem area for this PR may be that tserver resource groups do not exists in main, but only in elasticity.  This is a similar problem to #4220.