### PR TITLE
Fixed RecoveryIT, it was timing out

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -364,6 +364,11 @@ public enum Property {
   GENERAL_PROCESS_BIND_ADDRESS("general.process.bind.addr", "0.0.0.0", PropertyType.STRING,
       "The local IP address to which this server should bind for sending and receiving network traffic.",
       "3.0.0"),
+  GENERAL_RECOVERY_WALOG_SORT_INTERVAL("general.recovery.walog.sort.interval", "1m",
+      PropertyType.TIMEDURATION,
+      "The interval at which Compactor, ScanServer, and TabletServer processes should check for recovery logs"
+          + " that need to be sorted so that recovery can occur.",
+      "4.0.0"),
   // properties that are specific to manager server behavior
   MANAGER_PREFIX("manager.", null, PropertyType.PREFIX,
       "Properties in this category affect the behavior of the manager server.", "2.1.0"),

--- a/server/base/src/main/java/org/apache/accumulo/server/zookeeper/DistributedWorkQueue.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/zookeeper/DistributedWorkQueue.java
@@ -20,7 +20,6 @@ package org.apache.accumulo.server.zookeeper;
 
 import static java.lang.Math.toIntExact;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.util.ArrayList;
@@ -33,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil.NodeMissingPolicy;
@@ -176,17 +176,11 @@ public class DistributedWorkQueue {
   }
 
   public DistributedWorkQueue(String path, AccumuloConfiguration config, ServerContext context) {
-    // Preserve the old delay and period
-    this(path, config, context, RANDOM.get().nextInt(toIntExact(MINUTES.toMillis(1))),
-        MINUTES.toMillis(1));
-  }
-
-  public DistributedWorkQueue(String path, AccumuloConfiguration config, ServerContext context,
-      long timerInitialDelay, long timerPeriod) {
+    long interval = config.getTimeInMillis(Property.GENERAL_RECOVERY_WALOG_SORT_INTERVAL);
     this.path = path;
     this.context = context;
-    this.timerInitialDelay = timerInitialDelay;
-    this.timerPeriod = timerPeriod;
+    this.timerInitialDelay = RANDOM.get().nextInt(toIntExact(interval));
+    this.timerPeriod = interval;
     zoo = context.getZooReaderWriter();
   }
 


### PR DESCRIPTION
Test was waiting for 60s to confirm that recovery logs were sorted. However, the default interval for checking if recovery logs needed to be sorted was 1m. Added a new property, which defaults to 1m, but has a lower value in the tests so that it does not timeout.