### PR TITLE
Resolved timeout issue in MemoryStarvedMajCIT

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/ExternalCompactionUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/ExternalCompactionUtil.java
@@ -114,7 +114,6 @@ public class ExternalCompactionUtil {
       ZooReader zooReader = context.getZooReader();
       List<String> groups = zooReader.getChildren(compactorGroupsPath);
       for (String group : groups) {
-        groupsAndAddresses.putIfAbsent(group, new ArrayList<>());
         try {
           List<String> compactors = zooReader.getChildren(compactorGroupsPath + "/" + group);
           for (String compactor : compactors) {
@@ -124,6 +123,7 @@ public class ExternalCompactionUtil {
                 zooReader.getChildren(compactorGroupsPath + "/" + group + "/" + compactor);
             if (!children.isEmpty()) {
               LOG.trace("Found live compactor {} ", compactor);
+              groupsAndAddresses.putIfAbsent(group, new ArrayList<>());
               groupsAndAddresses.get(group).add(HostAndPort.fromString(compactor));
             }
           }

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterControl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterControl.java
@@ -519,6 +519,10 @@ public class MiniAccumuloClusterControl implements ClusterControl {
     stop(server, hostname);
   }
 
+  public List<Process> getCompactors(String resourceGroup) {
+    return compactorProcesses.get(resourceGroup);
+  }
+
   public List<Process> getTabletServers(String resourceGroup) {
     return tabletServerProcesses.get(resourceGroup);
   }


### PR DESCRIPTION
It appears that the test was stopping the Compactors, but not waiting for their ZooKeeper locks to be removed, before moving on and checking the number of zookeeper locks. I think what was happening is that the test code moved forward thinking that the Compactors were stopped, but the Compactors were actually stopping after this point and during the next step in the test.