### PR TITLE
Include hash in sserver metadata ref

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataSchema.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataSchema.java
@@ -491,12 +491,27 @@ public class MetadataSchema {
     private static final Section section =
         new Section(RESERVED_PREFIX + "sserv", true, RESERVED_PREFIX + "sserx", false);
 
+    private static final int encoded_prefix_length =
+        section.getRowPrefix().length() + SortSkew.SORTSKEW_LENGTH;
+
     public static Range getRange() {
       return section.getRange();
     }
 
-    public static String getRowPrefix() {
-      return section.getRowPrefix();
+    public static String encodeRow(String value) {
+      return section.getRowPrefix() + SortSkew.getCode(value) + value;
+    }
+
+    public static String decodeRow(String row) {
+      return row.substring(encoded_prefix_length);
+    }
+
+    /**
+     * Value to indicate that the row has been skewed/encoded.
+     */
+    public static class SkewedKeyValue {
+      public static final String STR_NAME = "skewed";
+      public static final Value NAME = new Value(STR_NAME);
     }
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/ScanServerMetadataEntriesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ScanServerMetadataEntriesIT.java
@@ -243,7 +243,7 @@ public class ScanServerMetadataEntriesIT extends SharedMiniClusterBase {
         metadataEntries.forEach(m -> {
           String row = m.getKey().getRow().toString();
           assertTrue(row.startsWith("~sserv"));
-          String file = row.substring(ScanServerFileReferenceSection.getRowPrefix().length());
+          String file = ScanServerFileReferenceSection.decodeRow(row);
           metadataScanFileRefs.add(file);
         });
         assertEquals(fileCount, metadataScanFileRefs.size());


### PR DESCRIPTION
Include a hash in the scan server metadata ref to reduce splits in the metadata table. 
This is the same logic that is currently used in the ~del ref markers