### PR TITLE
reduce the frequency that the list of scan servers is sorted

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.core.clientImpl;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Suppliers.memoize;
 import static com.google.common.base.Suppliers.memoizeWithExpiration;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
@@ -232,8 +233,7 @@ public class ClientContext implements AccumuloClient {
     saslSupplier = memoizeWithExpiration(
         () -> SaslConnectionParams.from(getConfiguration(), getCredentials().getToken()), 100,
         MILLISECONDS);
-    scanServerSelectorSupplier =
-        memoizeWithExpiration(this::createScanServerSelector, 100, MILLISECONDS);
+    scanServerSelectorSupplier = memoize(this::createScanServerSelector);
     this.singletonReservation = Objects.requireNonNull(reservation);
     this.tableops = new TableOperationsImpl(this);
     this.namespaceops = new NamespaceOperationsImpl(this, tableops);

--- a/core/src/main/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelector.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelector.java
@@ -303,7 +303,7 @@ public class ConfigurableScanServerSelector implements ScanServerSelector {
           .computeIfAbsent(sserver.getGroup(), k -> new ArrayList<>()).add(sserver.getAddress()));
       groupedServers.values().forEach(ssAddrs -> Collections.sort(ssAddrs));
       return groupedServers;
-    }, 100, TimeUnit.MILLISECONDS);
+    }, 3, TimeUnit.SECONDS);
 
     var opts = params.getOptions();
 


### PR DESCRIPTION
The provided plugin for working with scan servers sorts the list of scan servers fairly frequently.  This list will not change too often, so it could be sorted less to offer a better amortized cost as the total number of scan servers grows.

Also outside of the plugin, the plugin was being reset every 100ms. Removed this to give the plugin more control.  Also there is currently no way to change client config for a created Accumulo client, so there is no need to recreate the plugin.