### PR TITLE
Renames split property to avoid tserver

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -395,6 +395,13 @@ public enum Property {
           + "indefinitely. Default is 0 to block indefinitely. Only valid when tserver available "
           + "threshold is set greater than 0.",
       "1.10.0"),
+  SPLIT_MAXOPEN("split.files.max", "300", PropertyType.COUNT,
+      "To find a tablets split points, all RFiles are opened and their indexes"
+          + " are read. This setting determines how many RFiles can be opened at once."
+          + " When there are more RFiles than this setting multiple passes must be"
+          + " made, which is slower. However opening too many RFiles at once can cause"
+          + " problems.",
+      "3.1.0"),
   // properties that are specific to scan server behavior
   @Experimental
   SSERV_PREFIX("sserver.", null, PropertyType.PREFIX,
@@ -496,6 +503,8 @@ public enum Property {
   TSERV_TOTAL_MUTATION_QUEUE_MAX("tserver.total.mutation.queue.max", "5%", PropertyType.MEMORY,
       "The amount of memory used to store write-ahead-log mutations before flushing them.",
       "1.7.0"),
+  @ReplacedBy(property = SPLIT_MAXOPEN)
+  @Deprecated(since = "3.1")
   TSERV_TABLET_SPLIT_FINDMIDPOINT_MAXOPEN("tserver.tablet.split.midpoint.files.max", "300",
       PropertyType.COUNT,
       "To find a tablets split points, all RFiles are opened and their indexes"

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -395,6 +395,8 @@ public enum Property {
           + "indefinitely. Default is 0 to block indefinitely. Only valid when tserver available "
           + "threshold is set greater than 0.",
       "1.10.0"),
+  SPLIT_PREFIX("split.", null, PropertyType.PREFIX,
+      "System wide properties related to splitting tablets.", "3.1.0"),
   SPLIT_MAXOPEN("split.files.max", "300", PropertyType.COUNT,
       "To find a tablets split points, all RFiles are opened and their indexes"
           + " are read. This setting determines how many RFiles can be opened at once."

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
@@ -33,6 +33,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
+import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.PartialKey;
@@ -214,8 +215,7 @@ public class FileUtil {
 
     Path tmpDir = null;
 
-    int maxToOpen =
-        context.getConfiguration().getCount(Property.TSERV_TABLET_SPLIT_FINDMIDPOINT_MAXOPEN);
+    int maxToOpen = getMaxFilesToOpen(context.getConfiguration());
     ArrayList<FileSKVIterator> readers = new ArrayList<>(dataFiles.size());
 
     try {
@@ -276,6 +276,12 @@ public class FileUtil {
     }
   }
 
+  @SuppressWarnings("deprecation")
+  private static int getMaxFilesToOpen(AccumuloConfiguration conf) {
+    return conf.getCount(
+        conf.resolve(Property.SPLIT_MAXOPEN, Property.TSERV_TABLET_SPLIT_FINDMIDPOINT_MAXOPEN));
+  }
+
   /**
    *
    * @param dataFiles - list of data files to find the mid point key
@@ -294,8 +300,7 @@ public class FileUtil {
 
     Path tmpDir = null;
 
-    int maxToOpen =
-        context.getConfiguration().getCount(Property.TSERV_TABLET_SPLIT_FINDMIDPOINT_MAXOPEN);
+    int maxToOpen = getMaxFilesToOpen(context.getConfiguration());
     ArrayList<FileSKVIterator> readers = new ArrayList<>(dataFiles.size());
 
     try {


### PR DESCRIPTION
In 4.0.0 split code will no longer run in the tablet server.  This change deprecates a split related property that includes tablet server in the property perfix and replaces it with a property that does not include tablet sever.