### PR TITLE
Fixes 'admin fate --print/--summary' no node exception bug

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/AdminUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/AdminUtil.java
@@ -378,11 +378,16 @@ public class AdminUtil<T> {
         // If the cause of the Exception is a NoNodeException, it should be ignored as this
         // indicates the transaction has completed between the time the list of transactions was
         // acquired and the time the transaction was probed for info.
+        boolean nne = false;
         Throwable cause = e;
-        while (cause != null && !(cause instanceof KeeperException.NoNodeException)) {
+        while (cause != null) {
+          if (cause instanceof KeeperException.NoNodeException) {
+            nne = true;
+            break;
+          }
           cause = cause.getCause();
         }
-        if (cause == null) {
+        if (!nne) {
           throw e;
         }
         log.debug("Tried to get info on a since completed transaction - ignoring "

--- a/core/src/main/java/org/apache/accumulo/core/fate/AdminUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/AdminUtil.java
@@ -341,37 +341,52 @@ public class AdminUtil<T> {
     List<TransactionStatus> statuses = new ArrayList<>(transactions.size());
 
     for (Long tid : transactions) {
+      try {
+        zs.reserve(tid);
 
-      zs.reserve(tid);
+        String txName = (String) zs.getTransactionInfo(tid, Fate.TxInfo.TX_NAME);
 
-      String txName = (String) zs.getTransactionInfo(tid, Fate.TxInfo.TX_NAME);
+        List<String> hlocks = heldLocks.remove(tid);
 
-      List<String> hlocks = heldLocks.remove(tid);
+        if (hlocks == null) {
+          hlocks = Collections.emptyList();
+        }
 
-      if (hlocks == null) {
-        hlocks = Collections.emptyList();
-      }
+        List<String> wlocks = waitingLocks.remove(tid);
 
-      List<String> wlocks = waitingLocks.remove(tid);
+        if (wlocks == null) {
+          wlocks = Collections.emptyList();
+        }
 
-      if (wlocks == null) {
-        wlocks = Collections.emptyList();
-      }
+        String top = null;
+        ReadOnlyRepo<T> repo = zs.top(tid);
+        if (repo != null) {
+          top = repo.getName();
+        }
 
-      String top = null;
-      ReadOnlyRepo<T> repo = zs.top(tid);
-      if (repo != null) {
-        top = repo.getName();
-      }
+        TStatus status = zs.getStatus(tid);
 
-      TStatus status = zs.getStatus(tid);
+        long timeCreated = zs.timeCreated(tid);
 
-      long timeCreated = zs.timeCreated(tid);
+        zs.unreserve(tid, 0, TimeUnit.MILLISECONDS);
 
-      zs.unreserve(tid, 0, TimeUnit.MILLISECONDS);
-
-      if (includeByStatus(status, filterStatus) && includeByTxid(tid, filterTxid)) {
-        statuses.add(new TransactionStatus(tid, status, txName, hlocks, wlocks, top, timeCreated));
+        if (includeByStatus(status, filterStatus) && includeByTxid(tid, filterTxid)) {
+          statuses
+              .add(new TransactionStatus(tid, status, txName, hlocks, wlocks, top, timeCreated));
+        }
+      } catch (Exception e) {
+        // If the cause of the Exception is a NoNodeException, it should be ignored as this
+        // indicates the transaction has completed between the time the list of transactions was
+        // acquired and the time the transaction was probed for info.
+        Throwable cause = e;
+        while (cause != null && !(cause instanceof KeeperException.NoNodeException)) {
+          cause = cause.getCause();
+        }
+        if (cause == null) {
+          throw e;
+        }
+        log.debug("Tried to get info on a since completed transaction - ignoring "
+            + FateTxId.formatTid(tid));
       }
     }
 

--- a/test/src/main/java/org/apache/accumulo/test/FateSummaryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/FateSummaryIT.java
@@ -18,10 +18,13 @@
  */
 package org.apache.accumulo.test;
 
+import static org.apache.accumulo.core.util.compaction.ExternalCompactionUtil.getCompactorAddrs;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -36,7 +39,9 @@ import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.admin.NewTableConfiguration;
+import org.apache.accumulo.core.iterators.IteratorUtil;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
+import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl.ProcessInfo;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.server.util.Admin;
@@ -44,6 +49,7 @@ import org.apache.accumulo.server.util.fateCommand.FateSummaryReport;
 import org.apache.accumulo.test.functional.ConfigurableMacBase;
 import org.apache.accumulo.test.functional.ReadWriteIT;
 import org.apache.accumulo.test.functional.SlowIterator;
+import org.apache.accumulo.test.util.Wait;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.Test;
@@ -60,6 +66,12 @@ public class FateSummaryIT extends ConfigurableMacBase {
 
   @Test
   public void testFateSummaryCommandWithSlowCompaction() throws Exception {
+    // Occasionally, the summary/print cmds will see a COMMIT_COMPACTION transaction which was
+    // initiated on starting the manager, causing the test to fail. Stopping the compactor fixes
+    // this issue.
+    getCluster().getClusterControl().stopAllServers(ServerType.COMPACTOR);
+    Wait.waitFor(() -> getCompactorAddrs(getCluster().getServerContext()).isEmpty(), 60_000);
+
     try (AccumuloClient client = Accumulo.newClient().from(getClientProperties()).build()) {
       String namespace = "ns1";
       final String table = namespace + "." + getUniqueNames(1)[0];
@@ -79,7 +91,7 @@ public class FateSummaryIT extends ConfigurableMacBase {
       client.tableOperations().create(table, cfg);
 
       ReadWriteIT.ingest(client, 10, 10, 10, 0, table);
-      client.tableOperations().flush(table);
+      client.tableOperations().flush(table, null, null, true);
 
       // validate blank report, compactions have not started yet
       ProcessInfo p = getCluster().exec(Admin.class, "fate", "--summary", "-j", "-s", "NEW", "-s",
@@ -150,7 +162,98 @@ public class FateSummaryIT extends ConfigurableMacBase {
       assertFalse(report.getCmdCounts().isEmpty());
       assertEquals(0, report.getFateDetails().size());
 
+      client.tableOperations().delete(table);
     }
   }
 
+  @Test
+  public void testFatePrintAndSummaryCommandsWithInProgressTxns() throws Exception {
+    // This test was written for an issue with the 'admin fate --print' and 'admin fate --summary'
+    // commands where ZK NoNodeExceptions could occur. These commands first get a list of the
+    // transactions and then probe for info on these transactions. If a transaction completes
+    // between getting the list and probing for info on that transaction, a NoNodeException would
+    // occur causing the cmd to fail. This test ensures that this problem has been fixed (if the
+    // tx no longer exists, it should just be ignored so the print/summary can complete).
+
+    String[] commandsToTest = {"--print", "--summary"};
+    final int numTxns = 500;
+    final String table = getUniqueNames(1)[0];
+
+    // Occasionally, the summary/print cmds will see a COMMIT_COMPACTION transaction which was
+    // initiated on starting the manager, causing the test to fail. Stopping the compactor fixes
+    // this issue.
+    getCluster().getClusterControl().stopAllServers(ServerType.COMPACTOR);
+    Wait.waitFor(() -> getCompactorAddrs(getCluster().getServerContext()).isEmpty(), 60_000);
+
+    try (AccumuloClient client = Accumulo.newClient().from(getClientProperties()).build()) {
+      for (String command : commandsToTest) {
+        IteratorSetting is = new IteratorSetting(1, SlowIterator.class);
+        is.addOption("sleepTime", "2");
+
+        NewTableConfiguration cfg = new NewTableConfiguration();
+        cfg.attachIterator(is, EnumSet.of(IteratorUtil.IteratorScope.majc));
+        client.tableOperations().create(table, cfg);
+
+        ReadWriteIT.ingest(client, 10, 10, 10, 0, table);
+        client.tableOperations().flush(table, null, null, true);
+
+        // validate no transactions
+        ProcessInfo p = execAdminFateCommand(command);
+        assertEquals(0, p.getProcess().waitFor());
+        String result = p.readStdOut();
+        assertTrue(noTransactions(result, command));
+
+        // create 500 txns each taking >= 20ms to complete >= 10 seconds total
+        for (int i = 0; i < numTxns; i++) {
+          // Initiate compaction to create txn. This compaction will take >= 20ms to complete
+          // ((10 rows) * (2ms sleep time / row))
+          client.tableOperations().compact(table, null, null, false, false);
+        }
+
+        // Keep printing until we see a transaction complete mid-print or until we run out of
+        // transactions (they all complete).
+        // Realistically, should only take 1 or 2 iterations to see a transaction complete
+        // mid-print.
+        do {
+          // Execute the command when transactions are currently running and may complete mid-print
+          p = execAdminFateCommand(command);
+          // Previously, this check could fail due to a ZK NoNodeException
+          assertEquals(0, p.getProcess().waitFor());
+          result = p.readStdOut();
+          // A transaction should have completed mid-print and been ignored
+        } while (!result.contains("Tried to get info on a since completed transaction - ignoring")
+            && !noTransactions(result, command));
+
+        if (noTransactions(result, command)) {
+          // Fail since we printed until all transactions have completed and didn't see a
+          // transaction complete mid-print.
+          // This is highly unlikely to have occurred.
+          fail();
+        }
+        // Otherwise, we saw 'Tried to get info on a since completed transaction - ignoring', so
+        // test passes
+        client.tableOperations().delete(table);
+      }
+    }
+  }
+
+  private boolean noTransactions(String result, String command) {
+    if (command.equals("--print")) {
+      return result.contains(" 0 transactions");
+    } else { // --summary
+      result = result.substring(result.indexOf("{"), result.lastIndexOf("}") + 1);
+      FateSummaryReport report = FateSummaryReport.fromJson(result);
+      return report != null && report.getReportTime() != 0 && report.getStatusCounts().isEmpty()
+          && report.getStepCounts().isEmpty() && report.getCmdCounts().isEmpty()
+          && report.getStatusFilterNames().isEmpty() && report.getFateDetails().isEmpty();
+    }
+  }
+
+  private ProcessInfo execAdminFateCommand(String command) throws Exception {
+    if (command.equals("--print")) {
+      return getCluster().exec(Admin.class, "fate", command);
+    } else { // --summary
+      return getCluster().exec(Admin.class, "fate", command, "-j");
+    }
+  }
 }


### PR DESCRIPTION
closes https://github.com/apache/accumulo/issues/4462

- Fixes bug with admin fate print and summary commands failing due to ZK NoNodeException when a transaction completes between getting the list of transactions and probing for info on that transaction.
- Added test testFatePrintAndSummaryCommandsWithInProgressTxns() to FateSummaryIT to test changes
- Small changes to testFateSummaryCommandWithSlowCompaction() in FateSummaryIT
	- Stop the COMPACTOR to avoid seeing unnexpected transactions in the summary
	- Wait for the flush to complete
	- delete the table at the end of the test