### PR TITLE
Created new ThriftClientType for shell authentication

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/rpc/clients/ShellAuthenticatorThriftClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/clients/ShellAuthenticatorThriftClient.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.rpc.clients;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.clientImpl.ClientContext;
+import org.apache.accumulo.core.clientImpl.thrift.ClientService.Client;
+import org.apache.accumulo.core.fate.zookeeper.ServiceLock;
+import org.apache.accumulo.core.fate.zookeeper.ZooCache;
+import org.apache.accumulo.core.rpc.ThriftUtil;
+import org.apache.accumulo.core.util.HostAndPort;
+import org.apache.accumulo.core.util.Pair;
+import org.apache.accumulo.core.util.ServerServices;
+import org.apache.accumulo.core.util.ServerServices.Service;
+import org.apache.thrift.transport.TTransport;
+import org.apache.thrift.transport.TTransportException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ShellAuthenticatorThriftClient extends ThriftClientTypes<Client>
+    implements TServerClient<Client> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ClientServiceThriftClient.class);
+  private final AtomicBoolean warnedAboutTServersBeingDown = new AtomicBoolean(false);
+
+  public ShellAuthenticatorThriftClient(String serviceName) {
+    super(serviceName, new Client.Factory());
+  }
+
+  @Override
+  public Pair<String,Client> getTabletServerConnection(Logger LOG, ThriftClientTypes<Client> type,
+      ClientContext context, boolean preferCachedConnections, AtomicBoolean warned)
+      throws TTransportException {
+    checkArgument(context != null, "context is null");
+    final long rpcTimeout = context.getClientTimeoutInMillis();
+
+    List<String> tservers = new ArrayList<>();
+    final ZooCache zc = context.getZooCache();
+    for (String tserver : zc.getChildren(context.getZooKeeperRoot() + Constants.ZTSERVERS)) {
+      tservers.add(tserver);
+    }
+    if (tservers.isEmpty() && !warnedAboutTServersBeingDown.get()) {
+      LOG.warn("There are no tablet servers: check that zookeeper and accumulo are running.");
+      warnedAboutTServersBeingDown.set(true);
+      Collections.shuffle(tservers);
+
+      for (String tserver : tservers) {
+        var zLocPath =
+            ServiceLock.path(context.getZooKeeperRoot() + Constants.ZTSERVERS + "/" + tserver);
+        byte[] data = zc.getLockData(zLocPath);
+        if (data != null) {
+          String strData = new String(data, UTF_8);
+          if (!strData.equals("manager")) {
+            final HostAndPort tserverClientAddress =
+                new ServerServices(strData).getAddress(Service.TSERV_CLIENT);
+            try {
+              TTransport transport = context.getTransportPool().getTransport(tserverClientAddress,
+                  rpcTimeout, context);
+              Client client = ThriftUtil.createClient(type, transport);
+              return new Pair<String,Client>(tserverClientAddress.toString(), client);
+            } catch (TTransportException e) {
+              LOG.trace("Error creating transport to {}", tserverClientAddress);
+              continue;
+            }
+          }
+        }
+      }
+    }
+    LOG.warn("Failed to find an available server in the list of servers: {}", tservers);
+    throw new TTransportException("Failed to connect to a server");
+  }
+
+  @Override
+  public Pair<String,Client> getTabletServerConnection(ClientContext context,
+      boolean preferCachedConnections) throws TTransportException {
+    return getTabletServerConnection(LOG, this, context, preferCachedConnections,
+        warnedAboutTServersBeingDown);
+  }
+}

--- a/core/src/main/java/org/apache/accumulo/core/rpc/clients/ThriftClientTypes.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/clients/ThriftClientTypes.java
@@ -34,6 +34,9 @@ public abstract class ThriftClientTypes<C extends TServiceClient> {
 
   public static final ClientServiceThriftClient CLIENT = new ClientServiceThriftClient("client");
 
+  public static final ShellAuthenticatorThriftClient SHELL =
+      new ShellAuthenticatorThriftClient("client");
+
   public static final CompactorServiceThriftClient COMPACTOR =
       new CompactorServiceThriftClient("compactor");
 

--- a/shell/src/test/java/org/apache/accumulo/shell/commands/FateCommandTest.java
+++ b/shell/src/test/java/org/apache/accumulo/shell/commands/FateCommandTest.java
@@ -39,6 +39,8 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.fate.AdminUtil;
@@ -326,6 +328,15 @@ public class FateCommandTest {
     terminal.setSize(new Size(80, 24));
     LineReader reader = LineReaderBuilder.builder().terminal(terminal).build();
     Shell shell = new Shell(reader) {
+      @Override
+      protected void populateZooCache() {}
+
+      @Override
+      protected boolean initialAuthentication(AccumuloClient accumuloClient,
+          AuthenticationToken token) throws AccumuloException, AccumuloSecurityException {
+        return true;
+      }
+
       @Override
       protected boolean authenticateUser(AccumuloClient client, AuthenticationToken token) {
         return true;


### PR DESCRIPTION
TServerClient.getTabletServerConnection gets all of the TabletServers and their ServiceLocks from ZooKeeper via ZooCache. After that, it randomly gets a TabletServer connection and returns it to the caller. When this is done from the Shell it causes the initial login to wait as all of this information is gathered. The information gathering is useful as it populates ZooCache, but it can take a long time on large clusters.

This change:

1. Adds a new ThriftClientType which overrides getTabletServerConnection to quickly return a connection to a random TabletServer
2. Adds Shell.initialAuthentication which uses the new ThriftClientType to call authenticate user on the Client service
3. Creates a background thread which calls the ping method on a random TabletServer using the existing TServerClient getTabletServerConnection to populate ZooCache.

Fixes #4303