### PR TITLE
LogSorter was creating a ThreadPool and not using it

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/Constants.java
+++ b/core/src/main/java/org/apache/accumulo/core/Constants.java
@@ -88,6 +88,7 @@ public class Constants {
 
   public static final String ZNEXT_FILE = "/next_file";
 
+  // TODO: Remove when Property.TSERV_WORKQ_THREADS is removed
   public static final String ZBULK_FAILED_COPYQ = "/bulk_failed_copyq";
 
   public static final String ZHDFS_RESERVATIONS = "/hdfs_reservations";

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -811,11 +811,7 @@ public enum Property {
           + " that begin with 'table.file' can be used here. For example, to set the compression"
           + " of the sorted recovery files to snappy use 'tserver.wal.sort.file.compress.type=snappy'.",
       "2.1.0"),
-  TSERV_FAILED_BULK_COPY_THREADS("tserver.failed.bulk.threads", "2", PropertyType.COUNT,
-      "The number of threads used in the distributed work queue for copying failed bulk import RFiles.",
-      "2.1.3"),
   @Deprecated(since = "2.1.3")
-  @ReplacedBy(property = TSERV_FAILED_BULK_COPY_THREADS)
   TSERV_WORKQ_THREADS("tserver.workq.threads", "2", PropertyType.COUNT,
       "The number of threads for the distributed work queue. These threads are"
           + " used for copying failed bulk import RFiles.",

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -814,7 +814,7 @@ public enum Property {
   @Deprecated(since = "2.1.3")
   TSERV_WORKQ_THREADS("tserver.workq.threads", "2", PropertyType.COUNT,
       "The number of threads for the distributed work queue. These threads are"
-          + " used for copying failed bulk import RFiles.",
+          + " used for copying failed bulk import RFiles. This property will be removed when bulk import V1 is removed.",
       "1.4.2"),
   TSERV_WAL_SYNC("tserver.wal.sync", "true", PropertyType.BOOLEAN,
       "Use the SYNC_BLOCK create flag to sync WAL writes to disk. Prevents"

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -811,6 +811,11 @@ public enum Property {
           + " that begin with 'table.file' can be used here. For example, to set the compression"
           + " of the sorted recovery files to snappy use 'tserver.wal.sort.file.compress.type=snappy'.",
       "2.1.0"),
+  TSERV_FAILED_BULK_COPY_THREADS("tserver.failed.bulk.threads", "2", PropertyType.COUNT,
+      "The number of threads used in the distributed work queue for copying failed bulk import RFiles.",
+      "2.1.3"),
+  @Deprecated(since = "2.1.3")
+  @ReplacedBy(property = TSERV_FAILED_BULK_COPY_THREADS)
   TSERV_WORKQ_THREADS("tserver.workq.threads", "2", PropertyType.COUNT,
       "The number of threads for the distributed work queue. These threads are"
           + " used for copying failed bulk import RFiles.",

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
@@ -274,7 +274,6 @@ public class ThreadPools {
           return createFixedThreadPool(threads, "GatherTableInformation", emitThreadPoolMetrics);
         }
       case TSERV_WORKQ_THREADS:
-      case TSERV_FAILED_BULK_COPY_THREADS:
         return createFixedThreadPool(conf.getCount(p), "distributed work queue",
             emitThreadPoolMetrics);
       case TSERV_MINC_MAXCONCURRENT:

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
@@ -274,6 +274,7 @@ public class ThreadPools {
           return createFixedThreadPool(threads, "GatherTableInformation", emitThreadPoolMetrics);
         }
       case TSERV_WORKQ_THREADS:
+      case TSERV_FAILED_BULK_COPY_THREADS:
         return createFixedThreadPool(conf.getCount(p), "distributed work queue",
             emitThreadPoolMetrics);
       case TSERV_MINC_MAXCONCURRENT:

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterClasspathTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterClasspathTest.java
@@ -79,8 +79,10 @@ public class MiniAccumuloClusterClasspathTest extends WithTestNames {
 
     MiniAccumuloConfig config = new MiniAccumuloConfig(testDir, ROOT_PASSWORD).setJDWPEnabled(true);
     config.setZooKeeperPort(0);
+    @SuppressWarnings("deprecation")
+    String workQThreadsProp = Property.TSERV_WORKQ_THREADS.getKey();
     HashMap<String,String> site = new HashMap<>();
-    site.put(Property.TSERV_FAILED_BULK_COPY_THREADS.getKey(), "2");
+    site.put(workQThreadsProp, "2");
     site.put(VFS_CONTEXT_CLASSPATH_PROPERTY.getKey() + "cx1", jarFile.toURI().toString());
     config.setSiteConfig(site);
     accumulo = new MiniAccumuloCluster(config);

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterClasspathTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterClasspathTest.java
@@ -80,7 +80,7 @@ public class MiniAccumuloClusterClasspathTest extends WithTestNames {
     MiniAccumuloConfig config = new MiniAccumuloConfig(testDir, ROOT_PASSWORD).setJDWPEnabled(true);
     config.setZooKeeperPort(0);
     HashMap<String,String> site = new HashMap<>();
-    site.put(Property.TSERV_WORKQ_THREADS.getKey(), "2");
+    site.put(Property.TSERV_FAILED_BULK_COPY_THREADS.getKey(), "2");
     site.put(VFS_CONTEXT_CLASSPATH_PROPERTY.getKey() + "cx1", jarFile.toURI().toString());
     config.setSiteConfig(site);
     accumulo = new MiniAccumuloCluster(config);

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterClasspathTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterClasspathTest.java
@@ -79,10 +79,7 @@ public class MiniAccumuloClusterClasspathTest extends WithTestNames {
 
     MiniAccumuloConfig config = new MiniAccumuloConfig(testDir, ROOT_PASSWORD).setJDWPEnabled(true);
     config.setZooKeeperPort(0);
-    @SuppressWarnings("deprecation")
-    String workQThreadsProp = Property.TSERV_WORKQ_THREADS.getKey();
     HashMap<String,String> site = new HashMap<>();
-    site.put(workQThreadsProp, "2");
     site.put(VFS_CONTEXT_CLASSPATH_PROPERTY.getKey() + "cx1", jarFile.toURI().toString());
     config.setSiteConfig(site);
     accumulo = new MiniAccumuloCluster(config);

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterTest.java
@@ -78,10 +78,8 @@ public class MiniAccumuloClusterTest extends WithTestNames {
 
     MiniAccumuloConfig config = new MiniAccumuloConfig(testDir, ROOT_PASSWORD).setJDWPEnabled(true);
     config.setZooKeeperPort(0);
-    @SuppressWarnings("deprecation")
-    String workQThreadsProp = Property.TSERV_WORKQ_THREADS.getKey();
     HashMap<String,String> site = new HashMap<>();
-    site.put(workQThreadsProp, "2");
+    site.put(Property.TSERV_COMPACTION_WARN_TIME.getKey(), "5m");
     config.setSiteConfig(site);
     accumulo = new MiniAccumuloCluster(config);
     accumulo.start();
@@ -195,10 +193,8 @@ public class MiniAccumuloClusterTest extends WithTestNames {
   public void testConfig() {
     // ensure what user passed in is what comes back
     assertEquals(0, accumulo.getConfig().getZooKeeperPort());
-    @SuppressWarnings("deprecation")
-    String workQThreadsProp = Property.TSERV_WORKQ_THREADS.getKey();
     HashMap<String,String> site = new HashMap<>();
-    site.put(workQThreadsProp, "2");
+    site.put(Property.TSERV_COMPACTION_WARN_TIME.getKey(), "5m");
     assertEquals(site, accumulo.getConfig().getSiteConfig());
   }
 

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterTest.java
@@ -79,7 +79,7 @@ public class MiniAccumuloClusterTest extends WithTestNames {
     MiniAccumuloConfig config = new MiniAccumuloConfig(testDir, ROOT_PASSWORD).setJDWPEnabled(true);
     config.setZooKeeperPort(0);
     HashMap<String,String> site = new HashMap<>();
-    site.put(Property.TSERV_WORKQ_THREADS.getKey(), "2");
+    site.put(Property.TSERV_FAILED_BULK_COPY_THREADS.getKey(), "2");
     config.setSiteConfig(site);
     accumulo = new MiniAccumuloCluster(config);
     accumulo.start();
@@ -194,7 +194,7 @@ public class MiniAccumuloClusterTest extends WithTestNames {
     // ensure what user passed in is what comes back
     assertEquals(0, accumulo.getConfig().getZooKeeperPort());
     HashMap<String,String> site = new HashMap<>();
-    site.put(Property.TSERV_WORKQ_THREADS.getKey(), "2");
+    site.put(Property.TSERV_FAILED_BULK_COPY_THREADS.getKey(), "2");
     assertEquals(site, accumulo.getConfig().getSiteConfig());
   }
 

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterTest.java
@@ -78,8 +78,10 @@ public class MiniAccumuloClusterTest extends WithTestNames {
 
     MiniAccumuloConfig config = new MiniAccumuloConfig(testDir, ROOT_PASSWORD).setJDWPEnabled(true);
     config.setZooKeeperPort(0);
+    @SuppressWarnings("deprecation")
+    String workQThreadsProp = Property.TSERV_WORKQ_THREADS.getKey();
     HashMap<String,String> site = new HashMap<>();
-    site.put(Property.TSERV_FAILED_BULK_COPY_THREADS.getKey(), "2");
+    site.put(workQThreadsProp, "2");
     config.setSiteConfig(site);
     accumulo = new MiniAccumuloCluster(config);
     accumulo.start();
@@ -193,8 +195,10 @@ public class MiniAccumuloClusterTest extends WithTestNames {
   public void testConfig() {
     // ensure what user passed in is what comes back
     assertEquals(0, accumulo.getConfig().getZooKeeperPort());
+    @SuppressWarnings("deprecation")
+    String workQThreadsProp = Property.TSERV_WORKQ_THREADS.getKey();
     HashMap<String,String> site = new HashMap<>();
-    site.put(Property.TSERV_FAILED_BULK_COPY_THREADS.getKey(), "2");
+    site.put(workQThreadsProp, "2");
     assertEquals(site, accumulo.getConfig().getSiteConfig());
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/BulkFailedCopyProcessor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/BulkFailedCopyProcessor.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Copy failed bulk imports.
  */
+// TODO: Remove when Property.TSERV_WORKQ_THREADS is removed
 public class BulkFailedCopyProcessor implements Processor {
 
   private static final Logger log = LoggerFactory.getLogger(BulkFailedCopyProcessor.class);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -792,8 +792,11 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
       throw new RuntimeException(e);
     }
 
-    ThreadPoolExecutor distWorkQThreadPool = ThreadPools.getServerThreadPools()
-        .createExecutorService(getConfiguration(), Property.TSERV_WORKQ_THREADS, true);
+    @SuppressWarnings("deprecation")
+    final Property failedBulkCopyThreadProp = getConfiguration()
+        .resolve(Property.TSERV_FAILED_BULK_COPY_THREADS, Property.TSERV_WORKQ_THREADS);
+    final ThreadPoolExecutor distWorkQThreadPool = ThreadPools.getServerThreadPools()
+        .createExecutorService(getConfiguration(), failedBulkCopyThreadProp, true);
 
     bulkFailedCopyQ =
         new DistributedWorkQueue(getContext().getZooKeeperRoot() + Constants.ZBULK_FAILED_COPYQ,
@@ -806,7 +809,7 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
     }
 
     try {
-      logSorter.startWatchingForRecoveryLogs(distWorkQThreadPool);
+      logSorter.startWatchingForRecoveryLogs();
     } catch (Exception ex) {
       log.error("Error setting watches for recoveries");
       throw new RuntimeException(ex);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -227,8 +227,6 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
   private TServer server;
   private volatile TServer replServer;
 
-  private DistributedWorkQueue bulkFailedCopyQ;
-
   private String lockID;
   private volatile long lockSessionId = -1;
 
@@ -793,12 +791,11 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
     }
 
     @SuppressWarnings("deprecation")
-    final Property failedBulkCopyThreadProp = getConfiguration()
-        .resolve(Property.TSERV_FAILED_BULK_COPY_THREADS, Property.TSERV_WORKQ_THREADS);
-    final ThreadPoolExecutor distWorkQThreadPool = ThreadPools.getServerThreadPools()
-        .createExecutorService(getConfiguration(), failedBulkCopyThreadProp, true);
+    ThreadPoolExecutor distWorkQThreadPool = ThreadPools.getServerThreadPools()
+        .createExecutorService(getConfiguration(), Property.TSERV_WORKQ_THREADS, true);
 
-    bulkFailedCopyQ =
+    // TODO: Remove when Property.TSERV_WORKQ_THREADS is removed
+    DistributedWorkQueue bulkFailedCopyQ =
         new DistributedWorkQueue(getContext().getZooKeeperRoot() + Constants.ZBULK_FAILED_COPYQ,
             getConfiguration(), getContext());
     try {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
@@ -65,7 +65,6 @@ import com.google.common.annotations.VisibleForTesting;
 public class LogSorter {
 
   private static final Logger log = LoggerFactory.getLogger(LogSorter.class);
-  AccumuloConfiguration sortedLogConf;
 
   private final Map<String,LogProcessor> currentWork = Collections.synchronizedMap(new HashMap<>());
 
@@ -223,22 +222,20 @@ public class LogSorter {
     }
   }
 
-  ThreadPoolExecutor threadPool;
   private final ServerContext context;
+  private final AccumuloConfiguration conf;
   private final double walBlockSize;
   private final CryptoService cryptoService;
+  private final AccumuloConfiguration sortedLogConf;
 
   public LogSorter(ServerContext context, AccumuloConfiguration conf) {
     this.context = context;
-    this.sortedLogConf = extractSortedLogConfig(conf);
-    @SuppressWarnings("deprecation")
-    int threadPoolSize = conf.getCount(conf.resolve(Property.TSERV_WAL_SORT_MAX_CONCURRENT,
-        Property.TSERV_RECOVERY_MAX_CONCURRENT));
-    this.threadPool = ThreadPools.getServerThreadPools().createFixedThreadPool(threadPoolSize,
-        this.getClass().getName(), true);
-    this.walBlockSize = DfsLogger.getWalBlockSize(conf);
+    this.conf = conf;
+    this.sortedLogConf = extractSortedLogConfig(this.conf);
+    this.walBlockSize = DfsLogger.getWalBlockSize(this.conf);
     CryptoEnvironment env = new CryptoEnvironmentImpl(CryptoEnvironment.Scope.RECOVERY);
-    this.cryptoService = context.getCryptoFactory().getService(env, conf.getAllCryptoProperties());
+    this.cryptoService =
+        context.getCryptoFactory().getService(env, this.conf.getAllCryptoProperties());
   }
 
   /**
@@ -296,8 +293,13 @@ public class LogSorter {
   }
 
   public void startWatchingForRecoveryLogs() throws KeeperException, InterruptedException {
+    @SuppressWarnings("deprecation")
+    int threadPoolSize = this.conf.getCount(this.conf
+        .resolve(Property.TSERV_WAL_SORT_MAX_CONCURRENT, Property.TSERV_RECOVERY_MAX_CONCURRENT));
+    ThreadPoolExecutor threadPool = ThreadPools.getServerThreadPools()
+        .createFixedThreadPool(threadPoolSize, this.getClass().getName(), true);
     new DistributedWorkQueue(context.getZooKeeperRoot() + Constants.ZRECOVERY, sortedLogConf,
-        context).startProcessing(new LogProcessor(), this.threadPool);
+        context).startProcessing(new LogProcessor(), threadPool);
   }
 
   public List<RecoveryStatus> getLogSorts() {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
@@ -295,9 +295,7 @@ public class LogSorter {
     }
   }
 
-  public void startWatchingForRecoveryLogs(ThreadPoolExecutor distWorkQThreadPool)
-      throws KeeperException, InterruptedException {
-    this.threadPool = distWorkQThreadPool;
+  public void startWatchingForRecoveryLogs() throws KeeperException, InterruptedException {
     new DistributedWorkQueue(context.getZooKeeperRoot() + Constants.ZRECOVERY, sortedLogConf,
         context).startProcessing(new LogProcessor(), this.threadPool);
   }


### PR DESCRIPTION
LogSorter was creating a ThreadPool based off of the property TSERV_WAL_SORT_MAX_CONCURRENT, but then the reference to the thread pool was being overwritten to a thread pool that is created to copy failed bulk import files.

Fixes #4235