### PR TITLE
Move TestAmple to test module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -624,13 +624,6 @@
         <artifactId>snakeyaml</artifactId>
         <version>2.2</version>
       </dependency>
-      <dependency>
-        <groupId>org.apache.accumulo</groupId>
-        <artifactId>accumulo-server-base</artifactId>
-        <version>${project.version}</version>
-        <type>test-jar</type>
-        <scope>test</scope>
-      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>

--- a/server/base/pom.xml
+++ b/server/base/pom.xml
@@ -136,24 +136,6 @@
         <directory>src/test/resources</directory>
       </testResource>
     </testResources>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>test-jar</goal>
-            </goals>
-            <configuration>
-              <includes>
-                <include>**/metadata/**</include>
-              </includes>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
   </build>
   <profiles>
     <profile>

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/AsyncConditionalTabletsMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/AsyncConditionalTabletsMutatorImpl.java
@@ -33,6 +33,8 @@ import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
 import org.apache.accumulo.core.util.threads.Threads;
 import org.apache.accumulo.server.ServerContext;
 
+import com.google.common.annotations.VisibleForTesting;
+
 public class AsyncConditionalTabletsMutatorImpl implements Ample.AsyncConditionalTabletsMutator {
   private final Consumer<Ample.ConditionalResult> resultsConsumer;
   private final ExecutorService executor;
@@ -43,8 +45,9 @@ public class AsyncConditionalTabletsMutatorImpl implements Ample.AsyncConditiona
   public static final int BATCH_SIZE = 1000;
   private final Function<DataLevel,String> tableMapper;
 
-  AsyncConditionalTabletsMutatorImpl(ServerContext context, Function<DataLevel,String> tableMapper,
-      Consumer<Ample.ConditionalResult> resultsConsumer) {
+  @VisibleForTesting
+  public AsyncConditionalTabletsMutatorImpl(ServerContext context,
+      Function<DataLevel,String> tableMapper, Consumer<Ample.ConditionalResult> resultsConsumer) {
     this.resultsConsumer = Objects.requireNonNull(resultsConsumer);
     this.context = context;
     this.bufferingMutator = new ConditionalTabletsMutatorImpl(context, tableMapper);

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
@@ -347,7 +347,7 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
     }
   }
 
-  ServerContext getContext() {
+  protected ServerContext getContext() {
     return context;
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
@@ -34,7 +34,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.client.Scanner;
@@ -65,6 +64,8 @@ import org.apache.hadoop.io.Text;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
 
 public class ServerAmpleImpl extends AmpleImpl implements Ample {
 

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.client.Scanner;
@@ -347,6 +348,7 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
     }
   }
 
+  @VisibleForTesting
   protected ServerContext getContext() {
     return context;
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletsMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletsMutatorImpl.java
@@ -32,6 +32,7 @@ import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
 import org.apache.accumulo.core.metadata.schema.Ample.TabletsMutator;
 import org.apache.accumulo.server.ServerContext;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
 public class TabletsMutatorImpl implements TabletsMutator {
@@ -42,7 +43,8 @@ public class TabletsMutatorImpl implements TabletsMutator {
   private BatchWriter metaWriter;
   private final Function<DataLevel,String> tableMapper;
 
-  TabletsMutatorImpl(ServerContext context, Function<DataLevel,String> tableMapper) {
+  @VisibleForTesting
+  public TabletsMutatorImpl(ServerContext context, Function<DataLevel,String> tableMapper) {
     this.context = context;
     this.tableMapper = Objects.requireNonNull(tableMapper);
   }

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -113,12 +113,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.accumulo</groupId>
-      <artifactId>accumulo-server-base</artifactId>
-      <type>test-jar</type>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.accumulo</groupId>
       <artifactId>accumulo-shell</artifactId>
     </dependency>
     <dependency>

--- a/test/src/main/java/org/apache/accumulo/test/ample/TestAmpleIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ample/TestAmpleIT.java
@@ -20,7 +20,7 @@ package org.apache.accumulo.test.ample;
 
 import static org.apache.accumulo.core.client.ConditionalWriter.Status.ACCEPTED;
 import static org.apache.accumulo.core.client.ConditionalWriter.Status.UNKNOWN;
-import static org.apache.accumulo.server.metadata.ConditionalWriterInterceptor.withStatus;
+import static org.apache.accumulo.test.ample.metadata.ConditionalWriterInterceptor.withStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -39,8 +39,8 @@ import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
 import org.apache.accumulo.core.metadata.schema.TabletOperationId;
 import org.apache.accumulo.core.metadata.schema.TabletOperationType;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
-import org.apache.accumulo.server.metadata.TestAmple;
-import org.apache.accumulo.server.metadata.TestAmple.TestServerAmpleImpl;
+import org.apache.accumulo.test.ample.metadata.TestAmple;
+import org.apache.accumulo.test.ample.metadata.TestAmple.TestServerAmpleImpl;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;

--- a/test/src/main/java/org/apache/accumulo/test/ample/TestAmpleUtil.java
+++ b/test/src/main/java/org/apache/accumulo/test/ample/TestAmpleUtil.java
@@ -18,11 +18,11 @@
  */
 package org.apache.accumulo.test.ample;
 
