### PR TITLE
Fix Illegal Reflective Access Warning in Shell

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -624,7 +624,7 @@
       <dependency>
         <groupId>org.jline</groupId>
         <artifactId>jline</artifactId>
-        <version>3.24.1</version>
+        <version>3.25.1</version>
       </dependency>
       <dependency>
         <groupId>org.latencyutils</groupId>

--- a/shell/src/test/java/org/apache/accumulo/shell/commands/HistoryCommandTest.java
+++ b/shell/src/test/java/org/apache/accumulo/shell/commands/HistoryCommandTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.shell.commands;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
@@ -38,7 +39,7 @@ import org.jline.reader.LineReaderBuilder;
 import org.jline.reader.impl.DefaultExpander;
 import org.jline.reader.impl.history.DefaultHistory;
 import org.jline.terminal.Terminal;
-import org.jline.terminal.TerminalBuilder;
+import org.jline.terminal.impl.ExternalTerminal;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -69,8 +70,8 @@ public class HistoryCommandTest {
     baos = new ByteArrayOutputStream();
 
     String input = String.format("!1%n"); // Construct a platform dependent new-line
-    terminal = TerminalBuilder.builder().system(false)
-        .streams(new ByteArrayInputStream(input.getBytes()), baos).build();
+    terminal = new ExternalTerminal("shell", "ansi", new ByteArrayInputStream(input.getBytes()),
+        baos, UTF_8);
     reader = LineReaderBuilder.builder().history(history).terminal(terminal).build();
 
     shell = new Shell(reader);
@@ -80,8 +81,8 @@ public class HistoryCommandTest {
   public void testCorrectNumbering() throws IOException {
     command.execute("", cl, shell);
     terminal.writer().flush();
-
-    assertTrue(baos.toString().contains("2: bar"));
+    assertTrue(baos.toString().contains("2: bar"),
+        "History order is not correct: " + baos.toString());
   }
 
   @Test


### PR DESCRIPTION
Jline `3.24.1` throws an illegal reflective access warning when starting an accumulo shell.

```
$ ./accumulo shell
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.jline.terminal.impl.exec.ExecTerminalProvider$ReflectionRedirectPipeCreator (file:/data/workspace/fluo-uno/install/accumulo-2.1.3-SNAPSHOT/lib/jline-3.24.1.jar) to constructor java.lang.ProcessBuilder$RedirectPipeImpl()
WARNING: Please consider reporting this to the maintainers of org.jline.terminal.impl.exec.ExecTerminalProvider$ReflectionRedirectPipeCreator
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release

Shell - Apache Accumulo Interactive Shell
- 
- version: 2.1.3-SNAPSHOT
- instance name: uno
- instance id: ad82aa87-f2a2-4bfd-afa4-fc87f0384715
- 
- type 'help' for a list of available commands
- 
root@uno> exit
```
This only shows up when using java 11 and does not appear when using java 17.

This change updates jline to version `3.25.1` which fixes the reflective access issue.

Test was updated because the TerminalBuilder now returns a `PosixPtyTerminal` vs hitting an `UnsupportedOperationException` and returning an `ExternalTerminal`.

Modified the test to return the same `ExternalTerminal` that was created with Jline 3.24.1.

`PosixPtyTerminal` does not set the writer to the `out` stream which was failing the test 
https://github.com/jline/jline3/blob/c75301facc8716b59c1d57d3e3c5943358022560/terminal/src/main/java/org/jline/terminal/impl/PosixPtyTerminal.java#L77