### PR TITLE
Removed special handling logic in TabletManagementIterator

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/TabletState.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/TabletState.java
@@ -21,13 +21,9 @@ package org.apache.accumulo.core.metadata;
 import java.util.Set;
 
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public enum TabletState {
   UNASSIGNED, ASSIGNED, HOSTED, ASSIGNED_TO_DEAD_SERVER, SUSPENDED;
-
-  private static Logger log = LoggerFactory.getLogger(TabletState.class);
 
   public static TabletState compute(TabletMetadata tm, Set<TServerInstance> liveTServers) {
     TabletMetadata.Location current = null;

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletGoalState.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletGoalState.java
@@ -103,6 +103,9 @@ public enum TabletGoalState {
             if (!tm.getHostingRequested()) {
               return UNASSIGNED;
             }
+            break;
+          default:
+            break;
         }
       }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementIterator.java
@@ -43,7 +43,6 @@ import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iterators.user.WholeRowIterator;
 import org.apache.accumulo.core.manager.state.TabletManagement;
 import org.apache.accumulo.core.manager.state.TabletManagement.ManagementAction;
-import org.apache.accumulo.core.manager.thrift.ManagerState;
 import org.apache.accumulo.core.metadata.TabletState;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletOperationType;
@@ -200,18 +199,7 @@ public class TabletManagementIterator extends SkippingIterator {
       Exception error = null;
       try {
         LOG.trace("Evaluating extent: {}", tm);
-        if (tm.getExtent().isMeta()) {
-          computeTabletManagementActions(tm, actions);
-        } else {
-          if (tabletMgmtParams.getManagerState() != ManagerState.NORMAL
-              || tabletMgmtParams.getOnlineTsevers().isEmpty()
-              || tabletMgmtParams.getOnlineTables().isEmpty()) {
-            // when manager is in the process of starting up or shutting down return everything.
-            actions.add(ManagementAction.NEEDS_LOCATION_UPDATE);
-          } else {
-            computeTabletManagementActions(tm, actions);
-          }
-        }
+        computeTabletManagementActions(tm, actions);
       } catch (Exception e) {
         LOG.error("Error computing tablet management actions for extent: {}", tm.getExtent(), e);
         error = e;


### PR DESCRIPTION
Removed the logic that always returns the TabletMetadata when the Manager state is not normal, or there are no tablet servers, or no online tables. The code now just calls computeTabletManagementActions in all cases.

Closes #4256