### PR TITLE
Several small improvements to Compactor impl

### DIFF
--- a/server/compactor/src/test/java/org/apache/accumulo/compactor/CompactorTest.java
+++ b/server/compactor/src/test/java/org/apache/accumulo/compactor/CompactorTest.java
@@ -36,7 +36,6 @@ import java.util.function.Supplier;
 
 import org.apache.accumulo.core.compaction.thrift.TCompactionState;
 import org.apache.accumulo.core.compaction.thrift.TCompactionStatusUpdate;
-import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.Property;
@@ -182,11 +181,6 @@ public class CompactorTest {
       this.job = job;
       this.context = context;
       this.eci = eci;
-    }
-
-    @Override
-    public AccumuloConfiguration getConfiguration() {
-      return context.getConfiguration();
     }
 
     @Override

--- a/server/compactor/src/test/java/org/apache/accumulo/compactor/CompactorTest.java
+++ b/server/compactor/src/test/java/org/apache/accumulo/compactor/CompactorTest.java
@@ -176,7 +176,7 @@ public class CompactorTest {
 
     SuccessfulCompactor(Supplier<UUID> uuid, ServerAddress address, TExternalCompactionJob job,
         ServerContext context, ExternalCompactionId eci) {
-      super(new CompactorServerOpts(), new String[] {"-q", "testQ"}, context.getConfiguration());
+      super(new CompactorServerOpts(), new String[] {"-q", "testQ"});
       this.uuid = uuid;
       this.address = address;
       this.job = job;
@@ -190,13 +190,7 @@ public class CompactorTest {
     }
 
     @Override
-    protected void setupSecurity() {}
-
-    @Override
     protected void startGCLogger(ScheduledThreadPoolExecutor schedExecutor) {}
-
-    @Override
-    protected void printStartupMsg() {}
 
     @Override
     public ServerContext getContext() {
@@ -469,13 +463,14 @@ public class CompactorTest {
 
     PowerMock.replayAll();
 
-    SuccessfulCompactor c = new SuccessfulCompactor(null, null, null, context, null);
-    PowerMock.verifyAll();
+    try (var c = new SuccessfulCompactor(null, null, null, context, null)) {
+      Long maxWait = c.getWaitTimeBetweenCompactionChecks();
+      // compaction jitter means maxWait is between 0.9 and 1.1 of the desired value.
+      assertTrue(maxWait >= 720L);
+      assertTrue(maxWait <= 968L);
+    }
 
-    Long maxWait = c.getWaitTimeBetweenCompactionChecks();
-    // compaction jitter means maxWait is between 0.9 and 1.1 of the desired value.
-    assertTrue(maxWait >= 720L);
-    assertTrue(maxWait <= 968L);
+    PowerMock.verifyAll();
   }
 
 }


### PR DESCRIPTION
* Start threadpools when service is run, not when it is constructed (and importantly, after metrics have been fully initialized); this ensures that ServerContext, which is created during construction, is available before threadpools and metrics are started
* Use Supplier to start lazily load security operation instead of calling abstract impl method in constructor (bad practice)
* Remove unneeded second constructor with config overrides (can provide overridden config in test subclass instead)
* Remove redundant printStartupMsg (already printed the same details in AbstractServer base class)
* Make sure SuccessFulCompactor's close method is called in try-with-resources to remove unclosed resource warning in CompactorTest