### PR TITLE
Removed TODO in TabletRefresher

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/TabletRefresher.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/TabletRefresher.java
@@ -171,9 +171,6 @@ public class TabletRefresher {
     } catch (TException ex) {
       log.debug("rpc failed server: " + location + ", " + logId + " " + ex.getMessage(), ex);
 
-      // ELASTICITY_TODO are there any other exceptions we should catch in this method and check if
-      // the tserver is till alive?
-
       // something went wrong w/ RPC return all extents as unrefreshed
       return refreshes;
     } finally {


### PR DESCRIPTION
Other exceptions which could be more serious than TException would be raised as an ExecutionException when get() is called on the Future and would result in a RuntimeException being raised from TabletRefresher.refreshTablets. If a TException is thrown, then the refresh for all of the Tablets will be retried unless the TabletServer is no longer online.