### PR TITLE
Update FATE tests to create fate table with system config

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/fate/accumulo/AccumuloFateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/accumulo/AccumuloFateIT.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.test.fate.accumulo;
 
+import static org.apache.accumulo.test.fate.accumulo.AccumuloStoreIT.createFateTable;
+
 import java.util.stream.StreamSupport;
 
 import org.apache.accumulo.core.client.Accumulo;
@@ -57,7 +59,7 @@ public class AccumuloFateIT extends FateIT {
     table = getUniqueNames(1)[0];
     try (ClientContext client =
         (ClientContext) Accumulo.newClient().from(getClientProps()).build()) {
-      client.tableOperations().create(table);
+      createFateTable(client, table);
       testMethod.execute(new AccumuloStore<>(client, table, maxDeferred, fateIdGenerator),
           getCluster().getServerContext());
     }

--- a/test/src/main/java/org/apache/accumulo/test/fate/accumulo/AccumuloStoreFateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/accumulo/AccumuloStoreFateIT.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.test.fate.accumulo;
 
 import static org.apache.accumulo.core.fate.accumulo.AccumuloStore.getRowId;
+import static org.apache.accumulo.test.fate.accumulo.AccumuloStoreIT.createFateTable;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.BatchWriter;
@@ -53,7 +54,7 @@ public class AccumuloStoreFateIT extends FateStoreIT {
     String table = getUniqueNames(1)[0] + "fatestore";
     try (ClientContext client =
         (ClientContext) Accumulo.newClient().from(getClientProps()).build()) {
-      client.tableOperations().create(table);
+      createFateTable(client, table);
       testMethod.execute(new AccumuloStore<>(client, table, maxDeferred, fateIdGenerator),
           getCluster().getServerContext());
     }

--- a/test/src/main/java/org/apache/accumulo/test/fate/accumulo/AccumuloStoreIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/accumulo/AccumuloStoreIT.java
@@ -204,16 +204,15 @@ public class AccumuloStoreIT extends SharedMiniClusterBase {
   }
 
   protected static void createFateTable(ClientContext client, String table) throws Exception {
-
     final var fateTableProps =
         client.tableOperations().getTableProperties(AccumuloTable.FATE.tableName());
     client.tableOperations().create(table);
 
     // Use modifyProperties() instead of trying to set the properties as part of
-    // iniital table create and using NewTableConfiguration(). The reason is that
+    // initial table create and using NewTableConfiguration(). The reason is that
     // the create operation sets extra properties as well, and by using modifyProperties()
     // we can clear all existing properties first, so we end up with an identical config
-    // to the real FATE system table.
+    // to the real FATE user instance table.
     var testFateTableProps = client.tableOperations().modifyProperties(table, existing -> {
       existing.clear();
       existing.putAll(fateTableProps);


### PR DESCRIPTION
This commit updates the different FATE ITs to create the test table that is used to match the same configuration that is used when creating the system table in InitialConfiguration.

This closes #4321