### PR TITLE
fixes conditional mutation bug when loading tablet

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanfileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanfileManager.java
@@ -144,7 +144,7 @@ class ScanfileManager {
     }
   }
 
-  void removeFilesAfterScan(Collection<StoredTabletFile> scanFiles) {
+  void removeFilesAfterScan(Collection<StoredTabletFile> scanFiles, Location location) {
     if (scanFiles.isEmpty()) {
       return;
     }
@@ -163,8 +163,7 @@ class ScanfileManager {
 
     if (!filesToDelete.isEmpty()) {
       log.debug("Removing scan refs from metadata {} {}", tablet.getExtent(), filesToDelete);
-      var currLoc = Location.current(tablet.getTabletServer().getTabletSession());
-      removeScanFiles(tablet.getExtent(), filesToDelete, tablet.getContext(), currLoc,
+      removeScanFiles(tablet.getExtent(), filesToDelete, tablet.getContext(), location,
           tablet.getTabletServer().getLock());
     }
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -326,7 +326,8 @@ public class Tablet extends TabletBase {
 
     computeNumEntries();
 
-    getScanfileManager().removeFilesAfterScan(metadata.getScans());
+    getScanfileManager().removeFilesAfterScan(metadata.getScans(),
+        Location.future(tabletServer.getTabletSession()));
   }
 
   public TabletMetadata getMetadata() {
@@ -1614,7 +1615,8 @@ public class Tablet extends TabletBase {
     }
 
     if (refreshPurpose == RefreshPurpose.REFRESH_RPC) {
-      scanfileManager.removeFilesAfterScan(getMetadata().getScans());
+      scanfileManager.removeFilesAfterScan(getMetadata().getScans(),
+          Location.current(tabletServer.getTabletSession()));
     }
   }
 


### PR DESCRIPTION
In #4436 a tablet update was moved to use conditional mutations. The changed checked tablets current location in the conditional update. However when this code was called in the Tablet constructor the tablet server was the future location.  Adjusted to code to check for the future location when calling from the constructor.