### PR TITLE
Replace boolean with enum for table locks in Elasticity

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/DistributedReadWriteLock.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/DistributedReadWriteLock.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DistributedReadWriteLock implements java.util.concurrent.locks.ReadWriteLock {
 
-  public static enum LockType {
+  public enum LockType {
     READ, WRITE,
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
@@ -167,8 +167,7 @@ public class Utils {
     if (lock != null) {
 
       // Validate the recovered lock type
-      boolean isWriteLock = lock.getType() == LockType.WRITE;
-      if (!lock.getType().equals(lockType)) {
+      if (lock.getType() != lockType) {
         throw new IllegalStateException(
             "Unexpected lock type " + lock.getType() + " recovered for transaction " + fateId
                 + " on object " + id + ". Expected " + lockType + " lock instead.");

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/availability/SetTabletAvailability.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/availability/SetTabletAvailability.java
@@ -29,6 +29,7 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.dataImpl.thrift.TRange;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.metadata.schema.Ample.TabletsMutator;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
@@ -59,9 +60,9 @@ public class SetTabletAvailability extends ManagerRepo {
 
   @Override
   public long isReady(FateId fateId, Manager manager) throws Exception {
-    return Utils.reserveNamespace(manager, namespaceId, fateId, false, true,
+    return Utils.reserveNamespace(manager, namespaceId, fateId, LockType.READ, true,
         TableOperation.SET_TABLET_AVAILABILITY)
-        + Utils.reserveTable(manager, tableId, fateId, true, true,
+        + Utils.reserveTable(manager, tableId, fateId, LockType.WRITE, true,
             TableOperation.SET_TABLET_AVAILABILITY);
   }
 
@@ -116,15 +117,15 @@ public class SetTabletAvailability extends ManagerRepo {
         mutator.mutateTablet(tabletExtent).putTabletAvailability(tabletAvailability).mutate();
       }
     }
-    Utils.unreserveNamespace(manager, namespaceId, fateId, false);
-    Utils.unreserveTable(manager, tableId, fateId, true);
+    Utils.unreserveNamespace(manager, namespaceId, fateId, LockType.READ);
+    Utils.unreserveTable(manager, tableId, fateId, LockType.WRITE);
     return null;
   }
 
   @Override
   public void undo(FateId fateId, Manager manager) throws Exception {
-    Utils.unreserveNamespace(manager, namespaceId, fateId, false);
-    Utils.unreserveTable(manager, tableId, fateId, true);
+    Utils.unreserveNamespace(manager, namespaceId, fateId, LockType.READ);
+    Utils.unreserveTable(manager, tableId, fateId, LockType.WRITE);
   }
 
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneTable.java
@@ -26,6 +26,7 @@ import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.Utils;
@@ -49,9 +50,9 @@ public class CloneTable extends ManagerRepo {
 
   @Override
   public long isReady(FateId fateId, Manager environment) throws Exception {
-    long val = Utils.reserveNamespace(environment, cloneInfo.srcNamespaceId, fateId, false, true,
-        TableOperation.CLONE);
-    val += Utils.reserveTable(environment, cloneInfo.srcTableId, fateId, false, true,
+    long val = Utils.reserveNamespace(environment, cloneInfo.srcNamespaceId, fateId, LockType.READ,
+        true, TableOperation.CLONE);
+    val += Utils.reserveTable(environment, cloneInfo.srcTableId, fateId, LockType.READ, true,
         TableOperation.CLONE);
     return val;
   }
@@ -72,8 +73,8 @@ public class CloneTable extends ManagerRepo {
 
   @Override
   public void undo(FateId fateId, Manager environment) {
-    Utils.unreserveNamespace(environment, cloneInfo.srcNamespaceId, fateId, false);
-    Utils.unreserveTable(environment, cloneInfo.srcTableId, fateId, false);
+    Utils.unreserveNamespace(environment, cloneInfo.srcNamespaceId, fateId, LockType.READ);
+    Utils.unreserveTable(environment, cloneInfo.srcTableId, fateId, LockType.READ);
   }
 
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneZookeeper.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneZookeeper.java
@@ -24,6 +24,7 @@ import org.apache.accumulo.core.clientImpl.Namespaces;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.util.tables.TableNameUtil;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
@@ -46,10 +47,10 @@ class CloneZookeeper extends ManagerRepo {
   public long isReady(FateId fateId, Manager environment) throws Exception {
     long val = 0;
     if (!cloneInfo.srcNamespaceId.equals(cloneInfo.namespaceId)) {
-      val += Utils.reserveNamespace(environment, cloneInfo.namespaceId, fateId, false, true,
+      val += Utils.reserveNamespace(environment, cloneInfo.namespaceId, fateId, LockType.READ, true,
           TableOperation.CLONE);
     }
-    val += Utils.reserveTable(environment, cloneInfo.tableId, fateId, true, false,
+    val += Utils.reserveTable(environment, cloneInfo.tableId, fateId, LockType.WRITE, false,
         TableOperation.CLONE);
     return val;
   }
@@ -78,9 +79,9 @@ class CloneZookeeper extends ManagerRepo {
   public void undo(FateId fateId, Manager environment) throws Exception {
     environment.getTableManager().removeTable(cloneInfo.tableId);
     if (!cloneInfo.srcNamespaceId.equals(cloneInfo.namespaceId)) {
-      Utils.unreserveNamespace(environment, cloneInfo.namespaceId, fateId, false);
+      Utils.unreserveNamespace(environment, cloneInfo.namespaceId, fateId, LockType.READ);
     }
-    Utils.unreserveTable(environment, cloneInfo.tableId, fateId, true);
+    Utils.unreserveTable(environment, cloneInfo.tableId, fateId, LockType.WRITE);
     environment.getContext().clearTableListCache();
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/FinishCloneTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/FinishCloneTable.java
@@ -22,6 +22,7 @@ import java.util.EnumSet;
 
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
@@ -60,12 +61,12 @@ class FinishCloneTable extends ManagerRepo {
       environment.getTableManager().transitionTableState(cloneInfo.tableId, ts, expectedCurrStates);
     }
 
-    Utils.unreserveNamespace(environment, cloneInfo.srcNamespaceId, fateId, false);
+    Utils.unreserveNamespace(environment, cloneInfo.srcNamespaceId, fateId, LockType.READ);
     if (!cloneInfo.srcNamespaceId.equals(cloneInfo.namespaceId)) {
-      Utils.unreserveNamespace(environment, cloneInfo.namespaceId, fateId, false);
+      Utils.unreserveNamespace(environment, cloneInfo.namespaceId, fateId, LockType.READ);
     }
-    Utils.unreserveTable(environment, cloneInfo.srcTableId, fateId, false);
-    Utils.unreserveTable(environment, cloneInfo.tableId, fateId, true);
+    Utils.unreserveTable(environment, cloneInfo.srcTableId, fateId, LockType.READ);
+    Utils.unreserveTable(environment, cloneInfo.tableId, fateId, LockType.WRITE);
 
     environment.getEventCoordinator().event(cloneInfo.tableId, "Cloned table %s from %s",
         cloneInfo.tableName, cloneInfo.srcTableId);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactRange.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactRange.java
@@ -30,6 +30,7 @@ import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.util.TextUtil;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
@@ -74,8 +75,9 @@ public class CompactRange extends ManagerRepo {
 
   @Override
   public long isReady(FateId fateId, Manager env) throws Exception {
-    return Utils.reserveNamespace(env, namespaceId, fateId, false, true, TableOperation.COMPACT)
-        + Utils.reserveTable(env, tableId, fateId, false, true, TableOperation.COMPACT);
+    return Utils.reserveNamespace(env, namespaceId, fateId, LockType.READ, true,
+        TableOperation.COMPACT)
+        + Utils.reserveTable(env, tableId, fateId, LockType.READ, true, TableOperation.COMPACT);
   }
 
   @Override
@@ -89,8 +91,8 @@ public class CompactRange extends ManagerRepo {
     try {
       CompactionConfigStorage.deleteConfig(env.getContext(), fateId);
     } finally {
-      Utils.unreserveNamespace(env, namespaceId, fateId, false);
-      Utils.unreserveTable(env, tableId, fateId, false);
+      Utils.unreserveNamespace(env, namespaceId, fateId, LockType.READ);
+      Utils.unreserveTable(env, tableId, fateId, LockType.READ);
     }
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/cancel/CancelCompactions.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/cancel/CancelCompactions.java
@@ -23,6 +23,7 @@ import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.Utils;
@@ -45,9 +46,10 @@ public class CancelCompactions extends ManagerRepo {
 
   @Override
   public long isReady(FateId fateId, Manager env) throws Exception {
-    return Utils.reserveNamespace(env, namespaceId, fateId, false, true,
+    return Utils.reserveNamespace(env, namespaceId, fateId, LockType.READ, true,
         TableOperation.COMPACT_CANCEL)
-        + Utils.reserveTable(env, tableId, fateId, false, true, TableOperation.COMPACT_CANCEL);
+        + Utils.reserveTable(env, tableId, fateId, LockType.READ, true,
+            TableOperation.COMPACT_CANCEL);
   }
 
   @Override
@@ -64,8 +66,8 @@ public class CancelCompactions extends ManagerRepo {
 
   @Override
   public void undo(FateId fateId, Manager env) {
-    Utils.unreserveTable(env, tableId, fateId, false);
-    Utils.unreserveNamespace(env, namespaceId, fateId, false);
+    Utils.unreserveTable(env, tableId, fateId, LockType.READ);
+    Utils.unreserveNamespace(env, namespaceId, fateId, LockType.READ);
   }
 
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/cancel/FinishCancelCompaction.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/cancel/FinishCancelCompaction.java
@@ -22,6 +22,7 @@ import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.Utils;
@@ -38,8 +39,8 @@ class FinishCancelCompaction extends ManagerRepo {
 
   @Override
   public Repo<Manager> call(FateId fateId, Manager environment) {
-    Utils.unreserveTable(environment, tableId, fateId, false);
-    Utils.unreserveNamespace(environment, namespaceId, fateId, false);
+    Utils.unreserveTable(environment, tableId, fateId, LockType.READ);
+    Utils.unreserveNamespace(environment, namespaceId, fateId, LockType.READ);
     return null;
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/CreateTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/CreateTable.java
@@ -29,6 +29,7 @@ import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.TableInfo;
@@ -63,8 +64,8 @@ public class CreateTable extends ManagerRepo {
   @Override
   public long isReady(FateId fateId, Manager environment) throws Exception {
     // reserve the table's namespace to make sure it doesn't change while the table is created
-    return Utils.reserveNamespace(environment, tableInfo.getNamespaceId(), fateId, false, true,
-        TableOperation.CREATE);
+    return Utils.reserveNamespace(environment, tableInfo.getNamespaceId(), fateId, LockType.READ,
+        true, TableOperation.CREATE);
   }
 
   @Override
@@ -98,7 +99,7 @@ public class CreateTable extends ManagerRepo {
     } catch (IOException e) {
       log.error("Table failed to be created and failed to clean up split files at {}", p, e);
     } finally {
-      Utils.unreserveNamespace(env, tableInfo.getNamespaceId(), fateId, false);
+      Utils.unreserveNamespace(env, tableInfo.getNamespaceId(), fateId, LockType.READ);
     }
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/FinishCreateTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/FinishCreateTable.java
@@ -24,6 +24,7 @@ import java.util.EnumSet;
 import org.apache.accumulo.core.client.admin.InitialTableState;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
@@ -62,8 +63,8 @@ class FinishCreateTable extends ManagerRepo {
           TableState.ONLINE, expectedCurrStates);
     }
 
-    Utils.unreserveNamespace(env, tableInfo.getNamespaceId(), fateId, false);
-    Utils.unreserveTable(env, tableInfo.getTableId(), fateId, true);
+    Utils.unreserveNamespace(env, tableInfo.getNamespaceId(), fateId, LockType.READ);
+    Utils.unreserveTable(env, tableInfo.getTableId(), fateId, LockType.WRITE);
 
     env.getEventCoordinator().event(tableInfo.getTableId(), "Created table %s ",
         tableInfo.getTableName());

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/PopulateZookeeper.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/PopulateZookeeper.java
@@ -23,6 +23,7 @@ import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
 import org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.TableInfo;
@@ -42,7 +43,7 @@ class PopulateZookeeper extends ManagerRepo {
 
   @Override
   public long isReady(FateId fateId, Manager environment) throws Exception {
-    return Utils.reserveTable(environment, tableInfo.getTableId(), fateId, true, false,
+    return Utils.reserveTable(environment, tableInfo.getTableId(), fateId, LockType.WRITE, false,
         TableOperation.CREATE);
   }
 
@@ -80,7 +81,7 @@ class PopulateZookeeper extends ManagerRepo {
   @Override
   public void undo(FateId fateId, Manager manager) throws Exception {
     manager.getTableManager().removeTable(tableInfo.getTableId());
-    Utils.unreserveTable(manager, tableInfo.getTableId(), fateId, true);
+    Utils.unreserveTable(manager, tableInfo.getTableId(), fateId, LockType.WRITE);
     manager.getContext().clearTableListCache();
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/CleanUp.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/CleanUp.java
@@ -34,6 +34,7 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.iterators.user.GrepIterator;
 import org.apache.accumulo.core.metadata.AccumuloTable;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
@@ -178,8 +179,8 @@ class CleanUp extends ManagerRepo {
       log.error("{}", e.getMessage(), e);
     }
 
-    Utils.unreserveTable(manager, tableId, fateId, true);
-    Utils.unreserveNamespace(manager, namespaceId, fateId, false);
+    Utils.unreserveTable(manager, tableId, fateId, LockType.WRITE);
+    Utils.unreserveNamespace(manager, namespaceId, fateId, LockType.READ);
 
     LoggerFactory.getLogger(CleanUp.class).debug("Deleted table " + tableId);
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/DeleteTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/DeleteTable.java
@@ -25,6 +25,7 @@ import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
@@ -44,8 +45,9 @@ public class DeleteTable extends ManagerRepo {
 
   @Override
   public long isReady(FateId fateId, Manager env) throws Exception {
-    return Utils.reserveNamespace(env, namespaceId, fateId, false, false, TableOperation.DELETE)
-        + Utils.reserveTable(env, tableId, fateId, true, true, TableOperation.DELETE);
+    return Utils.reserveNamespace(env, namespaceId, fateId, LockType.READ, false,
+        TableOperation.DELETE)
+        + Utils.reserveTable(env, tableId, fateId, LockType.WRITE, true, TableOperation.DELETE);
   }
 
   @Override
@@ -59,7 +61,7 @@ public class DeleteTable extends ManagerRepo {
 
   @Override
   public void undo(FateId fateId, Manager env) {
-    Utils.unreserveTable(env, tableId, fateId, true);
-    Utils.unreserveNamespace(env, namespaceId, fateId, false);
+    Utils.unreserveTable(env, tableId, fateId, LockType.WRITE);
+    Utils.unreserveNamespace(env, namespaceId, fateId, LockType.READ);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/PreDeleteTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/PreDeleteTable.java
@@ -25,6 +25,7 @@ import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.accumulo.manager.Manager;
@@ -52,8 +53,9 @@ public class PreDeleteTable extends ManagerRepo {
 
   @Override
   public long isReady(FateId fateId, Manager env) throws Exception {
-    return Utils.reserveNamespace(env, namespaceId, fateId, false, true, TableOperation.DELETE)
-        + Utils.reserveTable(env, tableId, fateId, false, true, TableOperation.DELETE);
+    return Utils.reserveNamespace(env, namespaceId, fateId, LockType.READ, true,
+        TableOperation.DELETE)
+        + Utils.reserveTable(env, tableId, fateId, LockType.READ, true, TableOperation.DELETE);
   }
 
   private void preventFutureCompactions(Manager environment)
@@ -77,15 +79,15 @@ public class PreDeleteTable extends ManagerRepo {
       }
       return new DeleteTable(namespaceId, tableId);
     } finally {
-      Utils.unreserveTable(environment, tableId, fateId, false);
-      Utils.unreserveNamespace(environment, namespaceId, fateId, false);
+      Utils.unreserveTable(environment, tableId, fateId, LockType.READ);
+      Utils.unreserveNamespace(environment, namespaceId, fateId, LockType.READ);
     }
   }
 
   @Override
   public void undo(FateId fateId, Manager env) {
-    Utils.unreserveTable(env, tableId, fateId, false);
-    Utils.unreserveNamespace(env, namespaceId, fateId, false);
+    Utils.unreserveTable(env, tableId, fateId, LockType.READ);
+    Utils.unreserveNamespace(env, namespaceId, fateId, LockType.READ);
   }
 
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/FinishTableRangeOp.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/FinishTableRangeOp.java
@@ -28,6 +28,7 @@ import java.util.function.Consumer;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.TabletOperationId;
 import org.apache.accumulo.core.metadata.schema.TabletOperationType;
@@ -54,8 +55,8 @@ class FinishTableRangeOp extends ManagerRepo {
   public Repo<Manager> call(FateId fateId, Manager manager) throws Exception {
     removeOperationIds(log, data, fateId, manager);
 
-    Utils.unreserveTable(manager, data.tableId, fateId, true);
-    Utils.unreserveNamespace(manager, data.namespaceId, fateId, false);
+    Utils.unreserveTable(manager, data.tableId, fateId, LockType.WRITE);
+    Utils.unreserveNamespace(manager, data.namespaceId, fateId, LockType.READ);
     return null;
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/TableRangeOp.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/TableRangeOp.java
@@ -23,6 +23,7 @@ import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.metadata.AccumuloTable;
 import org.apache.accumulo.core.util.TextUtil;
 import org.apache.accumulo.manager.Manager;
@@ -41,8 +42,9 @@ public class TableRangeOp extends ManagerRepo {
 
   @Override
   public long isReady(FateId fateId, Manager env) throws Exception {
-    return Utils.reserveNamespace(env, data.namespaceId, fateId, false, true, TableOperation.MERGE)
-        + Utils.reserveTable(env, data.tableId, fateId, true, true, TableOperation.MERGE);
+    return Utils.reserveNamespace(env, data.namespaceId, fateId, LockType.READ, true,
+        TableOperation.MERGE)
+        + Utils.reserveTable(env, data.tableId, fateId, LockType.WRITE, true, TableOperation.MERGE);
   }
 
   public TableRangeOp(MergeInfo.Operation op, NamespaceId namespaceId, TableId tableId,
@@ -70,7 +72,7 @@ public class TableRangeOp extends ManagerRepo {
 
   @Override
   public void undo(FateId fateId, Manager env) throws Exception {
-    Utils.unreserveNamespace(env, data.namespaceId, fateId, false);
-    Utils.unreserveTable(env, data.tableId, fateId, true);
+    Utils.unreserveNamespace(env, data.namespaceId, fateId, LockType.READ);
+    Utils.unreserveTable(env, data.tableId, fateId, LockType.WRITE);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/FinishCreateNamespace.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/FinishCreateNamespace.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.manager.tableOps.namespace.create;
 
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.Utils;
@@ -43,7 +44,7 @@ class FinishCreateNamespace extends ManagerRepo {
   @Override
   public Repo<Manager> call(FateId fateId, Manager env) {
 
-    Utils.unreserveNamespace(env, namespaceInfo.namespaceId, fateId, true);
+    Utils.unreserveNamespace(env, namespaceInfo.namespaceId, fateId, LockType.WRITE);
 
     env.getEventCoordinator().event("Created namespace %s ", namespaceInfo.namespaceName);
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/PopulateZookeeperWithNamespace.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/PopulateZookeeperWithNamespace.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.manager.tableOps.namespace.create;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
@@ -41,8 +42,8 @@ class PopulateZookeeperWithNamespace extends ManagerRepo {
 
   @Override
   public long isReady(FateId fateId, Manager environment) throws Exception {
-    return Utils.reserveNamespace(environment, namespaceInfo.namespaceId, fateId, true, false,
-        TableOperation.CREATE);
+    return Utils.reserveNamespace(environment, namespaceInfo.namespaceId, fateId, LockType.WRITE,
+        false, TableOperation.CREATE);
   }
 
   @Override
@@ -72,7 +73,7 @@ class PopulateZookeeperWithNamespace extends ManagerRepo {
   public void undo(FateId fateId, Manager manager) throws Exception {
     manager.getTableManager().removeNamespace(namespaceInfo.namespaceId);
     manager.getContext().clearTableListCache();
-    Utils.unreserveNamespace(manager, namespaceInfo.namespaceId, fateId, true);
+    Utils.unreserveNamespace(manager, namespaceInfo.namespaceId, fateId, LockType.WRITE);
   }
 
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/delete/DeleteNamespace.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/delete/DeleteNamespace.java
@@ -22,6 +22,7 @@ import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.Utils;
@@ -38,7 +39,7 @@ public class DeleteNamespace extends ManagerRepo {
 
   @Override
   public long isReady(FateId fateId, Manager environment) throws Exception {
-    return Utils.reserveNamespace(environment, namespaceId, fateId, true, true,
+    return Utils.reserveNamespace(environment, namespaceId, fateId, LockType.WRITE, true,
         TableOperation.DELETE);
   }
 
@@ -50,7 +51,7 @@ public class DeleteNamespace extends ManagerRepo {
 
   @Override
   public void undo(FateId fateId, Manager environment) {
-    Utils.unreserveNamespace(environment, namespaceId, fateId, true);
+    Utils.unreserveNamespace(environment, namespaceId, fateId, LockType.WRITE);
   }
 
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/delete/NamespaceCleanUp.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/delete/NamespaceCleanUp.java
@@ -22,6 +22,7 @@ import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.Utils;
@@ -64,7 +65,7 @@ class NamespaceCleanUp extends ManagerRepo {
       log.error("{}", e.getMessage(), e);
     }
 
-    Utils.unreserveNamespace(manager, namespaceId, fateId, true);
+    Utils.unreserveNamespace(manager, namespaceId, fateId, LockType.WRITE);
 
     log.debug("Deleted namespace " + namespaceId);
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/rename/RenameNamespace.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/rename/RenameNamespace.java
@@ -27,6 +27,7 @@ import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
@@ -42,7 +43,7 @@ public class RenameNamespace extends ManagerRepo {
 
   @Override
   public long isReady(FateId fateId, Manager environment) throws Exception {
-    return Utils.reserveNamespace(environment, namespaceId, fateId, true, true,
+    return Utils.reserveNamespace(environment, namespaceId, fateId, LockType.WRITE, true,
         TableOperation.RENAME);
   }
 
@@ -79,7 +80,7 @@ public class RenameNamespace extends ManagerRepo {
       manager.getContext().clearTableListCache();
     } finally {
       Utils.getTableNameLock().unlock();
-      Utils.unreserveNamespace(manager, namespaceId, fateId, true);
+      Utils.unreserveNamespace(manager, namespaceId, fateId, LockType.WRITE);
     }
 
     LoggerFactory.getLogger(RenameNamespace.class).debug("Renamed namespace {} {} {}", namespaceId,
@@ -90,7 +91,7 @@ public class RenameNamespace extends ManagerRepo {
 
   @Override
   public void undo(FateId fateId, Manager env) {
-    Utils.unreserveNamespace(env, namespaceId, fateId, true);
+    Utils.unreserveNamespace(env, namespaceId, fateId, LockType.WRITE);
   }
 
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/FinishImportTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/FinishImportTable.java
@@ -24,6 +24,7 @@ import java.util.EnumSet;
 
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
@@ -59,8 +60,8 @@ class FinishImportTable extends ManagerRepo {
     final TableState newState = tableInfo.keepOffline ? TableState.OFFLINE : TableState.ONLINE;
     env.getTableManager().transitionTableState(tableInfo.tableId, newState, expectedCurrStates);
 
-    Utils.unreserveNamespace(env, tableInfo.namespaceId, fateId, false);
-    Utils.unreserveTable(env, tableInfo.tableId, fateId, true);
+    Utils.unreserveNamespace(env, tableInfo.namespaceId, fateId, LockType.READ);
+    Utils.unreserveTable(env, tableInfo.tableId, fateId, LockType.WRITE);
 
     for (ImportedTableInfo.DirectoryMapping dm : tableInfo.directories) {
       Utils.unreserveHdfsDirectory(env, new Path(dm.exportDir).toString(), fateId);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportPopulateZookeeper.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportPopulateZookeeper.java
@@ -29,6 +29,7 @@ import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.util.tables.TableNameUtil;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
@@ -51,7 +52,7 @@ class ImportPopulateZookeeper extends ManagerRepo {
 
   @Override
   public long isReady(FateId fateId, Manager environment) throws Exception {
-    return Utils.reserveTable(environment, tableInfo.tableId, fateId, true, false,
+    return Utils.reserveTable(environment, tableInfo.tableId, fateId, LockType.WRITE, false,
         TableOperation.IMPORT);
   }
 
@@ -105,7 +106,7 @@ class ImportPopulateZookeeper extends ManagerRepo {
   @Override
   public void undo(FateId fateId, Manager env) throws Exception {
     env.getTableManager().removeTable(tableInfo.tableId);
-    Utils.unreserveTable(env, tableInfo.tableId, fateId, true);
+    Utils.unreserveTable(env, tableInfo.tableId, fateId, LockType.WRITE);
     env.getContext().clearTableListCache();
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportTable.java
@@ -41,6 +41,7 @@ import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.Utils;
@@ -79,8 +80,8 @@ public class ImportTable extends ManagerRepo {
     for (ImportedTableInfo.DirectoryMapping dm : tableInfo.directories) {
       result += Utils.reserveHdfsDirectory(environment, new Path(dm.exportDir).toString(), fateId);
     }
-    result += Utils.reserveNamespace(environment, tableInfo.namespaceId, fateId, false, true,
-        TableOperation.IMPORT);
+    result += Utils.reserveNamespace(environment, tableInfo.namespaceId, fateId, LockType.READ,
+        true, TableOperation.IMPORT);
     return result;
   }
 
@@ -162,7 +163,7 @@ public class ImportTable extends ManagerRepo {
       Utils.unreserveHdfsDirectory(env, new Path(dm.exportDir).toString(), fateId);
     }
 
-    Utils.unreserveNamespace(env, tableInfo.namespaceId, fateId, false);
+    Utils.unreserveNamespace(env, tableInfo.namespaceId, fateId, LockType.READ);
   }
 
   static List<ImportedTableInfo.DirectoryMapping> parseExportDir(Set<String> exportDirs) {


### PR DESCRIPTION
Instead of using a boolean value for obtaining table locks, use an enum which makes the code more readable and makes it easier to search and catch errors with the lock type. The enum used already existed in `DistributedReadWriteLock`. This PR is for the same changes to elasticity as in main that is being done in #4297. Because everything conflicts #4297 will need to be merged forwards from main to elasticity as an empty commit and then this can be merged.

This closes #4276