### PR TITLE
Set all tablets availability to ONDEMAND on import

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
@@ -114,7 +114,9 @@ public interface TableOperations {
       throws AccumuloSecurityException, AccumuloException, TableExistsException;
 
   /**
-   * Imports a table exported via exportTable and copied via hadoop distcp.
+   * Imports a table exported via exportTable and copied via hadoop distcp. All tablets in the new
+   * table created via this operation will have the {@link TabletAvailability#ONDEMAND}
+   * availability.
    *
    * @param tableName Name of a table to create and import into.
    * @param importDir A directory containing the files copied by distcp from exportTable
@@ -128,7 +130,8 @@ public interface TableOperations {
 
   /**
    * Imports a table exported via {@link #exportTable(String, String)} and then copied via hadoop
-   * distcp.
+   * distcp. All tablets in the new table created via this operation will have the
+   * {@link TabletAvailability#ONDEMAND} availability.
    *
    * @param tableName Name of a table to create and import into.
    * @param ic ImportConfiguration for the table being created. If no configuration is needed pass

--- a/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
@@ -20,6 +20,8 @@ package org.apache.accumulo.test;
 
 import static org.apache.accumulo.core.Constants.IMPORT_MAPPINGS_FILE;
 import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
+import static org.apache.accumulo.test.TableOperationsIT.setExpectedTabletAvailability;
+import static org.apache.accumulo.test.TableOperationsIT.verifyTabletAvailabilites;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -33,11 +35,13 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.SortedSet;
 
 import org.apache.accumulo.cluster.AccumuloCluster;
 import org.apache.accumulo.core.Constants;
@@ -45,8 +49,10 @@ import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.admin.AvailabilityForTablet;
 import org.apache.accumulo.core.client.admin.CompactionConfig;
 import org.apache.accumulo.core.client.admin.ImportConfiguration;
+import org.apache.accumulo.core.client.admin.TabletAvailability;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
@@ -74,6 +80,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Sets;
 
 /**
  * ImportTable didn't correctly place absolute paths in metadata. This resulted in the imported
@@ -364,6 +372,144 @@ public class ImportExportIT extends AccumuloClusterHarness {
 
       verifyTableEquality(client, srcTable, destTable, expected);
       assertTrue(verifyMappingsFile(tableId), "Did not find mappings file");
+    }
+  }
+
+  /**
+   * Ensure all tablets in an imported table are ONDEMAND.
+   *
+   * Create a table with multiple tablets, each with a different tablet availability. Export the
+   * table. Import the table and make sure that all tablets on the imported table have the ONDEMAND
+   * tablet availability.
+   *
+   * This test case stitches together code from TableOperationsIT to create the table, set up the
+   * tablets and verify. The code to export then import the table is from
+   * ImportExportIT.testExportImportOffline()
+   */
+  @Test
+  public void testImportedTableIsOnDemand() throws Exception {
+
+    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
+      String[] tableNames = getUniqueNames(2);
+      String srcTable = tableNames[0], destTable = tableNames[1];
+
+      client.tableOperations().create(srcTable);
+      String srcTableId = client.tableOperations().tableIdMap().get(srcTable);
+
+      // add split 'h' and 'q'. Leave first as ONDEMAND, set second to UNHOSTED, and third to HOSTED
+      SortedSet<Text> splits = Sets.newTreeSet(Arrays.asList(new Text("h"), new Text("q")));
+      client.tableOperations().addSplits(srcTable, splits);
+      Range range = new Range(new Text("h"), false, new Text("q"), true);
+      client.tableOperations().setTabletAvailability(srcTable, range, TabletAvailability.UNHOSTED);
+      range = new Range(new Text("q"), false, null, true);
+      client.tableOperations().setTabletAvailability(srcTable, range, TabletAvailability.HOSTED);
+
+      // verify
+      List<AvailabilityForTablet> expectedTabletAvailability = new ArrayList<>();
+      setExpectedTabletAvailability(expectedTabletAvailability, srcTableId, "h", null,
+          TabletAvailability.ONDEMAND);
+      setExpectedTabletAvailability(expectedTabletAvailability, srcTableId, "q", "h",
+          TabletAvailability.UNHOSTED);
+      setExpectedTabletAvailability(expectedTabletAvailability, srcTableId, null, "q",
+          TabletAvailability.HOSTED);
+      verifyTabletAvailabilites(client, srcTable, new Range(), expectedTabletAvailability);
+
+      // Add a split within each of the existing tablets. Adding 'd', 'm', and 'v'
+      splits = Sets.newTreeSet(Arrays.asList(new Text("d"), new Text("m"), new Text("v")));
+      client.tableOperations().addSplits(srcTable, splits);
+
+      // verify results
+      expectedTabletAvailability.clear();
+      setExpectedTabletAvailability(expectedTabletAvailability, srcTableId, "d", null,
+          TabletAvailability.ONDEMAND);
+      setExpectedTabletAvailability(expectedTabletAvailability, srcTableId, "h", "d",
+          TabletAvailability.ONDEMAND);
+      setExpectedTabletAvailability(expectedTabletAvailability, srcTableId, "m", "h",
+          TabletAvailability.UNHOSTED);
+      setExpectedTabletAvailability(expectedTabletAvailability, srcTableId, "q", "m",
+          TabletAvailability.UNHOSTED);
+      setExpectedTabletAvailability(expectedTabletAvailability, srcTableId, "v", "q",
+          TabletAvailability.HOSTED);
+      setExpectedTabletAvailability(expectedTabletAvailability, srcTableId, null, "v",
+          TabletAvailability.HOSTED);
+      verifyTabletAvailabilites(client, srcTable, new Range(), expectedTabletAvailability);
+
+      // Make a directory we can use to throw the export and import directories
+      // Must exist on the filesystem the cluster is running.
+      FileSystem fs = cluster.getFileSystem();
+      log.info("Using FileSystem: " + fs);
+      Path baseDir = new Path(cluster.getTemporaryPath(), getClass().getName());
+      fs.deleteOnExit(baseDir);
+      if (fs.exists(baseDir)) {
+        log.info("{} exists on filesystem, deleting", baseDir);
+        assertTrue(fs.delete(baseDir, true), "Failed to deleted " + baseDir);
+      }
+      log.info("Creating {}", baseDir);
+      assertTrue(fs.mkdirs(baseDir), "Failed to create " + baseDir);
+      Path exportDir = new Path(baseDir, "export");
+      fs.deleteOnExit(exportDir);
+      Path importDirA = new Path(baseDir, "import-a");
+      Path importDirB = new Path(baseDir, "import-b");
+      fs.deleteOnExit(importDirA);
+      fs.deleteOnExit(importDirB);
+      for (Path p : new Path[] {exportDir, importDirA, importDirB}) {
+        assertTrue(fs.mkdirs(p), "Failed to create " + p);
+      }
+
+      Set<String> importDirs = Set.of(importDirA.toString(), importDirB.toString());
+
+      Path[] importDirAry = new Path[] {importDirA, importDirB};
+
+      log.info("Exporting table to {}", exportDir);
+      log.info("Importing table from {}", importDirs);
+
+      // test fast fail offline check
+      assertThrows(IllegalStateException.class,
+          () -> client.tableOperations().exportTable(srcTable, exportDir.toString()));
+
+      // Offline the table
+      client.tableOperations().offline(srcTable, true);
+      // Then export it
+      client.tableOperations().exportTable(srcTable, exportDir.toString());
+
+      // Make sure the distcp.txt file that exporttable creates is available
+      Path distcp = new Path(exportDir, "distcp.txt");
+      fs.deleteOnExit(distcp);
+      assertTrue(fs.exists(distcp), "Distcp file doesn't exist");
+      FSDataInputStream is = fs.open(distcp);
+      BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+
+      // Copy each file that was exported to one of the imports directory
+      String line;
+
+      while ((line = reader.readLine()) != null) {
+        Path p = new Path(line.substring(5));
+        assertTrue(fs.exists(p), "File doesn't exist: " + p);
+        Path importDir = importDirAry[RANDOM.get().nextInt(importDirAry.length)];
+        Path dest = new Path(importDir, p.getName());
+        assertFalse(fs.exists(dest), "Did not expect " + dest + " to exist");
+        FileUtil.copy(fs, p, fs, dest, false, fs.getConf());
+      }
+
+      reader.close();
+
+      log.info("Import dir A: {}", Arrays.toString(fs.listStatus(importDirA)));
+      log.info("Import dir B: {}", Arrays.toString(fs.listStatus(importDirB)));
+
+      // Import the exported data into a new table
+      client.tableOperations().importTable(destTable, importDirs, ImportConfiguration.empty());
+
+      // Get the table ID for the table that the importtable command created
+      final String destTableId = client.tableOperations().tableIdMap().get(destTable);
+      assertNotNull(destTableId);
+
+      // Get all `file` colfams from the metadata table for the new table
+      log.info("Imported into table with ID: {}", destTableId);
+
+      client.tableOperations().getTabletInformation(destTable, new Range())
+          .forEach(tabletInformation -> assertEquals(TabletAvailability.ONDEMAND,
+              tabletInformation.getTabletAvailability(),
+              "Expected all tablets in imported table to be ONDEMAND"));
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
@@ -83,7 +83,7 @@ import com.google.common.collect.Sets;
 
 public class TableOperationsIT extends AccumuloClusterHarness {
 
-  private AccumuloClient accumuloClient;
+  private static AccumuloClient accumuloClient;
   private static final int MAX_TABLE_NAME_LEN = 1024;
 
   @Override
@@ -727,9 +727,14 @@ public class TableOperationsIT extends AccumuloClusterHarness {
         expectedTabletAvailability);
   }
 
-  private void verifyTabletAvailabilites(String tableName, Range range,
+  public static void verifyTabletAvailabilites(String tableName, Range range,
       List<AvailabilityForTablet> expectedAvailability) throws TableNotFoundException {
-    List<TabletInformation> tabletInfo = accumuloClient.tableOperations()
+    verifyTabletAvailabilites(accumuloClient, tableName, range, expectedAvailability);
+  }
+
+  public static void verifyTabletAvailabilites(AccumuloClient client, String tableName, Range range,
+      List<AvailabilityForTablet> expectedAvailability) throws TableNotFoundException {
+    List<TabletInformation> tabletInfo = client.tableOperations()
         .getTabletInformation(tableName, range).collect(Collectors.toList());
     assertEquals(expectedAvailability.size(), tabletInfo.size());
     for (var i = 0; i < expectedAvailability.size(); i++) {
@@ -739,7 +744,7 @@ public class TableOperationsIT extends AccumuloClusterHarness {
     }
   }
 
-  private void setExpectedTabletAvailability(List<AvailabilityForTablet> expected, String id,
+  public static void setExpectedTabletAvailability(List<AvailabilityForTablet> expected, String id,
       String endRow, String prevEndRow, TabletAvailability availability) {
     KeyExtent ke = new KeyExtent(TableId.of(id), endRow == null ? null : new Text(endRow),
         prevEndRow == null ? null : new Text(prevEndRow));


### PR DESCRIPTION
This PR changes the logic in PopulateMetadataTable to make all tablets in an imported table ONDEMAND.

Other minor improvements were made to that file and and IT was added to test these changes.