### PR TITLE
Make RecoveryPath more strict

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/manager/recovery/RecoveryPath.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/recovery/RecoveryPath.java
@@ -30,19 +30,22 @@ public class RecoveryPath {
       String uuid = walPath.getName();
       // drop uuid
       walPath = walPath.getParent();
-      // recovered 1.4 WALs won't have a server component
-      if (!walPath.getName().equals(FileType.WAL.getDirectory())) {
-        // drop server
-        walPath = walPath.getParent();
-      }
 
-      if (!walPath.getName().equals(FileType.WAL.getDirectory())) {
-        throw new IllegalArgumentException("Bad path " + walPath);
+      // expect and drop the server component
+      if (walPath.getName().equals(FileType.WAL.getDirectory())) {
+        throw new IllegalArgumentException("Bath path " + walPath + " (missing server component)");
       }
-
-      // drop wal
       walPath = walPath.getParent();
 
+      // expect and drop the wal component
+      if (!walPath.getName().equals(FileType.WAL.getDirectory())) {
+        throw new IllegalArgumentException(
+            "Bad path " + walPath + " (missing wal directory component)");
+      }
+      walPath = walPath.getParent();
+
+      // create new path in recovery directory that is a sibling to the wal directory (same volume),
+      // without the server component
       walPath = new Path(walPath, FileType.RECOVERY.getDirectory());
       walPath = new Path(walPath, uuid);
 
@@ -50,7 +53,6 @@ public class RecoveryPath {
     }
 
     throw new IllegalArgumentException("Bad path " + walPath);
-
   }
 
 }


### PR DESCRIPTION
Make RecoveryPath more strictly check that a WAL file path includes the expected server that created it, and improve exception messages.

This fixes #4087
