### PR TITLE
Add a constraint check for suspend column

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/SuspendingTServer.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/SuspendingTServer.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 
 import org.apache.accumulo.core.data.Value;
 
+import com.google.common.base.Preconditions;
 import com.google.common.net.HostAndPort;
 
 /**
@@ -39,6 +40,8 @@ public class SuspendingTServer {
   public static SuspendingTServer fromValue(Value value) {
     String valStr = value.toString();
     String[] parts = valStr.split("[|]", 2);
+    // TODO: This line is temporary until #4545 is merged which already does the negative check
+    Preconditions.checkArgument(Long.parseLong(parts[1]) >= 0, "Suspended time cannot be negative");
     return new SuspendingTServer(HostAndPort.fromString(parts[0]), Long.parseLong(parts[1]));
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
@@ -36,6 +36,7 @@ import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.core.lock.ServiceLock;
 import org.apache.accumulo.core.metadata.AccumuloTable;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
+import org.apache.accumulo.core.metadata.SuspendingTServer;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.BulkFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ChoppedColumnFamily;
@@ -306,40 +307,50 @@ public class MetadataConstraints implements Constraint {
       } else {
         if (!isValidColumn(columnUpdate)) {
           violations = addViolation(violations, 2);
-        } else if (new ColumnFQ(columnUpdate).equals(TabletColumnFamily.PREV_ROW_COLUMN)
-            && columnUpdate.getValue().length > 0
-            && (violations == null || !violations.contains((short) 4))) {
-          KeyExtent ke = KeyExtent.fromMetaRow(new Text(mutation.getRow()));
+        } else {
+          final var column = new ColumnFQ(columnUpdate);
+          if (column.equals(TabletColumnFamily.PREV_ROW_COLUMN)
+              && columnUpdate.getValue().length > 0
+              && (violations == null || !violations.contains((short) 4))) {
+            KeyExtent ke = KeyExtent.fromMetaRow(new Text(mutation.getRow()));
 
-          Text per = TabletColumnFamily.decodePrevEndRow(new Value(columnUpdate.getValue()));
+            Text per = TabletColumnFamily.decodePrevEndRow(new Value(columnUpdate.getValue()));
 
-          boolean prevEndRowLessThanEndRow =
-              per == null || ke.endRow() == null || per.compareTo(ke.endRow()) < 0;
+            boolean prevEndRowLessThanEndRow =
+                per == null || ke.endRow() == null || per.compareTo(ke.endRow()) < 0;
 
-          if (!prevEndRowLessThanEndRow) {
-            violations = addViolation(violations, 3);
-          }
-        } else if (new ColumnFQ(columnUpdate).equals(ServerColumnFamily.LOCK_COLUMN)) {
-          if (zooCache == null) {
-            zooCache = new ZooCache(context.getZooReader(), null);
-            CleanerUtil.zooCacheClearer(this, zooCache);
-          }
+            if (!prevEndRowLessThanEndRow) {
+              violations = addViolation(violations, 3);
+            }
+          } else if (column.equals(ServerColumnFamily.LOCK_COLUMN)) {
+            if (zooCache == null) {
+              zooCache = new ZooCache(context.getZooReader(), null);
+              CleanerUtil.zooCacheClearer(this, zooCache);
+            }
 
-          if (zooRoot == null) {
-            zooRoot = context.getZooKeeperRoot();
-          }
+            if (zooRoot == null) {
+              zooRoot = context.getZooKeeperRoot();
+            }
 
-          boolean lockHeld = false;
-          String lockId = new String(columnUpdate.getValue(), UTF_8);
+            boolean lockHeld = false;
+            String lockId = new String(columnUpdate.getValue(), UTF_8);
 
-          try {
-            lockHeld = ServiceLock.isLockHeld(zooCache, new ZooUtil.LockID(zooRoot, lockId));
-          } catch (Exception e) {
-            log.debug("Failed to verify lock was held {} {}", lockId, e.getMessage());
-          }
+            try {
+              lockHeld = ServiceLock.isLockHeld(zooCache, new ZooUtil.LockID(zooRoot, lockId));
+            } catch (Exception e) {
+              log.debug("Failed to verify lock was held {} {}", lockId, e.getMessage());
+            }
 
-          if (!lockHeld) {
-            violations = addViolation(violations, 7);
+            if (!lockHeld) {
+              violations = addViolation(violations, 7);
+            }
+          } else if (column.equals(SuspendLocationColumn.SUSPEND_COLUMN)
+              && columnUpdate.getValue().length > 0) {
+            try {
+              SuspendingTServer.fromValue(new Value(columnUpdate.getValue()));
+            } catch (IllegalArgumentException e) {
+              violations = addViolation(violations, 10);
+            }
           }
         }
       }
@@ -379,6 +390,8 @@ public class MetadataConstraints implements Constraint {
         return "Bulk load mutation contains either inconsistent files or multiple fateTX ids";
       case 9:
         return "Invalid data file metadata format";
+      case 10:
+        return "Suspended timestamp can not be negative";
     }
     return null;
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
@@ -344,8 +344,7 @@ public class MetadataConstraints implements Constraint {
             if (!lockHeld) {
               violations = addViolation(violations, 7);
             }
-          } else if (column.equals(SuspendLocationColumn.SUSPEND_COLUMN)
-              && columnUpdate.getValue().length > 0) {
+          } else if (column.equals(SuspendLocationColumn.SUSPEND_COLUMN)) {
             try {
               SuspendingTServer.fromValue(new Value(columnUpdate.getValue()));
             } catch (IllegalArgumentException e) {
@@ -391,7 +390,7 @@ public class MetadataConstraints implements Constraint {
       case 9:
         return "Invalid data file metadata format";
       case 10:
-        return "Suspended timestamp can not be negative";
+        return "Suspended timestamp is not valid";
     }
     return null;
   }

--- a/server/base/src/test/java/org/apache/accumulo/server/constraints/MetadataConstraintsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/constraints/MetadataConstraintsTest.java
@@ -143,12 +143,14 @@ public class MetadataConstraintsTest {
     MetadataConstraints mc = new MetadataConstraints();
     TServerInstance ser1 = new TServerInstance(HostAndPort.fromParts("server1", 8555), "s001");
 
-    SuspendLocationColumn.SUSPEND_COLUMN.put(m, SuspendingTServer.toValue(ser1, SteadyTime.from(System.currentTimeMillis(), TimeUnit.MILLISECONDS)));
+    SuspendLocationColumn.SUSPEND_COLUMN.put(m, SuspendingTServer.toValue(ser1,
+        SteadyTime.from(System.currentTimeMillis(), TimeUnit.MILLISECONDS)));
     List<Short> violations = mc.check(createEnv(), m);
     assertNull(violations);
 
     m = new Mutation(new Text("0;foo"));
-    SuspendLocationColumn.SUSPEND_COLUMN.put(m, SuspendingTServer.toValue(ser1, SteadyTime.from(0, TimeUnit.MILLISECONDS)));
+    SuspendLocationColumn.SUSPEND_COLUMN.put(m,
+        SuspendingTServer.toValue(ser1, SteadyTime.from(0, TimeUnit.MILLISECONDS)));
     violations = mc.check(createEnv(), m);
     assertNull(violations);
 


### PR DESCRIPTION
This adds a new metadata constraint check for the suspend metadata column to ensure that the suspension time is not negative as we should never have a negative value.

This is a follow on to #4494 as I realized when working on that we should probably add a validation check for this

I wasn't sure if we should target this at 2.1 or 3.1 but for now this is targeting 3.1 because there is a (probably very small) risk in 2.1 of something breaking if there was an unexpected negative that existed. Although maybe this isn't a big concern if an existing negative would still cause things to break in other ways (I haven't traced through to see)