### PR TITLE
WIP add reservation related metrics to scan server

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metrics/MetricsProducer.java
+++ b/core/src/main/java/org/apache/accumulo/core/metrics/MetricsProducer.java
@@ -676,6 +676,7 @@ public interface MetricsProducer {
 
   String METRICS_SSERVER_PREFIX = "accumulo.sserver.";
   String METRICS_SSERVER_REGISTRATION_TIMER = METRICS_SSERVER_PREFIX + "registration.timer";
+  String METRICS_SSERVER_BUSY_COUNTER = METRICS_SSERVER_PREFIX + "busy.count";
 
   String METRICS_THRIFT_PREFIX = "accumulo.thrift.";
   String METRICS_THRIFT_EXECUTE = METRICS_THRIFT_PREFIX + "execute";

--- a/core/src/main/java/org/apache/accumulo/core/metrics/MetricsProducer.java
+++ b/core/src/main/java/org/apache/accumulo/core/metrics/MetricsProducer.java
@@ -674,6 +674,9 @@ public interface MetricsProducer {
   String METRICS_TSERVER_SCAN_RESULTS_BYTES = METRICS_TSERVER_PREFIX + "scan.results.bytes";
   String METRICS_TSERVER_SCANNED_ENTRIES = METRICS_TSERVER_PREFIX + "scan.scanned.entries";
 
+  String METRICS_SSERVER_PREFIX = "accumulo.sserver.";
+  String METRICS_SSERVER_REGISTRATION_TIMER = METRICS_SSERVER_PREFIX + "registration.timer";
+
   String METRICS_THRIFT_PREFIX = "accumulo.thrift.";
   String METRICS_THRIFT_EXECUTE = METRICS_THRIFT_PREFIX + "execute";
   String METRICS_THRIFT_IDLE = METRICS_THRIFT_PREFIX + "idle";

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServerMetrics.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServerMetrics.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.tserver;
+
+import org.apache.accumulo.core.metrics.MetricsProducer;
+import org.apache.accumulo.core.metrics.MetricsUtil;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+
+public class ScanServerMetrics implements MetricsProducer {
+
+  private Timer reservationTimer;
+
+  @Override
+  public void registerMetrics(MeterRegistry registry) {
+    reservationTimer = Timer.builder(MetricsProducer.METRICS_SSERVER_REGISTRATION_TIMER)
+        .description("Time to reserve a tablets files for scan").tags(MetricsUtil.getCommonTags())
+        .register(registry);
+  }
+
+  public Timer getReservationTimer() {
+    return reservationTimer;
+  }
+
+}

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServerMetrics.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServerMetrics.java
@@ -21,22 +21,30 @@ package org.apache.accumulo.tserver;
 import org.apache.accumulo.core.metrics.MetricsProducer;
 import org.apache.accumulo.core.metrics.MetricsUtil;
 
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 
 public class ScanServerMetrics implements MetricsProducer {
 
   private Timer reservationTimer;
+  private Counter busyCounter;
 
   @Override
   public void registerMetrics(MeterRegistry registry) {
     reservationTimer = Timer.builder(MetricsProducer.METRICS_SSERVER_REGISTRATION_TIMER)
         .description("Time to reserve a tablets files for scan").tags(MetricsUtil.getCommonTags())
         .register(registry);
+    busyCounter = Counter.builder(MetricsProducer.METRICS_SSERVER_BUSY_COUNTER)
+        .description("The number of scans where a busy timeout happened")
+        .tags(MetricsUtil.getCommonTags()).register(registry);
   }
 
   public Timer getReservationTimer() {
     return reservationTimer;
   }
 
+  public void incrementBusy() {
+    busyCounter.increment();
+  }
 }


### PR DESCRIPTION
Scan servers differ from in tablet servers in that they can service scans for any tablet, but must read the tablets files and reserve those files to prevent the Accumulo GC from removing them.  This happens the first time a tablet is read on a scan server and involves reads and writes to the metadata table.  This PR is a start at adding metrics related to reservations so that is possible to have visibility into the impact of this process on scans.