### PR TITLE
Logged msg instead of throwing exception in setFutureLocations

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/AbstractTabletStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/AbstractTabletStateStore.java
@@ -96,9 +96,8 @@ public abstract class AbstractTabletStateStore implements TabletStateStore {
 
       for (Entry<KeyExtent,ConditionalResult> entry : results.entrySet()) {
         if (entry.getValue().getStatus() != Status.ACCEPTED) {
-          LOG.debug(
-              "Failed to set future location for {}, likely concurrent FATE operation or non-empty location",
-              entry.getKey());
+          LOG.debug("Likely concurrent FATE operation prevented setting future location for {}, "
+              + "Manager will retry soon.", entry.getKey());
         }
       }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/AbstractTabletStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/AbstractTabletStateStore.java
@@ -21,21 +21,27 @@ package org.apache.accumulo.server.manager.state;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.schema.Ample;
+import org.apache.accumulo.core.metadata.schema.Ample.ConditionalResult;
 import org.apache.accumulo.core.metadata.schema.Ample.ConditionalResult.Status;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.LocationType;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
 import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 
 public abstract class AbstractTabletStateStore implements TabletStateStore {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractTabletStateStore.class);
 
   private final Ample ample;
 
@@ -86,11 +92,14 @@ public abstract class AbstractTabletStateStore implements TabletStateStore {
             });
       }
 
-      var results = tabletsMutator.process();
+      Map<KeyExtent,ConditionalResult> results = tabletsMutator.process();
 
-      if (results.values().stream().anyMatch(result -> result.getStatus() != Status.ACCEPTED)) {
-        throw new DistributedStoreException(
-            "failed to set tablet location, conditional mutation failed. ");
+      for (Entry<KeyExtent,ConditionalResult> entry : results.entrySet()) {
+        if (entry.getValue().getStatus() != Status.ACCEPTED) {
+          LOG.debug(
+              "Failed to set future location for {}, likely concurrent FATE operation or non-empty location",
+              entry.getKey());
+        }
       }
 
     } catch (RuntimeException ex) {


### PR DESCRIPTION
AbstractTabletStateStore.setFutureLocations was throwing an exception
when it could not set a future location in a tablets metadata. However,
it's possible that a concurrent FATE operation could prevent this and
this is not an error conditition. Modified the code to log a msg instead
as TabletGroupWatcher in the Manager will retry to assign the tablet when
the FATE operation has concluded and assignment is still needed.