### PR TITLE
WIP: Scan Server discussion

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
@@ -30,6 +30,7 @@ import java.lang.Thread.UncaughtExceptionHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -60,6 +61,7 @@ import org.apache.accumulo.core.client.Durability;
 import org.apache.accumulo.core.client.MultiTableBatchWriter;
 import org.apache.accumulo.core.client.NamespaceNotFoundException;
 import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.ScannerBase.ConsistencyLevel;
 import org.apache.accumulo.core.client.TableDeletedException;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.TableOfflineException;
@@ -801,6 +803,11 @@ public class ClientContext implements AccumuloClient {
     Integer batchSize = ClientProperty.SCANNER_BATCH_SIZE.getInteger(getProperties());
     if (batchSize != null) {
       scanner.setBatchSize(batchSize);
+    }
+    String[] tables =
+        ClientProperty.SCANNER_CONSISTENCY_SCAN_LEVEL.getValue(getProperties()).split(",");
+    if (Arrays.asList(tables).contains(tableName)) {
+      scanner.setConsistencyLevel(ConsistencyLevel.EVENTUAL);
     }
     return scanner;
   }

--- a/core/src/main/java/org/apache/accumulo/core/conf/ClientProperty.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ClientProperty.java
@@ -91,6 +91,8 @@ public enum ClientProperty {
   // Scanner
   SCANNER_BATCH_SIZE("scanner.batch.size", "1000", PropertyType.COUNT,
       "Number of key/value pairs that will be fetched at time from tablet server", "2.0.0", false),
+  SCANNER_CONSISTENCY_SCAN_LEVEL("scanner.consistency.level.eventual", "", PropertyType.STRING,
+      "List of table names that can be scanned via scan servers", "2.1.3", false),
 
   SCAN_SERVER_SELECTOR("scan.server.selector.impl", ConfigurableScanServerSelector.class.getName(),
       PropertyType.CLASSNAME, "Class used by client to find Scan Servers", "2.1.0", false),


### PR DESCRIPTION
Added client property for a list of tables that support eventual scanning.

Scanning level can be overridden by calling setConsistencyLevel() on the created scanner object.