### PR TITLE
Rename Fate store implementations

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
@@ -164,7 +164,7 @@ public class Fate<T> {
 
               // Here, deferTime is only used to determine success (zero) or failure (non-zero),
               // proceeding on success and returning to the while loop on failure.
-              // The value of deferTime is only used as a wait time in ZooStore.unreserve
+              // The value of deferTime is only used as a wait time in FateStore.unreserve
               if (deferTime == 0) {
                 prevOp = op;
                 if (status == SUBMITTED) {

--- a/core/src/main/java/org/apache/accumulo/core/fate/MetaFateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/MetaFateStore.java
@@ -54,9 +54,9 @@ import com.google.common.base.Suppliers;
 //TODO use zoocache? - ACCUMULO-1297
 //TODO handle zookeeper being down gracefully - ACCUMULO-1297
 
-public class ZooStore<T> extends AbstractFateStore<T> {
+public class MetaFateStore<T> extends AbstractFateStore<T> {
 
-  private static final Logger log = LoggerFactory.getLogger(ZooStore.class);
+  private static final Logger log = LoggerFactory.getLogger(MetaFateStore.class);
   private static final FateInstanceType fateInstanceType = FateInstanceType.META;
   private String path;
   private ZooReaderWriter zk;
@@ -65,13 +65,14 @@ public class ZooStore<T> extends AbstractFateStore<T> {
     return path + "/tx_" + fateId.getTxUUIDStr();
   }
 
-  public ZooStore(String path, ZooReaderWriter zk) throws KeeperException, InterruptedException {
+  public MetaFateStore(String path, ZooReaderWriter zk)
+      throws KeeperException, InterruptedException {
     this(path, zk, DEFAULT_MAX_DEFERRED, DEFAULT_FATE_ID_GENERATOR);
   }
 
   @VisibleForTesting
-  public ZooStore(String path, ZooReaderWriter zk, int maxDeferred, FateIdGenerator fateIdGenerator)
-      throws KeeperException, InterruptedException {
+  public MetaFateStore(String path, ZooReaderWriter zk, int maxDeferred,
+      FateIdGenerator fateIdGenerator) throws KeeperException, InterruptedException {
     super(maxDeferred, fateIdGenerator);
     this.path = path;
     this.zk = zk;
@@ -82,7 +83,7 @@ public class ZooStore<T> extends AbstractFateStore<T> {
   /**
    * For testing only
    */
-  ZooStore() {}
+  MetaFateStore() {}
 
   @Override
   public FateId create() {
@@ -257,7 +258,7 @@ public class ZooStore<T> extends AbstractFateStore<T> {
     public Serializable getTransactionInfo(Fate.TxInfo txInfo) {
       verifyReserved(false);
 
-      return ZooStore.this.getTransactionInfo(txInfo, fateId);
+      return MetaFateStore.this.getTransactionInfo(txInfo, fateId);
     }
 
     @Override

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/FateMutator.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/FateMutator.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.core.fate.accumulo;
+package org.apache.accumulo.core.fate.user;
 
 import org.apache.accumulo.core.fate.Fate;
 import org.apache.accumulo.core.fate.FateKey;

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/FateMutatorImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/FateMutatorImpl.java
@@ -16,12 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.core.fate.accumulo;
+package org.apache.accumulo.core.fate.user;
 
 import static org.apache.accumulo.core.fate.AbstractFateStore.serialize;
-import static org.apache.accumulo.core.fate.accumulo.AccumuloStore.getRow;
-import static org.apache.accumulo.core.fate.accumulo.AccumuloStore.getRowId;
-import static org.apache.accumulo.core.fate.accumulo.AccumuloStore.invertRepo;
+import static org.apache.accumulo.core.fate.user.UserFateStore.getRow;
+import static org.apache.accumulo.core.fate.user.UserFateStore.getRowId;
+import static org.apache.accumulo.core.fate.user.UserFateStore.invertRepo;
 
 import java.util.Objects;
 
@@ -41,9 +41,9 @@ import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.FateKey;
 import org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus;
 import org.apache.accumulo.core.fate.Repo;
-import org.apache.accumulo.core.fate.accumulo.schema.FateSchema.RepoColumnFamily;
-import org.apache.accumulo.core.fate.accumulo.schema.FateSchema.TxColumnFamily;
-import org.apache.accumulo.core.fate.accumulo.schema.FateSchema.TxInfoColumnFamily;
+import org.apache.accumulo.core.fate.user.schema.FateSchema.RepoColumnFamily;
+import org.apache.accumulo.core.fate.user.schema.FateSchema.TxColumnFamily;
+import org.apache.accumulo.core.fate.user.schema.FateSchema.TxInfoColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.hadoop.io.Text;
 

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/StatusMappingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/StatusMappingIterator.java
@@ -16,9 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.core.fate.accumulo;
+package org.apache.accumulo.core.fate.user;
 
-import static org.apache.accumulo.core.fate.accumulo.schema.FateSchema.TxColumnFamily.STATUS_COLUMN;
+import static org.apache.accumulo.core.fate.user.schema.FateSchema.TxColumnFamily.STATUS_COLUMN;
 
 import java.io.IOException;
 import java.util.Arrays;

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/UserFateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/UserFateStore.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.core.fate.accumulo;
+package org.apache.accumulo.core.fate.user;
 
 import java.io.Serializable;
 import java.util.List;
@@ -42,9 +42,9 @@ import org.apache.accumulo.core.fate.FateKey;
 import org.apache.accumulo.core.fate.ReadOnlyRepo;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.StackOverflowException;
-import org.apache.accumulo.core.fate.accumulo.schema.FateSchema.RepoColumnFamily;
-import org.apache.accumulo.core.fate.accumulo.schema.FateSchema.TxColumnFamily;
-import org.apache.accumulo.core.fate.accumulo.schema.FateSchema.TxInfoColumnFamily;
+import org.apache.accumulo.core.fate.user.schema.FateSchema.RepoColumnFamily;
+import org.apache.accumulo.core.fate.user.schema.FateSchema.TxColumnFamily;
+import org.apache.accumulo.core.fate.user.schema.FateSchema.TxInfoColumnFamily;
 import org.apache.accumulo.core.metadata.AccumuloTable;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.ColumnFQ;
@@ -57,9 +57,9 @@ import org.slf4j.LoggerFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
-public class AccumuloStore<T> extends AbstractFateStore<T> {
+public class UserFateStore<T> extends AbstractFateStore<T> {
 
-  private static final Logger log = LoggerFactory.getLogger(AccumuloStore.class);
+  private static final Logger log = LoggerFactory.getLogger(UserFateStore.class);
 
   private final ClientContext context;
   private final String tableName;
@@ -69,19 +69,19 @@ public class AccumuloStore<T> extends AbstractFateStore<T> {
   private static final com.google.common.collect.Range<Integer> REPO_RANGE =
       com.google.common.collect.Range.closed(1, maxRepos);
 
-  public AccumuloStore(ClientContext context, String tableName) {
+  public UserFateStore(ClientContext context, String tableName) {
     this(context, tableName, DEFAULT_MAX_DEFERRED, DEFAULT_FATE_ID_GENERATOR);
   }
 
   @VisibleForTesting
-  public AccumuloStore(ClientContext context, String tableName, int maxDeferred,
+  public UserFateStore(ClientContext context, String tableName, int maxDeferred,
       FateIdGenerator fateIdGenerator) {
     super(maxDeferred, fateIdGenerator);
     this.context = Objects.requireNonNull(context);
     this.tableName = Objects.requireNonNull(tableName);
   }
 
-  public AccumuloStore(ClientContext context) {
+  public UserFateStore(ClientContext context) {
     this(context, AccumuloTable.FATE.tableName());
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/schema/FateSchema.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/schema/FateSchema.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.core.fate.accumulo.schema;
+package org.apache.accumulo.core.fate.user.schema;
 
 import org.apache.accumulo.core.util.ColumnFQ;
 import org.apache.hadoop.io.Text;

--- a/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
@@ -771,12 +771,12 @@ public class Admin implements KeywordExecutable {
     var zTableLocksPath = ServiceLock.path(zkRoot + Constants.ZTABLE_LOCKS);
     String fateZkPath = zkRoot + Constants.ZFATE;
     ZooReaderWriter zk = context.getZooReaderWriter();
-    MetaFateStore<Admin> zs = new MetaFateStore<>(fateZkPath, zk);
-    UserFateStore<Admin> as = new UserFateStore<>(context);
+    MetaFateStore<Admin> mfs = new MetaFateStore<>(fateZkPath, zk);
+    UserFateStore<Admin> ufs = new UserFateStore<>(context);
     Map<FateInstanceType,FateStore<Admin>> fateStores =
-        Map.of(FateInstanceType.META, zs, FateInstanceType.USER, as);
+        Map.of(FateInstanceType.META, mfs, FateInstanceType.USER, ufs);
     Map<FateInstanceType,ReadOnlyFateStore<Admin>> readOnlyFateStores =
-        Map.of(FateInstanceType.META, zs, FateInstanceType.USER, as);
+        Map.of(FateInstanceType.META, mfs, FateInstanceType.USER, ufs);
 
     if (fateOpsCommand.cancel) {
       cancelSubmittedFateTxs(context, fateOpsCommand.fateIdList);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
@@ -57,9 +57,9 @@ import org.apache.accumulo.core.fate.AdminUtil;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.FateInstanceType;
 import org.apache.accumulo.core.fate.FateStore;
+import org.apache.accumulo.core.fate.MetaFateStore;
 import org.apache.accumulo.core.fate.ReadOnlyFateStore;
-import org.apache.accumulo.core.fate.ZooStore;
-import org.apache.accumulo.core.fate.accumulo.AccumuloStore;
+import org.apache.accumulo.core.fate.user.UserFateStore;
 import org.apache.accumulo.core.fate.zookeeper.ZooCache;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.lock.ServiceLock;
@@ -771,8 +771,8 @@ public class Admin implements KeywordExecutable {
     var zTableLocksPath = ServiceLock.path(zkRoot + Constants.ZTABLE_LOCKS);
     String fateZkPath = zkRoot + Constants.ZFATE;
     ZooReaderWriter zk = context.getZooReaderWriter();
-    ZooStore<Admin> zs = new ZooStore<>(fateZkPath, zk);
-    AccumuloStore<Admin> as = new AccumuloStore<>(context);
+    MetaFateStore<Admin> zs = new MetaFateStore<>(fateZkPath, zk);
+    UserFateStore<Admin> as = new UserFateStore<>(context);
     Map<FateInstanceType,FateStore<Admin>> fateStores =
         Map.of(FateInstanceType.META, zs, FateInstanceType.USER, as);
     Map<FateInstanceType,ReadOnlyFateStore<Admin>> readOnlyFateStores =

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -77,8 +77,8 @@ import org.apache.accumulo.core.fate.FateCleaner;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.FateInstanceType;
 import org.apache.accumulo.core.fate.FateStore;
-import org.apache.accumulo.core.fate.ZooStore;
-import org.apache.accumulo.core.fate.accumulo.AccumuloStore;
+import org.apache.accumulo.core.fate.MetaFateStore;
+import org.apache.accumulo.core.fate.user.UserFateStore;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.accumulo.core.lock.ServiceLock;
@@ -1073,9 +1073,9 @@ public class Manager extends AbstractServer
 
     try {
       var metaInstance = initializeFateInstance(context,
-          new ZooStore<>(getZooKeeperRoot() + Constants.ZFATE, context.getZooReaderWriter()));
+          new MetaFateStore<>(getZooKeeperRoot() + Constants.ZFATE, context.getZooReaderWriter()));
       var userInstance = initializeFateInstance(context,
-          new AccumuloStore<>(context, AccumuloTable.FATE.tableName()));
+          new UserFateStore<>(context, AccumuloTable.FATE.tableName()));
 
       if (!fateRefs.compareAndSet(null,
           Map.of(FateInstanceType.META, metaInstance, FateInstanceType.USER, userInstance))) {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/FateMetrics.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/FateMetrics.java
@@ -49,7 +49,7 @@ public class FateMetrics implements MetricsProducer {
   private static final String OP_TYPE_TAG = "op.type";
 
   private final ServerContext context;
-  private final ReadOnlyFateStore<FateMetrics> zooStore;
+  private final ReadOnlyFateStore<FateMetrics> fateStore;
   private final String fateRootPath;
   private final long refreshDelay;
 
@@ -71,7 +71,7 @@ public class FateMetrics implements MetricsProducer {
     this.refreshDelay = Math.max(DEFAULT_MIN_REFRESH_DELAY, minimumRefreshDelay);
 
     try {
-      this.zooStore = new MetaFateStore<>(fateRootPath, context.getZooReaderWriter());
+      this.fateStore = new MetaFateStore<>(fateRootPath, context.getZooReaderWriter());
     } catch (KeeperException ex) {
       throw new IllegalStateException(
           "FATE Metrics - Failed to create zoo store - metrics unavailable", ex);
@@ -86,7 +86,7 @@ public class FateMetrics implements MetricsProducer {
   private void update() {
 
     FateMetricValues metricValues =
-        FateMetricValues.getFromZooKeeper(context, fateRootPath, zooStore);
+        FateMetricValues.getFromZooKeeper(context, fateRootPath, fateStore);
 
     totalCurrentOpsGauge.set(metricValues.getCurrentFateOps());
     totalOpsGauge.set(metricValues.getZkFateChildOpsTotal());

--- a/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/FateMetrics.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/FateMetrics.java
@@ -25,8 +25,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.fate.MetaFateStore;
 import org.apache.accumulo.core.fate.ReadOnlyFateStore;
-import org.apache.accumulo.core.fate.ZooStore;
 import org.apache.accumulo.core.metrics.MetricsProducer;
 import org.apache.accumulo.core.metrics.MetricsUtil;
 import org.apache.accumulo.core.util.threads.ThreadPools;
@@ -71,7 +71,7 @@ public class FateMetrics implements MetricsProducer {
     this.refreshDelay = Math.max(DEFAULT_MIN_REFRESH_DELAY, minimumRefreshDelay);
 
     try {
-      this.zooStore = new ZooStore<>(fateRootPath, context.getZooReaderWriter());
+      this.zooStore = new MetaFateStore<>(fateRootPath, context.getZooReaderWriter());
     } catch (KeeperException ex) {
       throw new IllegalStateException(
           "FATE Metrics - Failed to create zoo store - metrics unavailable", ex);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeCoordinator.java
@@ -38,8 +38,8 @@ import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.NamespaceNotFoundException;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.conf.ConfigCheckUtil;
+import org.apache.accumulo.core.fate.MetaFateStore;
 import org.apache.accumulo.core.fate.ReadOnlyFateStore;
-import org.apache.accumulo.core.fate.ZooStore;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.core.volume.Volume;
@@ -307,7 +307,7 @@ public class UpgradeCoordinator {
       justification = "Want to immediately stop all manager threads on upgrade error")
   private void abortIfFateTransactions(ServerContext context) {
     try {
-      final ReadOnlyFateStore<UpgradeCoordinator> fate = new ZooStore<>(
+      final ReadOnlyFateStore<UpgradeCoordinator> fate = new MetaFateStore<>(
           context.getZooKeeperRoot() + Constants.ZFATE, context.getZooReaderWriter());
       try (var idStream = fate.list()) {
         if (idStream.findFirst().isPresent()) {

--- a/test/src/main/java/org/apache/accumulo/test/fate/FateStoreIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FateStoreIT.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.test.fate.accumulo;
+package org.apache.accumulo.test.fate;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -59,7 +59,6 @@ import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.test.fate.FateIT.TestRepo;
-import org.apache.accumulo.test.fate.FateTestRunner;
 import org.apache.accumulo.test.fate.FateTestRunner.TestEnv;
 import org.apache.accumulo.test.util.Wait;
 import org.apache.hadoop.io.Text;

--- a/test/src/main/java/org/apache/accumulo/test/fate/meta/MetaFateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/meta/MetaFateIT.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.test.fate.zookeeper;
+package org.apache.accumulo.test.fate.meta;
 
 import static org.apache.accumulo.harness.AccumuloITBase.ZOOKEEPER_TESTING_SERVER;
 import static org.easymock.EasyMock.createMock;
@@ -31,8 +31,8 @@ import java.util.UUID;
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.fate.AbstractFateStore.FateIdGenerator;
 import org.apache.accumulo.core.fate.FateId;
+import org.apache.accumulo.core.fate.MetaFateStore;
 import org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus;
-import org.apache.accumulo.core.fate.ZooStore;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.test.fate.FateIT;
@@ -45,7 +45,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.io.TempDir;
 
 @Tag(ZOOKEEPER_TESTING_SERVER)
-public class ZookeeperFateIT extends FateIT {
+public class MetaFateIT extends FateIT {
 
   private static ZooKeeperTestingServer szk = null;
   private static ZooReaderWriter zk = null;
@@ -75,8 +75,8 @@ public class ZookeeperFateIT extends FateIT {
     expect(sctx.getZooReaderWriter()).andReturn(zk).anyTimes();
     replay(sctx);
 
-    testMethod.execute(new ZooStore<>(ZK_ROOT + Constants.ZFATE, zk, maxDeferred, fateIdGenerator),
-        sctx);
+    testMethod.execute(
+        new MetaFateStore<>(ZK_ROOT + Constants.ZFATE, zk, maxDeferred, fateIdGenerator), sctx);
   }
 
   @Override
@@ -89,8 +89,8 @@ public class ZookeeperFateIT extends FateIT {
   }
 
   /*
-   * Get the status of the TX from ZK directly. Unable to call ZooStore.getStatus because this test
-   * thread does not have the reservation (the FaTE thread does)
+   * Get the status of the TX from ZK directly. Unable to call MetaFateStore.getStatus because this
+   * test thread does not have the reservation (the FaTE thread does)
    */
   private static TStatus getTxStatus(ZooReaderWriter zrw, FateId fateId)
       throws KeeperException, InterruptedException {

--- a/test/src/main/java/org/apache/accumulo/test/fate/meta/MetaFateOpsCommandsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/meta/MetaFateOpsCommandsIT.java
@@ -16,17 +16,22 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.test.fate.accumulo;
+package org.apache.accumulo.test.fate.meta;
 
+import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.fate.AbstractFateStore;
-import org.apache.accumulo.core.fate.accumulo.AccumuloStore;
+import org.apache.accumulo.core.fate.MetaFateStore;
+import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
+import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.test.fate.FateOpsCommandsIT;
 
-public class AccumuloFateOpsCommandsIT extends FateOpsCommandsIT {
+public class MetaFateOpsCommandsIT extends FateOpsCommandsIT {
   @Override
   public void executeTest(FateTestExecutor<TestEnv> testMethod, int maxDeferred,
       AbstractFateStore.FateIdGenerator fateIdGenerator) throws Exception {
-    testMethod.execute(new AccumuloStore<>(getCluster().getServerContext()),
-        getCluster().getServerContext());
+    ServerContext sctx = getCluster().getServerContext();
+    String path = sctx.getZooKeeperRoot() + Constants.ZFATE;
+    ZooReaderWriter zk = sctx.getZooReaderWriter();
+    testMethod.execute(new MetaFateStore<>(path, zk), sctx);
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/fate/meta/MetaFateStoreFateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/meta/MetaFateStoreFateIT.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.test.fate.zookeeper;
+package org.apache.accumulo.test.fate.meta;
 
 import static org.apache.accumulo.harness.AccumuloITBase.ZOOKEEPER_TESTING_SERVER;
 import static org.easymock.EasyMock.createMock;
@@ -32,12 +32,12 @@ import java.util.UUID;
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.fate.AbstractFateStore.FateIdGenerator;
 import org.apache.accumulo.core.fate.FateId;
+import org.apache.accumulo.core.fate.MetaFateStore;
 import org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus;
-import org.apache.accumulo.core.fate.ZooStore;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.accumulo.server.ServerContext;
-import org.apache.accumulo.test.fate.accumulo.FateStoreIT;
+import org.apache.accumulo.test.fate.FateStoreIT;
 import org.apache.accumulo.test.zookeeper.ZooKeeperTestingServer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -45,7 +45,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.io.TempDir;
 
 @Tag(ZOOKEEPER_TESTING_SERVER)
-public class ZooStoreFateIT extends FateStoreIT {
+public class MetaFateStoreFateIT extends FateStoreIT {
 
   private static ZooKeeperTestingServer szk = null;
   private static ZooReaderWriter zk = null;
@@ -75,8 +75,8 @@ public class ZooStoreFateIT extends FateStoreIT {
     expect(sctx.getZooReaderWriter()).andReturn(zk).anyTimes();
     replay(sctx);
 
-    testMethod.execute(new ZooStore<>(ZK_ROOT + Constants.ZFATE, zk, maxDeferred, fateIdGenerator),
-        sctx);
+    testMethod.execute(
+        new MetaFateStore<>(ZK_ROOT + Constants.ZFATE, zk, maxDeferred, fateIdGenerator), sctx);
   }
 
   @Override
@@ -85,7 +85,7 @@ public class ZooStoreFateIT extends FateStoreIT {
       // We have to use reflection since the NodeValue is internal to the store
 
       // Grab both the constructor that uses the serialized bytes and status
-      Class<?> nodeClass = Class.forName(ZooStore.class.getName() + "$NodeValue");
+      Class<?> nodeClass = Class.forName(MetaFateStore.class.getName() + "$NodeValue");
       Constructor<?> statusCons = nodeClass.getDeclaredConstructor(TStatus.class);
       Constructor<?> serializedCons = nodeClass.getDeclaredConstructor(byte[].class);
       statusCons.setAccessible(true);

--- a/test/src/main/java/org/apache/accumulo/test/fate/meta/ZooMutatorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/meta/ZooMutatorIT.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.test.fate.zookeeper;
+package org.apache.accumulo.test.fate.meta;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.harness.AccumuloITBase.ZOOKEEPER_TESTING_SERVER;

--- a/test/src/main/java/org/apache/accumulo/test/fate/user/FateMutatorImplIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/user/FateMutatorImplIT.java
@@ -16,10 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.test.fate.accumulo;
+package org.apache.accumulo.test.fate.user;
 
-import static org.apache.accumulo.core.fate.accumulo.FateMutator.Status.ACCEPTED;
-import static org.apache.accumulo.core.fate.accumulo.FateMutator.Status.REJECTED;
+import static org.apache.accumulo.core.fate.user.FateMutator.Status.ACCEPTED;
+import static org.apache.accumulo.core.fate.user.FateMutator.Status.REJECTED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -34,7 +34,7 @@ import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.FateInstanceType;
 import org.apache.accumulo.core.fate.ReadOnlyFateStore;
-import org.apache.accumulo.core.fate.accumulo.FateMutatorImpl;
+import org.apache.accumulo.core.fate.user.FateMutatorImpl;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.test.fate.FateIT;
 import org.junit.jupiter.api.AfterAll;

--- a/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateIT.java
@@ -16,9 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.test.fate.accumulo;
+package org.apache.accumulo.test.fate.user;
 
-import static org.apache.accumulo.test.fate.accumulo.AccumuloStoreIT.createFateTable;
+import static org.apache.accumulo.test.fate.user.UserFateStoreIT.createFateTable;
 
 import java.util.stream.StreamSupport;
 
@@ -30,8 +30,8 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.fate.AbstractFateStore.FateIdGenerator;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus;
-import org.apache.accumulo.core.fate.accumulo.AccumuloStore;
-import org.apache.accumulo.core.fate.accumulo.schema.FateSchema.TxColumnFamily;
+import org.apache.accumulo.core.fate.user.UserFateStore;
+import org.apache.accumulo.core.fate.user.schema.FateSchema.TxColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.server.ServerContext;
@@ -39,7 +39,7 @@ import org.apache.accumulo.test.fate.FateIT;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 
-public class AccumuloFateIT extends FateIT {
+public class UserFateIT extends FateIT {
 
   private String table;
 
@@ -60,7 +60,7 @@ public class AccumuloFateIT extends FateIT {
     try (ClientContext client =
         (ClientContext) Accumulo.newClient().from(getClientProps()).build()) {
       createFateTable(client, table);
-      testMethod.execute(new AccumuloStore<>(client, table, maxDeferred, fateIdGenerator),
+      testMethod.execute(new UserFateStore<>(client, table, maxDeferred, fateIdGenerator),
           getCluster().getServerContext());
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateOpsCommandsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateOpsCommandsIT.java
@@ -16,22 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.test.fate.zookeeper;
+package org.apache.accumulo.test.fate.user;
 
-import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.fate.AbstractFateStore;
-import org.apache.accumulo.core.fate.ZooStore;
-import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
-import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.core.fate.user.UserFateStore;
 import org.apache.accumulo.test.fate.FateOpsCommandsIT;
 
-public class ZookeeperFateOpsCommandsIT extends FateOpsCommandsIT {
+public class UserFateOpsCommandsIT extends FateOpsCommandsIT {
   @Override
   public void executeTest(FateTestExecutor<TestEnv> testMethod, int maxDeferred,
       AbstractFateStore.FateIdGenerator fateIdGenerator) throws Exception {
-    ServerContext sctx = getCluster().getServerContext();
-    String path = sctx.getZooKeeperRoot() + Constants.ZFATE;
-    ZooReaderWriter zk = sctx.getZooReaderWriter();
-    testMethod.execute(new ZooStore<>(path, zk), sctx);
+    testMethod.execute(new UserFateStore<>(getCluster().getServerContext()),
+        getCluster().getServerContext());
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateStoreFateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateStoreFateIT.java
@@ -16,10 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.test.fate.accumulo;
+package org.apache.accumulo.test.fate.user;
 
-import static org.apache.accumulo.core.fate.accumulo.AccumuloStore.getRowId;
-import static org.apache.accumulo.test.fate.accumulo.AccumuloStoreIT.createFateTable;
+import static org.apache.accumulo.core.fate.user.UserFateStore.getRowId;
+import static org.apache.accumulo.test.fate.user.UserFateStoreIT.createFateTable;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.BatchWriter;
@@ -29,14 +29,15 @@ import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.fate.AbstractFateStore.FateIdGenerator;
 import org.apache.accumulo.core.fate.FateId;
-import org.apache.accumulo.core.fate.accumulo.AccumuloStore;
-import org.apache.accumulo.core.fate.accumulo.schema.FateSchema.TxColumnFamily;
+import org.apache.accumulo.core.fate.user.UserFateStore;
+import org.apache.accumulo.core.fate.user.schema.FateSchema.TxColumnFamily;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.test.fate.FateStoreIT;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 
-public class AccumuloStoreFateIT extends FateStoreIT {
+public class UserFateStoreFateIT extends FateStoreIT {
 
   @BeforeAll
   public static void setup() throws Exception {
@@ -55,7 +56,7 @@ public class AccumuloStoreFateIT extends FateStoreIT {
     try (ClientContext client =
         (ClientContext) Accumulo.newClient().from(getClientProps()).build()) {
       createFateTable(client, table);
-      testMethod.execute(new AccumuloStore<>(client, table, maxDeferred, fateIdGenerator),
+      testMethod.execute(new UserFateStore<>(client, table, maxDeferred, fateIdGenerator),
           getCluster().getServerContext());
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateStoreIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateStoreIT.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.test.fate.accumulo;
+package org.apache.accumulo.test.fate.user;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -46,12 +46,13 @@ import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.FateInstanceType;
 import org.apache.accumulo.core.fate.FateStore;
 import org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus;
-import org.apache.accumulo.core.fate.accumulo.AccumuloStore;
-import org.apache.accumulo.core.fate.accumulo.schema.FateSchema;
+import org.apache.accumulo.core.fate.user.UserFateStore;
+import org.apache.accumulo.core.fate.user.schema.FateSchema;
 import org.apache.accumulo.core.iterators.user.VersioningIterator;
 import org.apache.accumulo.core.metadata.AccumuloTable;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.test.fate.FateIT;
+import org.apache.accumulo.test.fate.FateTestRunner.TestEnv;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -65,9 +66,9 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.MoreCollectors;
 
-public class AccumuloStoreIT extends SharedMiniClusterBase {
+public class UserFateStoreIT extends SharedMiniClusterBase {
 
-  private static final Logger log = LoggerFactory.getLogger(AccumuloStore.class);
+  private static final Logger log = LoggerFactory.getLogger(UserFateStore.class);
   private static final FateInstanceType fateInstanceType = FateInstanceType.USER;
 
   @BeforeAll
@@ -80,11 +81,11 @@ public class AccumuloStoreIT extends SharedMiniClusterBase {
     SharedMiniClusterBase.stopMiniCluster();
   }
 
-  private static class TestAccumuloStore extends AccumuloStore<FateIT.TestEnv> {
+  private static class TestUserFateStore extends UserFateStore<TestEnv> {
     private final Iterator<FateId> fateIdIterator;
 
     // use the list of fateIds to simulate collisions on fateIds
-    public TestAccumuloStore(ClientContext context, String tableName, List<FateId> fateIds) {
+    public TestUserFateStore(ClientContext context, String tableName, List<FateId> fateIds) {
       super(context, tableName);
       this.fateIdIterator = fateIds.iterator();
     }
@@ -166,7 +167,7 @@ public class AccumuloStoreIT extends SharedMiniClusterBase {
       List<FateId> fateIds = txids.stream().map(txid -> FateId.from(fateInstanceType, txid))
           .collect(Collectors.toList());
       Set<FateId> expectedFateIds = new LinkedHashSet<>(fateIds);
-      TestAccumuloStore store = new TestAccumuloStore(client, table, fateIds);
+      TestUserFateStore store = new TestUserFateStore(client, table, fateIds);
 
       // call create and expect we get the unique txids
       for (FateId expectedFateId : expectedFateIds) {
@@ -186,7 +187,7 @@ public class AccumuloStoreIT extends SharedMiniClusterBase {
     String tableName;
     ClientContext client;
     FateId fateId;
-    TestAccumuloStore store;
+    TestUserFateStore store;
     FateStore.FateTxStore<FateIT.TestEnv> txStore;
 
     @BeforeEach
@@ -195,7 +196,7 @@ public class AccumuloStoreIT extends SharedMiniClusterBase {
       tableName = getUniqueNames(1)[0];
       createFateTable(client, tableName);
       fateId = FateId.from(fateInstanceType, UUID.randomUUID());
-      store = new TestAccumuloStore(client, tableName, List.of(fateId));
+      store = new TestUserFateStore(client, tableName, List.of(fateId));
       store.create();
       txStore = store.reserve(fateId);
     }

--- a/test/src/main/java/org/apache/accumulo/test/functional/FateConcurrencyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FateConcurrencyIT.java
@@ -266,9 +266,9 @@ public class FateConcurrencyIT extends AccumuloClusterHarness {
             new MetaFateStore<>(ZooUtil.getRoot(instanceId) + Constants.ZFATE, zk);
         var lockPath =
             ServiceLock.path(ZooUtil.getRoot(instanceId) + Constants.ZTABLE_LOCKS + "/" + tableId);
-        UserFateStore<String> as = new UserFateStore<>(context);
+        UserFateStore<String> ufs = new UserFateStore<>(context);
         Map<FateInstanceType,ReadOnlyFateStore<String>> fateStores =
-            Map.of(FateInstanceType.META, zs, FateInstanceType.USER, as);
+            Map.of(FateInstanceType.META, zs, FateInstanceType.USER, ufs);
 
         withLocks = admin.getStatus(fateStores, zk, lockPath, null, null, null);
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/FateConcurrencyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FateConcurrencyIT.java
@@ -50,9 +50,9 @@ import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.AdminUtil;
 import org.apache.accumulo.core.fate.FateInstanceType;
+import org.apache.accumulo.core.fate.MetaFateStore;
 import org.apache.accumulo.core.fate.ReadOnlyFateStore;
-import org.apache.accumulo.core.fate.ZooStore;
-import org.apache.accumulo.core.fate.accumulo.AccumuloStore;
+import org.apache.accumulo.core.fate.user.UserFateStore;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.core.lock.ServiceLock;
@@ -262,10 +262,11 @@ public class FateConcurrencyIT extends AccumuloClusterHarness {
 
         InstanceId instanceId = context.getInstanceID();
         ZooReaderWriter zk = context.getZooReader().asWriter(secret);
-        ZooStore<String> zs = new ZooStore<>(ZooUtil.getRoot(instanceId) + Constants.ZFATE, zk);
+        MetaFateStore<String> zs =
+            new MetaFateStore<>(ZooUtil.getRoot(instanceId) + Constants.ZFATE, zk);
         var lockPath =
             ServiceLock.path(ZooUtil.getRoot(instanceId) + Constants.ZTABLE_LOCKS + "/" + tableId);
-        AccumuloStore<String> as = new AccumuloStore<>(context);
+        UserFateStore<String> as = new UserFateStore<>(context);
         Map<FateInstanceType,ReadOnlyFateStore<String>> fateStores =
             Map.of(FateInstanceType.META, zs, FateInstanceType.USER, as);
 
@@ -355,7 +356,8 @@ public class FateConcurrencyIT extends AccumuloClusterHarness {
 
       InstanceId instanceId = context.getInstanceID();
       ZooReaderWriter zk = context.getZooReader().asWriter(secret);
-      ZooStore<String> zs = new ZooStore<>(ZooUtil.getRoot(instanceId) + Constants.ZFATE, zk);
+      MetaFateStore<String> zs =
+          new MetaFateStore<>(ZooUtil.getRoot(instanceId) + Constants.ZFATE, zk);
       var lockPath =
           ServiceLock.path(ZooUtil.getRoot(instanceId) + Constants.ZTABLE_LOCKS + "/" + tableId);
       AdminUtil.FateStatus fateStatus = admin.getStatus(zs, zk, lockPath, null, null, null);
@@ -385,7 +387,7 @@ public class FateConcurrencyIT extends AccumuloClusterHarness {
 
       log.trace("tid: {}", tableId);
 
-      AccumuloStore<String> as = new AccumuloStore<>(context);
+      UserFateStore<String> as = new UserFateStore<>(context);
       AdminUtil.FateStatus fateStatus = admin.getStatus(as, null, null, null);
 
       log.trace("current fates: {}", fateStatus.getTransactions().size());

--- a/test/src/main/java/org/apache/accumulo/test/functional/FunctionalTestUtils.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FunctionalTestUtils.java
@@ -60,7 +60,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.fate.AdminUtil;
 import org.apache.accumulo.core.fate.AdminUtil.FateStatus;
-import org.apache.accumulo.core.fate.ZooStore;
+import org.apache.accumulo.core.fate.MetaFateStore;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.lock.ServiceLock;
 import org.apache.accumulo.core.metadata.AccumuloTable;
@@ -231,7 +231,8 @@ public class FunctionalTestUtils {
       AdminUtil<String> admin = new AdminUtil<>(false);
       ServerContext context = cluster.getServerContext();
       ZooReaderWriter zk = context.getZooReaderWriter();
-      ZooStore<String> zs = new ZooStore<>(context.getZooKeeperRoot() + Constants.ZFATE, zk);
+      MetaFateStore<String> zs =
+          new MetaFateStore<>(context.getZooKeeperRoot() + Constants.ZFATE, zk);
       var lockPath = ServiceLock.path(context.getZooKeeperRoot() + Constants.ZTABLE_LOCKS);
       return admin.getStatus(zs, zk, lockPath, null, null, null);
     } catch (KeeperException | InterruptedException e) {


### PR DESCRIPTION
This renames ZooStore to `MetaFateStore` and AccumuloStore to `UserFateStore` to be more descriptive and better align with what the different Fate stores are used for. This also aligns the names with the FateInstanceType enum.

This closes #4253