### PR TITLE
Throw error when non-standard chars exist

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/GenerateSplits.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/GenerateSplits.java
@@ -275,7 +275,8 @@ public class GenerateSplits implements KeywordExecutable {
           String errMsg = "non printable char: \\x" + Integer.toHexString(c);
           // Fail if non-printable characters are detected.
           if (!humanRead) {
-            throw new UnsupportedOperationException(errMsg + " detected");
+            throw new UnsupportedOperationException(
+                errMsg + " detected. Must use Base64 encoded output");
           }
           log.info("Dropping {}", errMsg);
         }

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/GenerateSplits.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/GenerateSplits.java
@@ -285,7 +285,7 @@ public class GenerateSplits implements KeywordExecutable {
         } else {
           // Fail if non-printable characters are detected.
           throw new UnsupportedOperationException("Non printable char: \\x" + Integer.toHexString(c)
-              + " detected. Must use Base64 encoded output");
+              + " detected. Must use Base64 encoded output.  The behavior around non printable chars changed in 2.1.3 to throw an error, the previous behavior was likely to cause bugs.");
         }
       }
       return sb.toString();

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/GenerateSplitsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/GenerateSplitsTest.java
@@ -194,19 +194,11 @@ public class GenerateSplitsTest {
     assertTrue(splitsFile.createNewFile(), "Failed to create file: " + splitsFile);
     splitsFilePath = splitsFile.getAbsolutePath();
 
-    List<String> args = List.of(rfilePath, "--num", "2", "-sf", splitsFilePath);
+    List<String> finalArgs = List.of(rfilePath, "--num", "2", "-sf", splitsFilePath);
+    assertThrows(UnsupportedOperationException.class,
+        () -> GenerateSplits.main(finalArgs.toArray(new String[0])));
 
-    try {
-      GenerateSplits.main(args.toArray(new String[0]));
-    } catch (Exception e) {
-      assertEquals(e.getClass(), UnsupportedOperationException.class);
-    }
-    args = List.of(rfilePath, "--num", "2", "-sf", splitsFilePath, "-hr");
-    GenerateSplits.main(args.toArray(new String[0]));
-    // Verify that malformed split points exist in the output
-    verifySplitsFile(false, "r6f", "r3c");
-
-    args = List.of(rfilePath, "--num", "2", "-sf", splitsFilePath, "-b64");
+    List<String> args = List.of(rfilePath, "--num", "2", "-sf", splitsFilePath, "-b64");
     GenerateSplits.main(args.toArray(new String[0]));
     // Validate that base64 split points are working
     verifySplitsFile(true, "r6\0f", "r3\0c");

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/GenerateSplitsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/GenerateSplitsTest.java
@@ -33,10 +33,13 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Base64;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -91,13 +94,13 @@ public class GenerateSplitsTest {
     List<String> args = List.of(rfilePath, "--num", "2", "-sf", splitsFilePath);
     log.info("Invoking GenerateSplits with {}", args);
     GenerateSplits.main(args.toArray(new String[0]));
-    verifySplitsFile("r3", "r6");
+    verifySplitsFile(false, "r6", "r3");
 
     // test more splits requested than indices
     args = List.of(rfilePath, "--num", "4", "-sf", splitsFilePath);
     log.info("Invoking GenerateSplits with {}", args);
     GenerateSplits.main(args.toArray(new String[0]));
-    verifySplitsFile("r2", "r3", "r4", "r5");
+    verifySplitsFile(false, "r2", "r3", "r4", "r5");
   }
 
   @Test
@@ -105,15 +108,25 @@ public class GenerateSplitsTest {
     List<String> args = List.of(rfilePath, "-ss", "21", "-sf", splitsFilePath);
     log.info("Invoking GenerateSplits with {}", args);
     GenerateSplits.main(args.toArray(new String[0]));
-    verifySplitsFile("r2", "r4", "r6");
+    verifySplitsFile(false, "r2", "r4", "r6");
   }
 
-  private void verifySplitsFile(String... splits) throws IOException {
-    String splitsFile = Files.readString(Paths.get(splitsFilePath));
-    assertEquals(splits.length, splitsFile.split("\n").length);
-    for (String s : splits) {
-      assertTrue(splitsFile.contains(s), "Did not find " + s + " in: " + splitsFile);
+  private void verifySplitsFile(boolean encoded, String... splits) throws IOException {
+    String[] gSplits = Files.readString(Paths.get(splitsFilePath)).split("\n");
+    assertEquals(splits.length, gSplits.length);
+    TreeSet<String> expectedSplits =
+        Arrays.stream(splits).collect(Collectors.toCollection(TreeSet::new));
+    TreeSet<String> generatedSplits = Arrays.stream(gSplits).map(s -> decode(encoded, s))
+        .map(String::new).collect(Collectors.toCollection(TreeSet::new));
+    assertEquals(expectedSplits, generatedSplits,
+        "Failed to find expected splits in " + generatedSplits);
+  }
+
+  private String decode(boolean decode, String string) {
+    if (decode) {
+      return new String(Base64.getDecoder().decode(string));
     }
+    return string;
   }
 
   @Test
@@ -154,6 +167,49 @@ public class GenerateSplitsTest {
     desired = getEvenlySpacedSplits(10, 9, numSplits(10));
     assertEquals(9, desired.size());
     assertEquals(Set.of("001", "002", "003", "004", "005", "006", "007", "008", "009"), desired);
+  }
+
+  @Test
+  public void testNullValues() throws Exception {
+    trf.openWriter(false);
+    trf.writer.startNewLocalityGroup("lg1", newColFamByteSequence("cf1", "cf2"));
+    trf.writer.append(newKey("r1\0a", "cf1", "cq1", "L1", 55), newValue("foo1"));
+    trf.writer.append(newKey("r2\0b", "cf2", "cq1", "L1", 55), newValue("foo2"));
+    trf.writer.append(newKey("r3\0c", "cf2", "cq1", "L1", 55), newValue("foo3"));
+    trf.writer.startNewLocalityGroup("lg2", newColFamByteSequence("cf3", "cf4"));
+    trf.writer.append(newKey("r4\0d", "cf3", "cq1", "L1", 55), newValue("foo4"));
+    trf.writer.append(newKey("r5\0e", "cf4", "cq1", "L1", 55), newValue("foo5"));
+    trf.writer.append(newKey("r6\0f", "cf4", "cq1", "L1", 55), newValue("foo6"));
+    trf.closeWriter();
+
+    File file = new File(tempDir, "testGenerateSplitsWithNulls.rf");
+    assertTrue(file.createNewFile(), "Failed to create file: " + file);
+    try (var fileOutputStream = new FileOutputStream(file)) {
+      fileOutputStream.write(trf.baos.toByteArray());
+    }
+    rfilePath = "file:" + file.getAbsolutePath();
+    log.info("Wrote to file {}", rfilePath);
+
+    File splitsFile = new File(tempDir, "testSplitsFileWithNulls");
+    assertTrue(splitsFile.createNewFile(), "Failed to create file: " + splitsFile);
+    splitsFilePath = splitsFile.getAbsolutePath();
+
+    List<String> args = List.of(rfilePath, "--num", "2", "-sf", splitsFilePath);
+
+    try {
+      GenerateSplits.main(args.toArray(new String[0]));
+    } catch (Exception e) {
+      assertEquals(e.getClass(), UnsupportedOperationException.class);
+    }
+    args = List.of(rfilePath, "--num", "2", "-sf", splitsFilePath, "-hr");
+    GenerateSplits.main(args.toArray(new String[0]));
+    // Verify that malformed split points exist in the output
+    verifySplitsFile(false, "r6f", "r3c");
+
+    args = List.of(rfilePath, "--num", "2", "-sf", splitsFilePath, "-b64");
+    GenerateSplits.main(args.toArray(new String[0]));
+    // Validate that base64 split points are working
+    verifySplitsFile(true, "r6\0f", "r3\0c");
   }
 
   /**


### PR DESCRIPTION
Adds an explicit error message when base64 encoding should have been used. 
Removes special character modification in favor of the user piping the output to `base64 -d`

closes: 4347