### PR TITLE
batches reading tablet metadata for refresh

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
@@ -1107,9 +1107,7 @@ public class TabletClientHandler implements TabletServerClientService.Iface,
       var extent = KeyExtent.fromThrift(tkextent);
       var tablet = tabletsSnapshot.get(extent);
       if (tablet != null) {
-        tablet.startRefresh().ifPresentOrElse(
-            refreshSession -> refreshSessions.put(extent, refreshSession),
-            () -> unableToRefresh.add(extent.toThrift()));
+        refreshSessions.put(extent, tablet.startRefresh());
       } else {
         unableToRefresh.add(extent.toThrift());
       }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
@@ -1099,7 +1099,7 @@ public class TabletClientHandler implements TabletServerClientService.Iface,
 
     Map<KeyExtent,Tablet.RefreshSession> refreshSessions = new HashMap<>();
 
-    // Created this as synchronized list because it passed to a lambda that could possibly run in
+    // Created this as synchronized list because it's passed to a lambda that could possibly run in
     // another thread.
     List<TKeyExtent> unableToRefresh = Collections.synchronizedList(new ArrayList<>());
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
@@ -31,6 +31,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -1096,80 +1097,49 @@ public class TabletClientHandler implements TabletServerClientService.Iface,
     // handle that more expensive case if needed.
     var tabletsSnapshot = server.getOnlineTablets();
 
-    Set<KeyExtent> notFound = new HashSet<>();
+    Map<KeyExtent,Tablet.RefreshSession> refreshSessions = new HashMap<>();
+
+    // Created this as synchronized list because it passed to a lambda that could possibly run in
+    // another thread.
+    List<TKeyExtent> unableToRefresh = Collections.synchronizedList(new ArrayList<>());
 
     for (var tkextent : refreshes) {
       var extent = KeyExtent.fromThrift(tkextent);
-
       var tablet = tabletsSnapshot.get(extent);
       if (tablet != null) {
-        // ELASTICITY_TODO use a batch reader to read all tablets metadata at once instead of one by
-        // one. This may be a bit tricky from a synchronization perspective (with multiple tablets
-        // and multiple concurrent refresh request), so defer doing this until after removing
-        // functionality from the tablet. No need to make the change now and have to change it
-        // later.
-        tablet.refreshMetadata(RefreshPurpose.REFRESH_RPC);
+        tablet.startRefresh().ifPresentOrElse(
+            refreshSession -> refreshSessions.put(extent, refreshSession),
+            () -> unableToRefresh.add(extent.toThrift()));
       } else {
-        notFound.add(extent);
+        unableToRefresh.add(extent.toThrift());
       }
     }
 
-    if (!notFound.isEmpty()) {
-      // Some tablets were not found, lets see if they are loading or moved to online while doing
-      // the refreshes above.
-      List<TKeyExtent> unableToRefresh = new ArrayList<>();
-      List<Tablet> foundTablets = new ArrayList<>();
-
-      synchronized (server.unopenedTablets) {
-        synchronized (server.openingTablets) {
-          synchronized (server.onlineTablets) {
-            // Get the snapshot again, however this time nothing will be changing while we iterate
-            // over the snapshot because all three locks are held.
-            tabletsSnapshot = server.getOnlineTablets();
-            for (var extent : notFound) {
-              // TODO investigate if its safe to ignore tablets in the unopened set because they
-              // have not yet read any metadata
-              if (server.unopenedTablets.contains(extent)
-                  || server.openingTablets.contains(extent)) {
-                // Can not refresh these tablets that are in the process of loading, but they may
-                // still need refreshing because we don't know when they read their metadata
-                // relative to the refresh event.
-                unableToRefresh.add(extent.toThrift());
-              } else {
-                var tablet = tabletsSnapshot.get(extent);
-                if (tablet != null) {
-                  // Intentionally not calling refresh on the tablet while holding these locks.
-                  foundTablets.add(tablet);
-                }
-              }
-            }
-
-            // If a tablet is not in any of the three sets then that is ok, it either means the
-            // tablet has not begun to load at all yet in which case it will see the metadata when
-            // it does load later OR it means the tablet has already completely unloaded. There is
-            // nothing to report back for either case.
-          }
+    // Read the metadata for all of the tablets that need to be refreshed. Its very important that
+    // this metadata read is done after calling Tablet.startRefresh, this is because the refresh
+    // session can detect changes that may necessitate rereading the tablet metadata. The refresh
+    // session assumes the metadata was read after the session was created in order to determine if
+    // its still valid.
+    try (var tabletsMeta = context.getAmple().readTablets()
+        .forTablets(refreshSessions.keySet(), Optional.of(e -> unableToRefresh.add(e.toThrift())))
+        .build()) {
+      for (var tabletMeta : tabletsMeta) {
+        var refreshSession = refreshSessions.get(tabletMeta.getExtent());
+        if (!refreshSession.refreshMetadata(RefreshPurpose.REFRESH_RPC, tabletMeta)) {
+          unableToRefresh.add(tabletMeta.getExtent().toThrift());
         }
       }
-
-      for (var tablet : foundTablets) {
-        tablet.refreshMetadata(RefreshPurpose.REFRESH_RPC);
-      }
-
-      if (log.isDebugEnabled()) {
-        for (var extent : unableToRefresh) {
-          // these tablet could hold up bulk import, lets logs the specific tablet in case it stays
-          // like this
-          log.debug("Unable to refresh tablet that is currently loading : {}",
-              KeyExtent.fromThrift(extent));
-        }
-      }
-
-      return unableToRefresh;
     }
 
-    // no problematic extents to report
-    return List.of();
+    if (log.isDebugEnabled()) {
+      for (var extent : unableToRefresh) {
+        // these tablet could hold up bulk import, lets logs the specific tablet in case it stays
+        // like this
+        log.debug("Unable to refresh tablet : {}", KeyExtent.fromThrift(extent));
+      }
+    }
+
+    return unableToRefresh;
   }
 
   @Override

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -1592,9 +1592,11 @@ public class Tablet extends TabletBase {
 
       // if the tablet metadata passed in is stale, then reread it
       if (observedRefreshCount == null || !observedRefreshCount.equals(this.refreshCount)) {
-        log.debug(
-            "Metadata read outside of refresh lock is no longer valid, rereading metadata. {} {} {}",
-            extent, observedRefreshCount, this.refreshCount);
+        if (observedRefreshCount != null) {
+          log.debug(
+              "Metadata read outside of refresh lock is no longer valid, rereading metadata. {} {} {}",
+              extent, observedRefreshCount, this.refreshCount);
+        }
         // do not want to hold tablet lock while doing metadata read as this could negatively impact
         // scans
         tabletMetadata = getContext().getAmple().readTablet(getExtent());


### PR DESCRIPTION
Changes tablet server code that refreshes tablet metadata to read tablet metadata for multiple tablets in a batch.  Also noticed the refresh code was not handling some race condition correctly and could result in spurious error messages.  It was also not handling closed tablets. Refactored the code to return false when refresh is not possble for acceptable reasons instead of throw an error.  This will cause the the RPC to retry for those tablets later.  Also remove some code that was attempting to handle complex race conditions that would be hard to test, realized if these conditions do happen that it would be best to retry rather than try to handle them.