### PR TITLE
Fixes ConcurrentModificationException in RunningCompaction

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/RunningCompaction.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/RunningCompaction.java
@@ -43,11 +43,15 @@ public class RunningCompaction {
   }
 
   public Map<Long,TCompactionStatusUpdate> getUpdates() {
-    return updates;
+    synchronized (updates) {
+      return new TreeMap<>(updates);
+    }
   }
 
   public void addUpdate(Long timestamp, TCompactionStatusUpdate update) {
-    this.updates.put(timestamp, update);
+    synchronized (updates) {
+      this.updates.put(timestamp, update);
+    }
   }
 
   public TExternalCompactionJob getJob() {


### PR DESCRIPTION
While working on #4382 I ran into an issue where a CME was being raised in a Thrift thread that was trying to serialize the updates from the RunningCompaction object.