### PR TITLE
always sets needs recovery flag in tablet mgmt iterator

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementIterator.java
@@ -202,12 +202,17 @@ public class TabletManagementIterator extends SkippingIterator {
       Exception error = null;
       try {
         LOG.trace("Evaluating extent: {}", tm);
-        computeTabletManagementActions(tm, actions);
-        if (tabletMgmtParams.getManagerState() != ManagerState.NORMAL
-            || tabletMgmtParams.getOnlineTsevers().isEmpty()
-            || tabletMgmtParams.getOnlineTables().isEmpty()) {
-          // when manager is in the process of starting up or shutting down return everything.
-          actions.add(ManagementAction.NEEDS_LOCATION_UPDATE);
+        if (tm.getExtent().isMeta()) {
+          computeTabletManagementActions(tm, actions);
+        } else {
+          if (tabletMgmtParams.getManagerState() != ManagerState.NORMAL
+              || tabletMgmtParams.getOnlineTsevers().isEmpty()
+              || tabletMgmtParams.getOnlineTables().isEmpty()) {
+            // when manager is in the process of starting up or shutting down return everything.
+            actions.add(ManagementAction.NEEDS_LOCATION_UPDATE);
+          } else {
+            computeTabletManagementActions(tm, actions);
+          }
         }
       } catch (Exception e) {
         LOG.error("Error computing tablet management actions for extent: {}", tm.getExtent(), e);

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementIterator.java
@@ -201,14 +201,13 @@ public class TabletManagementIterator extends SkippingIterator {
       actions.clear();
       Exception error = null;
       try {
+        LOG.trace("Evaluating extent: {}", tm);
+        computeTabletManagementActions(tm, actions);
         if (tabletMgmtParams.getManagerState() != ManagerState.NORMAL
             || tabletMgmtParams.getOnlineTsevers().isEmpty()
             || tabletMgmtParams.getOnlineTables().isEmpty()) {
           // when manager is in the process of starting up or shutting down return everything.
           actions.add(ManagementAction.NEEDS_LOCATION_UPDATE);
-        } else {
-          LOG.trace("Evaluating extent: {}", tm);
-          computeTabletManagementActions(tm, actions);
         }
       } catch (Exception e) {
         LOG.error("Error computing tablet management actions for extent: {}", tm.getExtent(), e);


### PR DESCRIPTION
This commit fixes #4251.  The WalSunnyDayIT was failing because the root tablet needed recovery, but the tablet mgmt iterator was not indicating this becaue the manager was in safe mode.  Therefore recovery never happened and the test timed out.