### PR TITLE
allows tablet refresh while in the process of closing

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -1635,7 +1635,7 @@ public class Tablet extends TabletBase {
       }
 
       synchronized (this) {
-        if (isClosed()) {
+        if (isCloseComplete()) {
           log.debug("Unable to refresh tablet {} for {} because the tablet is closed", extent,
               refreshPurpose);
           return false;


### PR DESCRIPTION
There was check in the tablet refresh code that was preventing tablet refresh while a tablet was in the middle of closing.  Modified the check to only prevent refresh after a tablet is competely closed.

fixes #4477