### PR TITLE
fixes bug and removes unneeded wait in delete table

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -520,16 +520,6 @@ public class Manager extends AbstractServer
     }
   }
 
-  public boolean hasCycled(long time) {
-    for (TabletGroupWatcher watcher : watchers) {
-      if (watcher.stats.lastScanFinished() < time) {
-        return false;
-      }
-    }
-
-    return true;
-  }
-
   public void clearMigrations(TableId tableId) {
     synchronized (migrations) {
       migrations.keySet().removeIf(extent -> extent.tableId().equals(tableId));

--- a/server/manager/src/main/java/org/apache/accumulo/manager/state/TableStats.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/state/TableStats.java
@@ -76,10 +76,6 @@ public class TableStats {
     return endScan - startScan;
   }
 
-  public synchronized long lastScanFinished() {
-    return endScan;
-  }
-
   @Override
   public String toString() {
     return new StringBuilder().append("last: ").append(last.toString()).toString();

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/CleanUp.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/CleanUp.java
@@ -61,32 +61,9 @@ class CleanUp extends ManagerRepo {
 
   private long creationTime;
 
-  private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
-    in.defaultReadObject();
-
-    // handle the case where we start executing on a new machine where the current time is in the
-    // past relative to the previous machine
-    // if the new machine has time in the future, that will work ok w/ hasCycled
-    if (System.currentTimeMillis() < creationTime) {
-      creationTime = System.currentTimeMillis();
-    }
-
-  }
-
   public CleanUp(TableId tableId, NamespaceId namespaceId) {
     this.tableId = tableId;
     this.namespaceId = namespaceId;
-    creationTime = System.currentTimeMillis();
-  }
-
-  @Override
-  public long isReady(FateId fateId, Manager manager) throws Exception {
-    // ELASTICITY_TODO investigate this, what is it for and is it still needed?
-    if (!manager.hasCycled(creationTime)) {
-      return 50;
-    }
-
-    return 0;
   }
 
   @Override

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/DeleteTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/DeleteTable.java
@@ -55,7 +55,7 @@ public class DeleteTable extends ManagerRepo {
     final EnumSet<TableState> expectedCurrStates =
         EnumSet.of(TableState.ONLINE, TableState.OFFLINE);
     env.getTableManager().transitionTableState(tableId, TableState.DELETING, expectedCurrStates);
-    env.getEventCoordinator().event(tableId, "deleting table %s ", tableId);
+    env.getEventCoordinator().event(tableId, "deleting table %s %s", tableId, fateId);
     return new ReserveTablets(tableId, namespaceId);
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/ReserveTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/ReserveTablets.java
@@ -83,7 +83,6 @@ public class ReserveTablets extends ManagerRepo {
           locations++;
           log.debug("Delete table is waiting on tablet unload {} {} {}", tabletMeta.getExtent(),
               tabletMeta.getLocation(), fateId);
-          continue;
         }
 
         if (tabletMeta.getOperationId() != null) {
@@ -93,9 +92,11 @@ public class ReserveTablets extends ManagerRepo {
                 tabletMeta.getExtent(), tabletMeta.getOperationId(), fateId);
           }
         } else {
+          // Its ok to set the operation id on a tablet with a location, but after setting it we
+          // must wait for the tablet to have no location before proceeding to actually delete. See
+          // the documentation about the opid column in the MetadataSchema class for more details.
           conditionalMutator.mutateTablet(tabletMeta.getExtent()).requireAbsentOperation()
-              .requireSame(tabletMeta, LOCATION).putOperation(opid)
-              .submit(tm -> opid.equals(tm.getOperationId()));
+              .putOperation(opid).submit(tm -> opid.equals(tm.getOperationId()));
           submitted++;
         }
       }
@@ -107,6 +108,10 @@ public class ReserveTablets extends ManagerRepo {
       return Math.min(Math.max(100, tabletsSeen), 30000);
     }
 
+    // Once all tablets have the delete opid column set AND no tablets have a location set then its
+    // safe to proceed with deleting the tablets. These two conditions being true should prevent any
+    // concurrent writes to tablet metadata by other threads assuming they are using conditional
+    // writes with standard conditional checks.
     return 0;
   }
 


### PR DESCRIPTION
Noticed an integration test was taking 0 to 5 seconds to delete a table. Investigated this and found some code in delete table that was waiting on the TabletGroupWatcher to cycle as the cause of the delay.

Investigated why this wait was there and could not find a definite answer.  Speculating that the purpose of the wait was to deal with possible concurrent writes to tablet metadata by the tablet group watcher in the case it has not yet noticed the table state is DELETING. Changes in elasticity make this wait unnecessary because the delete table fate sets an operation id on each tablet that should prevent any writes to the tablet after its set.  After being set this would prevent any in flight writes by the tablet group watcher from succeeding. Before elasticity there was no way for the delete table fate to prevent writes by the tablet group watcher, so thinking it just waited until it was certain the tablet group watcher was aware of the new table state and would therefore do no writes.

While looking into this, noticed a bug in the way delete table sets operation ids on a tablet when the tablet has a location.  Fixed this bug.

While researching I noticed the delete table code in 2.1 logged per tablet information about any tablet its was waiting on.  This was not being done in elasticity, so added logging for this.

With these changes TabletManagementIteratorIT went from 1 min runtime to 30 second runtime.  The test deleted 9 tables.