### PR TITLE
avoids acquiring recovery lock when tablet has no wals

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/AssignmentHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/AssignmentHandler.java
@@ -156,9 +156,7 @@ class AssignmentHandler implements Runnable {
     Tablet tablet = null;
     boolean successful = false;
 
-    try {
-      server.acquireRecoveryMemory(extent);
-
+    try (var recoveryMemory = server.acquireRecoveryMemory(tabletMetadata)) {
       TabletResourceManager trm = server.resourceManager.createTabletResourceManager(extent,
           server.getTableConfiguration(extent));
       TabletData data = new TabletData(tabletMetadata);
@@ -205,8 +203,6 @@ class AssignmentHandler implements Runnable {
       TableId tableId = extent.tableId();
       ProblemReports.getInstance(server.getContext()).report(new ProblemReport(tableId, TABLET_LOAD,
           extent.getUUID().toString(), server.getClientAddressString(), e));
-    } finally {
-      server.releaseRecoveryMemory(extent);
     }
 
     if (successful) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -533,9 +533,11 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
     managerMessages.addLast(m);
   }
 
+  private static final AutoCloseable NOOP_CLOSEABLE = () -> {};
+
   AutoCloseable acquireRecoveryMemory(TabletMetadata tabletMetadata) {
     if (tabletMetadata.getExtent().isMeta() || tabletMetadata.getLogs().isEmpty()) {
-      return () -> {};
+      return NOOP_CLOSEABLE;
     } else {
       recoveryLock.lock();
       return recoveryLock::unlock;


### PR DESCRIPTION
Tablet servers have a lock for recovery that has the purpose of preventing concurrent recovery of tablets using too much memory. This lock is acquired for tablets that have no walogs and will therefore do no recovery.  This commit changes the code to only obtain the lock when there are walogs.

Noticed this while reviewing #4404 and while researching found [ACCUMULO-1543](https://issues.apache.org/jira/browse/ACCUMULO-1543) which is an existing issue describing this change.