### PR TITLE
Replace boolean with enum for table locks in 3.1

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/DistributedReadWriteLock.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/DistributedReadWriteLock.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DistributedReadWriteLock implements java.util.concurrent.locks.ReadWriteLock {
 
-  public static enum LockType {
+  public enum LockType {
     READ, WRITE,
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
@@ -169,7 +169,7 @@ public class Utils {
     DistributedLock lock = DistributedReadWriteLock.recoverLock(qlock, lockData);
     if (lock != null) {
       // Validate the recovered lock type
-      if (!lock.getType().equals(lockType)) {
+      if (lock.getType() != lockType) {
         throw new IllegalStateException("Unexpected lock type " + lock.getType()
             + " recovered for transaction " + FateTxId.formatTid(tid) + " on object " + id
             + ". Expected " + lockType + " lock instead.");

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
@@ -90,9 +90,9 @@ public class Utils {
   static final Lock tableNameLock = new ReentrantLock();
   static final Lock idLock = new ReentrantLock();
 
-  public static long reserveTable(Manager env, TableId tableId, long tid, boolean writeLock,
+  public static long reserveTable(Manager env, TableId tableId, long tid, LockType lockType,
       boolean tableMustExist, TableOperation op) throws Exception {
-    if (getLock(env.getContext(), tableId, tid, writeLock).tryLock()) {
+    if (getLock(env.getContext(), tableId, tid, lockType).tryLock()) {
       if (tableMustExist) {
         ZooReaderWriter zk = env.getContext().getZooReaderWriter();
         if (!zk.exists(env.getContext().getZooKeeperRoot() + Constants.ZTABLES + "/" + tableId)) {
@@ -101,29 +101,27 @@ public class Utils {
         }
       }
       log.info("table {} {} locked for {} operation: {}", tableId, FateTxId.formatTid(tid),
-          (writeLock ? "write" : "read"), op);
+          lockType, op);
       return 0;
     } else {
       return 100;
     }
   }
 
-  public static void unreserveTable(Manager env, TableId tableId, long tid, boolean writeLock) {
-    getLock(env.getContext(), tableId, tid, writeLock).unlock();
-    log.info("table {} {} unlocked for {}", tableId, FateTxId.formatTid(tid),
-        (writeLock ? "write" : "read"));
+  public static void unreserveTable(Manager env, TableId tableId, long tid, LockType lockType) {
+    getLock(env.getContext(), tableId, tid, lockType).unlock();
+    log.info("table {} {} unlocked for {}", tableId, FateTxId.formatTid(tid), lockType);
   }
 
   public static void unreserveNamespace(Manager env, NamespaceId namespaceId, long id,
-      boolean writeLock) {
-    getLock(env.getContext(), namespaceId, id, writeLock).unlock();
-    log.info("namespace {} {} unlocked for {}", namespaceId, FateTxId.formatTid(id),
-        (writeLock ? "write" : "read"));
+      LockType lockType) {
+    getLock(env.getContext(), namespaceId, id, lockType).unlock();
+    log.info("namespace {} {} unlocked for {}", namespaceId, FateTxId.formatTid(id), lockType);
   }
 
   public static long reserveNamespace(Manager env, NamespaceId namespaceId, long id,
-      boolean writeLock, boolean mustExist, TableOperation op) throws Exception {
-    if (getLock(env.getContext(), namespaceId, id, writeLock).tryLock()) {
+      LockType lockType, boolean mustExist, TableOperation op) throws Exception {
+    if (getLock(env.getContext(), namespaceId, id, lockType).tryLock()) {
       if (mustExist) {
         ZooReaderWriter zk = env.getContext().getZooReaderWriter();
         if (!zk.exists(
@@ -133,7 +131,7 @@ public class Utils {
         }
       }
       log.info("namespace {} {} locked for {} operation: {}", namespaceId, FateTxId.formatTid(id),
-          (writeLock ? "write" : "read"), op);
+          lockType, op);
       return 0;
     } else {
       return 100;
@@ -163,27 +161,30 @@ public class Utils {
   }
 
   private static Lock getLock(ServerContext context, AbstractId<?> id, long tid,
-      boolean writeLock) {
+      LockType lockType) {
     byte[] lockData = FastFormat.toZeroPaddedHex(tid);
     var fLockPath =
         FateLock.path(context.getZooKeeperRoot() + Constants.ZTABLE_LOCKS + "/" + id.canonical());
     FateLock qlock = new FateLock(context.getZooReaderWriter(), fLockPath);
     DistributedLock lock = DistributedReadWriteLock.recoverLock(qlock, lockData);
     if (lock != null) {
-
       // Validate the recovered lock type
-      boolean isWriteLock = lock.getType() == LockType.WRITE;
-      if (writeLock != isWriteLock) {
+      if (!lock.getType().equals(lockType)) {
         throw new IllegalStateException("Unexpected lock type " + lock.getType()
             + " recovered for transaction " + FateTxId.formatTid(tid) + " on object " + id
-            + ". Expected " + (writeLock ? LockType.WRITE : LockType.READ) + " lock instead.");
+            + ". Expected " + lockType + " lock instead.");
       }
     } else {
       DistributedReadWriteLock locker = new DistributedReadWriteLock(qlock, lockData);
-      if (writeLock) {
-        lock = locker.writeLock();
-      } else {
-        lock = locker.readLock();
+      switch (lockType) {
+        case WRITE:
+          lock = locker.writeLock();
+          break;
+        case READ:
+          lock = locker.readLock();
+          break;
+        default:
+          throw new IllegalStateException("Unexpected LockType: " + lockType);
       }
     }
     return lock;
@@ -198,7 +199,7 @@ public class Utils {
   }
 
   public static Lock getReadLock(Manager env, AbstractId<?> id, long tid) {
-    return Utils.getLock(env.getContext(), id, tid, false);
+    return Utils.getLock(env.getContext(), id, tid, LockType.READ);
   }
 
   public static void checkNamespaceDoesNotExist(ServerContext context, String namespace,

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneTable.java
@@ -25,6 +25,7 @@ import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.Utils;
@@ -48,9 +49,9 @@ public class CloneTable extends ManagerRepo {
 
   @Override
   public long isReady(long tid, Manager environment) throws Exception {
-    long val = Utils.reserveNamespace(environment, cloneInfo.srcNamespaceId, tid, false, true,
-        TableOperation.CLONE);
-    val += Utils.reserveTable(environment, cloneInfo.srcTableId, tid, false, true,
+    long val = Utils.reserveNamespace(environment, cloneInfo.srcNamespaceId, tid, LockType.READ,
+        true, TableOperation.CLONE);
+    val += Utils.reserveTable(environment, cloneInfo.srcTableId, tid, LockType.READ, true,
         TableOperation.CLONE);
     return val;
   }
@@ -71,8 +72,8 @@ public class CloneTable extends ManagerRepo {
 
   @Override
   public void undo(long tid, Manager environment) {
-    Utils.unreserveNamespace(environment, cloneInfo.srcNamespaceId, tid, false);
-    Utils.unreserveTable(environment, cloneInfo.srcTableId, tid, false);
+    Utils.unreserveNamespace(environment, cloneInfo.srcNamespaceId, tid, LockType.READ);
+    Utils.unreserveTable(environment, cloneInfo.srcTableId, tid, LockType.READ);
   }
 
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/FinishCloneTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/FinishCloneTable.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.manager.tableOps.clone;
 import java.util.EnumSet;
 
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
@@ -58,12 +59,12 @@ class FinishCloneTable extends ManagerRepo {
           expectedCurrStates);
     }
 
-    Utils.unreserveNamespace(environment, cloneInfo.srcNamespaceId, tid, false);
+    Utils.unreserveNamespace(environment, cloneInfo.srcNamespaceId, tid, LockType.READ);
     if (!cloneInfo.srcNamespaceId.equals(cloneInfo.namespaceId)) {
-      Utils.unreserveNamespace(environment, cloneInfo.namespaceId, tid, false);
+      Utils.unreserveNamespace(environment, cloneInfo.namespaceId, tid, LockType.READ);
     }
-    Utils.unreserveTable(environment, cloneInfo.srcTableId, tid, false);
-    Utils.unreserveTable(environment, cloneInfo.tableId, tid, true);
+    Utils.unreserveTable(environment, cloneInfo.srcTableId, tid, LockType.READ);
+    Utils.unreserveTable(environment, cloneInfo.tableId, tid, LockType.WRITE);
 
     environment.getEventCoordinator().event("Cloned table %s from %s", cloneInfo.tableName,
         cloneInfo.srcTableId);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactRange.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactRange.java
@@ -33,6 +33,7 @@ import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.util.FastFormat;
 import org.apache.accumulo.core.util.TextUtil;
@@ -89,8 +90,9 @@ public class CompactRange extends ManagerRepo {
 
   @Override
   public long isReady(long tid, Manager env) throws Exception {
-    return Utils.reserveNamespace(env, namespaceId, tid, false, true, TableOperation.COMPACT)
-        + Utils.reserveTable(env, tableId, tid, false, true, TableOperation.COMPACT);
+    return Utils.reserveNamespace(env, namespaceId, tid, LockType.READ, true,
+        TableOperation.COMPACT)
+        + Utils.reserveTable(env, tableId, tid, LockType.READ, true, TableOperation.COMPACT);
   }
 
   @Override
@@ -179,8 +181,8 @@ public class CompactRange extends ManagerRepo {
     try {
       removeIterators(env, tid, tableId);
     } finally {
-      Utils.unreserveNamespace(env, namespaceId, tid, false);
-      Utils.unreserveTable(env, tableId, tid, false);
+      Utils.unreserveNamespace(env, namespaceId, tid, LockType.READ);
+      Utils.unreserveTable(env, tableId, tid, LockType.READ);
     }
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/cancel/CancelCompactions.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/cancel/CancelCompactions.java
@@ -26,6 +26,7 @@ import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.FateTxId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
@@ -48,8 +49,9 @@ public class CancelCompactions extends ManagerRepo {
 
   @Override
   public long isReady(long tid, Manager env) throws Exception {
-    return Utils.reserveNamespace(env, namespaceId, tid, false, true, TableOperation.COMPACT_CANCEL)
-        + Utils.reserveTable(env, tableId, tid, false, true, TableOperation.COMPACT_CANCEL);
+    return Utils.reserveNamespace(env, namespaceId, tid, LockType.READ, true,
+        TableOperation.COMPACT_CANCEL)
+        + Utils.reserveTable(env, tableId, tid, LockType.READ, true, TableOperation.COMPACT_CANCEL);
   }
 
   @Override
@@ -60,8 +62,8 @@ public class CancelCompactions extends ManagerRepo {
 
   @Override
   public void undo(long tid, Manager env) {
-    Utils.unreserveTable(env, tableId, tid, false);
-    Utils.unreserveNamespace(env, namespaceId, tid, false);
+    Utils.unreserveTable(env, tableId, tid, LockType.READ);
+    Utils.unreserveNamespace(env, namespaceId, tid, LockType.READ);
   }
 
   public static void mutateZooKeeper(long tid, TableId tableId, Manager environment)

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/cancel/FinishCancelCompaction.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/cancel/FinishCancelCompaction.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.manager.tableOps.compact.cancel;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.Utils;
@@ -37,8 +38,8 @@ class FinishCancelCompaction extends ManagerRepo {
 
   @Override
   public Repo<Manager> call(long tid, Manager environment) {
-    Utils.unreserveTable(environment, tableId, tid, false);
-    Utils.unreserveNamespace(environment, namespaceId, tid, false);
+    Utils.unreserveTable(environment, tableId, tid, LockType.READ);
+    Utils.unreserveNamespace(environment, namespaceId, tid, LockType.READ);
     return null;
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/CreateTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/CreateTable.java
@@ -27,6 +27,7 @@ import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.TableInfo;
@@ -60,7 +61,7 @@ public class CreateTable extends ManagerRepo {
   @Override
   public long isReady(long tid, Manager environment) throws Exception {
     // reserve the table's namespace to make sure it doesn't change while the table is created
-    return Utils.reserveNamespace(environment, tableInfo.getNamespaceId(), tid, false, true,
+    return Utils.reserveNamespace(environment, tableInfo.getNamespaceId(), tid, LockType.READ, true,
         TableOperation.CREATE);
   }
 
@@ -95,7 +96,7 @@ public class CreateTable extends ManagerRepo {
     } catch (IOException e) {
       log.error("Table failed to be created and failed to clean up split files at {}", p, e);
     } finally {
-      Utils.unreserveNamespace(env, tableInfo.getNamespaceId(), tid, false);
+      Utils.unreserveNamespace(env, tableInfo.getNamespaceId(), tid, LockType.READ);
     }
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/FinishCreateTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/FinishCreateTable.java
@@ -23,6 +23,7 @@ import java.util.EnumSet;
 
 import org.apache.accumulo.core.client.admin.InitialTableState;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
@@ -61,8 +62,8 @@ class FinishCreateTable extends ManagerRepo {
           TableState.ONLINE, expectedCurrStates);
     }
 
-    Utils.unreserveNamespace(env, tableInfo.getNamespaceId(), tid, false);
-    Utils.unreserveTable(env, tableInfo.getTableId(), tid, true);
+    Utils.unreserveNamespace(env, tableInfo.getNamespaceId(), tid, LockType.READ);
+    Utils.unreserveTable(env, tableInfo.getTableId(), tid, LockType.WRITE);
 
     env.getEventCoordinator().event("Created table %s ", tableInfo.getTableName());
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/PopulateZookeeper.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/PopulateZookeeper.java
@@ -22,6 +22,7 @@ import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
 import org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.TableInfo;
@@ -41,7 +42,7 @@ class PopulateZookeeper extends ManagerRepo {
 
   @Override
   public long isReady(long tid, Manager environment) throws Exception {
-    return Utils.reserveTable(environment, tableInfo.getTableId(), tid, true, false,
+    return Utils.reserveTable(environment, tableInfo.getTableId(), tid, LockType.WRITE, false,
         TableOperation.CREATE);
   }
 
@@ -79,7 +80,7 @@ class PopulateZookeeper extends ManagerRepo {
   @Override
   public void undo(long tid, Manager manager) throws Exception {
     manager.getTableManager().removeTable(tableInfo.getTableId());
-    Utils.unreserveTable(manager, tableInfo.getTableId(), tid, true);
+    Utils.unreserveTable(manager, tableInfo.getTableId(), tid, LockType.WRITE);
     manager.getContext().clearTableListCache();
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/CleanUp.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/CleanUp.java
@@ -35,6 +35,7 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.iterators.user.GrepIterator;
 import org.apache.accumulo.core.metadata.AccumuloTable;
 import org.apache.accumulo.core.metadata.TabletLocationState;
@@ -206,8 +207,8 @@ class CleanUp extends ManagerRepo {
       log.error("{}", e.getMessage(), e);
     }
 
-    Utils.unreserveTable(manager, tableId, tid, true);
-    Utils.unreserveNamespace(manager, namespaceId, tid, false);
+    Utils.unreserveTable(manager, tableId, tid, LockType.WRITE);
+    Utils.unreserveNamespace(manager, namespaceId, tid, LockType.READ);
 
     LoggerFactory.getLogger(CleanUp.class).debug("Deleted table " + tableId);
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/DeleteTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/DeleteTable.java
@@ -24,6 +24,7 @@ import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
@@ -43,8 +44,9 @@ public class DeleteTable extends ManagerRepo {
 
   @Override
   public long isReady(long tid, Manager env) throws Exception {
-    return Utils.reserveNamespace(env, namespaceId, tid, false, false, TableOperation.DELETE)
-        + Utils.reserveTable(env, tableId, tid, true, true, TableOperation.DELETE);
+    return Utils.reserveNamespace(env, namespaceId, tid, LockType.READ, false,
+        TableOperation.DELETE)
+        + Utils.reserveTable(env, tableId, tid, LockType.WRITE, true, TableOperation.DELETE);
   }
 
   @Override
@@ -58,7 +60,7 @@ public class DeleteTable extends ManagerRepo {
 
   @Override
   public void undo(long tid, Manager env) {
-    Utils.unreserveTable(env, tableId, tid, true);
-    Utils.unreserveNamespace(env, namespaceId, tid, false);
+    Utils.unreserveTable(env, tableId, tid, LockType.WRITE);
+    Utils.unreserveNamespace(env, namespaceId, tid, LockType.READ);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/PreDeleteTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/PreDeleteTable.java
@@ -24,6 +24,7 @@ import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.accumulo.manager.Manager;
@@ -51,8 +52,8 @@ public class PreDeleteTable extends ManagerRepo {
 
   @Override
   public long isReady(long tid, Manager env) throws Exception {
-    return Utils.reserveNamespace(env, namespaceId, tid, false, true, TableOperation.DELETE)
-        + Utils.reserveTable(env, tableId, tid, false, true, TableOperation.DELETE);
+    return Utils.reserveNamespace(env, namespaceId, tid, LockType.READ, true, TableOperation.DELETE)
+        + Utils.reserveTable(env, tableId, tid, LockType.READ, true, TableOperation.DELETE);
   }
 
   private void preventFutureCompactions(Manager environment)
@@ -69,15 +70,15 @@ public class PreDeleteTable extends ManagerRepo {
       CancelCompactions.mutateZooKeeper(tid, tableId, environment);
       return new DeleteTable(namespaceId, tableId);
     } finally {
-      Utils.unreserveTable(environment, tableId, tid, false);
-      Utils.unreserveNamespace(environment, namespaceId, tid, false);
+      Utils.unreserveTable(environment, tableId, tid, LockType.READ);
+      Utils.unreserveNamespace(environment, namespaceId, tid, LockType.READ);
     }
   }
 
   @Override
   public void undo(long tid, Manager env) {
-    Utils.unreserveTable(env, tableId, tid, false);
-    Utils.unreserveNamespace(env, namespaceId, tid, false);
+    Utils.unreserveTable(env, tableId, tid, LockType.READ);
+    Utils.unreserveNamespace(env, namespaceId, tid, LockType.READ);
   }
 
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/TableRangeOp.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/TableRangeOp.java
@@ -25,6 +25,7 @@ import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.metadata.AccumuloTable;
 import org.apache.accumulo.core.util.TextUtil;
 import org.apache.accumulo.manager.Manager;
@@ -50,8 +51,8 @@ public class TableRangeOp extends ManagerRepo {
 
   @Override
   public long isReady(long tid, Manager env) throws Exception {
-    return Utils.reserveNamespace(env, namespaceId, tid, false, true, TableOperation.MERGE)
-        + Utils.reserveTable(env, tableId, tid, true, true, TableOperation.MERGE);
+    return Utils.reserveNamespace(env, namespaceId, tid, LockType.READ, true, TableOperation.MERGE)
+        + Utils.reserveTable(env, tableId, tid, LockType.WRITE, true, TableOperation.MERGE);
   }
 
   public TableRangeOp(MergeInfo.Operation op, NamespaceId namespaceId, TableId tableId,
@@ -102,8 +103,8 @@ public class TableRangeOp extends ManagerRepo {
       log.info("removing merge information {}", mergeInfo);
     }
     env.clearMergeState(tableId);
-    Utils.unreserveNamespace(env, namespaceId, tid, false);
-    Utils.unreserveTable(env, tableId, tid, true);
+    Utils.unreserveNamespace(env, namespaceId, tid, LockType.READ);
+    Utils.unreserveTable(env, tableId, tid, LockType.WRITE);
   }
 
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/TableRangeOpWait.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/TableRangeOpWait.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.manager.tableOps.merge;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.Utils;
@@ -71,8 +72,8 @@ class TableRangeOpWait extends ManagerRepo {
     MergeInfo mergeInfo = manager.getMergeInfo(tableId);
     log.info("removing merge information " + mergeInfo);
     manager.clearMergeState(tableId);
-    Utils.unreserveTable(manager, tableId, tid, true);
-    Utils.unreserveNamespace(manager, namespaceId, tid, false);
+    Utils.unreserveTable(manager, tableId, tid, LockType.WRITE);
+    Utils.unreserveNamespace(manager, namespaceId, tid, LockType.READ);
     return null;
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/FinishCreateNamespace.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/FinishCreateNamespace.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.manager.tableOps.namespace.create;
 
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.Utils;
@@ -42,7 +43,7 @@ class FinishCreateNamespace extends ManagerRepo {
   @Override
   public Repo<Manager> call(long id, Manager env) {
 
-    Utils.unreserveNamespace(env, namespaceInfo.namespaceId, id, true);
+    Utils.unreserveNamespace(env, namespaceInfo.namespaceId, id, LockType.WRITE);
 
     env.getEventCoordinator().event("Created namespace %s ", namespaceInfo.namespaceName);
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/PopulateZookeeperWithNamespace.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/PopulateZookeeperWithNamespace.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.manager.tableOps.namespace.create;
 
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
@@ -40,7 +41,7 @@ class PopulateZookeeperWithNamespace extends ManagerRepo {
 
   @Override
   public long isReady(long id, Manager environment) throws Exception {
-    return Utils.reserveNamespace(environment, namespaceInfo.namespaceId, id, true, false,
+    return Utils.reserveNamespace(environment, namespaceInfo.namespaceId, id, LockType.WRITE, false,
         TableOperation.CREATE);
   }
 
@@ -71,7 +72,7 @@ class PopulateZookeeperWithNamespace extends ManagerRepo {
   public void undo(long tid, Manager manager) throws Exception {
     manager.getTableManager().removeNamespace(namespaceInfo.namespaceId);
     manager.getContext().clearTableListCache();
-    Utils.unreserveNamespace(manager, namespaceInfo.namespaceId, tid, true);
+    Utils.unreserveNamespace(manager, namespaceInfo.namespaceId, tid, LockType.WRITE);
   }
 
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/delete/DeleteNamespace.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/delete/DeleteNamespace.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.manager.tableOps.namespace.delete;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.Utils;
@@ -37,7 +38,8 @@ public class DeleteNamespace extends ManagerRepo {
 
   @Override
   public long isReady(long id, Manager environment) throws Exception {
-    return Utils.reserveNamespace(environment, namespaceId, id, true, true, TableOperation.DELETE);
+    return Utils.reserveNamespace(environment, namespaceId, id, LockType.WRITE, true,
+        TableOperation.DELETE);
   }
 
   @Override
@@ -48,7 +50,7 @@ public class DeleteNamespace extends ManagerRepo {
 
   @Override
   public void undo(long id, Manager environment) {
-    Utils.unreserveNamespace(environment, namespaceId, id, true);
+    Utils.unreserveNamespace(environment, namespaceId, id, LockType.WRITE);
   }
 
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/delete/NamespaceCleanUp.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/delete/NamespaceCleanUp.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.manager.tableOps.namespace.delete;
 import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.Utils;
@@ -63,7 +64,7 @@ class NamespaceCleanUp extends ManagerRepo {
       log.error("{}", e.getMessage(), e);
     }
 
-    Utils.unreserveNamespace(manager, namespaceId, id, true);
+    Utils.unreserveNamespace(manager, namespaceId, id, LockType.WRITE);
 
     log.debug("Deleted namespace " + namespaceId);
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/rename/RenameNamespace.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/rename/RenameNamespace.java
@@ -26,6 +26,7 @@ import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
@@ -41,7 +42,8 @@ public class RenameNamespace extends ManagerRepo {
 
   @Override
   public long isReady(long id, Manager environment) throws Exception {
-    return Utils.reserveNamespace(environment, namespaceId, id, true, true, TableOperation.RENAME);
+    return Utils.reserveNamespace(environment, namespaceId, id, LockType.WRITE, true,
+        TableOperation.RENAME);
   }
 
   public RenameNamespace(NamespaceId namespaceId, String oldName, String newName) {
@@ -77,7 +79,7 @@ public class RenameNamespace extends ManagerRepo {
       manager.getContext().clearTableListCache();
     } finally {
       Utils.getTableNameLock().unlock();
-      Utils.unreserveNamespace(manager, namespaceId, id, true);
+      Utils.unreserveNamespace(manager, namespaceId, id, LockType.WRITE);
     }
 
     LoggerFactory.getLogger(RenameNamespace.class).debug("Renamed namespace {} {} {}", namespaceId,
@@ -88,7 +90,7 @@ public class RenameNamespace extends ManagerRepo {
 
   @Override
   public void undo(long tid, Manager env) {
-    Utils.unreserveNamespace(env, namespaceId, tid, true);
+    Utils.unreserveNamespace(env, namespaceId, tid, LockType.WRITE);
   }
 
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/FinishImportTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/FinishImportTable.java
@@ -23,6 +23,7 @@ import static org.apache.accumulo.core.Constants.IMPORT_MAPPINGS_FILE;
 import java.util.EnumSet;
 
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
@@ -58,8 +59,8 @@ class FinishImportTable extends ManagerRepo {
     final TableState newState = tableInfo.keepOffline ? TableState.OFFLINE : TableState.ONLINE;
     env.getTableManager().transitionTableState(tableInfo.tableId, newState, expectedCurrStates);
 
-    Utils.unreserveNamespace(env, tableInfo.namespaceId, tid, false);
-    Utils.unreserveTable(env, tableInfo.tableId, tid, true);
+    Utils.unreserveNamespace(env, tableInfo.namespaceId, tid, LockType.READ);
+    Utils.unreserveTable(env, tableInfo.tableId, tid, LockType.WRITE);
 
     for (ImportedTableInfo.DirectoryMapping dm : tableInfo.directories) {
       Utils.unreserveHdfsDirectory(env, new Path(dm.exportDir).toString(), tid);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportPopulateZookeeper.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportPopulateZookeeper.java
@@ -28,6 +28,7 @@ import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.util.tables.TableNameUtil;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
@@ -50,7 +51,7 @@ class ImportPopulateZookeeper extends ManagerRepo {
 
   @Override
   public long isReady(long tid, Manager environment) throws Exception {
-    return Utils.reserveTable(environment, tableInfo.tableId, tid, true, false,
+    return Utils.reserveTable(environment, tableInfo.tableId, tid, LockType.WRITE, false,
         TableOperation.IMPORT);
   }
 
@@ -104,7 +105,7 @@ class ImportPopulateZookeeper extends ManagerRepo {
   @Override
   public void undo(long tid, Manager env) throws Exception {
     env.getTableManager().removeTable(tableInfo.tableId);
-    Utils.unreserveTable(env, tableInfo.tableId, tid, true);
+    Utils.unreserveTable(env, tableInfo.tableId, tid, LockType.WRITE);
     env.getContext().clearTableListCache();
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportTable.java
@@ -40,6 +40,7 @@ import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.Utils;
@@ -78,7 +79,7 @@ public class ImportTable extends ManagerRepo {
     for (ImportedTableInfo.DirectoryMapping dm : tableInfo.directories) {
       result += Utils.reserveHdfsDirectory(environment, new Path(dm.exportDir).toString(), tid);
     }
-    result += Utils.reserveNamespace(environment, tableInfo.namespaceId, tid, false, true,
+    result += Utils.reserveNamespace(environment, tableInfo.namespaceId, tid, LockType.READ, true,
         TableOperation.IMPORT);
     return result;
   }
@@ -161,7 +162,7 @@ public class ImportTable extends ManagerRepo {
       Utils.unreserveHdfsDirectory(env, new Path(dm.exportDir).toString(), tid);
     }
 
-    Utils.unreserveNamespace(env, tableInfo.namespaceId, tid, false);
+    Utils.unreserveNamespace(env, tableInfo.namespaceId, tid, LockType.READ);
   }
 
   static List<ImportedTableInfo.DirectoryMapping> parseExportDir(Set<String> exportDirs) {

--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
@@ -53,6 +53,7 @@ import org.apache.accumulo.core.fate.FateTxId;
 import org.apache.accumulo.core.fate.ReadOnlyTStore.TStatus;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.ZooStore;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
@@ -90,14 +91,15 @@ public class FateIT {
 
     @Override
     public long isReady(long tid, Manager manager) throws Exception {
-      return Utils.reserveNamespace(manager, namespaceId, tid, false, true, TableOperation.RENAME)
-          + Utils.reserveTable(manager, tableId, tid, true, true, TableOperation.RENAME);
+      return Utils.reserveNamespace(manager, namespaceId, tid, LockType.READ, true,
+          TableOperation.RENAME)
+          + Utils.reserveTable(manager, tableId, tid, LockType.WRITE, true, TableOperation.RENAME);
     }
 
     @Override
     public void undo(long tid, Manager manager) throws Exception {
-      Utils.unreserveNamespace(manager, namespaceId, tid, false);
-      Utils.unreserveTable(manager, tableId, tid, true);
+      Utils.unreserveNamespace(manager, namespaceId, tid, LockType.READ);
+      Utils.unreserveTable(manager, tableId, tid, LockType.WRITE);
     }
 
     @Override
@@ -107,8 +109,8 @@ public class FateIT {
         FateIT.inCall();
         return null;
       } finally {
-        Utils.unreserveNamespace(manager, namespaceId, tid, false);
-        Utils.unreserveTable(manager, tableId, tid, true);
+        Utils.unreserveNamespace(manager, namespaceId, tid, LockType.READ);
+        Utils.unreserveTable(manager, tableId, tid, LockType.WRITE);
         LOG.debug("Leaving call {}", FateTxId.formatTid(tid));
       }
 


### PR DESCRIPTION
Instead of using a boolean value for obtaining table locks, use an enum which makes the code more readable and makes it easier to search and catch errors with the lock type. The enum used already existed in DistributedReadWriteLock. 

This closes #4276