### PR TITLE
Fixed CompactionDriver after new column added to metadata

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriver.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriver.java
@@ -342,10 +342,9 @@ class CompactionDriver extends ManagerRepo {
         }
       };
 
-      try (
-          var tablets = ample.readTablets().forTable(tableId).overlapping(startRow, endRow)
-              .fetch(PREV_ROW, COMPACTED, SELECTED).checkConsistency().build();
-          var tabletsMutator = ample.conditionallyMutateTablets(resultConsumer)) {
+      try (var tablets = ample.readTablets().forTable(tableId).overlapping(startRow, endRow)
+          .fetch(PREV_ROW, COMPACTED, SELECTED, USER_COMPACTION_REQUESTED).checkConsistency()
+          .build(); var tabletsMutator = ample.conditionallyMutateTablets(resultConsumer)) {
         Predicate<TabletMetadata> needsUpdate =
             tabletMetadata -> (tabletMetadata.getSelectedFiles() != null
                 && tabletMetadata.getSelectedFiles().getFateId().equals(fateId))


### PR DESCRIPTION
CompactionDriver.cleanupTabletMetadata was not fetching the newly added metadata column USER_COMPACTION_REQUESTED causing CompactionExecutorIT and ExternalCompaction_2_IT to fail. The column was added in #4254.