### PR TITLE
Stop waiting on fate when reporting compaction complete

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
@@ -42,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TransferQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
@@ -480,6 +481,13 @@ public class Fate<T> {
     } finally {
       txStore.unreserve(0, TimeUnit.MILLISECONDS);
     }
+  }
+
+  /**
+   * Lists transctions for a given fate key type.
+   */
+  public Stream<FateKey> list(FateKey.FateKeyType type) {
+    return store.list(type);
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/fate/ReadOnlyFateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/ReadOnlyFateStore.java
@@ -139,6 +139,11 @@ public interface ReadOnlyFateStore<T> {
   Stream<FateIdStatus> list();
 
   /**
+   * list transaction in the store that have a given fate key type.
+   */
+  Stream<FateKey> list(FateKey.FateKeyType type);
+
+  /**
    * Finds all fate ops that are (IN_PROGRESS, SUBMITTED, or FAILED_IN_PROGRESS) and unreserved. Ids
    * that are found are passed to the consumer. This method will block until at least one runnable
    * is found or until the keepWaiting parameter is false. It will return once all runnable ids

--- a/core/src/main/java/org/apache/accumulo/core/fate/ZooStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/ZooStore.java
@@ -377,6 +377,12 @@ public class ZooStore<T> extends AbstractFateStore<T> {
     }
   }
 
+  @Override
+  public Stream<FateKey> list(FateKey.FateKeyType type) {
+    return getTransactions().flatMap(fis -> getKey(fis.getFateId()).stream())
+        .filter(fateKey -> fateKey.getType() == type);
+  }
+
   protected static class NodeValue {
     final TStatus status;
     final Optional<FateKey> fateKey;

--- a/core/src/main/java/org/apache/accumulo/core/logging/FateLogger.java
+++ b/core/src/main/java/org/apache/accumulo/core/logging/FateLogger.java
@@ -121,6 +121,11 @@ public class FateLogger {
       }
 
       @Override
+      public Stream<FateKey> list(FateKey.FateKeyType type) {
+        return store.list(type);
+      }
+
+      @Override
       public void runnable(AtomicBoolean keepWaiting, Consumer<FateId> idConsumer) {
         store.runnable(keepWaiting, idConsumer);
       }

--- a/core/src/test/java/org/apache/accumulo/core/fate/TestStore.java
+++ b/core/src/test/java/org/apache/accumulo/core/fate/TestStore.java
@@ -217,6 +217,11 @@ public class TestStore implements FateStore<String> {
   }
 
   @Override
+  public Stream<FateKey> list(FateKey.FateKeyType type) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public void runnable(AtomicBoolean keepWaiting, Consumer<FateId> idConsumer) {
     throw new UnsupportedOperationException();
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/RefreshTablet.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/RefreshTablet.java
@@ -27,6 +27,7 @@ import org.apache.accumulo.core.dataImpl.thrift.TKeyExtent;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.metadata.TServerInstance;
+import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
@@ -38,8 +39,10 @@ public class RefreshTablet extends ManagerRepo {
   private static final long serialVersionUID = 1L;
   private final TKeyExtent extent;
   private final String tserverInstance;
+  private final String compactionId;
 
-  public RefreshTablet(TKeyExtent extent, String tserverInstance) {
+  public RefreshTablet(String ecid, TKeyExtent extent, String tserverInstance) {
+    this.compactionId = ecid;
     this.extent = extent;
     this.tserverInstance = tserverInstance;
   }
@@ -59,6 +62,8 @@ public class RefreshTablet extends ManagerRepo {
     } finally {
       executorService.shutdownNow();
     }
+
+    manager.getCompactionCoordinator().recordCompletion(ExternalCompactionId.of(compactionId));
 
     return null;
   }


### PR DESCRIPTION
Compactors were waiting on the Fate transaction that does compaction commit.  They were doing this so that the dead compaction detector would not kill the compaction during commit.  This change removes the need for compactors to wait on compaction commit, freeing them to run another compaction.

To accomplish this the dead compaction detector was modified to look for fate operations commiting compactions.  This work leveraged the new FateKey.  A bonus for this changes is that duplicate RPC messages reporting a compaction as completed will no longer spin up duplicate Fate operations to commit.  The Fate operations would have likely been harmless, but would have consumed resources.

A new method was added to Fate to list transactions with a certain FateKeyType.  Tests were added for this new Fate method.

An integration test was added to ensure the dead compaction detector does not delete compactions that no compactors knows of but do have a Fate transaction committing them.