### PR TITLE
Enable background refresh for the scan server tablet metadata cache

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -446,8 +446,17 @@ public enum Property {
       "Specifies a default blocksize for the scan server caches.", "2.1.0"),
   @Experimental
   SSERV_CACHED_TABLET_METADATA_EXPIRATION("sserver.cache.metadata.expiration", "5m",
-      PropertyType.TIMEDURATION, "The time after which cached tablet metadata will be refreshed.",
+      PropertyType.TIMEDURATION,
+      "The time after which cached tablet metadata will be expired if not previously refreshed.",
       "2.1.0"),
+  @Experimental
+  SSERV_CACHED_TABLET_METADATA_REFRESH_PERCENT("sserver.cache.metadata.refresh.percent", ".75",
+      PropertyType.FRACTION,
+      "The time after which cached tablet metadata will be refreshed, expressed as a "
+          + "percentage of the expiration time. Cache hits after this time, but before the "
+          + "expiration time, will trigger a background refresh for future hits. "
+          + "Value must be less than 100%. Set to 0 will disable refresh.",
+      "2.1.3"),
   @Experimental
   SSERV_PORTSEARCH("sserver.port.search", "true", PropertyType.BOOLEAN,
       "if the ports above are in use, search higher ports until one is available.", "2.1.0"),

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -256,7 +256,8 @@ public class ScanServer extends AbstractServer
           cacheRefreshPercentage);
 
       var builder = Caffeine.newBuilder().expireAfterWrite(cacheExpiration, TimeUnit.MILLISECONDS)
-          .scheduler(Scheduler.systemScheduler()).recordStats();
+          .scheduler(Scheduler.systemScheduler()).executor(context.getScheduledExecutor())
+          .recordStats();
       if (cacheRefreshPercentage > 0) {
         // Compute the refresh time as a percentage of the expiration time
         // Cache hits after this time, but before expiration, will trigger a background

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -259,8 +259,8 @@ public class ScanServer extends AbstractServer
           "Tablet metadata cache refresh percentage is '%s' but must be less than 1",
           cacheRefreshPercentage);
 
