### PR TITLE
Fixed performance issues that were impacting SplitMillionIT

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooCache.java
@@ -295,19 +295,21 @@ public class ZooCache {
 
         // only read volatile once for consistency
         ImmutableCacheCopies lic = immutableCache;
-        if (lic.childrenCache.containsKey(zPath)) {
-          return lic.childrenCache.get(zPath);
+        var cachedChildren = lic.childrenCache.get(zPath);
+        if (cachedChildren != null) {
+          return cachedChildren;
         }
 
         cacheWriteLock.lock();
         try {
-          if (childrenCache.containsKey(zPath)) {
-            return childrenCache.get(zPath);
+          List<String> children = childrenCache.get(zPath);
+          if (children != null) {
+            return children;
           }
 
           final ZooKeeper zooKeeper = getZooKeeper();
 
-          List<String> children = zooKeeper.getChildren(zPath, watcher);
+          children = zooKeeper.getChildren(zPath, watcher);
           if (children != null) {
             children = List.copyOf(children);
           }

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooCache.java
@@ -296,14 +296,16 @@ public class ZooCache {
         // only read volatile once for consistency
         ImmutableCacheCopies lic = immutableCache;
         var cachedChildren = lic.childrenCache.get(zPath);
-        if (cachedChildren != null) {
+        // null is cached as a value, that is the reason for the secondary containsKey check
+        if (cachedChildren != null || lic.childrenCache.containsKey(zPath)) {
           return cachedChildren;
         }
 
         cacheWriteLock.lock();
         try {
           List<String> children = childrenCache.get(zPath);
-          if (children != null) {
+          // null is cached as a value, that is the reason for the secondary containsKey check
+          if (children != null || lic.childrenCache.containsKey(zPath)) {
             return children;
           }
 

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooUtil.java
@@ -74,7 +74,7 @@ public class ZooUtil {
         path = root + "/" + sa[0].substring(0, lastSlash);
       }
       node = sa[0].substring(lastSlash + 1);
-      eid = Long.parseLong(sa[1], 16);
+      eid = Long.parseUnsignedLong(sa[1], 16);
     }
 
     public LockID(String path, String node, long eid) {

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooUtil.java
@@ -20,7 +20,6 @@ package org.apache.accumulo.core.fate.zookeeper;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import java.math.BigInteger;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -75,7 +74,7 @@ public class ZooUtil {
         path = root + "/" + sa[0].substring(0, lastSlash);
       }
       node = sa[0].substring(lastSlash + 1);
-      eid = new BigInteger(sa[1], 16).longValue();
+      eid = Long.parseLong(sa[1], 16);
     }
 
     public LockID(String path, String node, long eid) {

--- a/core/src/main/java/org/apache/accumulo/core/lock/ServiceLock.java
+++ b/core/src/main/java/org/apache/accumulo/core/lock/ServiceLock.java
@@ -189,7 +189,7 @@ public class ServiceLock implements Watcher {
    */
   public static List<String> validateAndSort(ServiceLockPath path, List<String> children) {
     LOG.trace("validating and sorting children at path {}", path);
-    List<String> validChildren = new ArrayList<>(children.size());
+    List<String> validChildren = children == null ? List.of() : new ArrayList<>(children.size());
     if (children == null || children.isEmpty()) {
       return validChildren;
     }

--- a/core/src/main/java/org/apache/accumulo/core/lock/ServiceLock.java
+++ b/core/src/main/java/org/apache/accumulo/core/lock/ServiceLock.java
@@ -189,10 +189,10 @@ public class ServiceLock implements Watcher {
    */
   public static List<String> validateAndSort(ServiceLockPath path, List<String> children) {
     LOG.trace("validating and sorting children at path {}", path);
-    List<String> validChildren = children == null ? List.of() : new ArrayList<>(children.size());
     if (children == null || children.isEmpty()) {
-      return validChildren;
+      return List.of();
     }
+    List<String> validChildren = new ArrayList<>(children.size());
     children.forEach(c -> {
       LOG.trace("Validating {}", c);
       if (c.startsWith(ZLOCK_PREFIX)) {

--- a/core/src/main/java/org/apache/accumulo/core/lock/ServiceLock.java
+++ b/core/src/main/java/org/apache/accumulo/core/lock/ServiceLock.java
@@ -32,6 +32,7 @@ import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil.LockID;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil.NodeMissingPolicy;
+import org.apache.accumulo.core.util.UuidUtil;
 import org.apache.accumulo.core.util.time.NanoTime;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
@@ -188,7 +189,7 @@ public class ServiceLock implements Watcher {
    */
   public static List<String> validateAndSort(ServiceLockPath path, List<String> children) {
     LOG.trace("validating and sorting children at path {}", path);
-    List<String> validChildren = new ArrayList<>();
+    List<String> validChildren = new ArrayList<>(children.size());
     if (children == null || children.isEmpty()) {
       return validChildren;
     }
@@ -202,9 +203,7 @@ public class ServiceLock implements Watcher {
           String sequenceNum = candidate.substring(idx + 1);
           try {
             LOG.trace("Testing uuid format of {}", uuid);
-            // string check guards uuids like "1-1-1-1-1" that parse to
-            // "00000001-0001-0001-0001-000000000001"
-            if (!uuid.equals(UUID.fromString(uuid).toString())) {
+            if (!UuidUtil.isUUID(uuid, 0)) {
               throw new IllegalArgumentException(uuid + " is an invalid UUID");
             }
             if (sequenceNum.length() == 10) {

--- a/core/src/main/java/org/apache/accumulo/core/util/UuidUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/UuidUtil.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.util;
+
+public class UuidUtil {
+
+  private static boolean isHex(String s, int offset, int start, int end) {
+    for (int i = start; i < end; i++) {
+      var c = s.charAt(i + offset);
+      boolean isHex = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+      if (!isHex) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  public static boolean isUUID(String uuid, int offset) {
+    // TODO not getting full coverage in unit test
+    return uuid.length() - offset == 36 && isHex(uuid, offset, 0, 8)
+        && uuid.charAt(8 + offset) == '-' && isHex(uuid, offset, 9, 13)
+        && uuid.charAt(13 + offset) == '-' && isHex(uuid, offset, 14, 18)
+        && uuid.charAt(18 + offset) == '-' && isHex(uuid, offset, 19, 23)
+        && uuid.charAt(23 + offset) == '-' && isHex(uuid, offset, 24, 36);
+  }
+
+}

--- a/core/src/main/java/org/apache/accumulo/core/util/UuidUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/UuidUtil.java
@@ -19,18 +19,6 @@
 package org.apache.accumulo.core.util;
 
 public class UuidUtil {
-  private static boolean isHex(String s, int offset, int start, int end) {
-    for (int i = start; i < end; i++) {
-      var c = s.charAt(i + offset);
-      boolean isHex = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
-      if (!isHex) {
-        return false;
-      }
-    }
-
-    return true;
-  }
-
   /**
    * A fast method for verifying a suffix of a string looks like a uuid.
    *
@@ -42,12 +30,14 @@ public class UuidUtil {
       return false;
     }
     for (int i = 0; i < 36; i++) {
-      var c = s.charAt(i + offset);
-      if ((i == 8 || i == 13 || i == 18 || i == 23)  && c != '-' ) {
-        return false;
-      } else if ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
-        continue;
-      } else {
+      var c = uuid.charAt(i + offset);
+      if (i == 8 || i == 13 || i == 18 || i == 23) {
+        if (c != '-') {
+          // expect '-' char at above positions, did not see it
+          return false;
+        }
+      } else if (c < '0' || (c > '9' && c < 'A') || (c > 'F' && c < 'a') || c > 'f') {
+        // expected hex at all other positions, did not see hex chars
         return false;
       }
     }

--- a/core/src/main/java/org/apache/accumulo/core/util/UuidUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/UuidUtil.java
@@ -32,6 +32,12 @@ public class UuidUtil {
     return true;
   }
 
+  /**
+   * A fast method for verifying a suffix of a string looks like a uuid.
+   *
+   * @param offset location where the uuid starts. Its expected the uuid occupies the rest of the
+   *        string.
+   */
   public static boolean isUUID(String uuid, int offset) {
     return uuid.length() - offset == 36 && isHex(uuid, offset, 0, 8)
         && uuid.charAt(8 + offset) == '-' && isHex(uuid, offset, 9, 13)

--- a/core/src/main/java/org/apache/accumulo/core/util/UuidUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/UuidUtil.java
@@ -38,10 +38,19 @@ public class UuidUtil {
    *        string.
    */
   public static boolean isUUID(String uuid, int offset) {
-    return uuid.length() - offset == 36 && isHex(uuid, offset, 0, 8)
-        && uuid.charAt(8 + offset) == '-' && isHex(uuid, offset, 9, 13)
-        && uuid.charAt(13 + offset) == '-' && isHex(uuid, offset, 14, 18)
-        && uuid.charAt(18 + offset) == '-' && isHex(uuid, offset, 19, 23)
-        && uuid.charAt(23 + offset) == '-' && isHex(uuid, offset, 24, 36);
+    if (uuid.length() - offset != 36) {
+      return false;
+    }
+    for (int i = 0; i < 36; i++) {
+      var c = s.charAt(i + offset);
+      if ((i == 8 || i == 13 || i == 18 || i == 23)  && c != '-' ) {
+        return false;
+      } else if ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+        continue;
+      } else {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/util/UuidUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/UuidUtil.java
@@ -33,7 +33,6 @@ public class UuidUtil {
   }
 
   public static boolean isUUID(String uuid, int offset) {
-    // TODO not getting full coverage in unit test
     return uuid.length() - offset == 36 && isHex(uuid, offset, 0, 8)
         && uuid.charAt(8 + offset) == '-' && isHex(uuid, offset, 9, 13)
         && uuid.charAt(13 + offset) == '-' && isHex(uuid, offset, 14, 18)

--- a/core/src/main/java/org/apache/accumulo/core/util/UuidUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/UuidUtil.java
@@ -19,7 +19,6 @@
 package org.apache.accumulo.core.util;
 
 public class UuidUtil {
-
   private static boolean isHex(String s, int offset, int start, int end) {
     for (int i = start; i < end; i++) {
       var c = s.charAt(i + offset);
@@ -45,5 +44,4 @@ public class UuidUtil {
         && uuid.charAt(18 + offset) == '-' && isHex(uuid, offset, 19, 23)
         && uuid.charAt(23 + offset) == '-' && isHex(uuid, offset, 24, 36);
   }
-
 }

--- a/core/src/test/java/org/apache/accumulo/core/fate/FateIdTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/fate/FateIdTest.java
@@ -62,5 +62,14 @@ public class FateIdTest {
       assertThrows(IllegalArgumentException.class, () -> FateId.from(illegalId));
       assertFalse(FateId.isFateId(illegalId));
     }
+
+    // Try an illegal character in every position
+    for (int i = 0; i < legalId.toString().length(); i++) {
+      var chars = legalId.toString().toCharArray();
+      chars[i] = '#';
+      var illegalId = new String(chars);
+      assertThrows(IllegalArgumentException.class, () -> FateId.from(illegalId));
+      assertFalse(FateId.isFateId(illegalId));
+    }
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/fate/FateIdTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/fate/FateIdTest.java
@@ -71,5 +71,20 @@ public class FateIdTest {
       assertThrows(IllegalArgumentException.class, () -> FateId.from(illegalId));
       assertFalse(FateId.isFateId(illegalId));
     }
+
+    // place number and dash chars in unexpected positions
+    for (int i = 0; i < legalId.toString().length(); i++) {
+      var chars = legalId.toString().toCharArray();
+      if (chars[i] == '-') {
+        chars[i] = '2';
+      } else {
+        chars[i] = '-';
+      }
+      var illegalId = new String(chars);
+      assertThrows(IllegalArgumentException.class, () -> FateId.from(illegalId));
+      assertFalse(FateId.isFateId(illegalId));
+
+    }
+
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
@@ -120,13 +120,13 @@ public class MetadataConstraints implements Constraint {
       );
   // @formatter:on
 
-  private static boolean isValidColumn(ColumnUpdate cu) {
+  private static boolean isValidColumn(Text family, Text qualifier) {
 
-    if (validColumnFams.contains(new Text(cu.getColumnFamily()))) {
+    if (validColumnFams.contains(family)) {
       return true;
     }
 
-    return validColumnQuals.contains(new ColumnFQ(cu));
+    return validColumnQuals.contains(new ColumnFQ(family, qualifier));
   }
 
   private static ArrayList<Short> addViolation(ArrayList<Short> lst, int violation) {
@@ -225,7 +225,7 @@ public class MetadataConstraints implements Constraint {
       Text columnQualifier = new Text(columnUpdate.getColumnQualifier());
 
       if (columnUpdate.isDeleted()) {
-        if (!isValidColumn(columnUpdate)) {
+        if (!isValidColumn(columnFamily, columnQualifier)) {
           violations = addViolation(violations, 2);
         }
         continue;
@@ -364,7 +364,7 @@ public class MetadataConstraints implements Constraint {
           checkedBulk = true;
         }
       } else {
-        if (!isValidColumn(columnUpdate)) {
+        if (!isValidColumn(columnFamily, columnQualifier)) {
           violations = addViolation(violations, 2);
         } else if (new ColumnFQ(columnUpdate).equals(TabletColumnFamily.PREV_ROW_COLUMN)
             && columnUpdate.getValue().length > 0

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ConditionalTabletMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ConditionalTabletMutatorImpl.java
@@ -31,6 +31,7 @@ import static org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSec
 
 import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -55,6 +56,7 @@ import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.accumulo.core.metadata.schema.TabletMutatorBase;
 import org.apache.accumulo.core.metadata.schema.TabletOperationId;
+import org.apache.accumulo.core.tabletserver.log.LogEntry;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.metadata.iterators.LocationExistsIterator;
@@ -278,8 +280,9 @@ public class ConditionalTabletMutatorImpl extends TabletMutatorBase<Ample.Condit
   @Override
   public Ample.ConditionalTabletMutator requireAbsentLogs() {
     Preconditions.checkState(updatesEnabled, "Cannot make updates after calling mutate.");
-    // create a tablet metadata with an empty set of logs and require the same as that
-    requireSameSingle(TabletMetadata.builder(extent).build(ColumnType.LOGS), ColumnType.LOGS);
+    Condition c = SetEncodingIterator.createCondition(Set.<LogEntry>of(),
+        logEntry -> logEntry.getColumnQualifier().toString().getBytes(UTF_8), LogColumnFamily.NAME);
+    mutation.addCondition(c);
     return this;
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ConditionalTabletMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ConditionalTabletMutatorImpl.java
@@ -296,7 +296,7 @@ public class ConditionalTabletMutatorImpl extends TabletMutatorBase<Ample.Condit
               .setValue(encodePrevEndRow(extent.prevEndRow()).get());
       mutation.addCondition(c);
     }
-    // this.putZooLock(context.getZooKeeperRoot(), lock);
+    this.putZooLock(context.getZooKeeperRoot(), lock);
     getMutation();
     mutationConsumer.accept(mutation);
     rejectionHandlerConsumer.accept(extent, rejectionCheck);

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ConditionalTabletMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ConditionalTabletMutatorImpl.java
@@ -296,7 +296,7 @@ public class ConditionalTabletMutatorImpl extends TabletMutatorBase<Ample.Condit
               .setValue(encodePrevEndRow(extent.prevEndRow()).get());
       mutation.addCondition(c);
     }
-    this.putZooLock(context.getZooKeeperRoot(), lock);
+    // this.putZooLock(context.getZooKeeperRoot(), lock);
     getMutation();
     mutationConsumer.accept(mutation);
     rejectionHandlerConsumer.accept(extent, rejectionCheck);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/DeleteTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/DeleteTablets.java
@@ -100,9 +100,11 @@ public class DeleteTablets extends ManagerRepo {
           break;
         }
 
-        tabletMeta.getKeyValues().keySet().forEach(key -> {
-          log.trace("{} deleting {}", fateId, key);
-        });
+        if (log.isTraceEnabled()) {
+          tabletMeta.getKeyValues().keySet().forEach(key -> {
+            log.trace("{} deleting {}", fateId, key);
+          });
+        }
 
         tabletMutator.deleteAll(tabletMeta.getKeyValues().keySet());
         // if the tablet no longer exists, then it was successful

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitMillionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitMillionIT.java
@@ -85,10 +85,7 @@ public class SplitMillionIT extends ConfigurableMacBase {
         String metaSplit = String.format("%s;%010d", tableId, 100_000_000 / 10 * i);
         metaSplits.add(new Text(metaSplit));
       }
-      var mt1 = System.currentTimeMillis();
       c.tableOperations().addSplits(AccumuloTable.METADATA.tableName(), metaSplits);
-      var mt2 = System.currentTimeMillis();
-      log.info("Time to add metadata splits : {}ms", mt2 - mt1);
 
       SortedSet<Text> splits = new TreeSet<>();
 
@@ -168,19 +165,7 @@ public class SplitMillionIT extends ConfigurableMacBase {
       log.info("Time to clone table : {}ms", t2 - t1);
       vefifyData(rows, c, cloneName, expected);
 
-      // pre split the metadata table
-      var cloneTableId = getServerContext().getTableId(cloneName);
-      metaSplits.clear();
-      for (int i = 1; i < 10; i++) {
-        String metaSplit = String.format("%s;%010d", cloneTableId, 100_000_000 / 10 * i);
-        metaSplits.add(new Text(metaSplit));
-      }
-      t1 = System.currentTimeMillis();
-      c.tableOperations().addSplits(AccumuloTable.METADATA.tableName(), metaSplits);
-      t2 = System.currentTimeMillis();
-      log.info("Time to add metadata splits for clone : {}ms", t2 - t1);
-
-      // merge the clone, so that delete table can run later on table with lots and lots of tablets
+      // merge the clone, so that delete table can run later on tablet with lots and lots of tablets
       t1 = System.currentTimeMillis();
       c.tableOperations().merge(cloneName, null, null);
       t2 = System.currentTimeMillis();

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitMillionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitMillionIT.java
@@ -78,7 +78,7 @@ public class SplitMillionIT extends ConfigurableMacBase {
       String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
 
-      //pre split the metadata table
+      // pre split the metadata table
       var tableId = getServerContext().getTableId(tableName);
       SortedSet<Text> metaSplits = new TreeSet<>();
       for (int i = 1; i < 10; i++) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitMillionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitMillionIT.java
@@ -39,7 +39,11 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.Filter;
-import org.apache.accumulo.harness.AccumuloClusterHarness;
+import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.minicluster.MemoryUnit;
+import org.apache.accumulo.minicluster.ServerType;
+import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -47,7 +51,7 @@ import org.slf4j.LoggerFactory;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-public class SplitMillionIT extends AccumuloClusterHarness {
+public class SplitMillionIT extends ConfigurableMacBase {
 
   private static final Logger log = LoggerFactory.getLogger(SplitMillionIT.class);
 
@@ -59,14 +63,29 @@ public class SplitMillionIT extends AccumuloClusterHarness {
     }
   }
 
+  @Override
+  public void configure(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
+    cfg.setMemory(ServerType.MANAGER, 1, MemoryUnit.GIGABYTE);
+    cfg.setMemory(ServerType.TABLET_SERVER, 1, MemoryUnit.GIGABYTE);
+  }
+
   @SuppressFBWarnings(value = {"PREDICTABLE_RANDOM", "DMI_RANDOM_USED_ONLY_ONCE"},
       justification = "predictable random is ok for testing")
   @Test
   public void testOneMillionTablets() throws Exception {
 
-    try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
+    try (AccumuloClient c = Accumulo.newClient().from(getClientProperties()).build()) {
       String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
+
+      //pre split the metadata table
+      var tableId = getServerContext().getTableId(tableName);
+      SortedSet<Text> metaSplits = new TreeSet<>();
+      for (int i = 1; i < 10; i++) {
+        String metaSplit = String.format("%s;%010d", tableId, 100_000_000 / 10 * i);
+        metaSplits.add(new Text(metaSplit));
+      }
+      c.tableOperations().addSplits(AccumuloTable.METADATA.tableName(), metaSplits);
 
       SortedSet<Text> splits = new TreeSet<>();
 


### PR DESCRIPTION
The following changes were made as result of running Java Flight Recorder repeatedly on the manager and tablet server while SplitMillionIT was running.  After these changes the following methods would not show up as much in the JFR results.

 * Sped up validation of FateId.  When deleting 1 million tablets, 1 million fate id are written and then read.  Was seeing the regex for validation show up when reading 1 million tablets w/ fate ids.
 * Sped up getting children from ZooCache.  The code related to service locks was calling this.
 * Sped up parsing of server locks by speeding up the UUID validation, that is where it was spending most of its time.
 * Sped up metadata constraint.  Seeing conditional mutation metadata updates spend a lot of time checking metadata constraints.
 * Sped up the conditional check for absent walogs by removing the creation of an empty TabletMetadata object
 * Sped up SetEncodingIterator.encode by having a special case for size 1 and avoiding streams for size >1.
 * Increased memory of manager and tsevers in SplitMillionIT because GC pauses were being seen
 * Pre split the metadata table in SplitMillionIT.  This allowed the tablets to spread across the two tablet servers.  Pre splitting the metadata table uncovered a bug.  The add splits table operation would fail if metadata tables it needed were not hosted.  Fixed this bug.
 * Made some other misc changes for little things that were seen in profiling.

 SplitMillionIT is now running faster, however it still does not seem as
fast as it used to be. Further investigation is needed. These changes are mostly good general performance fixes.  Can follow up wit more fixes as investigation continues.