### PR TITLE
Update TabletsMetadata stream() to autoclose TabletsMetadata - 2.1

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
@@ -603,6 +603,6 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
   }
 
   public Stream<TabletMetadata> stream() {
-    return StreamSupport.stream(tablets.spliterator(), false);
+    return StreamSupport.stream(tablets.spliterator(), false).onClose(this::close);
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
@@ -33,12 +33,16 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Constructor;
 import java.util.EnumSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
 
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
@@ -253,6 +257,27 @@ public class TabletMetadataTest {
     assertEquals(ser2.getHostAndPort(), tm.getSuspend().server);
     assertNull(tm.getLocation());
     assertFalse(tm.hasCurrent());
+  }
+
+  @Test
+  public void testTabletsMetadataAutoClose() throws Exception {
+    AtomicBoolean closeCalled = new AtomicBoolean();
+    AutoCloseable autoCloseable = () -> closeCalled.set(true);
+    Constructor<TabletsMetadata> tmConstructor =
+        TabletsMetadata.class.getDeclaredConstructor(AutoCloseable.class, Iterable.class);
+    tmConstructor.setAccessible(true);
+
+    try (TabletsMetadata ignored = tmConstructor.newInstance(autoCloseable, List.of())) {
+      // test autoCloseable used directly on TabletsMetadata
+    }
+    assertTrue(closeCalled.get());
+
+    closeCalled.set(false);
+    try (Stream<TabletMetadata> ignored =
+        tmConstructor.newInstance(autoCloseable, List.of()).stream()) {
+      // test stream delegates to close on TabletsMetadata
+    }
+    assertTrue(closeCalled.get());
   }
 
   private SortedMap<Key,Value> toRowMap(Mutation mutation) {


### PR DESCRIPTION
This PR is to address the comment https://github.com/apache/accumulo/pull/4354#discussion_r1518637550

Before this change if stream() was used the the TabletsMetadata close method still had to be called manually as the close method on the stream did not delegate. With this change if the stream is used in a try-with-resources to autoClsoe the stream or if the stream is closed manually, TabletsMetadata will also be closed.

Note that in 2.1, there wasn't anything else to update but the stream() method itself (and a test) because currently there is no where in the code that calls the onClose() method on a stream, but in main and elasticity there are so I will have follow on PRs/changes for those branches.

I thought it was best to change this in 2.1, 3.1 and elasticity so it's consistent and we don't make a mistake and forget that the stream won't be autoclosed if not supported everywhere.