### PR TITLE
fixes continue scan in tablet mgmt iterator

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementIterator.java
@@ -217,7 +217,11 @@ public class TabletManagementIterator extends SkippingIterator {
           // can pull this K,V pair from the results by looking at the colf.
           TabletManagement.addActions(decodedRow, actions);
         }
-        topKey = decodedRow.firstKey();
+
+        // This key is being created exactly the same way as the whole row iterator creates keys.
+        // This is important for ensuring that seek works as expected in the continue case. See
+        // WholeRowIterator seek function for details, it looks for keys w/o columns.
+        topKey = new Key(decodedRow.firstKey().getRow());
         topValue = WholeRowIterator.encodeRow(new ArrayList<>(decodedRow.keySet()),
             new ArrayList<>(decodedRow.values()));
         LOG.trace("Returning extent {} with reasons: {}", tm.getExtent(), actions);


### PR DESCRIPTION
Many places in the accumulo code will read a batch of key/values and then use the last key in the batch to construct a range to get the next batch.  The last key in the batch will be a non inclusive start key for the range.  The tablet mgmt iterator was not handling this case and returning the key that should have been excluded.