### PR TITLE
Replaced System.currentTimeMillis() with System.nanoTime()

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.tserver.log;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.apache.accumulo.tserver.logger.LogEvents.COMPACTION_FINISH;
 import static org.apache.accumulo.tserver.logger.LogEvents.COMPACTION_START;
@@ -187,9 +188,9 @@ public final class DfsLogger implements Comparable<DfsLogger> {
         } catch (IOException | RuntimeException ex) {
           fail(work, ex, "synching");
         }
-        long duration = NANOSECONDS.toMillis(System.nanoTime() - start);
-        if (duration > slowFlushMillis) {
-          log.info("Slow sync cost: {} ms, current pipeline: {}", duration,
+        long duration = System.nanoTime() - start;
+        if (duration > MILLISECONDS.toNanos(slowFlushMillis)) {
+          log.info("Slow sync cost: {} ms, current pipeline: {}", NANOSECONDS.toMillis(duration),
               Arrays.toString(getPipeLine()));
           if (expectedReplication > 0) {
             int current = expectedReplication;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.tserver.log;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.apache.accumulo.tserver.logger.LogEvents.COMPACTION_FINISH;
 import static org.apache.accumulo.tserver.logger.LogEvents.COMPACTION_START;
 import static org.apache.accumulo.tserver.logger.LogEvents.DEFINE_TABLET;
@@ -186,7 +187,7 @@ public final class DfsLogger implements Comparable<DfsLogger> {
         } catch (IOException | RuntimeException ex) {
           fail(work, ex, "synching");
         }
-        long duration = System.nanoTime() - start;
+        long duration = NANOSECONDS.toMillis(System.nanoTime() - start);
         if (duration > slowFlushMillis) {
           log.info("Slow sync cost: {} ms, current pipeline: {}", duration,
               Arrays.toString(getPipeLine()));

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
@@ -172,7 +172,7 @@ public final class DfsLogger implements Comparable<DfsLogger> {
           }
         }
 
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
         try {
           if (shouldHSync.isPresent()) {
             if (shouldHSync.orElseThrow()) {
@@ -186,7 +186,7 @@ public final class DfsLogger implements Comparable<DfsLogger> {
         } catch (IOException | RuntimeException ex) {
           fail(work, ex, "synching");
         }
-        long duration = System.currentTimeMillis() - start;
+        long duration = System.nanoTime() - start;
         if (duration > slowFlushMillis) {
           log.info("Slow sync cost: {} ms, current pipeline: {}", duration,
               Arrays.toString(getPipeLine()));


### PR DESCRIPTION
Fixed bug, by replacing `System.currentTimeMillis()` with `System.nanoTime()`. 
Fixes  [issue 4245](https://github.com/apache/accumulo/issues/4245)