### PR TITLE
Changed default value of TSERV_PORTSEARCH from false to true

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -485,7 +485,8 @@ public enum Property {
       "2.1.0"),
   @Experimental
   SSERV_PORTSEARCH("sserver.port.search", "true", PropertyType.BOOLEAN,
-      "if the ports above are in use, search higher ports until one is available.", "2.1.0"),
+      "if the sserver.port.client ports are in use, search higher ports until one is available.",
+      "2.1.0"),
   @Experimental
   SSERV_CLIENTPORT("sserver.port.client", "9996", PropertyType.PORT,
       "The port used for handling client connections on the tablet servers.", "2.1.0"),
@@ -553,8 +554,9 @@ public enum Property {
       "Specifies the size of the cache for RFile index blocks.", "1.3.5"),
   TSERV_SUMMARYCACHE_SIZE("tserver.cache.summary.size", "10%", PropertyType.MEMORY,
       "Specifies the size of the cache for summary data on each tablet server.", "2.0.0"),
-  TSERV_PORTSEARCH("tserver.port.search", "false", PropertyType.BOOLEAN,
-      "if the ports above are in use, search higher ports until one is available.", "1.3.5"),
+  TSERV_PORTSEARCH("tserver.port.search", "true", PropertyType.BOOLEAN,
+      "if the tserver.port.client ports are in use, search higher ports until one is available.",
+      "1.3.5"),
   TSERV_CLIENTPORT("tserver.port.client", "9997", PropertyType.PORT,
       "The port used for handling client connections on the tablet servers.", "1.3.5"),
   TSERV_TOTAL_MUTATION_QUEUE_MAX("tserver.total.mutation.queue.max", "5%", PropertyType.MEMORY,
@@ -1101,7 +1103,7 @@ public enum Property {
       "4.0.0"),
   @Experimental
   COMPACTOR_PORTSEARCH("compactor.port.search", "true", PropertyType.BOOLEAN,
-      "If the compactor.port.client is in use, search higher ports until one is available.",
+      "If the compactor.port.client ports are in use, search higher ports until one is available.",
       "2.1.0"),
   @Experimental
   COMPACTOR_CLIENTPORT("compactor.port.client", "9133", PropertyType.PORT,

--- a/server/base/src/test/java/org/apache/accumulo/server/rpc/TServerUtilsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/rpc/TServerUtilsTest.java
@@ -93,6 +93,7 @@ public class TServerUtilsTest {
   public void testStartServerZeroPort() throws Exception {
     TServer server = null;
     conf.set(Property.TSERV_CLIENTPORT, "0");
+    conf.set(Property.TSERV_PORTSEARCH, "false");
     try {
       ServerAddress address = startServer();
       assertNotNull(address);
@@ -111,6 +112,7 @@ public class TServerUtilsTest {
     TServer server = null;
     int port = getFreePort(1024);
     conf.set(Property.TSERV_CLIENTPORT, Integer.toString(port));
+    conf.set(Property.TSERV_PORTSEARCH, "false");
     try {
       ServerAddress address = startServer();
       assertNotNull(address);
@@ -131,6 +133,7 @@ public class TServerUtilsTest {
     InetAddress addr = InetAddress.getByName("localhost");
     // Bind to the port
     conf.set(Property.TSERV_CLIENTPORT, Integer.toString(port));
+    conf.set(Property.TSERV_PORTSEARCH, "false");
     try (ServerSocket s = new ServerSocket(port, 50, addr)) {
       assertNotNull(s);
       assertThrows(UnknownHostException.class, this::startServer);
@@ -145,7 +148,6 @@ public class TServerUtilsTest {
     // Bind to the port
     InetAddress addr = InetAddress.getByName("localhost");
     conf.set(Property.TSERV_CLIENTPORT, Integer.toString(port[0]));
-    conf.set(Property.TSERV_PORTSEARCH, "true");
     try (ServerSocket s = new ServerSocket(port[0], 50, addr)) {
       assertNotNull(s);
       ServerAddress address = startServer();
@@ -188,8 +190,6 @@ public class TServerUtilsTest {
     ports = findTwoFreeSequentialPorts(monitorPort + 1);
     int tserverFinalPort = ports[0];
 
-    conf.set(Property.TSERV_PORTSEARCH, "true");
-
     // Ensure that the TServer client port we set above is NOT in the reserved ports
     Map<Integer,Property> reservedPorts =
         TServerUtils.getReservedPorts(conf, Property.TSERV_CLIENTPORT);
@@ -224,6 +224,7 @@ public class TServerUtilsTest {
     int[] port = findTwoFreeSequentialPorts(1024);
     String portRange = port[0] + "-" + port[1];
     conf.set(Property.TSERV_CLIENTPORT, portRange);
+    conf.set(Property.TSERV_PORTSEARCH, "false");
     try {
       ServerAddress address = startServer();
       assertNotNull(address);
@@ -247,6 +248,7 @@ public class TServerUtilsTest {
     String portRange = port[0] + "-" + port[1];
     // Bind to the port
     conf.set(Property.TSERV_CLIENTPORT, portRange);
+    conf.set(Property.TSERV_PORTSEARCH, "false");
     try (ServerSocket s = new ServerSocket(port[0], 50, addr)) {
       assertNotNull(s);
       ServerAddress address = startServer();


### PR DESCRIPTION
Changed the default value of TSERV_PORTSEARCH from false to true to provide some consistency in the PORTSEARCH properties. The default values for the Compactors and ScanServers is already set to true.

Closes #4476