### PR TITLE
fetches all columns in tablet mgmt iterator

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/manager/state/TabletManagement.java
+++ b/core/src/main/java/org/apache/accumulo/core/manager/state/TabletManagement.java
@@ -42,10 +42,7 @@ import com.google.common.base.Splitter;
  */
 public class TabletManagement {
 
-  public static final EnumSet<ColumnType> CONFIGURED_COLUMNS = EnumSet.of(ColumnType.PREV_ROW,
-      ColumnType.LOCATION, ColumnType.SUSPEND, ColumnType.LOGS, ColumnType.AVAILABILITY,
-      ColumnType.HOSTING_REQUESTED, ColumnType.FILES, ColumnType.LAST, ColumnType.OPID,
-      ColumnType.ECOMP, ColumnType.DIR, ColumnType.SELECTED, ColumnType.USER_COMPACTION_REQUESTED);
+  public static final EnumSet<ColumnType> CONFIGURED_COLUMNS = EnumSet.allOf(ColumnType.class);
 
   private static final Text ERROR_COLUMN_NAME = new Text("ERROR");
   private static final Text REASONS_COLUMN_NAME = new Text("REASONS");

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementIterator.java
@@ -45,16 +45,6 @@ import org.apache.accumulo.core.manager.state.TabletManagement.ManagementAction;
 import org.apache.accumulo.core.manager.thrift.ManagerState;
 import org.apache.accumulo.core.metadata.TabletState;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ExternalCompactionColumnFamily;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.FutureLocationColumnFamily;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LastLocationColumnFamily;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LogColumnFamily;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.SuspendLocationColumn;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.UserCompactionRequestedColumnFamily;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletOperationType;
 import org.apache.accumulo.core.spi.balancer.SimpleLoadBalancer;
@@ -125,20 +115,6 @@ public class TabletManagementIterator extends SkippingIterator {
 
   public static void configureScanner(final ScannerBase scanner,
       final TabletManagementParameters tabletMgmtParams) {
-    // TODO so many columns are being fetch it may not make sense to fetch columns
-    TabletColumnFamily.PREV_ROW_COLUMN.fetch(scanner);
-    ServerColumnFamily.DIRECTORY_COLUMN.fetch(scanner);
-    ServerColumnFamily.SELECTED_COLUMN.fetch(scanner);
-    scanner.fetchColumnFamily(CurrentLocationColumnFamily.NAME);
-    scanner.fetchColumnFamily(FutureLocationColumnFamily.NAME);
-    scanner.fetchColumnFamily(LastLocationColumnFamily.NAME);
-    scanner.fetchColumnFamily(SuspendLocationColumn.SUSPEND_COLUMN.getColumnFamily());
-    scanner.fetchColumnFamily(LogColumnFamily.NAME);
-    scanner.fetchColumnFamily(TabletColumnFamily.NAME);
-    scanner.fetchColumnFamily(DataFileColumnFamily.NAME);
-    scanner.fetchColumnFamily(ExternalCompactionColumnFamily.NAME);
-    ServerColumnFamily.OPID_COLUMN.fetch(scanner);
-    scanner.fetchColumnFamily(UserCompactionRequestedColumnFamily.NAME);
     scanner.addScanIterator(new IteratorSetting(1000, "wholeRows", WholeRowIterator.class));
     IteratorSetting tabletChange =
         new IteratorSetting(1001, "ManagerTabletInfoIterator", TabletManagementIterator.class);

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementIterator.java
@@ -115,6 +115,8 @@ public class TabletManagementIterator extends SkippingIterator {
 
   public static void configureScanner(final ScannerBase scanner,
       final TabletManagementParameters tabletMgmtParams) {
+    // Note : if the scanner is ever made to fetch columns, then TabletManagement.CONFIGURED_COLUMNS
+    // must be updated
     scanner.addScanIterator(new IteratorSetting(1000, "wholeRows", WholeRowIterator.class));
     IteratorSetting tabletChange =
         new IteratorSetting(1001, "ManagerTabletInfoIterator", TabletManagementIterator.class);


### PR DESCRIPTION
The tablet mgmt iterator was configuring a scanner to fetch almost all of the tablets columns.  Since most columns were being fetched the filtering offered no benefit and probably added extra cost.  It also added code complexity.  This commit removes the fetch columns calls on the scanner so that everything is fetched.