### PR TITLE
lowers logging level for first seen dead compaction

### DIFF
--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/DeadCompactionDetector.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/DeadCompactionDetector.java
@@ -117,8 +117,15 @@ public class DeadCompactionDetector {
         });
 
     tabletCompactions.forEach((ecid, extent) -> {
-      log.debug("Possible dead compaction detected {} {}", ecid, extent);
-      this.deadCompactions.merge(ecid, 1L, Long::sum);
+      var count = this.deadCompactions.merge(ecid, 1L, Long::sum);
+      if (count == 1) {
+        // The first time a possible dead compaction is seen, for quick compactions there is a good
+        // chance that it is already complete instead of dead. In order to avoid spamming the logs
+        // w/ false positives, log the first seen at trace.
+        log.trace("Possible dead compaction detected {} {} {}", ecid, extent, count);
+      } else {
+        log.debug("Possible dead compaction detected {} {} {}", ecid, extent, count);
+      }
     });
 
     // Everything left in tabletCompactions is no longer running anywhere and should be failed.


### PR DESCRIPTION
For the case of really quick compactions there is a good chance these finish during the check done by the dead compaction detector.  Currently when this happens a log message is logged about a possible dead compaction that is a false positive.  A large number of quick external compactions can cause a lot of these false positives.

This change adjust the first time a possible dead compaction is logged to trace.