### PR TITLE
Added interface to support SPI configuration validation

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/spi/SpiConfigurationValidation.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/SpiConfigurationValidation.java
@@ -20,8 +20,21 @@ package org.apache.accumulo.core.spi;
 
 import org.apache.accumulo.core.client.PluginEnvironment;
 
+/**
+ * Interface to be used on SPI classes where custom properties are in use. When
+ * {@code #validateConfiguration(org.apache.accumulo.core.client.PluginEnvironment.Configuration)}
+ * is called validation of the custom properties should be performed, if applicable. Implementations
+ * should log any configuration issues at the warning level before finally returning false.
+ *
+ */
 public interface SpiConfigurationValidation {
 
+  /**
+   * Validates implementation custom property configuration
+   *
+   * @param conf configuration
+   * @return true if configuration is valid, else false after logging all warnings
+   */
   public boolean validateConfiguration(PluginEnvironment.Configuration conf);
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/spi/SpiConfigurationValidation.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/SpiConfigurationValidation.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.spi;
+
+import org.apache.accumulo.core.client.PluginEnvironment;
+
+public interface SpiConfigurationValidation {
+
+  public boolean validateConfiguration(PluginEnvironment.Configuration conf);
+
+}

--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancer.java
@@ -49,6 +49,7 @@ import org.apache.accumulo.core.manager.balancer.AssignmentParamsImpl;
 import org.apache.accumulo.core.manager.balancer.BalanceParamsImpl;
 import org.apache.accumulo.core.manager.balancer.TServerStatusImpl;
 import org.apache.accumulo.core.manager.balancer.TableStatisticsImpl;
+import org.apache.accumulo.core.spi.SpiConfigurationValidation;
 import org.apache.accumulo.core.spi.balancer.data.TServerStatus;
 import org.apache.accumulo.core.spi.balancer.data.TableStatistics;
 import org.apache.accumulo.core.spi.balancer.data.TabletMigration;
@@ -91,7 +92,8 @@ import com.google.common.collect.Multimap;
  *
  * @since 2.1.0
  */
-public class HostRegexTableLoadBalancer extends TableLoadBalancer {
+public class HostRegexTableLoadBalancer extends TableLoadBalancer
+    implements SpiConfigurationValidation {
 
   private static final SecureRandom random = new SecureRandom();
   private static final String PROP_PREFIX = Property.TABLE_ARBITRARY_PROP_PREFIX.getKey();
@@ -566,6 +568,17 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer {
   private static String limitTen(Collection<?> iterable) {
     return iterable.stream().limit(10).map(String::valueOf)
         .collect(Collectors.joining(", ", "[", "]"));
+  }
+
+  @Override
+  public boolean validateConfiguration(PluginEnvironment.Configuration conf) {
+    try {
+      new HrtlbConf(conf);
+      return true;
+    } catch (RuntimeException e) {
+      LOG.warn("Error validating configuration", e);
+      return false;
+    }
   }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancer.java
@@ -49,12 +49,12 @@ import org.apache.accumulo.core.manager.balancer.AssignmentParamsImpl;
 import org.apache.accumulo.core.manager.balancer.BalanceParamsImpl;
 import org.apache.accumulo.core.manager.balancer.TServerStatusImpl;
 import org.apache.accumulo.core.manager.balancer.TableStatisticsImpl;
-import org.apache.accumulo.core.spi.SpiConfigurationValidation;
 import org.apache.accumulo.core.spi.balancer.data.TServerStatus;
 import org.apache.accumulo.core.spi.balancer.data.TableStatistics;
 import org.apache.accumulo.core.spi.balancer.data.TabletMigration;
 import org.apache.accumulo.core.spi.balancer.data.TabletServerId;
 import org.apache.accumulo.core.spi.balancer.data.TabletStatistics;
+import org.apache.accumulo.core.spi.common.CustomPropertyValidation;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.slf4j.Logger;
@@ -93,7 +93,7 @@ import com.google.common.collect.Multimap;
  * @since 2.1.0
  */
 public class HostRegexTableLoadBalancer extends TableLoadBalancer
-    implements SpiConfigurationValidation {
+    implements CustomPropertyValidation {
 
   private static final SecureRandom random = new SecureRandom();
   private static final String PROP_PREFIX = Property.TABLE_ARBITRARY_PROP_PREFIX.getKey();

--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancer.java
@@ -54,7 +54,7 @@ import org.apache.accumulo.core.spi.balancer.data.TableStatistics;
 import org.apache.accumulo.core.spi.balancer.data.TabletMigration;
 import org.apache.accumulo.core.spi.balancer.data.TabletServerId;
 import org.apache.accumulo.core.spi.balancer.data.TabletStatistics;
-import org.apache.accumulo.core.spi.common.CustomPropertyValidation;
+import org.apache.accumulo.core.spi.common.CustomPropertyValidator;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.slf4j.Logger;
@@ -93,7 +93,7 @@ import com.google.common.collect.Multimap;
  * @since 2.1.0
  */
 public class HostRegexTableLoadBalancer extends TableLoadBalancer
-    implements CustomPropertyValidation {
+    implements CustomPropertyValidator {
 
   private static final SecureRandom random = new SecureRandom();
   private static final String PROP_PREFIX = Property.TABLE_ARBITRARY_PROP_PREFIX.getKey();
@@ -571,9 +571,9 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer
   }
 
   @Override
-  public boolean validateConfiguration(PluginEnvironment.Configuration conf) {
+  public boolean validateConfiguration(PropertyValidationEnvironment env) {
     try {
-      new HrtlbConf(conf);
+      new HrtlbConf(env.getConfiguration());
       return true;
     } catch (RuntimeException e) {
       LOG.warn("Error validating configuration", e);

--- a/core/src/main/java/org/apache/accumulo/core/spi/common/CustomPropertyValidation.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/common/CustomPropertyValidation.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.core.spi;
+package org.apache.accumulo.core.spi.common;
 
 import org.apache.accumulo.core.client.PluginEnvironment;
 
@@ -27,7 +27,7 @@ import org.apache.accumulo.core.client.PluginEnvironment;
  * should log any configuration issues at the warning level before finally returning false.
  *
  */
-public interface SpiConfigurationValidation {
+public interface CustomPropertyValidation {
 
   /**
    * Validates implementation custom property configuration

--- a/core/src/main/java/org/apache/accumulo/core/spi/common/CustomPropertyValidator.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/common/CustomPropertyValidator.java
@@ -18,7 +18,9 @@
  */
 package org.apache.accumulo.core.spi.common;
 
-import org.apache.accumulo.core.client.PluginEnvironment;
+import java.util.Optional;
+
+import org.apache.accumulo.core.data.TableId;
 
 /**
  * Interface to be used on SPI classes where custom properties are in use. When
@@ -26,15 +28,22 @@ import org.apache.accumulo.core.client.PluginEnvironment;
  * is called validation of the custom properties should be performed, if applicable. Implementations
  * should log any configuration issues at the warning level before finally returning false.
  *
+ * @since 2.1.3
  */
-public interface CustomPropertyValidation {
+public interface CustomPropertyValidator {
+
+  public interface PropertyValidationEnvironment extends ServiceEnvironment {
+
+    public Optional<TableId> getTableId();
+
+  }
 
   /**
    * Validates implementation custom property configuration
    *
-   * @param conf configuration
+   * @param env PropertyValidationEnvironment instance
    * @return true if configuration is valid, else false after logging all warnings
    */
-  public boolean validateConfiguration(PluginEnvironment.Configuration conf);
+  public boolean validateConfiguration(PropertyValidationEnvironment env);
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/spi/common/CustomPropertyValidator.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/common/CustomPropertyValidator.java
@@ -18,9 +18,12 @@
  */
 package org.apache.accumulo.core.spi.common;
 
+import java.util.Map;
 import java.util.Optional;
 
 import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.spi.compaction.CompactionDispatcher;
+import org.apache.accumulo.core.spi.scan.ScanDispatcher;
 
 /**
  * Interface to be used on SPI classes where custom properties are in use. When
@@ -34,8 +37,25 @@ public interface CustomPropertyValidator {
 
   public interface PropertyValidationEnvironment extends ServiceEnvironment {
 
-    public Optional<TableId> getTableId();
+    Optional<TableId> getTableId();
 
+    /**
+     * Some plugins in Accumulo support a map of options that go along with the plugin. If the
+     * plugin being validated follows this pattern, then this method can help get its options.
+     * Accumulo know what plugin it is currently validating and can therefore return appropriate
+     * options for it.
+     *
+     * @return The options for the plugin being validated. This will return different options
+     *         depending on which plugin is being validated. For example if
+     *         {@link org.apache.accumulo.core.spi.compaction.CompactionDispatcher} is being
+     *         validated then will return the same thing as
+     *         {@link CompactionDispatcher.InitParameters#getOptions()}. If a
+     *         {@link org.apache.accumulo.core.spi.scan.ScanDispatcher} plugin is being validated
+     *         then this will return the same thing as
+     *         {@link ScanDispatcher.InitParameters#getOptions()}
+     * @throws IllegalArgumentException if the plugin type being validated does not have options.
+     */
+    Map<String,String> getPluginOptions();
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
@@ -30,10 +30,14 @@ import java.util.Objects;
 import java.util.Set;
 
 import org.apache.accumulo.core.client.admin.compaction.CompactableFile;
+import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.ConfigurationTypeHelper;
 import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.spi.common.CustomPropertyValidator;
 import org.apache.accumulo.core.spi.common.ServiceEnvironment;
 import org.apache.accumulo.core.util.compaction.CompactionJobPrioritizer;
+import org.apache.accumulo.core.util.compaction.CompactionPlannerInitParams;
+import org.apache.accumulo.core.util.compaction.CompactionServicesConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -128,7 +132,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * @see org.apache.accumulo.core.spi.compaction
  */
 
-public class DefaultCompactionPlanner implements CompactionPlanner {
+public class DefaultCompactionPlanner implements CompactionPlanner, CustomPropertyValidator {
 
   private static final Logger log = LoggerFactory.getLogger(DefaultCompactionPlanner.class);
 
@@ -618,5 +622,24 @@ public class DefaultCompactionPlanner implements CompactionPlanner {
         .thenComparing(CompactableFile::getUri));
 
     return sortedFiles;
+  }
+
+  @Override
+  public boolean validateConfiguration(PropertyValidationEnvironment env) {
+
+    try {
+      CompactionServicesConfig csc =
+          new CompactionServicesConfig(new ConfigurationCopy(env.getConfiguration()), log::warn);
+      for (var entry : csc.getPlanners().entrySet()) {
+        String serviceId = entry.getKey();
+        CompactionPlannerInitParams params = new CompactionPlannerInitParams(
+            CompactionServiceId.of(serviceId), csc.getOptions().get(serviceId), env);
+        this.init(params);
+      }
+      return true;
+    } catch (RuntimeException e) {
+      log.warn("Error validating DefaultCompactionPlanner configuration", e);
+      return false;
+    }
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
@@ -638,7 +638,7 @@ public class DefaultCompactionPlanner implements CompactionPlanner, CustomProper
       }
       return true;
     } catch (RuntimeException e) {
-      log.warn("Error validating DefaultCompactionPlanner configuration", e);
+      log.warn("Error validating configuration", e);
       return false;
     }
   }

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
@@ -627,6 +627,9 @@ public class DefaultCompactionPlanner implements CompactionPlanner, CustomProper
   @Override
   public boolean validateConfiguration(PropertyValidationEnvironment env) {
 
+    // ELASTICITY_TODO refactor code to validate config using the following plugin opts
+    var opts = env.getPluginOptions();
+
     try {
       CompactionServicesConfig csc =
           new CompactionServicesConfig(new ConfigurationCopy(env.getConfiguration()), log::warn);

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
@@ -631,10 +631,12 @@ public class DefaultCompactionPlanner implements CompactionPlanner, CustomProper
       CompactionServicesConfig csc =
           new CompactionServicesConfig(new ConfigurationCopy(env.getConfiguration()), log::warn);
       for (var entry : csc.getPlanners().entrySet()) {
-        String serviceId = entry.getKey();
-        CompactionPlannerInitParams params = new CompactionPlannerInitParams(
-            CompactionServiceId.of(serviceId), csc.getOptions().get(serviceId), env);
-        this.init(params);
+        if (entry.getKey().equals(this.getClass().getName())) {
+          String serviceId = entry.getKey();
+          CompactionPlannerInitParams params = new CompactionPlannerInitParams(
+              CompactionServiceId.of(serviceId), csc.getOptions().get(serviceId), env);
+          this.init(params);
+        }
       }
       return true;
     } catch (RuntimeException e) {

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/SimpleCompactionDispatcher.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/SimpleCompactionDispatcher.java
@@ -168,6 +168,7 @@ public class SimpleCompactionDispatcher implements CompactionDispatcher, CustomP
       });
       return true;
     } catch (RuntimeException e) {
+      LOG.warn("Error validating configuration", e);
       return false;
     }
   }

--- a/core/src/main/java/org/apache/accumulo/core/spi/crypto/GenericCryptoServiceFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/crypto/GenericCryptoServiceFactory.java
@@ -23,12 +23,21 @@ import static org.apache.accumulo.core.conf.Property.TABLE_CRYPTO_PREFIX;
 
 import java.util.Map;
 
+import org.apache.accumulo.core.client.PluginEnvironment.Configuration;
+import org.apache.accumulo.core.spi.SpiConfigurationValidation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Factory that will load a crypto service configured, first checking
  * {@link #GENERAL_SERVICE_NAME_PROP} and then {@link #TABLE_SERVICE_NAME_PROP}. Useful for general
  * purpose on disk encryption, with no Table context.
  */
-public class GenericCryptoServiceFactory implements CryptoServiceFactory {
+public class GenericCryptoServiceFactory
+    implements CryptoServiceFactory, SpiConfigurationValidation {
+
+  private static final Logger LOG = LoggerFactory.getLogger(GenericCryptoServiceFactory.class);
+
   public static final String GENERAL_SERVICE_NAME_PROP =
       GENERAL_ARBITRARY_PROP_PREFIX + "crypto.service";
   public static final String TABLE_SERVICE_NAME_PROP = TABLE_CRYPTO_PREFIX + "service";
@@ -49,5 +58,24 @@ public class GenericCryptoServiceFactory implements CryptoServiceFactory {
     var cs = newCryptoService(cryptoServiceName);
     cs.init(properties);
     return cs;
+  }
+
+  @Override
+  public boolean validateConfiguration(Configuration conf) {
+    String generalService = conf.get(GENERAL_SERVICE_NAME_PROP);
+    if (generalService == null || generalService.isBlank()) {
+      LOG.warn("GenericCryptoServiceFactory configured, but " + GENERAL_SERVICE_NAME_PROP
+          + " is not set.");
+    }
+
+    String tableService = conf.get(TABLE_SERVICE_NAME_PROP);
+    if (tableService == null || tableService.isBlank()) {
+      LOG.warn("GenericCryptoServiceFactory configured, but " + TABLE_SERVICE_NAME_PROP
+          + " is not set.");
+    }
+
+    // Return true because getService falls back to
+    // NoCryptoServiceFactory.NONE
+    return true;
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/spi/crypto/GenericCryptoServiceFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/crypto/GenericCryptoServiceFactory.java
@@ -24,7 +24,7 @@ import static org.apache.accumulo.core.conf.Property.TABLE_CRYPTO_PREFIX;
 import java.util.Map;
 
 import org.apache.accumulo.core.client.PluginEnvironment.Configuration;
-import org.apache.accumulo.core.spi.SpiConfigurationValidation;
+import org.apache.accumulo.core.spi.common.CustomPropertyValidation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,8 +33,7 @@ import org.slf4j.LoggerFactory;
  * {@link #GENERAL_SERVICE_NAME_PROP} and then {@link #TABLE_SERVICE_NAME_PROP}. Useful for general
  * purpose on disk encryption, with no Table context.
  */
-public class GenericCryptoServiceFactory
-    implements CryptoServiceFactory, SpiConfigurationValidation {
+public class GenericCryptoServiceFactory implements CryptoServiceFactory, CustomPropertyValidation {
 
   private static final Logger LOG = LoggerFactory.getLogger(GenericCryptoServiceFactory.class);
 

--- a/core/src/main/java/org/apache/accumulo/core/spi/crypto/GenericCryptoServiceFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/crypto/GenericCryptoServiceFactory.java
@@ -23,8 +23,7 @@ import static org.apache.accumulo.core.conf.Property.TABLE_CRYPTO_PREFIX;
 
 import java.util.Map;
 
-import org.apache.accumulo.core.client.PluginEnvironment.Configuration;
-import org.apache.accumulo.core.spi.common.CustomPropertyValidation;
+import org.apache.accumulo.core.spi.common.CustomPropertyValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,7 +32,7 @@ import org.slf4j.LoggerFactory;
  * {@link #GENERAL_SERVICE_NAME_PROP} and then {@link #TABLE_SERVICE_NAME_PROP}. Useful for general
  * purpose on disk encryption, with no Table context.
  */
-public class GenericCryptoServiceFactory implements CryptoServiceFactory, CustomPropertyValidation {
+public class GenericCryptoServiceFactory implements CryptoServiceFactory, CustomPropertyValidator {
 
   private static final Logger LOG = LoggerFactory.getLogger(GenericCryptoServiceFactory.class);
 
@@ -60,14 +59,14 @@ public class GenericCryptoServiceFactory implements CryptoServiceFactory, Custom
   }
 
   @Override
-  public boolean validateConfiguration(Configuration conf) {
-    String generalService = conf.get(GENERAL_SERVICE_NAME_PROP);
+  public boolean validateConfiguration(PropertyValidationEnvironment env) {
+    String generalService = env.getConfiguration().get(GENERAL_SERVICE_NAME_PROP);
     if (generalService == null || generalService.isBlank()) {
       LOG.warn("GenericCryptoServiceFactory configured, but " + GENERAL_SERVICE_NAME_PROP
           + " is not set.");
     }
 
-    String tableService = conf.get(TABLE_SERVICE_NAME_PROP);
+    String tableService = env.getConfiguration().get(TABLE_SERVICE_NAME_PROP);
     if (tableService == null || tableService.isBlank()) {
       LOG.warn("GenericCryptoServiceFactory configured, but " + TABLE_SERVICE_NAME_PROP
           + " is not set.");

--- a/core/src/main/java/org/apache/accumulo/core/spi/crypto/PerTableCryptoServiceFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/crypto/PerTableCryptoServiceFactory.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.accumulo.core.client.PluginEnvironment.Configuration;
 import org.apache.accumulo.core.data.TableId;
-import org.apache.accumulo.core.spi.SpiConfigurationValidation;
+import org.apache.accumulo.core.spi.common.CustomPropertyValidation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  * A factory that loads a CryptoService based on {@link TableId}.
  */
 public class PerTableCryptoServiceFactory
-    implements CryptoServiceFactory, SpiConfigurationValidation {
+    implements CryptoServiceFactory, CustomPropertyValidation {
   private static final Logger log = LoggerFactory.getLogger(PerTableCryptoServiceFactory.class);
   private final ConcurrentHashMap<TableId,CryptoService> cryptoServiceMap =
       new ConcurrentHashMap<>();

--- a/core/src/main/java/org/apache/accumulo/core/spi/crypto/PerTableCryptoServiceFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/crypto/PerTableCryptoServiceFactory.java
@@ -25,17 +25,15 @@ import static org.apache.accumulo.core.conf.Property.TABLE_CRYPTO_PREFIX;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.apache.accumulo.core.client.PluginEnvironment.Configuration;
 import org.apache.accumulo.core.data.TableId;
-import org.apache.accumulo.core.spi.common.CustomPropertyValidation;
+import org.apache.accumulo.core.spi.common.CustomPropertyValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * A factory that loads a CryptoService based on {@link TableId}.
  */
-public class PerTableCryptoServiceFactory
-    implements CryptoServiceFactory, CustomPropertyValidation {
+public class PerTableCryptoServiceFactory implements CryptoServiceFactory, CustomPropertyValidator {
   private static final Logger log = LoggerFactory.getLogger(PerTableCryptoServiceFactory.class);
   private final ConcurrentHashMap<TableId,CryptoService> cryptoServiceMap =
       new ConcurrentHashMap<>();
@@ -104,10 +102,10 @@ public class PerTableCryptoServiceFactory
   }
 
   @Override
-  public boolean validateConfiguration(Configuration conf) {
-    String wal = conf.get(WAL_NAME_PROP);
-    String recovery = conf.get(RECOVERY_NAME_PROP);
-    String table = conf.get(TABLE_SERVICE_NAME_PROP);
+  public boolean validateConfiguration(PropertyValidationEnvironment env) {
+    String wal = env.getConfiguration().get(WAL_NAME_PROP);
+    String recovery = env.getConfiguration().get(RECOVERY_NAME_PROP);
+    String table = env.getConfiguration().get(TABLE_SERVICE_NAME_PROP);
     boolean result = true;
     if (wal == null || wal.isBlank()) {
       log.warn("The property " + WAL_NAME_PROP + " is required for encrypting WALs.");

--- a/core/src/main/java/org/apache/accumulo/core/spi/crypto/PerTableCryptoServiceFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/crypto/PerTableCryptoServiceFactory.java
@@ -108,10 +108,20 @@ public class PerTableCryptoServiceFactory
     String wal = conf.get(WAL_NAME_PROP);
     String recovery = conf.get(RECOVERY_NAME_PROP);
     String table = conf.get(TABLE_SERVICE_NAME_PROP);
-    if (wal == null || recovery == null || table == null || wal.isBlank() || recovery.isBlank()
-        || table.isBlank()) {
-      return false;
+    boolean result = true;
+    if (wal == null || wal.isBlank()) {
+      log.warn("The property " + WAL_NAME_PROP + " is required for encrypting WALs.");
+      result = false;
     }
-    return true;
+    if (recovery == null || recovery.isBlank()) {
+      log.warn(
+          "The property " + RECOVERY_NAME_PROP + " is required for encrypting during recovery.");
+      result = false;
+    }
+    if (table == null || table.isBlank()) {
+      log.warn("The property " + TABLE_SERVICE_NAME_PROP + " is required for encrypting tables.");
+      result = false;
+    }
+    return result;
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/spi/crypto/PerTableCryptoServiceFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/crypto/PerTableCryptoServiceFactory.java
@@ -25,14 +25,17 @@ import static org.apache.accumulo.core.conf.Property.TABLE_CRYPTO_PREFIX;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.accumulo.core.client.PluginEnvironment.Configuration;
 import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.spi.SpiConfigurationValidation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * A factory that loads a CryptoService based on {@link TableId}.
  */
-public class PerTableCryptoServiceFactory implements CryptoServiceFactory {
+public class PerTableCryptoServiceFactory
+    implements CryptoServiceFactory, SpiConfigurationValidation {
   private static final Logger log = LoggerFactory.getLogger(PerTableCryptoServiceFactory.class);
   private final ConcurrentHashMap<TableId,CryptoService> cryptoServiceMap =
       new ConcurrentHashMap<>();
@@ -98,5 +101,17 @@ public class PerTableCryptoServiceFactory implements CryptoServiceFactory {
 
   public int getCount() {
     return cryptoServiceMap.size();
+  }
+
+  @Override
+  public boolean validateConfiguration(Configuration conf) {
+    String wal = conf.get(WAL_NAME_PROP);
+    String recovery = conf.get(RECOVERY_NAME_PROP);
+    String table = conf.get(TABLE_SERVICE_NAME_PROP);
+    if (wal == null || recovery == null || table == null || wal.isBlank() || recovery.isBlank()
+        || table.isBlank()) {
+      return false;
+    }
+    return true;
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/spi/fs/DelegatingChooser.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/fs/DelegatingChooser.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.core.spi.fs;
 
-import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -170,13 +169,12 @@ public class DelegatingChooser implements VolumeChooser, CustomPropertyValidator
 
   @Override
   public boolean validateConfiguration(PropertyValidationEnvironment env) {
-    final Set<String> options = new HashSet<>();
-    String vols = env.getConfiguration().get(Property.INSTANCE_VOLUMES.getKey());
-    for (String vol : vols.split(",")) {
-      options.add(vol);
-    }
     try {
       for (Scope scope : VolumeChooserEnvironment.Scope.values()) {
+        if (scope == Scope.DEFAULT
+            && !env.getConfiguration().getCustom().containsKey(DEFAULT_SCOPED_VOLUME_CHOOSER)) {
+          continue;
+        }
         VolumeChooser chooser = this.getDelegateChooser(new VolumeChooserEnvironment() {
           @Override
           public Text getEndRow() {

--- a/core/src/main/java/org/apache/accumulo/core/spi/fs/DelegatingChooser.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/fs/DelegatingChooser.java
@@ -18,12 +18,17 @@
  */
 package org.apache.accumulo.core.spi.fs;
 
+import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.spi.common.CustomPropertyValidator;
+import org.apache.accumulo.core.spi.common.ServiceEnvironment;
 import org.apache.accumulo.core.spi.fs.VolumeChooserEnvironment.Scope;
+import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +41,7 @@ import org.slf4j.LoggerFactory;
  *
  * @since 2.1.0
  */
-public class DelegatingChooser implements VolumeChooser {
+public class DelegatingChooser implements VolumeChooser, CustomPropertyValidator {
   private static final Logger log = LoggerFactory.getLogger(DelegatingChooser.class);
   /* Track VolumeChooser instances so they can keep state. */
   private final ConcurrentHashMap<TableId,VolumeChooser> tableSpecificChooserCache =
@@ -161,5 +166,46 @@ public class DelegatingChooser implements VolumeChooser {
         throw new RuntimeException(msg, e);
       }
     });
+  }
+
+  @Override
+  public boolean validateConfiguration(PropertyValidationEnvironment env) {
+    final Set<String> options = new HashSet<>();
+    String vols = env.getConfiguration().get(Property.INSTANCE_VOLUMES.getKey());
+    for (String vol : vols.split(",")) {
+      options.add(vol);
+    }
+    try {
+      for (Scope scope : VolumeChooserEnvironment.Scope.values()) {
+        VolumeChooser chooser = this.getDelegateChooser(new VolumeChooserEnvironment() {
+          @Override
+          public Text getEndRow() {
+            return null;
+          }
+
+          @Override
+          public Optional<TableId> getTable() {
+            return env.getTableId();
+          }
+
+          @Override
+          public Scope getChooserScope() {
+            return scope;
+          }
+
+          @Override
+          public ServiceEnvironment getServiceEnv() {
+            return env;
+          }
+        });
+        if (chooser instanceof CustomPropertyValidator) {
+          ((CustomPropertyValidator) chooser).validateConfiguration(env);
+        }
+      }
+      return true;
+    } catch (RuntimeException e) {
+      log.warn("Error validating properties", e);
+      return false;
+    }
   }
 }

--- a/minicluster/src/main/java/org/apache/accumulo/cluster/standalone/StandaloneAccumuloCluster.java
+++ b/minicluster/src/main/java/org/apache/accumulo/cluster/standalone/StandaloneAccumuloCluster.java
@@ -41,6 +41,7 @@ import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.manager.thrift.ManagerGoalState;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.ServerInfo;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -132,8 +133,8 @@ public class StandaloneAccumuloCluster implements AccumuloCluster {
   @Override
   public synchronized ServerContext getServerContext() {
     if (context == null) {
-      context = ServerContext.override(siteConfig, info.getInstanceName(), info.getZooKeepers(),
-          info.getZooKeepersSessionTimeOut());
+      context = ServerContext.override(ServerInfo.ServerType.UTILITY, siteConfig,
+          info.getInstanceName(), info.getZooKeepers(), info.getZooKeepersSessionTimeOut());
     }
     return context;
   }

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
@@ -86,6 +86,7 @@ import org.apache.accumulo.minicluster.MiniAccumuloCluster;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.ServerDirs;
+import org.apache.accumulo.server.ServerInfo;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.init.Initialize;
 import org.apache.accumulo.server.util.AccumuloStatus;
@@ -247,7 +248,8 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
     File siteFile = new File(config.getConfDir(), "accumulo.properties");
     writeConfigProperties(siteFile, config.getSiteConfig());
     this.siteConfig = SiteConfiguration.fromFile(siteFile).build();
-    this.context = Suppliers.memoize(() -> new ServerContext(siteConfig));
+    this.context =
+        Suppliers.memoize(() -> new ServerContext(ServerInfo.ServerType.UTILITY, siteConfig));
 
     if (!config.useExistingInstance() && !config.useExistingZooKeepers()) {
       zooCfgFile = new File(config.getConfDir(), "zoo.cfg");

--- a/server/base/src/main/java/org/apache/accumulo/server/AbstractServer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/AbstractServer.java
@@ -26,6 +26,7 @@ import org.apache.accumulo.core.classloader.ClassLoaderUtil;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.metrics.MetricsUtil;
 import org.apache.accumulo.core.trace.TraceUtil;
+import org.apache.accumulo.server.ServerInfo.ServerType;
 import org.apache.accumulo.server.security.SecurityUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,14 +38,14 @@ public abstract class AbstractServer implements AutoCloseable, Runnable {
   private final String hostname;
   private final Logger log;
 
-  protected AbstractServer(String appName, ServerOpts opts, String[] args) {
+  protected AbstractServer(ServerType type, String appName, ServerOpts opts, String[] args) {
     this.log = LoggerFactory.getLogger(getClass().getName());
     this.applicationName = appName;
     opts.parseArgs(appName, args);
     this.hostname = Objects.requireNonNull(opts.getAddress());
     var siteConfig = opts.getSiteConfiguration();
     SecurityUtil.serverLogin(siteConfig);
-    context = new ServerContext(siteConfig);
+    context = new ServerContext(type, siteConfig);
     log.info("Version " + Constants.VERSION);
     log.info("Instance " + context.getInstanceID());
     context.init(appName);

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
@@ -60,7 +60,7 @@ import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.rpc.SslConnectionParams;
 import org.apache.accumulo.core.singletons.SingletonReservation;
-import org.apache.accumulo.core.spi.SpiConfigurationValidation;
+import org.apache.accumulo.core.spi.common.CustomPropertyValidation;
 import org.apache.accumulo.core.spi.common.ServiceEnvironment;
 import org.apache.accumulo.core.spi.crypto.CryptoServiceFactory;
 import org.apache.accumulo.core.util.AddressUtil;
@@ -515,14 +515,14 @@ public class ServerContext extends ClientContext {
       return true;
     }
     try {
-      Class<? extends SpiConfigurationValidation> clazz;
+      Class<? extends CustomPropertyValidation> clazz;
       try {
-        clazz = ClassLoaderUtil.loadClass(context, className, SpiConfigurationValidation.class);
+        clazz = ClassLoaderUtil.loadClass(context, className, CustomPropertyValidation.class);
       } catch (ClassNotFoundException e) {
         log.error("Unable to load class for configuration validation: " + className);
         return false;
       }
-      SpiConfigurationValidation instance = clazz.getDeclaredConstructor().newInstance();
+      CustomPropertyValidation instance = clazz.getDeclaredConstructor().newInstance();
       return instance.validateConfiguration(createServiceEnvironment(conf).getConfiguration());
     } catch (InstantiationException | IllegalAccessException | IllegalArgumentException
         | InvocationTargetException | NoSuchMethodException | SecurityException e) {

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
@@ -559,6 +559,7 @@ public class ServerContext extends ClientContext {
         return new ConfigurationImpl(config);
       }
 
+      @Override
       public Optional<TableId> getTableId() {
         return (config instanceof TableConfiguration)
             ? Optional.of(((TableConfiguration) config).getTableId()) : Optional.empty();

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
@@ -467,8 +467,7 @@ public class ServerContext extends ClientContext {
 
   public void validateSpiConfiguration(boolean validateNsAndTables)
       throws AccumuloException, AccumuloSecurityException {
-    boolean valid = validateClasses(getSiteConfiguration(), RootTable.ID);
-    valid = valid && validateClasses(getConfiguration(), RootTable.ID);
+    boolean valid = validateClasses(getConfiguration(), RootTable.ID);
     if (validateNsAndTables) {
       for (String ns : namespaceOperations().list()) {
         NamespaceId nsId = NamespaceId.of(namespaceOperations().namespaceIdMap().get(ns));

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerInfo.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerInfo.java
@@ -45,6 +45,18 @@ import org.apache.hadoop.fs.Path;
 
 public class ServerInfo implements ClientInfo {
 
+  public static enum ServerType {
+    COMPACTION_COORDINATOR,
+    COMPACTOR,
+    GARBAGE_COLLECTOR,
+    MANAGER,
+    MONITOR,
+    SCAN_SERVER,
+    TABLET_SERVER,
+    UTILITY
+  }
+
+  private final ServerType serverType;
   private final SiteConfiguration siteConfig;
   private final Configuration hadoopConf;
   private final InstanceId instanceID;
@@ -56,9 +68,10 @@ public class ServerInfo implements ClientInfo {
   private final ServerDirs serverDirs;
   private final Credentials credentials;
 
-  ServerInfo(SiteConfiguration siteConfig, String instanceName, String zooKeepers,
+  ServerInfo(ServerType type, SiteConfiguration siteConfig, String instanceName, String zooKeepers,
       int zooKeepersSessionTimeOut) {
     SingletonManager.setMode(Mode.SERVER);
+    this.serverType = type;
     this.siteConfig = siteConfig;
     this.hadoopConf = new Configuration();
     this.instanceName = instanceName;
@@ -88,8 +101,9 @@ public class ServerInfo implements ClientInfo {
     credentials = SystemCredentials.get(instanceID, siteConfig);
   }
 
-  ServerInfo(SiteConfiguration config) {
+  ServerInfo(ServerType type, SiteConfiguration config) {
     SingletonManager.setMode(Mode.SERVER);
+    serverType = type;
     siteConfig = config;
     hadoopConf = new Configuration();
     try {
@@ -107,8 +121,10 @@ public class ServerInfo implements ClientInfo {
     credentials = SystemCredentials.get(instanceID, siteConfig);
   }
 
-  ServerInfo(SiteConfiguration config, String instanceName, InstanceId instanceID) {
+  ServerInfo(ServerType type, SiteConfiguration config, String instanceName,
+      InstanceId instanceID) {
     SingletonManager.setMode(Mode.SERVER);
+    serverType = type;
     siteConfig = config;
     hadoopConf = new Configuration();
     try {
@@ -190,5 +206,9 @@ public class ServerInfo implements ClientInfo {
 
   public ServerDirs getServerDirs() {
     return serverDirs;
+  }
+
+  public ServerType getServerType() {
+    return serverType;
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/cli/ServerUtilOpts.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/cli/ServerUtilOpts.java
@@ -22,6 +22,7 @@ import org.apache.accumulo.core.cli.ClientOpts;
 import org.apache.accumulo.core.clientImpl.ClientInfo;
 import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.ServerInfo.ServerType;
 
 public class ServerUtilOpts extends ClientOpts {
 
@@ -30,11 +31,11 @@ public class ServerUtilOpts extends ClientOpts {
   public synchronized ServerContext getServerContext() {
     if (context == null) {
       if (getClientConfigFile() == null) {
-        context = new ServerContext(SiteConfiguration.auto());
+        context = new ServerContext(ServerType.UTILITY, SiteConfiguration.auto());
       } else {
         ClientInfo info = ClientInfo.from(getClientProps());
-        context = ServerContext.override(SiteConfiguration.auto(), info.getInstanceName(),
-            info.getZooKeepers(), info.getZooKeepersSessionTimeOut());
+        context = ServerContext.override(ServerType.UTILITY, SiteConfiguration.auto(),
+            info.getInstanceName(), info.getZooKeepers(), info.getZooKeepersSessionTimeOut());
       }
     }
     return context;

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/CheckServerConfig.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/CheckServerConfig.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.server.conf;
 
 import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.ServerInfo.ServerType;
 import org.apache.accumulo.start.spi.KeywordExecutable;
 
 import com.google.auto.service.AutoService;
@@ -28,7 +29,7 @@ import com.google.auto.service.AutoService;
 public class CheckServerConfig implements KeywordExecutable {
 
   public static void main(String[] args) {
-    try (var context = new ServerContext(SiteConfiguration.auto())) {
+    try (var context = new ServerContext(ServerType.UTILITY, SiteConfiguration.auto())) {
       context.getConfiguration();
     }
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/util/ZooInfoViewer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/util/ZooInfoViewer.java
@@ -55,6 +55,7 @@ import org.apache.accumulo.core.fate.zookeeper.ZooReader;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.ServerInfo.ServerType;
 import org.apache.accumulo.server.conf.codec.VersionedProperties;
 import org.apache.accumulo.server.conf.store.NamespacePropKey;
 import org.apache.accumulo.server.conf.store.SystemPropKey;
@@ -119,7 +120,7 @@ public class ZooInfoViewer implements KeywordExecutable {
 
     ZooReader zooReader = new ZooReaderWriter(conf);
 
-    try (ServerContext context = new ServerContext(conf)) {
+    try (ServerContext context = new ServerContext(ServerType.UTILITY, conf)) {
       InstanceId iid = context.getInstanceID();
       generateReport(iid, opts, zooReader);
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/util/ZooPropEditor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/util/ZooPropEditor.java
@@ -40,6 +40,7 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.zookeeper.ZooReader;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.ServerInfo.ServerType;
 import org.apache.accumulo.server.conf.codec.VersionedProperties;
 import org.apache.accumulo.server.conf.store.NamespacePropKey;
 import org.apache.accumulo.server.conf.store.PropStoreKey;
@@ -88,7 +89,7 @@ public class ZooPropEditor implements KeywordExecutable {
     ZooReaderWriter zrw = new ZooReaderWriter(opts.getSiteConfiguration());
 
     var siteConfig = opts.getSiteConfiguration();
-    try (ServerContext context = new ServerContext(siteConfig)) {
+    try (ServerContext context = new ServerContext(ServerType.UTILITY, siteConfig)) {
 
       InstanceId iid = context.getInstanceID();
 

--- a/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
@@ -51,6 +51,7 @@ import org.apache.accumulo.core.volume.VolumeConfiguration;
 import org.apache.accumulo.server.AccumuloDataVersion;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.ServerDirs;
+import org.apache.accumulo.server.ServerInfo.ServerType;
 import org.apache.accumulo.server.fs.VolumeChooserEnvironmentImpl;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.fs.VolumeManagerImpl;
@@ -163,8 +164,8 @@ public class Initialize implements KeywordExecutable {
     ZooKeeperInitializer zki = new ZooKeeperInitializer();
     zki.initializeConfig(instanceId, zoo);
 
-    try (ServerContext context =
-        ServerContext.initialize(initConfig.getSiteConf(), instanceName, instanceId)) {
+    try (ServerContext context = ServerContext.initialize(ServerType.UTILITY,
+        initConfig.getSiteConf(), instanceName, instanceId)) {
       var chooserEnv = new VolumeChooserEnvironmentImpl(Scope.INIT, RootTable.ID, null, context);
       String rootTabletDirName = RootTable.ROOT_TABLET_DIR_NAME;
       String ext = FileOperations.getNewFileExtension(DefaultConfiguration.getInstance());
@@ -558,7 +559,7 @@ public class Initialize implements KeywordExecutable {
 
   private boolean resetSecurity(InitialConfiguration initConfig, Opts opts, VolumeManager fs) {
     log.info("Resetting security on accumulo.");
-    try (ServerContext context = new ServerContext(initConfig.getSiteConf())) {
+    try (ServerContext context = new ServerContext(ServerType.UTILITY, initConfig.getSiteConf())) {
       if (!isInitialized(fs, initConfig)) {
         throw new IllegalStateException(
             "FATAL: Attempted to reset security on accumulo before it was initialized");

--- a/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReports.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReports.java
@@ -48,6 +48,7 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.ProblemSection;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.ServerInfo.ServerType;
 import org.apache.commons.collections4.map.LRUMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -289,7 +290,7 @@ public class ProblemReports implements Iterable<ProblemReport> {
   }
 
   public static void main(String[] args) {
-    var context = new ServerContext(SiteConfiguration.auto());
+    var context = new ServerContext(ServerType.UTILITY, SiteConfiguration.auto());
     getInstance(context).printProblems();
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/Info.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/Info.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.server.util;
 import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.util.MonitorUtil;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.ServerInfo.ServerType;
 import org.apache.accumulo.start.spi.KeywordExecutable;
 import org.apache.zookeeper.KeeperException;
 
@@ -46,7 +47,7 @@ public class Info implements KeywordExecutable {
 
   @Override
   public void execute(final String[] args) throws KeeperException, InterruptedException {
-    var context = new ServerContext(SiteConfiguration.auto());
+    var context = new ServerContext(ServerType.UTILITY, SiteConfiguration.auto());
     System.out.println("monitor: " + MonitorUtil.getLocation(context));
     System.out.println("managers: " + context.getManagerLocations());
     System.out.println("zookeepers: " + context.getZooKeepers());

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ListVolumesUsed.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ListVolumesUsed.java
@@ -28,6 +28,7 @@ import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.ServerInfo.ServerType;
 import org.apache.accumulo.server.fs.VolumeManager.FileType;
 import org.apache.accumulo.server.log.WalStateManager;
 import org.apache.hadoop.fs.Path;
@@ -35,7 +36,7 @@ import org.apache.hadoop.fs.Path;
 public class ListVolumesUsed {
 
   public static void main(String[] args) throws Exception {
-    listVolumes(new ServerContext(SiteConfiguration.auto()));
+    listVolumes(new ServerContext(ServerType.UTILITY, SiteConfiguration.auto()));
   }
 
   private static String getTableURI(String rootTabletDir) {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/LoginProperties.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/LoginProperties.java
@@ -25,6 +25,7 @@ import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.ServerInfo.ServerType;
 import org.apache.accumulo.server.security.handler.Authenticator;
 import org.apache.accumulo.start.spi.KeywordExecutable;
 
@@ -45,7 +46,7 @@ public class LoginProperties implements KeywordExecutable {
 
   @Override
   public void execute(String[] args) throws Exception {
-    try (var context = new ServerContext(SiteConfiguration.auto())) {
+    try (var context = new ServerContext(ServerType.UTILITY, SiteConfiguration.auto())) {
       AccumuloConfiguration config = context.getConfiguration();
       Authenticator authenticator = ClassLoaderUtil
           .loadClass(config.get(Property.INSTANCE_SECURITY_AUTHENTICATOR), Authenticator.class)

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ZooKeeperMain.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ZooKeeperMain.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.server.util;
 import org.apache.accumulo.core.cli.Help;
 import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.ServerInfo.ServerType;
 import org.apache.accumulo.start.spi.KeywordExecutable;
 
 import com.beust.jcommander.Parameter;
@@ -63,7 +64,7 @@ public class ZooKeeperMain implements KeywordExecutable {
   public void execute(final String[] args) throws Exception {
     Opts opts = new Opts();
     opts.parseArgs(ZooKeeperMain.class.getName(), args);
-    try (var context = new ServerContext(SiteConfiguration.auto())) {
+    try (var context = new ServerContext(ServerType.UTILITY, SiteConfiguration.auto())) {
       if (opts.servers == null) {
         opts.servers = context.getZooKeepers();
       }

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
@@ -78,6 +78,7 @@ import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.server.AbstractServer;
 import org.apache.accumulo.server.GarbageCollectionLogger;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.ServerInfo.ServerType;
 import org.apache.accumulo.server.ServerOpts;
 import org.apache.accumulo.server.manager.LiveTServerSet;
 import org.apache.accumulo.server.manager.LiveTServerSet.TServerConnection;
@@ -137,7 +138,7 @@ public class CompactionCoordinator extends AbstractServer
   }
 
   protected CompactionCoordinator(ServerOpts opts, String[] args, AccumuloConfiguration conf) {
-    super("compaction-coordinator", opts, args);
+    super(ServerType.COMPACTION_COORDINATOR, "compaction-coordinator", opts, args);
     aconf = conf == null ? super.getConfiguration() : conf;
     schedExecutor = ThreadPools.getServerThreadPools().createGeneralScheduledExecutorService(aconf);
     compactionFinalizer = createCompactionFinalizer(schedExecutor);

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -94,6 +94,7 @@ import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.core.util.threads.Threads;
 import org.apache.accumulo.server.AbstractServer;
 import org.apache.accumulo.server.GarbageCollectionLogger;
+import org.apache.accumulo.server.ServerInfo.ServerType;
 import org.apache.accumulo.server.ServerOpts;
 import org.apache.accumulo.server.compaction.CompactionInfo;
 import org.apache.accumulo.server.compaction.CompactionWatcher;
@@ -162,7 +163,7 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
   }
 
   protected Compactor(CompactorServerOpts opts, String[] args, AccumuloConfiguration conf) {
-    super("compactor", opts, args);
+    super(ServerType.COMPACTOR, "compactor", opts, args);
     queueName = opts.getQueueName();
     aconf = conf == null ? super.getConfiguration() : conf;
     setupSecurity();

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -53,6 +53,7 @@ import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.gc.metrics.GcCycleMetrics;
 import org.apache.accumulo.gc.metrics.GcMetrics;
 import org.apache.accumulo.server.AbstractServer;
+import org.apache.accumulo.server.ServerInfo.ServerType;
 import org.apache.accumulo.server.ServerOpts;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.manager.LiveTServerSet;
@@ -81,7 +82,7 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
   private final GcCycleMetrics gcCycleMetrics = new GcCycleMetrics();
 
   SimpleGarbageCollector(ServerOpts opts, String[] args) {
-    super("gc", opts, args);
+    super(ServerType.GARBAGE_COLLECTOR, "gc", opts, args);
 
     final AccumuloConfiguration conf = getConfiguration();
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -119,6 +119,7 @@ import org.apache.accumulo.manager.upgrade.UpgradeCoordinator;
 import org.apache.accumulo.server.AbstractServer;
 import org.apache.accumulo.server.HighlyAvailableService;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.ServerInfo.ServerType;
 import org.apache.accumulo.server.ServerOpts;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.manager.LiveTServerSet;
@@ -414,7 +415,7 @@ public class Manager extends AbstractServer
   }
 
   Manager(ServerOpts opts, String[] args) throws IOException {
-    super("manager", opts, args);
+    super(ServerType.MANAGER, "manager", opts, args);
     ServerContext context = super.getContext();
     balancerEnvironment = new BalancerEnvironmentImpl(context);
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/state/SetGoalState.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/state/SetGoalState.java
@@ -28,6 +28,7 @@ import org.apache.accumulo.core.singletons.SingletonManager;
 import org.apache.accumulo.core.singletons.SingletonManager.Mode;
 import org.apache.accumulo.manager.upgrade.RenameMasterDirInZK;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.ServerInfo.ServerType;
 import org.apache.accumulo.server.security.SecurityUtil;
 
 public class SetGoalState {
@@ -45,7 +46,7 @@ public class SetGoalState {
     try {
       var siteConfig = SiteConfiguration.auto();
       SecurityUtil.serverLogin(siteConfig);
-      var context = new ServerContext(siteConfig);
+      var context = new ServerContext(ServerType.UTILITY, siteConfig);
       RenameMasterDirInZK.renameMasterDirInZK(context);
       context.waitForZookeeperAndHdfs();
       context.getZooReaderWriter().putPersistentData(

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/RenameMasterDirInZK.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/RenameMasterDirInZK.java
@@ -23,6 +23,7 @@ import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.ServerInfo.ServerType;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,7 +45,7 @@ public class RenameMasterDirInZK {
   private static final Logger LOG = LoggerFactory.getLogger(RenameMasterDirInZK.class);
 
   public static void main(String[] args) {
-    var ctx = new ServerContext(SiteConfiguration.auto());
+    var ctx = new ServerContext(ServerType.UTILITY, SiteConfiguration.auto());
     if (!renameMasterDirInZK(ctx)) {
       LOG.info(
           "Masters directory in ZooKeeper has already been renamed to managers. No action was taken.");

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeCoordinator.java
@@ -240,7 +240,7 @@ public class UpgradeCoordinator {
         ConfigCheckUtil.validate(context.tableOperations().getTableProperties(table).entrySet(),
             table + " table configuration");
       }
-      context.validateSpiConfiguration();
+      context.validateSpiConfiguration(true);
     } catch (AccumuloException | AccumuloSecurityException | NamespaceNotFoundException
         | TableNotFoundException e) {
       throw new IllegalStateException("Error checking properties", e);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeCoordinator.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.manager.upgrade;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.TreeMap;
@@ -28,20 +29,31 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.classloader.ClassLoaderUtil;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.NamespaceNotFoundException;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.ConfigCheckUtil;
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.conf.PropertyType;
+import org.apache.accumulo.core.data.NamespaceId;
+import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.fate.ReadOnlyTStore;
 import org.apache.accumulo.core.fate.ZooStore;
+import org.apache.accumulo.core.spi.SpiConfigurationValidation;
+import org.apache.accumulo.core.spi.common.ServiceEnvironment;
+import org.apache.accumulo.core.util.ConfigurationImpl;
 import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.core.volume.Volume;
 import org.apache.accumulo.manager.EventCoordinator;
 import org.apache.accumulo.server.AccumuloDataVersion;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.ServerDirs;
+import org.apache.accumulo.server.conf.NamespaceConfiguration;
+import org.apache.accumulo.server.conf.TableConfiguration;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
@@ -229,21 +241,107 @@ public class UpgradeCoordinator {
 
   private void validateProperties(ServerContext context) {
     ConfigCheckUtil.validate(context.getSiteConfiguration(), "site configuration");
+    validateClasses(context.getSiteConfiguration());
     ConfigCheckUtil.validate(context.getConfiguration(), "system configuration");
+    validateClasses(context.getConfiguration());
     try {
       for (String ns : context.namespaceOperations().list()) {
         ConfigCheckUtil.validate(
             context.namespaceOperations().getNamespaceProperties(ns).entrySet(),
             ns + " namespace configuration");
+        NamespaceId nsId = NamespaceId.of(context.namespaceOperations().namespaceIdMap().get(ns));
+        validateClasses(context.getNamespaceConfiguration(nsId));
       }
       for (String table : context.tableOperations().list()) {
         ConfigCheckUtil.validate(context.tableOperations().getTableProperties(table).entrySet(),
             table + " table configuration");
+        TableId tableId = TableId.of(context.tableOperations().tableIdMap().get(table));
+        validateClasses(context.getTableConfiguration(tableId));
       }
     } catch (AccumuloException | AccumuloSecurityException | NamespaceNotFoundException
         | TableNotFoundException e) {
       throw new IllegalStateException("Error checking properties", e);
     }
+  }
+
+  private void validateClasses(AccumuloConfiguration conf) {
+
+    String context = null;
+    if (conf instanceof TableConfiguration) {
+      TableConfiguration tconf = (TableConfiguration) conf;
+      context = tconf.get(Property.TABLE_CLASSLOADER_CONTEXT);
+    } else if (conf instanceof NamespaceConfiguration) {
+      NamespaceConfiguration nconf = (NamespaceConfiguration) conf;
+      context = nconf.get(Property.TABLE_CLASSLOADER_CONTEXT);
+    }
+
+    for (Property p : Property.values()) {
+      if (p.getType().equals(PropertyType.CLASSNAMELIST)) {
+        String[] classNames = conf.get(p).split(",");
+        for (String className : classNames) {
+          try {
+            validateClassConfiguration(conf, p, context);
+          } catch (ClassNotFoundException e) {
+            throw new IllegalStateException(
+                "Unable to load class for configuration validation: " + className);
+          }
+        }
+      } else if (p.getType().equals(PropertyType.CLASSNAME)) {
+        try {
+          validateClassConfiguration(conf, p, context);
+        } catch (ClassNotFoundException e) {
+          throw new IllegalStateException(
+              "Unable to load class for configuration validation: " + conf.get(p));
+        }
+      }
+    }
+  }
+
+  private void validateClassConfiguration(AccumuloConfiguration conf, Property p, String context)
+      throws ClassNotFoundException {
+    String className = conf.get(p);
+    try {
+      Class<? extends SpiConfigurationValidation> clazz =
+          ClassLoaderUtil.loadClass(context, className, SpiConfigurationValidation.class);
+      SpiConfigurationValidation instance = clazz.getDeclaredConstructor().newInstance();
+      instance.validateConfiguration(createServiceEnvironment(conf).getConfiguration());
+    } catch (InstantiationException | IllegalAccessException | IllegalArgumentException
+        | InvocationTargetException | NoSuchMethodException | SecurityException e) {
+      throw new IllegalArgumentException(
+          className + " does not implement no-arg constructor for configuration validation");
+    } catch (ClassCastException e) {
+      // not an error, this class does not implement CustomSPIConfiguration
+    }
+  }
+
+  private ServiceEnvironment createServiceEnvironment(AccumuloConfiguration config) {
+    return new ServiceEnvironment() {
+
+      @Override
+      public <T> T instantiate(TableId tableId, String className, Class<T> base) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public <T> T instantiate(String className, Class<T> base) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public String getTableName(TableId tableId) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public Configuration getConfiguration(TableId tableId) {
+        return new ConfigurationImpl(config);
+      }
+
+      @Override
+      public Configuration getConfiguration() {
+        return new ConfigurationImpl(config);
+      }
+    };
   }
 
   // visible for testing

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -81,6 +81,7 @@ import org.apache.accumulo.monitor.util.logging.RecentLogs;
 import org.apache.accumulo.server.AbstractServer;
 import org.apache.accumulo.server.HighlyAvailableService;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.ServerInfo.ServerType;
 import org.apache.accumulo.server.ServerOpts;
 import org.apache.accumulo.server.problems.ProblemReports;
 import org.apache.accumulo.server.problems.ProblemType;
@@ -117,7 +118,7 @@ public class Monitor extends AbstractServer implements HighlyAvailableService {
   }
 
   Monitor(ServerOpts opts, String[] args) {
-    super("monitor", opts, args);
+    super(ServerType.MONITOR, "monitor", opts, args);
     START_TIME = System.currentTimeMillis();
   }
 

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/util/logging/AccumuloMonitorAppender.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/util/logging/AccumuloMonitorAppender.java
@@ -37,6 +37,7 @@ import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.monitor.rest.logs.LogResource;
 import org.apache.accumulo.monitor.rest.logs.SingleLogEvent;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.ServerInfo.ServerType;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.Core;
 import org.apache.logging.log4j.core.Filter;
@@ -90,7 +91,7 @@ public class AccumuloMonitorAppender extends AbstractAppender {
     monitorLocator = () -> {
       // lazily set up context/path
       if (context == null) {
-        context = new ServerContext(SiteConfiguration.auto());
+        context = new ServerContext(ServerType.UTILITY, SiteConfiguration.auto());
         path = context.getZooKeeperRoot() + Constants.ZMONITOR_HTTP_ADDR;
       }
       // get the current location from the cache

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -89,6 +89,7 @@ import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.server.AbstractServer;
 import org.apache.accumulo.server.GarbageCollectionLogger;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.ServerInfo.ServerType;
 import org.apache.accumulo.server.ServerOpts;
 import org.apache.accumulo.server.conf.TableConfiguration;
 import org.apache.accumulo.server.fs.VolumeManager;
@@ -206,7 +207,7 @@ public class ScanServer extends AbstractServer
   private final String groupName;
 
   public ScanServer(ScanServerOpts opts, String[] args) {
-    super("sserver", opts, args);
+    super(ServerType.SCAN_SERVER, "sserver", opts, args);
 
     context = super.getContext();
     log.info("Version " + Constants.VERSION);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -110,6 +110,7 @@ import org.apache.accumulo.core.util.threads.Threads;
 import org.apache.accumulo.server.AbstractServer;
 import org.apache.accumulo.server.GarbageCollectionLogger;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.ServerInfo.ServerType;
 import org.apache.accumulo.server.ServerOpts;
 import org.apache.accumulo.server.TabletLevel;
 import org.apache.accumulo.server.client.ClientServiceHandler;
@@ -245,7 +246,7 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
   }
 
   protected TabletServer(ServerOpts opts, String[] args) {
-    super("tserver", opts, args);
+    super(ServerType.TABLET_SERVER, "tserver", opts, args);
     context = super.getContext();
     this.managerLockCache = new ZooCache(context.getZooReader(), null);
     final AccumuloConfiguration aconf = getConfiguration();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogReader.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogReader.java
@@ -43,6 +43,7 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.spi.crypto.CryptoEnvironment;
 import org.apache.accumulo.core.spi.crypto.NoFileEncrypter;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.ServerInfo.ServerType;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.start.spi.KeywordExecutable;
 import org.apache.accumulo.tserver.log.DfsLogger;
@@ -112,7 +113,7 @@ public class LogReader implements KeywordExecutable {
     }
 
     var siteConfig = opts.getSiteConfiguration();
-    ServerContext context = new ServerContext(siteConfig);
+    ServerContext context = new ServerContext(ServerType.UTILITY, siteConfig);
     try (VolumeManager fs = context.getVolumeManager()) {
       var walCryptoService = CryptoFactoryLoader.getServiceForClient(CryptoEnvironment.Scope.WAL,
           siteConfig.getAllCryptoProperties());

--- a/test/src/main/java/org/apache/accumulo/test/GetManagerStats.java
+++ b/test/src/main/java/org/apache/accumulo/test/GetManagerStats.java
@@ -32,12 +32,13 @@ import org.apache.accumulo.core.master.thrift.TabletServerStatus;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
 import org.apache.accumulo.core.trace.TraceUtil;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.ServerInfo.ServerType;
 import org.apache.accumulo.server.util.TableInfoUtil;
 
 public class GetManagerStats {
   public static void main(String[] args) throws Exception {
     ManagerMonitorInfo stats = null;
-    var context = new ServerContext(SiteConfiguration.auto());
+    var context = new ServerContext(ServerType.UTILITY, SiteConfiguration.auto());
     stats = ThriftClientTypes.MANAGER.execute(context,
         client -> client.getManagerStats(TraceUtil.traceInfo(), context.rpcCreds()));
     out(0, "State: " + stats.state.name());

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
@@ -70,6 +70,7 @@ import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.ColumnFQ;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.ServerInfo.ServerType;
 import org.apache.accumulo.server.manager.state.Assignment;
 import org.apache.accumulo.server.util.ManagerMetadataUtil;
 import org.apache.accumulo.server.util.MetadataTableUtil;
@@ -334,7 +335,7 @@ public class SplitRecoveryIT extends ConfigurableMacBase {
   }
 
   public static void main(String[] args) throws Exception {
-    new SplitRecoveryIT().run(new ServerContext(SiteConfiguration.auto()));
+    new SplitRecoveryIT().run(new ServerContext(ServerType.UTILITY, SiteConfiguration.auto()));
   }
 
   @Test

--- a/test/src/main/java/org/apache/accumulo/test/functional/ZombieTServer.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ZombieTServer.java
@@ -47,6 +47,7 @@ import org.apache.accumulo.core.util.ServerServices;
 import org.apache.accumulo.core.util.ServerServices.Service;
 import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.ServerInfo.ServerType;
 import org.apache.accumulo.server.client.ClientServiceHandler;
 import org.apache.accumulo.server.rpc.ServerAddress;
 import org.apache.accumulo.server.rpc.TServerUtils;
@@ -104,7 +105,7 @@ public class ZombieTServer {
 
   public static void main(String[] args) throws Exception {
     int port = random.nextInt(30000) + 2000;
-    var context = new ServerContext(SiteConfiguration.auto());
+    var context = new ServerContext(ServerType.UTILITY, SiteConfiguration.auto());
     final ClientServiceHandler csh =
         new ClientServiceHandler(context, new TransactionWatcher(context));
     final ZombieTServerThriftClientHandler tch = new ZombieTServerThriftClientHandler();

--- a/test/src/main/java/org/apache/accumulo/test/performance/NullTserver.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/NullTserver.java
@@ -75,6 +75,7 @@ import org.apache.accumulo.core.trace.thrift.TInfo;
 import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.ServerInfo.ServerType;
 import org.apache.accumulo.server.client.ClientServiceHandler;
 import org.apache.accumulo.server.manager.state.Assignment;
 import org.apache.accumulo.server.manager.state.MetaDataTableScanner;
@@ -327,7 +328,8 @@ public class NullTserver {
     int zkTimeOut =
         (int) DefaultConfiguration.getInstance().getTimeInMillis(Property.INSTANCE_ZK_TIMEOUT);
     var siteConfig = SiteConfiguration.auto();
-    ServerContext context = ServerContext.override(siteConfig, opts.iname, opts.keepers, zkTimeOut);
+    ServerContext context =
+        ServerContext.override(ServerType.UTILITY, siteConfig, opts.iname, opts.keepers, zkTimeOut);
     ClientServiceHandler csh = new ClientServiceHandler(context, new TransactionWatcher(context));
     NullTServerTabletClientHandler tch = new NullTServerTabletClientHandler();
 

--- a/test/src/main/java/org/apache/accumulo/test/server/security/SystemCredentialsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/server/security/SystemCredentialsIT.java
@@ -35,6 +35,7 @@ import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.ServerInfo.ServerType;
 import org.apache.accumulo.server.security.SystemCredentials;
 import org.apache.accumulo.test.functional.ConfigurableMacBase;
 import org.junit.jupiter.api.Test;
@@ -60,7 +61,7 @@ public class SystemCredentialsIT extends ConfigurableMacBase {
 
   public static void main(final String[] args) throws AccumuloException, TableNotFoundException {
     var siteConfig = SiteConfiguration.auto();
-    try (ServerContext context = new ServerContext(siteConfig)) {
+    try (ServerContext context = new ServerContext(ServerType.UTILITY, siteConfig)) {
       Credentials creds;
       InstanceId badInstanceID = InstanceId.of(SystemCredentials.class.getName());
       if (args.length < 2) {


### PR DESCRIPTION
This commit adds the SpiConfigurationValidation interface and an initial implementation that attempts to perform configuration validation on classes referenced in the configuration. No-arg constructors are required for validation.