### PR TITLE
Fixes compaction dispatcher documentation

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/Constants.java
+++ b/core/src/main/java/org/apache/accumulo/core/Constants.java
@@ -129,4 +129,5 @@ public class Constants {
   public static final String HDFS_TABLES_DIR = "/tables";
 
   public static final int DEFAULT_VISIBILITY_CACHE_SIZE = 1000;
+  public static final String DEFAULT_COMPACTION_SERVICE_NAME = "default";
 }

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.core.conf;
 
+import static org.apache.accumulo.core.Constants.DEFAULT_COMPACTION_SERVICE_NAME;
+
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.EnumSet;
@@ -683,19 +685,23 @@ public enum Property {
       PropertyType.JSON,
       "See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %}.",
       "2.1.0"),
-  TSERV_COMPACTION_SERVICE_DEFAULT_PLANNER("tserver.compaction.major.service.default.planner",
+  TSERV_COMPACTION_SERVICE_DEFAULT_PLANNER(
+      "tserver.compaction.major.service." + DEFAULT_COMPACTION_SERVICE_NAME + ".planner",
       DefaultCompactionPlanner.class.getName(), PropertyType.CLASSNAME,
       "Planner for default compaction service.", "2.1.0"),
-  TSERV_COMPACTION_SERVICE_DEFAULT_RATE_LIMIT("tserver.compaction.major.service.default.rate.limit",
-      "0B", PropertyType.BYTES,
+  TSERV_COMPACTION_SERVICE_DEFAULT_RATE_LIMIT(
+      "tserver.compaction.major.service." + DEFAULT_COMPACTION_SERVICE_NAME + ".rate.limit", "0B",
+      PropertyType.BYTES,
       "Maximum number of bytes to read or write per second over all major"
           + " compactions in this compaction service, or 0B for unlimited.",
       "2.1.0"),
   TSERV_COMPACTION_SERVICE_DEFAULT_MAX_OPEN(
-      "tserver.compaction.major.service.default.planner.opts.maxOpen", "10", PropertyType.COUNT,
-      "The maximum number of files a compaction will open.", "2.1.0"),
+      "tserver.compaction.major.service." + DEFAULT_COMPACTION_SERVICE_NAME
+          + ".planner.opts.maxOpen",
+      "10", PropertyType.COUNT, "The maximum number of files a compaction will open.", "2.1.0"),
   TSERV_COMPACTION_SERVICE_DEFAULT_EXECUTORS(
-      "tserver.compaction.major.service.default.planner.opts.executors",
+      "tserver.compaction.major.service." + DEFAULT_COMPACTION_SERVICE_NAME
+          + ".planner.opts.executors",
       "[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'medium','type':'internal','maxSize':'128M','numThreads':2},{'name':'large','type':'internal','numThreads':2}]"
           .replaceAll("'", "\""),
       PropertyType.STRING,

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/SimpleCompactionDispatcher.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/SimpleCompactionDispatcher.java
@@ -29,7 +29,7 @@ import org.apache.accumulo.core.client.admin.CompactionConfig;
 /**
  * Dispatcher that supports simple configuration for making tables use compaction services. By
  * default, it dispatches to the compaction service named default
- * {@link org.apache.accumulo.core.Constants#DEFAULT_COMPACTION_SERVICE_NAME}.
+ * {@value org.apache.accumulo.core.Constants#DEFAULT_COMPACTION_SERVICE_NAME}.
  *
  * <p>
  * The following schema is supported for configuration options.

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/SimpleCompactionDispatcher.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/SimpleCompactionDispatcher.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.core.spi.compaction;
 
+import static org.apache.accumulo.core.Constants.DEFAULT_COMPACTION_SERVICE_NAME;
+
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
@@ -26,13 +28,14 @@ import org.apache.accumulo.core.client.admin.CompactionConfig;
 
 /**
  * Dispatcher that supports simple configuration for making tables use compaction services. By
- * default it dispatches to a compaction service named default.
+ * default, it dispatches to the compaction service named default
+ * {@link org.apache.accumulo.core.Constants#DEFAULT_COMPACTION_SERVICE_NAME}.
  *
  * <p>
  * The following schema is supported for configuration options.
  *
  * <p>
- * {@code table.compaction.dispatcher.opts.service[.user[.<user type>]|selected|system|chop]=
+ * {@code table.compaction.dispatcher.opts.service[.user[.<user type>]|selector|system|chop]=
  * <service>}
  *
  * <p>
@@ -72,7 +75,8 @@ public class SimpleCompactionDispatcher implements CompactionDispatcher {
   public void init(InitParameters params) {
     services = new EnumMap<>(CompactionKind.class);
 
-    var defaultService = CompactionDispatch.builder().toService("default").build();
+    var defaultService =
+        CompactionDispatch.builder().toService(DEFAULT_COMPACTION_SERVICE_NAME).build();
 
     if (params.getOptions().containsKey("service")) {
       defaultService =

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/CheckCompactionConfig.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/CheckCompactionConfig.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.server.conf;
 
+import static org.apache.accumulo.core.Constants.DEFAULT_COMPACTION_SERVICE_NAME;
+
 import java.io.FileNotFoundException;
 import java.nio.file.Path;
 import java.util.Set;
@@ -53,7 +55,7 @@ public class CheckCompactionConfig implements KeywordExecutable {
 
   private final static Logger log = LoggerFactory.getLogger(CheckCompactionConfig.class);
 
-  final static String DEFAULT = "default";
+  final static String DEFAULT = DEFAULT_COMPACTION_SERVICE_NAME;
   final static String META = "meta";
   final static String ROOT = "root";
 

--- a/test/src/main/java/org/apache/accumulo/test/compaction/BadCompactionServiceConfigIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/BadCompactionServiceConfigIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.test.compaction;
 
+import static org.apache.accumulo.core.Constants.DEFAULT_COMPACTION_SERVICE_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collections;
@@ -210,7 +211,8 @@ public class BadCompactionServiceConfigIT extends AccumuloClusterHarness {
 
           // fix the compaction dispatcher config
           client.tableOperations().setProperty(table,
-              Property.TABLE_COMPACTION_DISPATCHER_OPTS.getKey() + "service", "default");
+              Property.TABLE_COMPACTION_DISPATCHER_OPTS.getKey() + "service",
+              DEFAULT_COMPACTION_SERVICE_NAME);
         } catch (Exception e) {
           throw new RuntimeException(e);
         }


### PR DESCRIPTION
Fixes the documentation which directed users to use "selected" while the code actually checked for "selector".
Also replaced the hardcoded "default" compaction service name string with a constant.