### PR TITLE
Fixes CompactionIT.testMultiStepCompactionThatDeletesAll()

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
@@ -76,6 +76,7 @@ import org.apache.accumulo.core.iterators.user.GrepIterator;
 import org.apache.accumulo.core.metadata.AccumuloTable;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
@@ -258,7 +259,7 @@ public class CompactionIT extends AccumuloClusterHarness {
       FunctionalTestUtils.createRFiles(c, fs, testrf.toString(), 500000, 59, 4);
 
       c.tableOperations().importDirectory(testrf.toString()).to(tableName).load();
-      int beforeCount = countFiles(c);
+      int beforeCount = countFiles(c, tableName);
 
       final AtomicBoolean fail = new AtomicBoolean(false);
       final int THREADS = 5;
@@ -288,7 +289,7 @@ public class CompactionIT extends AccumuloClusterHarness {
             "Failed to successfully run all threads, Check the test output for error");
       }
 
-      int finalCount = countFiles(c);
+      int finalCount = countFiles(c, tableName);
       assertTrue(finalCount < beforeCount);
       try {
         getClusterControl().adminStopAll();
@@ -315,7 +316,7 @@ public class CompactionIT extends AccumuloClusterHarness {
       c.tableOperations().setProperty(tableName, Property.TABLE_FILE_MAX.getKey(), "1001");
       c.tableOperations().setProperty(tableName, Property.TABLE_MAJC_RATIO.getKey(), "100.0");
 
-      var beforeCount = countFiles(c);
+      var beforeCount = countFiles(c, tableName);
 
       final int NUM_ENTRIES_AND_FILES = 60;
 
@@ -334,7 +335,7 @@ public class CompactionIT extends AccumuloClusterHarness {
         assertEquals(NUM_ENTRIES_AND_FILES, scanner.stream().count());
       }
 
-      var afterCount = countFiles(c);
+      var afterCount = countFiles(c, tableName);
 
       assertTrue(afterCount >= beforeCount + NUM_ENTRIES_AND_FILES);
 
@@ -350,8 +351,9 @@ public class CompactionIT extends AccumuloClusterHarness {
         assertEquals(0, scanner.stream().count());
       }
 
-      var finalCount = countFiles(c);
-      assertTrue(finalCount <= beforeCount);
+      var finalCount = countFiles(c, tableName);
+      assertTrue(finalCount <= beforeCount,
+          () -> "finalCount:" + finalCount + "  beforeCount:" + beforeCount);
 
       ExternalCompactionTestUtils.assertNoCompactionMetadata(getServerContext(), tableName);
     }
@@ -908,9 +910,14 @@ public class CompactionIT extends AccumuloClusterHarness {
     }
   }
 
-  private int countFiles(AccumuloClient c) throws Exception {
+  /**
+   * Counts the number of tablets and files in a table.
+   */
+  private int countFiles(AccumuloClient c, String tableName) throws Exception {
+    var tableId = getCluster().getServerContext().getTableId(tableName);
     try (Scanner s = c.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
-      s.fetchColumnFamily(new Text(TabletColumnFamily.NAME));
+      s.setRange(MetadataSchema.TabletsSection.getRange(tableId));
+      TabletColumnFamily.PREV_ROW_COLUMN.fetch(s);
       s.fetchColumnFamily(new Text(DataFileColumnFamily.NAME));
       return Iterators.size(s.iterator());
     }


### PR DESCRIPTION
CompactionIT.countFiles() was counting in an overly broad way that included the new +fate table and the new availability columns in ~tab. This was causing a test failure.  Narrowed the scope of countFiles to fix this.