### PR TITLE
Update Ample to use SteadyTime for suspension

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/logging/TabletLogger.java
+++ b/core/src/main/java/org/apache/accumulo/core/logging/TabletLogger.java
@@ -24,7 +24,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.admin.CompactionConfig;
 import org.apache.accumulo.core.client.admin.compaction.CompactableFile;
@@ -37,6 +36,7 @@ import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
 import org.apache.accumulo.core.spi.compaction.CompactionJob;
 import org.apache.accumulo.core.spi.compaction.CompactionKind;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
+import org.apache.accumulo.core.util.time.SteadyTime;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,10 +75,9 @@ public class TabletLogger {
     locLog.debug("Loading {} on {}", extent, server);
   }
 
-  public static void suspended(KeyExtent extent, HostAndPort server, long time, TimeUnit timeUnit,
+  public static void suspended(KeyExtent extent, HostAndPort server, SteadyTime time,
       int numWalogs) {
-    locLog.debug("Suspended {} to {} at {} ms with {} walogs", extent, server,
-        timeUnit.toMillis(time), numWalogs);
+    locLog.debug("Suspended {} to {} at {} ms with {} walogs", extent, server, time, numWalogs);
   }
 
   public static void unsuspended(KeyExtent extent) {

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
@@ -37,6 +37,7 @@ import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
+import org.apache.accumulo.core.util.time.SteadyTime;
 import org.apache.hadoop.io.Text;
 
 /**
@@ -299,7 +300,7 @@ public interface Ample {
 
     TabletMutator deleteBulkFile(StoredTabletFile bulkref);
 
-    TabletMutator putSuspension(TServerInstance tserver, long suspensionTime);
+    TabletMutator putSuspension(TServerInstance tserver, SteadyTime suspensionTime);
 
     TabletMutator deleteSuspension();
 

--- a/core/src/main/java/org/apache/accumulo/core/util/time/SteadyTime.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/time/SteadyTime.java
@@ -52,6 +52,10 @@ public class SteadyTime implements Comparable<SteadyTime> {
     return time;
   }
 
+  public Duration minus(SteadyTime other) {
+    return time.minus(other.getDuration());
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -72,6 +76,11 @@ public class SteadyTime implements Comparable<SteadyTime> {
   @Override
   public int compareTo(SteadyTime other) {
     return time.compareTo(other.time);
+  }
+
+  @Override
+  public String toString() {
+    return "SteadyTime[" + time + "]";
   }
 
   public static SteadyTime from(long time, TimeUnit unit) {

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/LoggingTabletStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/LoggingTabletStateStore.java
@@ -21,12 +21,12 @@ package org.apache.accumulo.server.manager.state;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.logging.TabletLogger;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.TabletLocationState;
 import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
+import org.apache.accumulo.core.util.time.SteadyTime;
 import org.apache.hadoop.fs.Path;
 
 import com.google.common.net.HostAndPort;
@@ -86,7 +86,7 @@ class LoggingTabletStateStore implements TabletStateStore {
 
   @Override
   public void suspend(Collection<TabletLocationState> tablets,
-      Map<TServerInstance,List<Path>> logsForDeadServers, long suspensionTimestamp)
+      Map<TServerInstance,List<Path>> logsForDeadServers, SteadyTime suspensionTimestamp)
       throws DistributedStoreException {
     wrapped.suspend(tablets, logsForDeadServers, suspensionTimestamp);
 
@@ -100,8 +100,7 @@ class LoggingTabletStateStore implements TabletStateStore {
       if (location != null) {
         server = location.getHostAndPort();
       }
-      TabletLogger.suspended(tls.extent, server, suspensionTimestamp, TimeUnit.MILLISECONDS,
-          logsForDeadServers.size());
+      TabletLogger.suspended(tls.extent, server, suspensionTimestamp, logsForDeadServers.size());
     }
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletStateStore.java
@@ -28,6 +28,7 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.TabletLocationState;
 import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
+import org.apache.accumulo.core.util.time.SteadyTime;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.hadoop.fs.Path;
 
@@ -76,7 +77,7 @@ public interface TabletStateStore extends Iterable<TabletLocationState> {
    * previous tserver.
    */
   void suspend(Collection<TabletLocationState> tablets,
-      Map<TServerInstance,List<Path>> logsForDeadServers, long suspensionTimestamp)
+      Map<TServerInstance,List<Path>> logsForDeadServers, SteadyTime suspensionTimestamp)
       throws DistributedStoreException;
 
   /**
@@ -91,7 +92,7 @@ public interface TabletStateStore extends Iterable<TabletLocationState> {
   }
 
   public static void suspend(ServerContext context, TabletLocationState tls,
-      Map<TServerInstance,List<Path>> logsForDeadServers, long suspensionTimestamp)
+      Map<TServerInstance,List<Path>> logsForDeadServers, SteadyTime suspensionTimestamp)
       throws DistributedStoreException {
     getStoreForTablet(tls.extent, context).suspend(Collections.singletonList(tls),
         logsForDeadServers, suspensionTimestamp);

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/ZooTabletStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/ZooTabletStateStore.java
@@ -36,6 +36,7 @@ import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.LocationType;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
+import org.apache.accumulo.core.util.time.SteadyTime;
 import org.apache.accumulo.server.util.ManagerMetadataUtil;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
@@ -188,7 +189,7 @@ class ZooTabletStateStore implements TabletStateStore {
 
   @Override
   public void suspend(Collection<TabletLocationState> tablets,
-      Map<TServerInstance,List<Path>> logsForDeadServers, long suspensionTimestamp)
+      Map<TServerInstance,List<Path>> logsForDeadServers, SteadyTime suspensionTimestamp)
       throws DistributedStoreException {
     // No support for suspending root tablet.
     unassign(tablets, logsForDeadServers);

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorBase.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorBase.java
@@ -46,6 +46,7 @@ import org.apache.accumulo.core.metadata.schema.MetadataTime;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.LocationType;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
+import org.apache.accumulo.core.util.time.SteadyTime;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.hadoop.io.Text;
 
@@ -201,7 +202,7 @@ public abstract class TabletMutatorBase implements Ample.TabletMutator {
   }
 
   @Override
-  public Ample.TabletMutator putSuspension(TServerInstance tServer, long suspensionTime) {
+  public Ample.TabletMutator putSuspension(TServerInstance tServer, SteadyTime suspensionTime) {
     Preconditions.checkState(updatesEnabled, "Cannot make updates after calling mutate.");
     mutation.put(SuspendLocationColumn.SUSPEND_COLUMN.getColumnFamily(),
         SuspendLocationColumn.SUSPEND_COLUMN.getColumnQualifier(),

--- a/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
@@ -454,7 +454,7 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
 
   private void hostSuspendedTablet(TabletLists tLists, TabletLocationState tls, Location location,
       TableConfiguration tableConf) {
-    if (manager.getSteadyTime().getMillis() - tls.suspend.suspensionTime
+    if (manager.getSteadyTime().minus(tls.suspend.suspensionTime).toMillis()
         < tableConf.getTimeInMillis(Property.TABLE_SUSPEND_DURATION)) {
       // Tablet is suspended. See if its tablet server is back.
       TServerInstance returnInstance = null;
@@ -1386,7 +1386,7 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
           deadTablets.subList(0, maxServersToShow));
       Manager.log.debug("logs for dead servers: {}", deadLogs);
       if (canSuspendTablets()) {
-        store.suspend(deadTablets, deadLogs, manager.getSteadyTime().getMillis());
+        store.suspend(deadTablets, deadLogs, manager.getSteadyTime());
       } else {
         store.unassign(deadTablets, deadLogs);
       }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/UnloadTabletHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/UnloadTabletHandler.java
@@ -18,7 +18,10 @@
  */
 package org.apache.accumulo.tserver;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
@@ -28,6 +31,7 @@ import org.apache.accumulo.core.metadata.TabletLocationState;
 import org.apache.accumulo.core.metadata.TabletLocationState.BadLocationStateException;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.accumulo.core.tablet.thrift.TUnloadTabletGoal;
+import org.apache.accumulo.core.util.time.SteadyTime;
 import org.apache.accumulo.server.manager.state.DistributedStoreException;
 import org.apache.accumulo.server.manager.state.TabletStateStore;
 import org.apache.accumulo.tserver.managermessage.TabletStatusMessage;
@@ -120,8 +124,8 @@ class UnloadTabletHandler implements Runnable {
               && !server.getConfiguration().getBoolean(Property.MANAGER_METADATA_SUSPENDABLE))) {
         TabletStateStore.unassign(server.getContext(), tls, null);
       } else {
-        TabletStateStore.suspend(server.getContext(), tls, null,
-            requestTimeSkew + NANOSECONDS.toMillis(System.nanoTime()));
+        TabletStateStore.suspend(server.getContext(), tls, null, SteadyTime.from(
+            requestTimeSkew + NANOSECONDS.toMillis(System.nanoTime()), TimeUnit.MILLISECONDS));
       }
     } catch (DistributedStoreException ex) {
       log.warn("Unable to update storage", ex);


### PR DESCRIPTION
SteadyTime was added in #4494 which creates a strong type for tracking the total duration for the time the cluster has had a manager. This time is used for suspension so we this updates Ample to use the new type instead of just a long.