### PR TITLE
Uncommented code in Monitor that retrieved TServer active compactions

### DIFF
--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -762,10 +762,8 @@ public class Monitor extends AbstractServer implements HighlyAvailableService {
       Client tserver = null;
       try {
         tserver = ThriftUtil.getClient(ThriftClientTypes.TABLET_SERVER, parsedServer, context);
-        // ELASTICITY_TODO tservers no longer have any compaction information, following code was
-        // commented out as the thrift calls no longer exists
-        // var compacts = tserver.getActiveCompactions(null, context.rpcCreds());
-        // allCompactions.put(parsedServer, new CompactionStats(compacts));
+        var compacts = tserver.getActiveCompactions(null, context.rpcCreds());
+        allCompactions.put(parsedServer, new CompactionStats(compacts));
         compactsFetchedNanos = System.nanoTime();
       } catch (Exception ex) {
         log.debug("Failed to get active compactions from {}", server, ex);


### PR DESCRIPTION
Code was commented out in the Monitor that called
TabletClientHandler.getActiveCompactions. This method was removed when major compactions were removed from the tserver, then restored in #3827 because we still need to report minor compaction stats to the monitor.