-import static org.apache.accumulo.server.metadata.TestAmple.testAmpleServerContext;
+import static org.apache.accumulo.test.ample.metadata.TestAmple.testAmpleServerContext;
 
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.server.ServerContext;
-import org.apache.accumulo.server.metadata.TestAmple.TestServerAmpleImpl;
+import org.apache.accumulo.test.ample.metadata.TestAmple.TestServerAmpleImpl;
 import org.easymock.EasyMock;
 
 public class TestAmpleUtil {

--- a/test/src/main/java/org/apache/accumulo/test/ample/metadata/ConditionalWriterDelegator.java
+++ b/test/src/main/java/org/apache/accumulo/test/ample/metadata/ConditionalWriterDelegator.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.server.metadata;
+package org.apache.accumulo.test.ample.metadata;
 
 import java.util.Iterator;
 

--- a/test/src/main/java/org/apache/accumulo/test/ample/metadata/ConditionalWriterInterceptor.java
+++ b/test/src/main/java/org/apache/accumulo/test/ample/metadata/ConditionalWriterInterceptor.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.server.metadata;
+package org.apache.accumulo.test.ample.metadata;
 
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/test/src/main/java/org/apache/accumulo/test/ample/metadata/TestAmple.java
+++ b/test/src/main/java/org/apache/accumulo/test/ample/metadata/TestAmple.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.server.metadata;
+package org.apache.accumulo.test.ample.metadata;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -48,7 +48,6 @@ import org.apache.accumulo.core.iterators.user.WholeRowIterator;
 import org.apache.accumulo.core.lock.ServiceLock;
 import org.apache.accumulo.core.metadata.AccumuloTable;
 import org.apache.accumulo.core.metadata.schema.Ample;
-import org.apache.accumulo.core.metadata.schema.Ample.ConditionalTabletsMutator;
 import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
@@ -58,6 +57,10 @@ import org.apache.accumulo.core.metadata.schema.TabletsMetadata.TableOptions;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.ColumnFQ;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.metadata.AsyncConditionalTabletsMutatorImpl;
+import org.apache.accumulo.server.metadata.ConditionalTabletsMutatorImpl;
+import org.apache.accumulo.server.metadata.ServerAmpleImpl;
+import org.apache.accumulo.server.metadata.TabletsMutatorImpl;
 import org.apache.hadoop.io.Text;
 
 import com.google.common.base.Preconditions;
@@ -212,7 +215,7 @@ public class TestAmple {
     }
 
     @Override
-    ServerContext getContext() {
+    protected ServerContext getContext() {
       return testContext.get();
     }
 

--- a/test/src/main/java/org/apache/accumulo/test/fate/ManagerRepoIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/ManagerRepoIT.java
@@ -18,8 +18,8 @@
  */
 package org.apache.accumulo.test.fate;
 
-import static org.apache.accumulo.server.metadata.TestAmple.not;
 import static org.apache.accumulo.test.ample.TestAmpleUtil.mockWithAmple;
+import static org.apache.accumulo.test.ample.metadata.TestAmple.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -57,8 +57,8 @@ import org.apache.accumulo.manager.tableOps.merge.MergeTablets;
 import org.apache.accumulo.manager.tableOps.merge.ReserveTablets;
 import org.apache.accumulo.manager.tableOps.split.FindSplits;
 import org.apache.accumulo.manager.tableOps.split.PreSplit;
-import org.apache.accumulo.server.metadata.TestAmple;
-import org.apache.accumulo.server.metadata.TestAmple.TestServerAmpleImpl;
+import org.apache.accumulo.test.ample.metadata.TestAmple;
+import org.apache.accumulo.test.ample.metadata.TestAmple.TestServerAmpleImpl;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
This moves the TestAmple implementation out of the server/base module test jar and into the test module. TestAmple and associated classes were originally put there to match the same package as Ample but this does not work due to jars being sealed. This changes the visibility of some of the constructors and methods in order to be able to override now that TestAmple is in a new package.

This is a follow on to #4415