### PR TITLE
Deprecated MiniAccumuloConfig setNumServer methods

### DIFF
--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/MiniAccumuloConfig.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/MiniAccumuloConfig.java
@@ -56,6 +56,7 @@ public class MiniAccumuloConfig {
    *
    * @param numTservers the number of tablet servers that mini accumulo cluster should start
    */
+  @Deprecated(since = "3.1.0")
   public MiniAccumuloConfig setNumTservers(int numTservers) {
     impl.setNumTservers(numTservers);
     return this;
@@ -67,6 +68,7 @@ public class MiniAccumuloConfig {
    * @param numScanServers the number of scan servers that mini accumulo cluster should start
    * @since 2.1.0
    */
+  @Deprecated(since = "3.1.0")
   public MiniAccumuloConfig setNumScanServers(int numScanServers) {
     impl.setNumScanServers(numScanServers);
     return this;
@@ -224,6 +226,7 @@ public class MiniAccumuloConfig {
   /**
    * @return the number of tservers configured for this cluster
    */
+  @Deprecated(since = "3.1.0")
   public int getNumTservers() {
     return impl.getNumTservers();
   }

--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/MiniAccumuloRunner.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/MiniAccumuloRunner.java
@@ -150,6 +150,7 @@ public class MiniAccumuloRunner {
    *
    * @param args An optional -p argument can be specified with the path to a valid properties file.
    */
+  @SuppressWarnings("deprecation")
   @SuppressFBWarnings(value = {"PATH_TRAVERSAL_IN", "UNENCRYPTED_SERVER_SOCKET"},
       justification = "code runs in same security context as user who provided input file name; "
           + "socket need not be encrypted, since this class is provided for testing only")


### PR DESCRIPTION
These methods are removed in the elasticity branch in favor of a cluster server configuration object