### PR TITLE
fixes volume replacement failures

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementIterator.java
@@ -239,6 +239,10 @@ public class TabletManagementIterator extends SkippingIterator {
     }
   }
 
+  private static final Set<ManagementAction> REASONS_NOT_TO_SPLIT_OR_COMPACT =
+      Collections.unmodifiableSet(EnumSet.of(ManagementAction.BAD_STATE,
+          ManagementAction.NEEDS_VOLUME_REPLACEMENT, ManagementAction.NEEDS_RECOVERY));
+
   /**
    * Evaluates whether or not this Tablet should be returned so that it can be acted upon by the
    * Manager
@@ -264,7 +268,8 @@ public class TabletManagementIterator extends SkippingIterator {
       reasonsToReturnThisTablet.add(ManagementAction.NEEDS_LOCATION_UPDATE);
     }
 
-    if (tm.getOperationId() == null) {
+    if (tm.getOperationId() == null
+        && Collections.disjoint(REASONS_NOT_TO_SPLIT_OR_COMPACT, reasonsToReturnThisTablet)) {
       try {
         final long splitThreshold =
             ConfigurationTypeHelper.getFixedMemoryAsBytes(this.env.getPluginEnv()

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementIterator.java
@@ -260,11 +260,6 @@ public class TabletManagementIterator extends SkippingIterator {
       reasonsToReturnThisTablet.add(ManagementAction.NEEDS_VOLUME_REPLACEMENT);
     }
 
-    if (!reasonsToReturnThisTablet.isEmpty()) {
-      // If volume replacement or recovery is needed, then return early.
-      return;
-    }
-
     if (shouldReturnDueToLocation(tm)) {
       reasonsToReturnThisTablet.add(ManagementAction.NEEDS_LOCATION_UPDATE);
     }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
@@ -512,10 +512,10 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
 
       if (Manager.log.isTraceEnabled()) {
         Manager.log.trace(
-            "[{}] Shutting down all Tservers: {}, dependentCount: {} Extent: {}, state: {}, goal: {} actions:{}",
+            "[{}] Shutting down all Tservers: {}, dependentCount: {} Extent: {}, state: {}, goal: {} actions:{} #wals:{}",
             store.name(), tableMgmtParams.getServersToShutdown().equals(currentTServers.keySet()),
             dependentWatcher == null ? "null" : dependentWatcher.assignedOrHosted(), tm.getExtent(),
-            state, goal, actions);
+            state, goal, actions, tm.getLogs().size());
       }
 
       if (actions.contains(ManagementAction.NEEDS_SPLITTING)) {


### PR DESCRIPTION
VolumeIT was failing because of two problems with volume replacement. First, tablets needing volume replacement were being assigned preventing volume replacement from happening. A change was made to TabletGoalState to fix this.  Second when tablet was assigned to dead server, the location of the dead server was never removed preventing volume replacement.  A change was made to TabletManagementIterator to fix this.