### PR TITLE
Remove excessive logging message

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -905,7 +905,7 @@ public class ScanServer extends AbstractServer
   public ScanResult continueScan(TInfo tinfo, long scanID, long busyTimeout)
       throws NoSuchScanIDException, NotServingTabletException, TooManyFilesException,
       TSampleNotPresentException, TException {
-    LOG.debug("continue scan: {}", scanID);
+    LOG.trace("continue scan: {}", scanID);
 
     try (ScanReservation reservation = reserveFiles(scanID)) {
       Preconditions.checkState(reservation.getFailures().isEmpty());


### PR DESCRIPTION
When testing scan servers this log message was spamming the contents of the log.

Dropping it down to `trace` level from `debug` to help improve readability.