### PR TITLE
Fix PausedCompactionMetrics caused by merge issue

### DIFF
--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -135,7 +135,7 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
 
   private ServiceLock compactorLock;
   private ServerAddress compactorAddress = null;
-  private PausedCompactionMetrics pausedMetrics;
+  private final PausedCompactionMetrics pausedMetrics = new PausedCompactionMetrics();
 
   // Exposed for tests
   protected volatile boolean shutdown = false;


### PR DESCRIPTION
Discovered issue created during merge with the initialization of the pause metrics.