### PR TITLE
improves efficiency of migration set clean up

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -95,6 +95,7 @@ import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.TabletLocationState;
 import org.apache.accumulo.core.metadata.TabletState;
 import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.metrics.MetricsUtil;
 import org.apache.accumulo.core.replication.thrift.ReplicationCoordinator;
@@ -710,14 +711,17 @@ public class Manager extends AbstractServer
         throws TableNotFoundException {
       Scanner scanner = accumuloClient.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
       TabletColumnFamily.PREV_ROW_COLUMN.fetch(scanner);
-      Set<KeyExtent> found = new HashSet<>();
+      scanner.setRange(MetadataSchema.TabletsSection.getRange());
+      Set<KeyExtent> notSeen;
+      synchronized (migrations) {
+        notSeen = new HashSet<>(migrations.keySet());
+      }
       for (Entry<Key,Value> entry : scanner) {
         KeyExtent extent = KeyExtent.fromMetaPrevRow(entry);
-        if (migrations.containsKey(extent)) {
-          found.add(extent);
-        }
+        notSeen.remove(extent);
       }
-      migrations.keySet().retainAll(found);
+      // remove tablets that used to be in migrations and were not seen in the metadata table
+      migrations.keySet().removeAll(notSeen);
     }
 
     /**


### PR DESCRIPTION
Cleanup of the set of migrating tablets would read the entire metadata table and read all tablet extents into memory. This changes limits the scan to the tablets section of the metadata table and avoids reading all tablet extents into memory.