### PR TITLE
Added validation of configuration during upgrade

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -136,6 +136,10 @@
       <artifactId>zookeeper-jute</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.checkerframework</groupId>
+      <artifactId>checker-qual</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/core/src/main/java/org/apache/accumulo/core/conf/ConfigCheckUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ConfigCheckUtil.java
@@ -129,7 +129,7 @@ public class ConfigCheckUtil {
   }
 
   /**
-   * The exception thrown when {@link ConfigCheckUtil#validate(Iterable)} fails.
+   * The exception thrown when {@link ConfigCheckUtil#validate(Iterable, String)} fails.
    */
   public static class ConfigCheckException extends RuntimeException {
     private static final long serialVersionUID = 1L;

--- a/core/src/main/java/org/apache/accumulo/core/conf/ConfigCheckUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ConfigCheckUtil.java
@@ -23,6 +23,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 
 import org.apache.accumulo.core.spi.crypto.CryptoServiceFactory;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,7 +46,7 @@ public class ConfigCheckUtil {
    * @param entries iterable through configuration keys and values
    * @throws ConfigCheckException if a fatal configuration error is found
    */
-  public static void validate(Iterable<Entry<String,String>> entries) {
+  public static void validate(Iterable<Entry<String,String>> entries, @NonNull String source) {
     String instanceZkTimeoutValue = null;
     for (Entry<String,String> entry : entries) {
       String key = entry.getKey();
@@ -54,12 +55,12 @@ public class ConfigCheckUtil {
       if (prop == null && Property.isValidPropertyKey(key)) {
         continue; // unknown valid property (i.e. has proper prefix)
       } else if (prop == null) {
-        log.warn(PREFIX + "unrecognized property key (" + key + ")");
+        log.warn(PREFIX + "unrecognized property key ({}) for {}", key, source);
       } else if (prop.getType() == PropertyType.PREFIX) {
-        fatal(PREFIX + "incomplete property key (" + key + ")");
+        fatal(PREFIX + "incomplete property key (" + key + ") for {}" + source);
       } else if (!prop.getType().isValidFormat(value)) {
         fatal(PREFIX + "improperly formatted value for key (" + key + ", type=" + prop.getType()
-            + ") : " + value);
+            + ") : " + value + " for " + source);
       }
 
       if (key.equals(Property.INSTANCE_ZK_TIMEOUT.getKey())) {

--- a/core/src/main/java/org/apache/accumulo/core/conf/SiteConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/SiteConfiguration.java
@@ -212,7 +212,7 @@ public class SiteConfiguration extends AccumuloConfiguration {
   private final Map<String,String> config;
 
   private SiteConfiguration(Map<String,String> config) {
-    ConfigCheckUtil.validate(config.entrySet());
+    ConfigCheckUtil.validate(config.entrySet(), "site config");
     this.config = config;
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/conf/ConfigCheckUtilTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/ConfigCheckUtilTest.java
@@ -40,51 +40,51 @@ public class ConfigCheckUtilTest {
     m.put(Property.MANAGER_TABLET_BALANCER.getKey(),
         "org.apache.accumulo.server.manager.balancer.TableLoadBalancer");
     m.put(Property.MANAGER_BULK_RETRIES.getKey(), "3");
-    ConfigCheckUtil.validate(m.entrySet());
+    ConfigCheckUtil.validate(m.entrySet(), "test");
   }
 
   @Test
   public void testPass_Empty() {
-    ConfigCheckUtil.validate(m.entrySet());
+    ConfigCheckUtil.validate(m.entrySet(), "test");
   }
 
   @Test
   public void testPass_UnrecognizedValidProperty() {
     m.put(Property.MANAGER_CLIENTPORT.getKey(), "9999");
     m.put(Property.MANAGER_PREFIX.getKey() + "something", "abcdefg");
-    ConfigCheckUtil.validate(m.entrySet());
+    ConfigCheckUtil.validate(m.entrySet(), "test");
   }
 
   @Test
   public void testPass_UnrecognizedProperty() {
     m.put(Property.MANAGER_CLIENTPORT.getKey(), "9999");
     m.put("invalid.prefix.value", "abcdefg");
-    ConfigCheckUtil.validate(m.entrySet());
+    ConfigCheckUtil.validate(m.entrySet(), "test");
   }
 
   @Test
   public void testFail_Prefix() {
     m.put(Property.MANAGER_CLIENTPORT.getKey(), "9999");
     m.put(Property.MANAGER_PREFIX.getKey(), "oops");
-    assertThrows(ConfigCheckException.class, () -> ConfigCheckUtil.validate(m.entrySet()));
+    assertThrows(ConfigCheckException.class, () -> ConfigCheckUtil.validate(m.entrySet(), "test"));
   }
 
   @Test
   public void testFail_InstanceZkTimeoutOutOfRange() {
     m.put(Property.INSTANCE_ZK_TIMEOUT.getKey(), "10ms");
-    assertThrows(ConfigCheckException.class, () -> ConfigCheckUtil.validate(m.entrySet()));
+    assertThrows(ConfigCheckException.class, () -> ConfigCheckUtil.validate(m.entrySet(), "test"));
   }
 
   @Test
   public void testFail_badCryptoFactory() {
     m.put(Property.INSTANCE_CRYPTO_FACTORY.getKey(), "DoesNotExistCryptoFactory");
-    assertThrows(ConfigCheckException.class, () -> ConfigCheckUtil.validate(m.entrySet()));
+    assertThrows(ConfigCheckException.class, () -> ConfigCheckUtil.validate(m.entrySet(), "test"));
   }
 
   @Test
   public void testPass_defaultCryptoFactory() {
     m.put(Property.INSTANCE_CRYPTO_FACTORY.getKey(),
         Property.INSTANCE_CRYPTO_FACTORY.getDefaultValue());
-    ConfigCheckUtil.validate(m.entrySet());
+    ConfigCheckUtil.validate(m.entrySet(), "test");
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/conf/DefaultConfigurationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/DefaultConfigurationTest.java
@@ -52,6 +52,6 @@ public class DefaultConfigurationTest {
 
   @Test
   public void testSanityCheck() {
-    ConfigCheckUtil.validate(c);
+    ConfigCheckUtil.validate(c, "test");
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/ServerConfigurationFactory.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/ServerConfigurationFactory.java
@@ -115,7 +115,7 @@ public class ServerConfigurationFactory extends ServerConfiguration {
         context.getPropStore().registerAsListener(TablePropKey.of(context, tableId), changeWatcher);
         var conf =
             new TableConfiguration(context, tableId, getNamespaceConfigurationForTable(tableId));
-        ConfigCheckUtil.validate(conf);
+        ConfigCheckUtil.validate(conf, "table id: " + tableId.toString());
         return conf;
       }
       return null;
@@ -138,7 +138,7 @@ public class ServerConfigurationFactory extends ServerConfiguration {
       context.getPropStore().registerAsListener(NamespacePropKey.of(context, namespaceId),
           changeWatcher);
       var conf = new NamespaceConfiguration(context, namespaceId, getSystemConfiguration());
-      ConfigCheckUtil.validate(conf);
+      ConfigCheckUtil.validate(conf, "namespace id: " + namespaceId.toString());
       return conf;
     });
   }


### PR DESCRIPTION
Backported second parameter to CheckConfigUtil.validate and updated all call locations to supply the second parameter. Added method to UpgradeCoordinator to call CheckConfigUtil.validate after the upgradeMetadata method is called on all Upgraders

Fixes #3972