### PR TITLE
Update TabletMetadata to be immutable

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/TabletLocationState.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/TabletLocationState.java
@@ -22,6 +22,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.accumulo.core.dataImpl.KeyExtent;
@@ -58,7 +59,7 @@ public class TabletLocationState {
 
   public TabletLocationState(KeyExtent extent, Location future, Location current, Location last,
       SuspendingTServer suspend, Collection<LogEntry> walogs) throws BadLocationStateException {
-    this.extent = extent;
+    this.extent = Objects.requireNonNull(extent);
     this.future = validateLocation(future, TabletMetadata.LocationType.FUTURE);
     this.current = validateLocation(current, TabletMetadata.LocationType.CURRENT);
     this.last = validateLocation(last, TabletMetadata.LocationType.LAST);

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -391,7 +391,6 @@ public class TabletMetadata {
     ensureFetched(ColumnType.LOCATION);
     ensureFetched(ColumnType.LAST);
     ensureFetched(ColumnType.SUSPEND);
-    ensureFetched(ColumnType.PREV_ROW);
     try {
       Location current = null;
       Location future = null;
@@ -516,15 +515,17 @@ public class TabletMetadata {
       }
     }
 
-    return tmBuilder.fetchedCols(fetchedColumns).build();
+    return tmBuilder.build(fetchedColumns);
   }
 
   @VisibleForTesting
   static TabletMetadata create(String id, String prevEndRow, String endRow) {
-    return new Builder().table(TableId.of(id)).sawPrevEndRow(true)
-        .prevEndRow(prevEndRow == null ? null : new Text(prevEndRow))
-        .endRow(endRow == null ? null : new Text(endRow))
-        .fetchedCols(EnumSet.of(ColumnType.PREV_ROW)).build();
+    final var tmBuilder = new Builder();
+    tmBuilder.table(TableId.of(id));
+    tmBuilder.sawPrevEndRow(true);
+    tmBuilder.prevEndRow(prevEndRow == null ? null : new Text(prevEndRow));
+    tmBuilder.endRow(endRow == null ? null : new Text(endRow));
+    return tmBuilder.build(EnumSet.of(ColumnType.PREV_ROW));
   }
 
   /**
@@ -585,129 +586,103 @@ public class TabletMetadata {
         ExternalCompactionMetadata> extCompactions = ImmutableMap.builder();
     private boolean merged;
 
-    Builder table(TableId tableId) {
+    void table(TableId tableId) {
       this.tableId = tableId;
-      return this;
     }
 
-    Builder endRow(Text endRow) {
+    void endRow(Text endRow) {
       this.endRow = endRow;
-      return this;
     }
 
-    Builder prevEndRow(Text prevEndRow) {
+    void prevEndRow(Text prevEndRow) {
       this.prevEndRow = prevEndRow;
-      return this;
     }
 
-    Builder sawPrevEndRow(boolean sawPrevEndRow) {
+    void sawPrevEndRow(boolean sawPrevEndRow) {
       this.sawPrevEndRow = sawPrevEndRow;
-      return this;
     }
 
-    Builder oldPrevEndRow(Text oldPrevEndRow) {
+    void oldPrevEndRow(Text oldPrevEndRow) {
       this.oldPrevEndRow = oldPrevEndRow;
-      return this;
     }
 
-    Builder sawOldPrevEndRow(boolean sawOldPrevEndRow) {
+    void sawOldPrevEndRow(boolean sawOldPrevEndRow) {
       this.sawOldPrevEndRow = sawOldPrevEndRow;
-      return this;
     }
 
-    Builder splitRatio(Double splitRatio) {
+    void splitRatio(Double splitRatio) {
       this.splitRatio = splitRatio;
-      return this;
     }
 
-    Builder dirName(String dirName) {
+    void dirName(String dirName) {
       this.dirName = dirName;
-      return this;
     }
 
-    Builder time(MetadataTime time) {
+    void time(MetadataTime time) {
       this.time = time;
-      return this;
     }
 
-    Builder flush(long flush) {
+    void flush(long flush) {
       this.flush = OptionalLong.of(flush);
-      return this;
     }
 
-    Builder compact(long compact) {
+    void compact(long compact) {
       this.compact = OptionalLong.of(compact);
-      return this;
     }
 
-    Builder file(StoredTabletFile stf, DataFileValue dfv) {
+    void file(StoredTabletFile stf, DataFileValue dfv) {
       this.files.put(stf, dfv);
-      return this;
     }
 
-    Builder loadedFile(StoredTabletFile stf, Long tid) {
+    void loadedFile(StoredTabletFile stf, Long tid) {
       this.loadedFiles.put(stf, tid);
-      return this;
     }
 
-    Builder location(String val, String qual, LocationType lt) {
+    void location(String val, String qual, LocationType lt) {
       if (location != null) {
         throw new IllegalStateException("Attempted to set second location for tableId: " + tableId
             + " endrow: " + endRow + " -- " + location + " " + qual + " " + val);
       }
       this.location = new Location(val, qual, lt);
-      return this;
     }
 
-    Builder last(Location last) {
+    void last(Location last) {
       this.last = last;
-      return this;
     }
 
-    Builder suspend(SuspendingTServer suspend) {
+    void suspend(SuspendingTServer suspend) {
       this.suspend = suspend;
-      return this;
     }
 
-    Builder scan(StoredTabletFile stf) {
+    void scan(StoredTabletFile stf) {
       this.scans.add(stf);
-      return this;
     }
 
-    Builder cloned(String cloned) {
+    void cloned(String cloned) {
       this.cloned = cloned;
-      return this;
     }
 
-    Builder log(LogEntry log) {
+    void log(LogEntry log) {
       this.logs.add(log);
-      return this;
     }
 
-    Builder extCompaction(ExternalCompactionId id, ExternalCompactionMetadata metadata) {
+    void extCompaction(ExternalCompactionId id, ExternalCompactionMetadata metadata) {
       this.extCompactions.put(id, metadata);
-      return this;
     }
 
-    Builder merged(boolean merged) {
+    void merged(boolean merged) {
       this.merged = merged;
-      return this;
     }
 
-    Builder fetchedCols(EnumSet<ColumnType> fetchedCols) {
-      this.fetchedCols = fetchedCols;
-      return this;
-    }
-
-    Builder keyValue(Key key, Value value) {
+    void keyValue(Key key, Value value) {
       if (this.keyValues == null) {
         this.keyValues = ImmutableSortedMap.naturalOrder();
       }
       this.keyValues.put(key, value);
-      return this;
     }
 
-    TabletMetadata build() {
+    TabletMetadata build(EnumSet<ColumnType> fetchedCols) {
+      this.fetchedCols = fetchedCols;
       return new TabletMetadata(this);
     }
   }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -121,7 +121,7 @@ public class TabletMetadata {
     this.files = Objects.requireNonNull(tmBuilder.files.build());
     this.scans = Objects.requireNonNull(tmBuilder.scans.build());
     this.loadedFiles = tmBuilder.loadedFiles.build();
-    this.fetchedCols = tmBuilder.fetchedCols;
+    this.fetchedCols = Objects.requireNonNull(tmBuilder.fetchedCols);
     this.last = tmBuilder.last;
     this.suspend = tmBuilder.suspend;
     this.dirName = tmBuilder.dirName;


### PR DESCRIPTION
This commit refactors all of the fields to be final for TabletMetadata. The object is already treated as immutable in practice, but previously didn't declare fields final so this could lead to potential future bugs and also means not being able to guarantee the state of a field which is now possible.

This was originally done this way to make the construction of the object simpler when constructing from a row as there are so many fields. This refactoring adds a new builder that is used to construct the object and passes that to the constructor so we don't need constructor arguments for all values which simplifies things.

This change will now allow verifying state going forward during construction (such as requiring the files map to be non null) which should reduce the chance for future bugs. This also makes the object thread safe by making all fields final and immutable.

I came up with the idea to make this change due to the comment [here](https://github.com/apache/accumulo/pull/4404#discussion_r1546945822) . With the field being final we can now guarantee that getLogs() will never return null.

A couple notes:

1. I went ahead and added a few non null checks but more could be added, several of the fields can be null so left them alone. 
2. I used a supplier for returning the extent because that requires prevEndRow to be fetched which is not always the case. This also led to uncovering a potential bug with getTabletState() when creating `TabletLocationState` where the extent was [passed](https://github.com/apache/accumulo/blob/b912506d43fbac9477aa3efb9ea81d39ce4d1a5c/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java#L374) but could have been null so ~~I fixed that as well and added a null check and also added a check to ensure that prevEndRow as fetched.~~ This was fixed in #4438 
3. I updated the `testAllColumns()` test inside of `TabletMetadataTest` to include missing fields and ran with code coverage which verified all the new builder methods were used. This in combination with the existing tests should have enough test coverage.
4. I decided to make this change in main and not 2.1 as it has a small chance to introduce bugs and the metadata schema should not be changed there anyways. When this is merged to main I can fix the merge issues and update elasticity as there are some extra fields there.