### PR TITLE
Change to use ServerContext to get scheduled thread pool

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/ManagerTime.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/ManagerTime.java
@@ -64,10 +64,9 @@ public class ManagerTime {
       throw new IOException("Error updating manager time", ex);
     }
 
-    ThreadPools.watchCriticalScheduledTask(
-        ThreadPools.getServerThreadPools().createGeneralScheduledExecutorService(conf)
-            .scheduleWithFixedDelay(Threads.createNamedRunnable("Manager time keeper", () -> run()),
-                0, SECONDS.toMillis(10), MILLISECONDS));
+    ThreadPools.watchCriticalScheduledTask(manager.getContext().getScheduledExecutor()
+        .scheduleWithFixedDelay(Threads.createNamedRunnable("Manager time keeper", () -> run()), 0,
+            SECONDS.toMillis(10), MILLISECONDS));
   }
 
   /**


### PR DESCRIPTION
This is another metrics related pool change.  The ManagerTime runs within the Manager context space and can use the scheduled thread pool that already exists on ServerContext.  This unifies the metrics that will be reported for that common pool instead of potentially creating another set of pool metrics.