### PR TITLE
sets compaction coordinator status update log to trace

### DIFF
--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
@@ -546,8 +546,8 @@ public class CompactionCoordinator extends AbstractServer
     }
 
     var extent = KeyExtent.fromThrift(textent);
-    STATUS_LOG.info("Compaction completed, id: {}, stats: {}, extent: {}", externalCompactionId,
-        stats, extent);
+    LOG.info("Compaction completed, id: {}, stats: {}, extent: {}", externalCompactionId, stats,
+        extent);
     final var ecid = ExternalCompactionId.of(externalCompactionId);
     compactionFinalizer.commitCompaction(ecid, extent, stats.fileSize, stats.entriesWritten);
     // It's possible that RUNNING might not have an entry for this ecid in the case
@@ -565,8 +565,7 @@ public class CompactionCoordinator extends AbstractServer
           SecurityErrorCode.PERMISSION_DENIED).asThriftException();
     }
     KeyExtent fromThriftExtent = KeyExtent.fromThrift(extent);
-    STATUS_LOG.info("Compaction failed: id: {}, extent: {}", externalCompactionId,
-        fromThriftExtent);
+    LOG.info("Compaction failed: id: {}, extent: {}", externalCompactionId, fromThriftExtent);
     final var ecid = ExternalCompactionId.of(externalCompactionId);
     compactionFailed(Map.of(ecid, KeyExtent.fromThrift(extent)));
   }

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
@@ -591,7 +591,7 @@ public class CompactionCoordinator extends AbstractServer
       throw new AccumuloSecurityException(credentials.getPrincipal(),
           SecurityErrorCode.PERMISSION_DENIED).asThriftException();
     }
-    LOG.debug("Compaction status update, id: {}, timestamp: {}, update: {}", externalCompactionId,
+    LOG.trace("Compaction status update, id: {}, timestamp: {}, update: {}", externalCompactionId,
         timestamp, update);
     final RunningCompaction rc = RUNNING_CACHE.get(ExternalCompactionId.of(externalCompactionId));
     if (null != rc) {


### PR DESCRIPTION
The log message set to trace in this PR was consuming 20% to 30% of the logs for the compaction coordinator.