### PR TITLE
cleaned up a few TODOs in the split code

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
@@ -719,10 +719,6 @@ class FateServiceHandler implements FateService.Iface {
       case TABLE_SPLIT: {
         TableOperation tableOp = TableOperation.SPLIT;
 
-        // ELASTICITY_TODO this does not check if table is offline for now, that is usually done in
-        // FATE operation with a table lock. Deferring that check for now as its possible tablet
-        // locks may not be needed.
-
         int SPLIT_OFFSET = 3; // offset where split data begins in arguments list
         if (arguments.size() < (SPLIT_OFFSET + 1)) {
           throw new ThriftTableOperationException(null, null, tableOp,
@@ -752,8 +748,6 @@ class FateServiceHandler implements FateService.Iface {
         endRow = endRow.getLength() == 0 ? null : endRow;
         prevEndRow = prevEndRow.getLength() == 0 ? null : prevEndRow;
 
-        // ELASTICITY_TODO create table stores splits in a file, maybe this operation should do the
-        // same
         SortedSet<Text> splits = arguments.subList(SPLIT_OFFSET, arguments.size()).stream()
             .map(ByteBufferUtil::toText).collect(Collectors.toCollection(TreeSet::new));
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/FindSplits.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/FindSplits.java
@@ -28,6 +28,7 @@ import java.util.function.Consumer;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.core.metadata.schema.Ample.ConditionalResult;
 import org.apache.accumulo.core.metadata.schema.Ample.ConditionalResult.Status;
 import org.apache.accumulo.core.metadata.schema.UnSplittableMetadata;
@@ -85,6 +86,12 @@ public class FindSplits extends ManagerRepo {
       // points.
       log.debug("Not splitting {} because it has walogs {}", tabletMetadata.getExtent(),
           tabletMetadata.getLogs().size());
+      return null;
+    }
+
+    if (manager.getContext().getTableState(extent.tableId()) != TableState.ONLINE) {
+      // The table is offline, do not bother finding splits
+      log.debug("Not splitting {} because the table is not online", tabletMetadata.getExtent());
       return null;
     }
 


### PR DESCRIPTION
Removed TODOs in the code related to #3415, #3709, #3412.  These todos were done or had issues opened.

Added some best effot checks to avoid doing splits if a table is offline. The checks have race conditions as the table lock is not acquired by the split fate op.  However as outlined in a comment on #3412 the offline code that waits could be made more comprehensive to account for this.

One TODO was handled by using
`Ample.RejectionHandler.acceptAbsentTablet()` which likely did not exists when the TODO was written.