### PR TITLE
Optimized logic for getting a random TabletServer connection

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
@@ -42,6 +42,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -99,6 +100,7 @@ import org.apache.accumulo.core.spi.scan.ScanServerInfo;
 import org.apache.accumulo.core.spi.scan.ScanServerSelector;
 import org.apache.accumulo.core.util.OpTimer;
 import org.apache.accumulo.core.util.Pair;
+import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.core.util.tables.TableZooHelper;
 import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.core.util.threads.Threads;
@@ -249,6 +251,27 @@ public class ClientContext implements AccumuloClient {
         clientThreadPools = ThreadPools.getClientThreadPools(ueh);
       }
     }
+    // Kick off a task to try and populate the ZooCache with TabletServer
+    // information. It may not be complete as the cluster may be starting.
+    // It's a best effort
+    clientThreadPools
+        .createThreadPool(0, 1, 1, TimeUnit.MINUTES, "TabletServerZooCachePopulator", false)
+        .execute(() -> {
+          while (true) {
+            List<String> tservers = zooCache.getChildren(getZooKeeperRoot() + Constants.ZTSERVERS);
+            if (tservers.isEmpty()) {
+              UtilWaitThread.sleep(100);
+              continue;
+            } else {
+              for (String tserver : tservers) {
+                var zLocPath =
+                    ServiceLock.path(getZooKeeperRoot() + Constants.ZTSERVERS + "/" + tserver);
+                zooCache.getLockData(zLocPath);
+              }
+              break;
+            }
+          }
+        });
   }
 
   public Ample getAmple() {

--- a/core/src/main/java/org/apache/accumulo/core/rpc/ThriftUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/ThriftUtil.java
@@ -110,8 +110,8 @@ public class ThriftUtil {
    */
   public static <T extends TServiceClient> T getClient(ThriftClientTypes<T> type,
       HostAndPort address, ClientContext context) throws TTransportException {
-    TTransport transport = context.getTransportPool().getTransport(address,
-        context.getClientTimeoutInMillis(), context);
+    TTransport transport = context.getTransportPool().getTransport(type, address,
+        context.getClientTimeoutInMillis(), context, true);
     return createClient(type, transport);
   }
 
@@ -126,7 +126,8 @@ public class ThriftUtil {
    */
   public static <T extends TServiceClient> T getClient(ThriftClientTypes<T> type,
       HostAndPort address, ClientContext context, long timeout) throws TTransportException {
-    TTransport transport = context.getTransportPool().getTransport(address, timeout, context);
+    TTransport transport =
+        context.getTransportPool().getTransport(type, address, timeout, context, true);
     return createClient(type, transport);
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/rpc/clients/TServerClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/clients/TServerClient.java
@@ -24,6 +24,8 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.accumulo.core.util.UtilWaitThread.sleepUninterruptibly;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.accumulo.core.Constants;
@@ -31,16 +33,17 @@ import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.clientImpl.AccumuloServerException;
 import org.apache.accumulo.core.clientImpl.ClientContext;
-import org.apache.accumulo.core.clientImpl.ThriftTransportKey;
 import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.fate.zookeeper.ServiceLock;
 import org.apache.accumulo.core.fate.zookeeper.ZooCache;
 import org.apache.accumulo.core.rpc.ThriftUtil;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes.Exec;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes.ExecVoid;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.core.util.ServerServices;
 import org.apache.accumulo.core.util.ServerServices.Service;
+import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TException;
 import org.apache.thrift.TServiceClient;
@@ -57,44 +60,54 @@ public interface TServerClient<C extends TServiceClient> {
       ClientContext context, boolean preferCachedConnections, AtomicBoolean warned)
       throws TTransportException {
     checkArgument(context != null, "context is null");
-    long rpcTimeout = context.getClientTimeoutInMillis();
-    // create list of servers
-    ArrayList<ThriftTransportKey> servers = new ArrayList<>();
+    final long rpcTimeout = context.getClientTimeoutInMillis();
 
-    // add tservers
-    ZooCache zc = context.getZooCache();
-    for (String tserver : zc.getChildren(context.getZooKeeperRoot() + Constants.ZTSERVERS)) {
-      var zLocPath =
-          ServiceLock.path(context.getZooKeeperRoot() + Constants.ZTSERVERS + "/" + tserver);
-      byte[] data = zc.getLockData(zLocPath);
-      if (data != null) {
-        String strData = new String(data, UTF_8);
-        if (!strData.equals("manager")) {
-          servers.add(new ThriftTransportKey(
-              new ServerServices(strData).getAddress(Service.TSERV_CLIENT), rpcTimeout, context));
+    final ZooCache zc = context.getZooCache();
+    final List<String> tservers = new ArrayList<>();
+    final AtomicBoolean warnedAboutTServersBeingDown = new AtomicBoolean(false);
+
+    for (int retries = 0; retries < 10; retries++) {
+      // Cluster may not be up, wait for tservers to come online
+      while (true) {
+        tservers.addAll(zc.getChildren(context.getZooKeeperRoot() + Constants.ZTSERVERS));
+
+        if (!tservers.isEmpty()) {
+          break;
         }
-      }
-    }
 
-    boolean opened = false;
-    try {
-      Pair<String,TTransport> pair =
-          context.getTransportPool().getAnyTransport(servers, preferCachedConnections);
-      C client = ThriftUtil.createClient(type, pair.getSecond());
-      opened = true;
-      warned.set(false);
-      return new Pair<>(pair.getFirst(), client);
-    } finally {
-      if (!opened) {
-        if (warned.compareAndSet(false, true)) {
-          if (servers.isEmpty()) {
-            LOG.warn("There are no tablet servers: check that zookeeper and accumulo are running.");
-          } else {
-            LOG.warn("Failed to find an available server in the list of servers: {}", servers);
+        if (tservers.isEmpty() && !warnedAboutTServersBeingDown.get()) {
+          LOG.warn("There are no tablet servers: check that zookeeper and accumulo are running.");
+          warnedAboutTServersBeingDown.set(true);
+        }
+        UtilWaitThread.sleep(100);
+      }
+
+      // Try to connect to an online tserver
+      Collections.shuffle(tservers);
+      for (String tserver : tservers) {
+        var zLocPath =
+            ServiceLock.path(context.getZooKeeperRoot() + Constants.ZTSERVERS + "/" + tserver);
+        byte[] data = zc.getLockData(zLocPath);
+        if (data != null) {
+          String strData = new String(data, UTF_8);
+          if (!strData.equals("manager")) {
+            final HostAndPort tserverClientAddress =
+                new ServerServices(strData).getAddress(Service.TSERV_CLIENT);
+            try {
+              TTransport transport = context.getTransportPool().getTransport(tserverClientAddress,
+                  rpcTimeout, context);
+              C client = ThriftUtil.createClient(type, transport);
+              return new Pair<String,C>(tserverClientAddress.toString(), client);
+            } catch (TTransportException e) {
+              LOG.trace("Error creating transport to {}", tserverClientAddress);
+              continue;
+            }
           }
         }
+        LOG.warn("Failed to find an available server in the list of servers: {}", tservers);
       }
     }
+    throw new TTransportException("Failed to connect to a server");
   }
 
   default <R> R execute(Logger LOG, ClientContext context, Exec<R,C> exec)

--- a/core/src/main/java/org/apache/accumulo/core/rpc/clients/TServerClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/clients/TServerClient.java
@@ -107,8 +107,11 @@ public interface TServerClient<C extends TServiceClient> {
         }
       }
     }
-    LOG.warn("Failed to find an available server in the list of servers: {}", tservers);
-    throw new TTransportException("Failed to connect to any server");
+    if (warned.compareAndSet(false, true)) {
+      LOG.warn("Failed to find an available server in the list of servers: {} for API type: {}",
+          tservers, type);
+    }
+    throw new TTransportException("Failed to connect to any server for API type " + type);
   }
 
   default <R> R execute(Logger LOG, ClientContext context, Exec<R,C> exec)

--- a/core/src/main/java/org/apache/accumulo/core/rpc/clients/ThriftClientTypes.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/clients/ThriftClientTypes.java
@@ -122,4 +122,8 @@ public abstract class ThriftClientTypes<C extends TServiceClient> {
     throw new UnsupportedOperationException("This method has not been implemented");
   }
 
+  @Override
+  public String toString() {
+    return serviceName;
+  }
 }

--- a/core/src/main/java/org/apache/accumulo/core/rpc/clients/ThriftClientTypes.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/clients/ThriftClientTypes.java
@@ -80,7 +80,7 @@ public abstract class ThriftClientTypes<C extends TServiceClient> {
   private final String serviceName;
   private final TServiceClientFactory<C> clientFactory;
 
-  public ThriftClientTypes(String serviceName, TServiceClientFactory<C> factory) {
+  protected ThriftClientTypes(String serviceName, TServiceClientFactory<C> factory) {
     this.serviceName = serviceName;
     this.clientFactory = factory;
   }

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/ThriftTransportKeyTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/ThriftTransportKeyTest.java
@@ -35,6 +35,7 @@ import org.apache.accumulo.core.client.security.tokens.KerberosToken;
 import org.apache.accumulo.core.conf.ClientProperty;
 import org.apache.accumulo.core.rpc.SaslConnectionParams;
 import org.apache.accumulo.core.rpc.SslConnectionParams;
+import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
 import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
@@ -76,9 +77,8 @@ public class ThriftTransportKeyTest {
     replay(clientCtx);
 
     try {
-      assertThrows(RuntimeException.class,
-          () -> new ThriftTransportKey(HostAndPort.fromParts("localhost", 9999), 120_000,
-              clientCtx));
+      assertThrows(RuntimeException.class, () -> new ThriftTransportKey(ThriftClientTypes.CLIENT,
+          HostAndPort.fromParts("localhost", 9999), 120_000, clientCtx));
     } finally {
       verify(clientCtx);
     }
@@ -98,9 +98,10 @@ public class ThriftTransportKeyTest {
         user1.doAs((PrivilegedExceptionAction<SaslConnectionParams>) () -> createSaslParams(token));
 
     ThriftTransportKey ttk1 =
-        new ThriftTransportKey(HostAndPort.fromParts("localhost", 9997), 1L, null, saslParams1),
-        ttk2 =
-            new ThriftTransportKey(HostAndPort.fromParts("localhost", 9997), 1L, null, saslParams2);
+        new ThriftTransportKey(ThriftClientTypes.CLIENT, HostAndPort.fromParts("localhost", 9997),
+            1L, null, saslParams1),
+        ttk2 = new ThriftTransportKey(ThriftClientTypes.CLIENT,
+            HostAndPort.fromParts("localhost", 9997), 1L, null, saslParams2);
 
     // Should equals() and hashCode() to make sure we don't throw away thrift cnxns
     assertEquals(ttk1, ttk2);
@@ -119,9 +120,10 @@ public class ThriftTransportKeyTest {
         user2.doAs((PrivilegedExceptionAction<SaslConnectionParams>) () -> createSaslParams(token));
 
     ThriftTransportKey ttk1 =
-        new ThriftTransportKey(HostAndPort.fromParts("localhost", 9997), 1L, null, saslParams1),
-        ttk2 =
-            new ThriftTransportKey(HostAndPort.fromParts("localhost", 9997), 1L, null, saslParams2);
+        new ThriftTransportKey(ThriftClientTypes.CLIENT, HostAndPort.fromParts("localhost", 9997),
+            1L, null, saslParams1),
+        ttk2 = new ThriftTransportKey(ThriftClientTypes.CLIENT,
+            HostAndPort.fromParts("localhost", 9997), 1L, null, saslParams2);
 
     assertNotEquals(ttk1, ttk2);
     assertNotEquals(ttk1.hashCode(), ttk2.hashCode());
@@ -136,8 +138,8 @@ public class ThriftTransportKeyTest {
 
     replay(clientCtx);
 
-    ThriftTransportKey ttk =
-        new ThriftTransportKey(HostAndPort.fromParts("localhost", 9999), 120_000, clientCtx);
+    ThriftTransportKey ttk = new ThriftTransportKey(ThriftClientTypes.CLIENT,
+        HostAndPort.fromParts("localhost", 9999), 120_000, clientCtx);
 
     assertEquals(ttk, ttk, "Normal ThriftTransportKey doesn't equal itself");
   }

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/ThriftTransportKeyTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/ThriftTransportKeyTest.java
@@ -142,5 +142,6 @@ public class ThriftTransportKeyTest {
         HostAndPort.fromParts("localhost", 9999), 120_000, clientCtx);
 
     assertEquals(ttk, ttk, "Normal ThriftTransportKey doesn't equal itself");
+    assertEquals(ttk.hashCode(), ttk.hashCode());
   }
 }

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
@@ -491,8 +491,8 @@ public class CompactionCoordinator extends AbstractServer
       throws TTransportException {
     TServerConnection connection = tserverSet.getConnection(tserver);
     ServerContext serverContext = getContext();
-    TTransport transport =
-        serverContext.getTransportPool().getTransport(connection.getAddress(), 0, serverContext);
+    TTransport transport = serverContext.getTransportPool().getTransport(
+        ThriftClientTypes.TABLET_SERVER, connection.getAddress(), 0, serverContext, true);
     return ThriftUtil.createClient(ThriftClientTypes.TABLET_SERVER, transport);
   }
 


### PR DESCRIPTION
The previous logic in this class would gather all of the Tserver ZNodes in ZooKeeper, then get the data for each ZNode and validate their ServiceLock. Then, after all of that it would randomly pick one of the TabletServers to connect to. It did this through the ZooCache object which on an initial connection would be empty and causes a lot of back and forth to ZooKeeper. The side effect of this is that the ZooCache would be populated with TabletServer information.

This change modifies the ClientContext to populate the ZooCache in a single-shot background task and modifies the default logic for getting a connection to a TabletServer. The new logic will make 2 calls to ZooKeeper in the best case scenario, one to get the list of TServer ZNodes in Zookeeper and another to get the ZNode data for one of them.

Fixes #4303