### PR TITLE
bump zookeeper version from 3.9.1 to 3.9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
     <version.powermock>2.0.9</version.powermock>
     <version.slf4j>2.0.11</version.slf4j>
     <version.thrift>0.17.0</version.thrift>
-    <version.zookeeper>3.9.1</version.zookeeper>
+    <version.zookeeper>3.9.2</version.zookeeper>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
Version was flagged by GH on main. This changes the ZooKeeper version from 3.9.1 to 3.9.2, starting with 2.1