### PR TITLE
Fixed check in TabletResourceGroupBalanceIT to use Wait.waitFor

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletResourceGroupBalanceIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletResourceGroupBalanceIT.java
@@ -226,10 +226,10 @@ public class TabletResourceGroupBalanceIT extends SharedMiniClusterBase {
       getCluster().getClusterControl().start(ServerType.TABLET_SERVER);
 
       try {
-      client.instanceOperations().waitForBalance();
-      Wait.waitFor(() -> getCountOfHostedTablets(client, tableName) == 26);
-      ingest.join();
-      assertNull(error.get());
+        client.instanceOperations().waitForBalance();
+        Wait.waitFor(() -> getCountOfHostedTablets(client, tableName) == 26);
+        ingest.join();
+        assertNull(error.get());
 
       } finally {
         client.tableOperations().delete(tableName);

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletResourceGroupBalanceIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletResourceGroupBalanceIT.java
@@ -225,20 +225,22 @@ public class TabletResourceGroupBalanceIT extends SharedMiniClusterBase {
           .addTabletServerResourceGroup("GROUP2", 1);
       getCluster().getClusterControl().start(ServerType.TABLET_SERVER);
 
+      try {
       client.instanceOperations().waitForBalance();
-      assertEquals(26, getCountOfHostedTablets(client, tableName));
+      Wait.waitFor(() -> getCountOfHostedTablets(client, tableName) == 26);
       ingest.join();
       assertNull(error.get());
 
-      client.tableOperations().delete(tableName);
-      // Stop all tablet servers because there is no way to just stop
-      // the GROUP2 server yet.
-      getCluster().getClusterControl().stopAllServers(ServerType.TABLET_SERVER);
-      getCluster().getConfig().getClusterServerConfiguration().clearTServerResourceGroups();
-      getCluster().getConfig().getClusterServerConfiguration()
-          .addTabletServerResourceGroup("GROUP1", 1);
-      getCluster().getClusterControl().start(ServerType.TABLET_SERVER);
-
+      } finally {
+        client.tableOperations().delete(tableName);
+        // Stop all tablet servers because there is no way to just stop
+        // the GROUP2 server yet.
+        getCluster().getClusterControl().stopAllServers(ServerType.TABLET_SERVER);
+        getCluster().getConfig().getClusterServerConfiguration().clearTServerResourceGroups();
+        getCluster().getConfig().getClusterServerConfiguration()
+            .addTabletServerResourceGroup("GROUP1", 1);
+        getCluster().getClusterControl().start(ServerType.TABLET_SERVER);
+      }
     }
   }
 
@@ -258,7 +260,7 @@ public class TabletResourceGroupBalanceIT extends SharedMiniClusterBase {
       client.tableOperations().create(tableName, ntc1);
 
       // wait for all tablets to be hosted
-      Wait.waitFor(() -> 26 != getCountOfHostedTablets(client, tableName));
+      Wait.waitFor(() -> 26 == getCountOfHostedTablets(client, tableName));
 
       client.instanceOperations().waitForBalance();
 


### PR DESCRIPTION
The assertion in testResourceGroupBalanceWithNoTServers started returning zero for the number of hosted tablets after the `waitForBalance`. Not sure which modification caused this to change behavior, but this fix is likely the correct one regardless.