### PR TITLE
Update scan server metrics for file reservations

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -707,7 +707,8 @@ public class ScanServer extends AbstractServer
     return new ScanReservation(tabletsMetadata, myReservationId, failures);
   }
 
-  private ScanReservation reserveFilesInstrumented(long scanId) throws NoSuchScanIDException {
+  @VisibleForTesting
+  ScanReservation reserveFilesInstrumented(long scanId) throws NoSuchScanIDException {
     long start = System.nanoTime();
     try {
       return reserveFiles(scanId);
@@ -934,7 +935,7 @@ public class ScanServer extends AbstractServer
       TSampleNotPresentException, TException {
     LOG.trace("continue scan: {}", scanID);
 
-    try (ScanReservation reservation = reserveFiles(scanID)) {
+    try (ScanReservation reservation = reserveFilesInstrumented(scanID)) {
       Preconditions.checkState(reservation.getFailures().isEmpty());
       return delegate.continueScan(tinfo, scanID, busyTimeout);
     } catch (ScanServerBusyException be) {
@@ -1002,7 +1003,7 @@ public class ScanServer extends AbstractServer
       throws NoSuchScanIDException, TSampleNotPresentException, TException {
     LOG.trace("continue multi scan: {}", scanID);
 
-    try (ScanReservation reservation = reserveFiles(scanID)) {
+    try (ScanReservation reservation = reserveFilesInstrumented(scanID)) {
       Preconditions.checkState(reservation.getFailures().isEmpty());
       return delegate.continueMultiScan(tinfo, scanID, busyTimeout);
     } catch (ScanServerBusyException be) {

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/ScanServerTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/ScanServerTest.java
@@ -105,6 +105,11 @@ public class ScanServerTest {
     ScanReservation reserveFilesInstrumented(Map<KeyExtent,List<TRange>> extents) {
       return reservation;
     }
+
+    @Override
+    ScanReservation reserveFilesInstrumented(long scanId) {
+      return reservation;
+    }
   }
 
   private ThriftScanClientHandler handler;


### PR DESCRIPTION
These changes are a follow-on to #4461 - and include the file reservation metrics in additional places.  The omission was noticed while merging #4461 into main. 

