### PR TITLE
Removed elasticity comment to do in ExternalCompaction_2_IT

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_2_IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_2_IT.java
@@ -238,6 +238,7 @@ public class ExternalCompaction_2_IT extends SharedMiniClusterBase {
       confirmCompactionCompleted(getCluster().getServerContext(), ecids,
           TCompactionState.CANCELLED);
 
+      // Ensure compaction did not write anything to metadata table after delete table
       try (var scanner = client.createScanner(AccumuloTable.METADATA.tableName())) {
         scanner.setRange(MetadataSchema.TabletsSection.getRange(tid));
         assertEquals(0, scanner.stream().count());

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_2_IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_2_IT.java
@@ -238,9 +238,6 @@ public class ExternalCompaction_2_IT extends SharedMiniClusterBase {
       confirmCompactionCompleted(getCluster().getServerContext(), ecids,
           TCompactionState.CANCELLED);
 
-      // ELASTICITY_TODO make delete table fate op get operation ids before deleting
-      // there should be no metadata for the table, check to see if the compaction wrote anything
-      // after table delete
       try (var scanner = client.createScanner(AccumuloTable.METADATA.tableName())) {
         scanner.setRange(MetadataSchema.TabletsSection.getRange(tid));
         assertEquals(0, scanner.stream().count());


### PR DESCRIPTION
The comment said that the operation id needed to be set when deleting the tablets. This is now done in ReserveTablets.isReady.