-      tmCacheExecutor =
-          context.threadPools().getPoolBuilder("scanServerTmCache").numCoreThreads(8).build();
+      tmCacheExecutor = context.threadPools().getPoolBuilder("scanServerTmCache").numCoreThreads(8)
+          .enableThreadPoolMetrics().build();
       var builder = Caffeine.newBuilder().expireAfterWrite(cacheExpiration, TimeUnit.MILLISECONDS)
           .scheduler(Scheduler.systemScheduler()).executor(tmCacheExecutor).recordStats();
       if (cacheRefreshPercentage > 0) {

--- a/test/src/main/java/org/apache/accumulo/test/ScanServerConcurrentTabletScanIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ScanServerConcurrentTabletScanIT.java
@@ -81,7 +81,7 @@ public class ScanServerConcurrentTabletScanIT extends SharedMiniClusterBase {
     SharedMiniClusterBase.stopMiniCluster();
   }
 
-  private void startScanServer(boolean cacheEnabled)
+  private void startScanServer(String cacheExpiration, String cacheRefresh)
       throws IOException, KeeperException, InterruptedException {
 
     String zooRoot = getCluster().getServerContext().getZooKeeperRoot();
@@ -91,8 +91,8 @@ public class ScanServerConcurrentTabletScanIT extends SharedMiniClusterBase {
     SharedMiniClusterBase.getCluster().getClusterControl().stop(ServerType.SCAN_SERVER);
 
     Map<String,String> overrides = new HashMap<>();
-    overrides.put(Property.SSERV_CACHED_TABLET_METADATA_EXPIRATION.getKey(),
-        cacheEnabled ? "300m" : "0m");
+    overrides.put(Property.SSERV_CACHED_TABLET_METADATA_EXPIRATION.getKey(), cacheExpiration);
+    overrides.put(Property.SSERV_CACHED_TABLET_METADATA_REFRESH_PERCENT.getKey(), cacheRefresh);
     SharedMiniClusterBase.getCluster().getClusterControl().start(ServerType.SCAN_SERVER, overrides,
         1);
     while (zrw.getChildren(scanServerRoot).size() == 0) {
@@ -102,9 +102,31 @@ public class ScanServerConcurrentTabletScanIT extends SharedMiniClusterBase {
   }
 
   @Test
-  public void testScanSameTabletDifferentDataTabletMetadataCacheEnabled() throws Exception {
+  public void testScanSameTabletDifferentDataTmCacheEnabledRefreshNotTriggered() throws Exception {
+    // Set the cache time to 10 minutes so it won't expire
+    // Set the cache refresh to 50%, which is 5 minutes so a refresh won't be triggered
+    startScanServer("10m", ".5");
+    testScanSameTabletDifferentDataTabletMetadataCacheEnabled(false);
+  }
 
-    startScanServer(true);
+  @Test
+  public void testScanSameTabletDifferentDataTmCacheEnabledRefreshTriggered() throws Exception {
+    // Set the cache time to 10 minutes so it won't expire
+    // Set the cache refresh to 6ms, so a second hit after 6ms will trigger a background refresh
+    // .00001 * 10m (600000ms) = 6 ms
+    startScanServer("10m", ".00001");
+    testScanSameTabletDifferentDataTabletMetadataCacheEnabled(true);
+  }
+
+  @Test
+  public void testScanSameTabletDifferentDataTmCacheEnabledRefreshDisabled() throws Exception {
+    // Set the cache time to 10 minutes so it won't expire and disable the refresh entirely
+    startScanServer("5m", "0");
+    testScanSameTabletDifferentDataTabletMetadataCacheEnabled(false);
+  }
+
+  private void testScanSameTabletDifferentDataTabletMetadataCacheEnabled(boolean shouldRefresh)
+      throws Exception {
 
     Properties clientProperties = getClientProps();
     clientProperties.put(ClientProperty.SCANNER_BATCH_SIZE.getKey(), "100");
@@ -135,7 +157,15 @@ public class ScanServerConcurrentTabletScanIT extends SharedMiniClusterBase {
       // Ingest another 100 k/v with a different column family
       final int secondBatchOfEntriesCount = ingest(client, tableName, 10, 10, 0, "COLB", true);
 
+      // Add a sleep that is long enough that the configured refresh interval passes if
+      // the test has been set to use one.
+      Thread.sleep(1000);
+
       // iter2 should read 1000 k/v because the tablet metadata is cached.
+      // This call will trigger a cache refresh for the entry in the background if refresh is
+      // enabled.
+      // This current iter2 scan will still return the old data (1000 k/v) as the new value
+      // won't be visible until the reload finishes
       Iterator<Entry<Key,Value>> iter2 = scanner1.iterator();
       int count2 = 0;
       boolean useIter1 = true;
@@ -157,6 +187,22 @@ public class ScanServerConcurrentTabletScanIT extends SharedMiniClusterBase {
       assertEquals(firstBatchOfEntriesCount, count1);
       assertEquals(firstBatchOfEntriesCount, count2);
 
+      // If a refresh was done this should see 1100 entries
+      // Sleep again before reading just to make sure the async refresh
+      // had time to finish as there isn't a good way to know it's done loading
+      Thread.sleep(1000);
+
+      // Count the number of entries for the third iterator to test if
+      // refresh worked depending on configs
+      int count3 = 0;
+      Iterator<Entry<Key,Value>> iter3 = scanner1.iterator();
+      while (iter3.hasNext()) {
+        iter3.next();
+        count3++;
+      }
+      assertEquals(shouldRefresh ? firstBatchOfEntriesCount + secondBatchOfEntriesCount
+          : firstBatchOfEntriesCount, count3);
+
       scanner1.close();
 
       // A new scan should read all 1100 entries
@@ -170,7 +216,7 @@ public class ScanServerConcurrentTabletScanIT extends SharedMiniClusterBase {
   @Test
   public void testScanSameTabletDifferentDataTabletMetadataCacheDisabled() throws Exception {
 
-    startScanServer(false);
+    startScanServer("0m", "0");
 
     Properties clientProperties = getClientProps();
     clientProperties.put(ClientProperty.SCANNER_BATCH_SIZE.getKey(), "100");


### PR DESCRIPTION
This adds a property to configure the scan server tablet metadata Caffeine cache to refresh cached tablet metadata in the background on cache hits after the refresh time has passed. The refresh time is expressed as a percentage of the expiration time. This allows the cached entries to refresh before expiration if they are frequently used so that scans will not be blocked waiting on a refresh on expiration. Entries still expire if no cache hits come after the refresh time and expiration time passes.

See: https://github.com/ben-manes/caffeine/wiki/Refresh

This closes #4544