### PR TITLE
Remove pool metrics instrumentation from LRU caches

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/lru/LruBlockCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/lru/LruBlockCache.java
@@ -103,7 +103,7 @@ public class LruBlockCache extends SynchronousLoadingBlockCache implements Block
 
   /** Statistics thread schedule pool (for heavy debugging, could remove) */
   private final ScheduledExecutorService scheduleThreadPool = ThreadPools.getServerThreadPools()
-      .createScheduledExecutorService(1, "LRUBlockCacheStats", true);
+      .createScheduledExecutorService(1, "LRUBlockCacheStats", false);
 
   /** Current size of cache */
   private final AtomicLong size;
@@ -391,9 +391,9 @@ public class LruBlockCache extends SynchronousLoadingBlockCache implements Block
    */
   private class BlockBucket implements Comparable<BlockBucket> {
 
-    private CachedBlockQueue queue;
-    private long totalSize = 0;
-    private long bucketSize;
+    private final CachedBlockQueue queue;
+    private long totalSize;
+    private final long bucketSize;
 
     public BlockBucket(long bytesToFree, long blockSize, long bucketSize) {
       this.bucketSize = bucketSize;
@@ -512,7 +512,7 @@ public class LruBlockCache extends SynchronousLoadingBlockCache implements Block
    * Thread is triggered into action by {@link LruBlockCache#runEviction()}
    */
   private static class EvictionThread extends AccumuloDaemonThread {
-    private WeakReference<LruBlockCache> cache;
+    private final WeakReference<LruBlockCache> cache;
     private boolean running = false;
 
     public EvictionThread(LruBlockCache cache) {
@@ -532,7 +532,9 @@ public class LruBlockCache extends SynchronousLoadingBlockCache implements Block
           running = true;
           try {
             this.wait();
-          } catch (InterruptedException e) {}
+          } catch (InterruptedException e) {
+            // empty
+          }
         }
         LruBlockCache cache = this.cache.get();
         if (cache == null) {

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/tinylfu/TinyLfuBlockCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/tinylfu/TinyLfuBlockCache.java
@@ -62,7 +62,7 @@ public final class TinyLfuBlockCache implements BlockCache {
   private final Policy.Eviction<String,Block> policy;
   private final int maxSize;
   private final ScheduledExecutorService statsExecutor = ThreadPools.getServerThreadPools()
-      .createScheduledExecutorService(1, "TinyLfuBlockCacheStatsExecutor", true);
+      .createScheduledExecutorService(1, "TinyLfuBlockCacheStatsExecutor", false);
 
   public TinyLfuBlockCache(Configuration conf, CacheType type) {
     cache = Caffeine.newBuilder()
@@ -118,7 +118,7 @@ public final class TinyLfuBlockCache implements BlockCache {
 
   private void logStats() {
     double maxMB = ((double) policy.getMaximum()) / ((double) (1024 * 1024));
-    double sizeMB = ((double) policy.weightedSize().getAsLong()) / ((double) (1024 * 1024));
+    double sizeMB = ((double) policy.weightedSize().orElse(0)) / ((double) (1024 * 1024));
     double freeMB = maxMB - sizeMB;
     log.debug("Cache Size={}MB, Free={}MB, Max={}MB, Blocks={}", sizeMB, freeMB, maxMB,
         cache.estimatedSize());


### PR DESCRIPTION
The LRU caches use a thread pool with 1 thread to generate cache statistics. The pool size is not configurable. It seems unnecessary to produce detail pool metrics for these caches. This disable metrics for those caches.

other minor changes:

* resolve quality check for missing isPresent for weighted size, default to 0 if not present (in TinyLfuBlockCache)
* other minor quality check improvements. (final variables, unneeded initialization...)

Breaking up general metrics changes into small PRs to make reviews easier.