### PR TITLE
added conditionals to expand compaction range

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/ConcurrentKeyExtentCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/ConcurrentKeyExtentCache.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 
-class ConcurrentKeyExtentCache implements KeyExtentCache {
+public class ConcurrentKeyExtentCache implements KeyExtentCache {
 
   private static Logger log = LoggerFactory.getLogger(ConcurrentKeyExtentCache.class);
 
@@ -59,7 +59,7 @@ class ConcurrentKeyExtentCache implements KeyExtentCache {
   private TableId tableId;
   private ClientContext ctx;
 
-  ConcurrentKeyExtentCache(TableId tableId, ClientContext ctx) {
+  public ConcurrentKeyExtentCache(TableId tableId, ClientContext ctx) {
     this.tableId = tableId;
     this.ctx = ctx;
   }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/ConcurrentKeyExtentCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/ConcurrentKeyExtentCache.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 
-public class ConcurrentKeyExtentCache implements KeyExtentCache {
+class ConcurrentKeyExtentCache implements KeyExtentCache {
 
   private static Logger log = LoggerFactory.getLogger(ConcurrentKeyExtentCache.class);
 
@@ -59,7 +59,7 @@ public class ConcurrentKeyExtentCache implements KeyExtentCache {
   private TableId tableId;
   private ClientContext ctx;
 
-  public ConcurrentKeyExtentCache(TableId tableId, ClientContext ctx) {
+  ConcurrentKeyExtentCache(TableId tableId, ClientContext ctx) {
     this.tableId = tableId;
     this.ctx = ctx;
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactRange.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactRange.java
@@ -102,13 +102,15 @@ public class CompactRange extends ManagerRepo {
       // startRow
       Text nextPossibleRow = new Key(startRow).followingKey(PartialKey.ROW).getRow();
       keyExtent = findContaining(env.getContext().getAmple(), tableId, nextPossibleRow);
-      prevRowOfStartRowTablet = keyExtent.prevEndRow().getBytes();
+      prevRowOfStartRowTablet =
+          keyExtent.prevEndRow() == null ? null : TextUtil.getBytes(keyExtent.prevEndRow());
     }
 
     if (endRow != null) {
       // find the tablet containing endRow and pass its end row to the CompactionDriver constructor.
       keyExtent = findContaining(env.getContext().getAmple(), tableId, new Text(endRow));
-      endRowOfEndRowTablet = keyExtent.endRow().getBytes();
+      endRowOfEndRowTablet =
+          keyExtent.endRow().getBytes() == null ? null : TextUtil.getBytes(keyExtent.endRow());
     }
     return new CompactionDriver(namespaceId, tableId, prevRowOfStartRowTablet,
         endRowOfEndRowTablet);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactRange.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactRange.java
@@ -20,20 +20,23 @@ package org.apache.accumulo.manager.tableOps.compact;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.accumulo.core.client.admin.CompactionConfig;
 import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
-import org.apache.accumulo.core.clientImpl.bulk.BulkImport;
-import org.apache.accumulo.core.clientImpl.bulk.ConcurrentKeyExtentCache;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
+import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.NamespaceId;
+import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
+import org.apache.accumulo.core.metadata.schema.Ample;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.util.TextUtil;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
@@ -42,6 +45,8 @@ import org.apache.accumulo.server.compaction.CompactionConfigStorage;
 import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.MoreCollectors;
 
 public class CompactRange extends ManagerRepo {
   private static final Logger log = LoggerFactory.getLogger(CompactRange.class);
@@ -87,23 +92,36 @@ public class CompactRange extends ManagerRepo {
   @Override
   public Repo<Manager> call(final FateId fateId, Manager env) throws Exception {
     CompactionConfigStorage.setConfig(env.getContext(), fateId, config);
-    BulkImport.KeyExtentCache extentCache = new ConcurrentKeyExtentCache(tableId, env.getContext());
-    KeyExtent keyExtent = extentCache.lookup(new Text(startRow));
+    KeyExtent keyExtent;
     byte[] prevRowOfStartRowTablet = startRow;
     byte[] endRowOfEndRowTablet = endRow;
 
     if (startRow != null) {
-      // find the tablet containing startRow and pass its prev row to the CompactionDriver
+      // The startRow in a compaction range is not inclusive, so do not want to find the tablet
+      // containing startRow but instead find the tablet that contains the next possible row after
+      // startRow
+      Text nextPossibleRow = new Key(startRow).followingKey(PartialKey.ROW).getRow();
+      keyExtent = findContaining(env.getContext().getAmple(), tableId, nextPossibleRow);
       prevRowOfStartRowTablet = keyExtent.prevEndRow().getBytes();
     }
 
-    keyExtent = extentCache.lookup(new Text(endRow));
     if (endRow != null) {
       // find the tablet containing endRow and pass its end row to the CompactionDriver constructor.
+      keyExtent = findContaining(env.getContext().getAmple(), tableId, new Text(endRow));
       endRowOfEndRowTablet = keyExtent.endRow().getBytes();
     }
     return new CompactionDriver(namespaceId, tableId, prevRowOfStartRowTablet,
         endRowOfEndRowTablet);
+  }
+
+  private static KeyExtent findContaining(Ample ample, TableId tableId, Text row) {
+    Objects.requireNonNull(row);
+    try (var tablets = ample.readTablets().forTable(tableId).overlapping(row, true, row)
+        .fetch(TabletMetadata.ColumnType.PREV_ROW).build()) {
+      return tablets.stream().collect(MoreCollectors.onlyElement()).getExtent();
+
+    }
+
   }
 
   @Override


### PR DESCRIPTION
Added conditionals to catch any splits that are outside the specified range. To do so I made `ConcurrentKeyExtentCache` a public class and am using `KeyExtent` to find the tablets that contain the `startRow` and `endRow`. 

Fixes [Issue#4341](https://github.com/apache/accumulo/issues/4341)