### PR TITLE
fixes bug with starting multiple group of scan servers

### DIFF
--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -141,7 +141,7 @@ function control_service() {
     ACCUMULO_SERVICE_INSTANCE=""
     [[ $service == "tserver" && ${NUM_TSERVERS:-1} -gt 1 ]] && ACCUMULO_SERVICE_INSTANCE=${inst_id}
     [[ $service == "compactor" ]] && ACCUMULO_SERVICE_INSTANCE="${inst_id}_${5}"
-    [[ $service == "sserver" && ${NUM_SSERVERS:-1} -gt 1 ]] && ACCUMULO_SERVICE_INSTANCE=${inst_id}
+    [[ $service == "sserver" ]] && ACCUMULO_SERVICE_INSTANCE="${inst_id}_${5}"
 
     if [[ $host == localhost || $host == "$(hostname -s)" || $host == "$(hostname -f)" || "$(hostname -I)" =~ $host ]]; then
       #


### PR DESCRIPTION
When trying to start and stop multiple groups of scan servers using the accumulo-cluster script the groups would interfere with each other. This change fixes that by making the the scan servers use the group in the instance id like compactors do.

Ran into this while workiing on #4444 and pulled it out as a stand alone fix.