### PR TITLE
Provide a default metrics implementation using a LoggingProvider

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -273,6 +273,7 @@
               </includes>
               <excludes />
               <allows>
+                <allow>io[.]micrometer[.]core[.]instrument[.]MeterRegistry</allow>
                 <allow>io[.]opentelemetry[.]api[.]OpenTelemetry</allow>
                 <allow>org[.]apache[.]hadoop[.]io[.]Text</allow>
                 <allow>org[.]apache[.]accumulo[.]core[.]client[.].*</allow>

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -303,7 +303,9 @@ public enum Property {
   GENERAL_MICROMETER_FACTORY("general.micrometer.factory",
       "org.apache.accumulo.core.spi.metrics.SimpleLoggingMeterRegistryFactory",
       PropertyType.CLASSNAMELIST,
-      "A comma separated list of one or more class names that implement MeterRegistryFactory.",
+      "A comma separated list of one or more class names that implement MeterRegistryFactory. Prior to"
+          + " 2.1.3 this was a single value and the default was an empty string.  In 2.1.3 the default "
+          + " was changed and it now can accept multiple class names.",
       "2.1.0"),
   // properties that are specific to manager server behavior
   MANAGER_PREFIX("manager.", null, PropertyType.PREFIX,

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -300,8 +300,11 @@ public enum Property {
       "Enables metrics functionality using Micrometer.", "2.1.0"),
   GENERAL_MICROMETER_JVM_METRICS_ENABLED("general.micrometer.jvm.metrics.enabled", "false",
       PropertyType.BOOLEAN, "Enables JVM metrics functionality using Micrometer.", "2.1.0"),
-  GENERAL_MICROMETER_FACTORY("general.micrometer.factory", "", PropertyType.CLASSNAME,
-      "Name of class that implements MeterRegistryFactory.", "2.1.0"),
+  GENERAL_MICROMETER_FACTORY("general.micrometer.factory",
+      "org.apache.accumulo.core.spi.metrics.SimpleLoggingMeterRegistryFactory",
+      PropertyType.CLASSNAMELIST,
+      "A comma separated list of one or more class names that implement MeterRegistryFactory.",
+      "2.1.0"),
   // properties that are specific to manager server behavior
   MANAGER_PREFIX("manager.", null, PropertyType.PREFIX,
       "Properties in this category affect the behavior of the manager server. "

--- a/core/src/main/java/org/apache/accumulo/core/spi/metrics/MeterRegistryFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/metrics/MeterRegistryFactory.java
@@ -16,15 +16,25 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.core.metrics;
+package org.apache.accumulo.core.spi.metrics;
 
 import io.micrometer.core.instrument.MeterRegistry;
 
 /**
- * @deprecated since 2.1.3; use {@link org.apache.accumulo.core.spi.metrics.MeterRegistryFactory}
- *             instead
+ * The Micrometer metrics allows for different monitoring systems. and can be enabled within
+ * Accumulo with properties and are initialized by implementing this interface and providing the
+ * factory implementation clas name as a property. Metrics are specified with the following
+ * properties:
+ * <p>
+ * Property.GENERAL_MICROMETER_ENABLED = true
+ * <p>
+ * Property.GENERAL_MICROMETER_FACTORY = [implementation].class.getName()
  */
-@Deprecated()
 public interface MeterRegistryFactory {
+  /**
+   * Called on metrics initialization.
+   *
+   * @return a Micrometer registry that will be added to the metrics configuration.
+   */
   MeterRegistry create();
 }

--- a/core/src/main/java/org/apache/accumulo/core/spi/metrics/SimpleLoggingMeterRegistryFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/metrics/SimpleLoggingMeterRegistryFactory.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.spi.metrics;
+
+import java.util.function.Consumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.logging.LoggingMeterRegistry;
+import io.micrometer.core.instrument.logging.LoggingRegistryConfig;
+
+/**
+ * Example implementation of enabling a metrics provider by implementing the
+ * {@link org.apache.accumulo.core.spi.metrics.MeterRegistryFactory} interface. When enabled though
+ * properties by enabling {@code Property.GENERAL_MICROMETER_ENABLED} and providing this class for
+ * the {@code Property.GENERAL_MICROMETER_FACTORY}
+ * <p>
+ * The metrics will appear in the normal service logs with a named logger of
+ * {@code org.apache.accumulo.METRICS} at the INFO level. The metrics output can be directed to a
+ * file using standard logging configuration properties.
+ */
+public class SimpleLoggingMeterRegistryFactory implements MeterRegistryFactory {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(SimpleLoggingMeterRegistryFactory.class);
+
+  // named logger that can be configured using standard logging properties.
+  private static final Logger METRICS = LoggerFactory.getLogger("org.apache.accumulo.METRICS");
+
+  private final Consumer<String> metricConsumer = METRICS::info;
+
+  // defines the metrics update period, default is 60 seconds.
+  private final LoggingRegistryConfig lconf = c -> {
+    if (c.equals("logging.step")) {
+      return "60s";
+    }
+    return null;
+  };
+
+  @Override
+  public MeterRegistry create() {
+    LOG.info("starting metrics registration.");
+    return LoggingMeterRegistry.builder(lconf).loggingSink(metricConsumer).build();
+  }
+}

--- a/core/src/test/java/org/apache/accumulo/core/metrics/MetricsUtilTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metrics/MetricsUtilTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+public class MetricsUtilTest {
+  @Test
+  public void factoryTest() throws Exception {
+
+    assertNotNull(MetricsUtil.getRegistryFromFactory(SPIFactory.class.getName()));
+
+    assertNotNull(MetricsUtil.getRegistryFromFactory(DeprecatedFactory.class.getName()));
+
+    assertThrows(ClassNotFoundException.class,
+        () -> MetricsUtil.getRegistryFromFactory(String.class.getName()));
+  }
+
+  @SuppressWarnings({"deprecation",
+      "support for org.apache.accumulo.core.metrics.MeterRegistryFactory can be removed in 3.1"})
+  static final class DeprecatedFactory
+      implements org.apache.accumulo.core.metrics.MeterRegistryFactory {
+    DeprecatedFactory() {
+
+    }
+
+    @Override
+    public MeterRegistry create() {
+      return new SimpleMeterRegistry();
+    }
+  }
+
+  static class SPIFactory implements org.apache.accumulo.core.spi.metrics.MeterRegistryFactory {
+
+    SPIFactory() {
+
+    }
+
+    @Override
+    public MeterRegistry create() {
+      return new SimpleMeterRegistry();
+    }
+  }
+}

--- a/core/src/test/java/org/apache/accumulo/core/spi/metrics/SimpleLoggingMeterRegistryFactoryTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/metrics/SimpleLoggingMeterRegistryFactoryTest.java
@@ -20,7 +20,6 @@ package org.apache.accumulo.core.spi.metrics;
 
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
-import org.apache.accumulo.core.conf.Property;
 import org.junit.jupiter.api.Test;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -31,11 +30,5 @@ class SimpleLoggingMeterRegistryFactoryTest {
   public void createTest() {
     SimpleLoggingMeterRegistryFactory factory = new SimpleLoggingMeterRegistryFactory();
     assertInstanceOf(MeterRegistry.class, factory.create());
-  }
-
-  @Test
-  public void x() {
-    System.out.println(Property.GENERAL_MICROMETER_FACTORY.getType());
-
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/spi/metrics/SimpleLoggingMeterRegistryFactoryTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/metrics/SimpleLoggingMeterRegistryFactoryTest.java
@@ -16,15 +16,26 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.core.metrics;
+package org.apache.accumulo.core.spi.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import org.apache.accumulo.core.conf.Property;
+import org.junit.jupiter.api.Test;
 
 import io.micrometer.core.instrument.MeterRegistry;
 
-/**
- * @deprecated since 2.1.3; use {@link org.apache.accumulo.core.spi.metrics.MeterRegistryFactory}
- *             instead
- */
-@Deprecated()
-public interface MeterRegistryFactory {
-  MeterRegistry create();
+class SimpleLoggingMeterRegistryFactoryTest {
+
+  @Test
+  public void createTest() {
+    SimpleLoggingMeterRegistryFactory factory = new SimpleLoggingMeterRegistryFactory();
+    assertInstanceOf(MeterRegistry.class, factory.create());
+  }
+
+  @Test
+  public void x() {
+    System.out.println(Property.GENERAL_MICROMETER_FACTORY.getType());
+
+  }
 }

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
@@ -147,6 +147,9 @@ public class MiniAccumuloConfigImpl {
         mergeProp(Property.INSTANCE_SECRET.getKey(), DEFAULT_INSTANCE_SECRET);
       }
 
+      // enable metrics reporting - by default will appear in standard log files.
+      mergeProp(Property.GENERAL_MICROMETER_ENABLED.getKey(), "true");
+
       mergeProp(Property.TSERV_PORTSEARCH.getKey(), "true");
       mergeProp(Property.TSERV_DATACACHE_SIZE.getKey(), "10M");
       mergeProp(Property.TSERV_INDEXCACHE_SIZE.getKey(), "10M");

--- a/test/src/main/java/org/apache/accumulo/test/metrics/MetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/metrics/MetricsIT.java
@@ -43,6 +43,7 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.metrics.MetricsProducer;
+import org.apache.accumulo.core.spi.metrics.SimpleLoggingMeterRegistryFactory;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.test.functional.ConfigurableMacBase;
 import org.apache.accumulo.test.metrics.TestStatsDSink.Metric;
@@ -80,10 +81,12 @@ public class MetricsIT extends ConfigurableMacBase implements MetricsProducer {
     cfg.setProperty(Property.GC_CYCLE_DELAY, "1s");
     cfg.setProperty(Property.MANAGER_FATE_METRICS_MIN_UPDATE_INTERVAL, "1s");
 
-    // Tell the server processes to use a StatsDMeterRegistry that will be configured
-    // to push all metrics to the sink we started.
+    // Tell the server processes to use a StatsDMeterRegistry and the simple logging registry
+    // that will be configured to push all metrics to the sink we started.
     cfg.setProperty(Property.GENERAL_MICROMETER_ENABLED, "true");
-    cfg.setProperty(Property.GENERAL_MICROMETER_FACTORY, TestStatsDRegistryFactory.class.getName());
+    String clazzList = SimpleLoggingMeterRegistryFactory.class.getName() + ","
+        + TestStatsDRegistryFactory.class.getName();
+    cfg.setProperty(Property.GENERAL_MICROMETER_FACTORY, clazzList);
     Map<String,String> sysProps = Map.of(TestStatsDRegistryFactory.SERVER_HOST, "127.0.0.1",
         TestStatsDRegistryFactory.SERVER_PORT, Integer.toString(sink.getPort()));
     cfg.setSystemProperties(sysProps);

--- a/test/src/main/java/org/apache/accumulo/test/metrics/TestStatsDRegistryFactory.java
+++ b/test/src/main/java/org/apache/accumulo/test/metrics/TestStatsDRegistryFactory.java
@@ -20,7 +20,7 @@ package org.apache.accumulo.test.metrics;
 
 import java.time.Duration;
 
-import org.apache.accumulo.core.metrics.MeterRegistryFactory;
+import org.apache.accumulo.core.spi.metrics.MeterRegistryFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +39,7 @@ public class TestStatsDRegistryFactory implements MeterRegistryFactory {
 
   @Override
   public MeterRegistry create() {
-
+    LOG.info("starting metrics registration.");
     String host = System.getProperty(SERVER_HOST, null);
     String port = System.getProperty(SERVER_PORT, null);
 

--- a/test/src/main/resources/log4j2-test.properties
+++ b/test/src/main/resources/log4j2-test.properties
@@ -152,29 +152,6 @@ logger.38.level = debug
 logger.39.name = org.apache.accumulo.manager.Manager
 logger.39.level = trace
 
-property.metricsFilename = ./target/test-metrics
-
-# appender.metrics.type = Console
-appender.metrics.type = RollingFile
-appender.metrics.name = LoggingMetricsOutput
-appender.metrics.fileName = ${metricsFilename}.metrics
-appender.metrics.filePattern = ${metricsFilename}-%d{MM-dd-yy-HH}-%i.metrics.gz
-appender.metrics.layout.type = PatternLayout
-appender.metrics.layout.pattern = METRICS: %d{ISO8601}, %m%n
-appender.metrics.policies.type = Policies
-appender.metrics.policies.time.type = TimeBasedTriggeringPolicy
-appender.metrics.policies.time.interval = 1
-appender.metrics.policies.time.modulate = true
-appender.metrics.policies.size.type = SizeBasedTriggeringPolicy
-appender.metrics.policies.size.size=100MB
-appender.metrics.strategy.type = DefaultRolloverStrategy
-appender.metrics.strategy.max = 10
-
-logger.metrics.name = org.apache.accumulo.metrics
-logger.metrics.level = info
-logger.metrics.additivity = false
-logger.metrics.appenderRef.metrics.ref = LoggingMetricsOutput
-
 rootLogger.level = debug
 rootLogger.appenderRef.console.ref = STDOUT
 


### PR DESCRIPTION
 - Adds the MeterRegistryFactory to `..core.spi.metrics` and deprecates the one in `..core.metrics`
 - Modified the GENERAL_MICROMETER_FACTORY to be a list of class names. This would allow multiple provides to be used. For example, logging and statsd. Primarly this may help track down metrics issues.
 - set the default for mini cluster to log metrics. This should increase the visibility of metrics during development, but may be cluttering the logs.

This replaces #4218 