### PR TITLE
speed up merge operation for lots of tablets

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
@@ -21,7 +21,6 @@ package org.apache.accumulo.core.metadata.schema;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -32,6 +31,7 @@ import org.apache.accumulo.core.client.admin.TabletAvailability;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.gc.GcCandidate;
@@ -408,7 +408,7 @@ public interface Ample {
      * @throws IllegalArgumentException if rows in keys do not match tablet row or column visibility
      *         is not empty
      */
-    T deleteAll(Set<Key> keys);
+    T deleteAll(Iterable<Map.Entry<Key,Value>> entries);
 
     T setMerged();
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -39,7 +39,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
-import java.util.SortedMap;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.admin.TabletAvailability;
@@ -88,7 +87,6 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.net.HostAndPort;
 
 public class TabletMetadata {
@@ -111,7 +109,7 @@ public class TabletMetadata {
   private final String dirName;
   private final MetadataTime time;
   private final String cloned;
-  private final SortedMap<Key,Value> keyValues;
+  private final List<Entry<Key,Value>> keyValues;
   private final OptionalLong flush;
   private final OptionalLong flushNonce;
   private final List<LogEntry> logs;
@@ -142,8 +140,8 @@ public class TabletMetadata {
     this.dirName = tmBuilder.dirName;
     this.time = tmBuilder.time;
     this.cloned = tmBuilder.cloned;
-    this.keyValues = Optional.ofNullable(tmBuilder.keyValues).map(ImmutableSortedMap.Builder::build)
-        .orElse(null);
+    this.keyValues =
+        Optional.ofNullable(tmBuilder.keyValues).map(ImmutableList.Builder::build).orElse(null);
     this.flush = tmBuilder.flush;
     this.flushNonce = tmBuilder.flushNonce;
     this.logs = Objects.requireNonNull(tmBuilder.logs.build());
@@ -450,7 +448,7 @@ public class TabletMetadata {
         .append("unSplittableMetadata", unSplittableMetadata).toString();
   }
 
-  public SortedMap<Key,Value> getKeyValues() {
+  public Iterable<Entry<Key,Value>> getKeyValues() {
     Preconditions.checkState(keyValues != null, "Requested key values when it was not saved");
     return keyValues;
   }
@@ -495,7 +493,7 @@ public class TabletMetadata {
       final String qual = key.getColumnQualifierData().toString();
 
       if (buildKeyValueMap) {
-        tmBuilder.keyValue(key, kv.getValue());
+        tmBuilder.keyValue(kv);
       }
 
       if (row == null) {
@@ -670,7 +668,7 @@ public class TabletMetadata {
     private String dirName;
     private MetadataTime time;
     private String cloned;
-    private ImmutableSortedMap.Builder<Key,Value> keyValues;
+    private ImmutableList.Builder<Entry<Key,Value>> keyValues;
     private OptionalLong flush = OptionalLong.empty();
     private OptionalLong flushNonce = OptionalLong.empty();
     private final ImmutableList.Builder<LogEntry> logs = ImmutableList.builder();
@@ -794,11 +792,11 @@ public class TabletMetadata {
       this.unSplittableMetadata = unSplittableMetadata;
     }
 
-    void keyValue(Key key, Value value) {
+    void keyValue(Entry<Key,Value> kv) {
       if (this.keyValues == null) {
-        this.keyValues = ImmutableSortedMap.naturalOrder();
+        this.keyValues = ImmutableList.builder();
       }
-      this.keyValues.put(key, value);
+      this.keyValues.add(kv);
     }
 
     TabletMetadata build(EnumSet<ColumnType> fetchedCols) {

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadataBuilder.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadataBuilder.java
@@ -41,7 +41,7 @@ import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType
 
 import java.util.Arrays;
 import java.util.EnumSet;
-import java.util.Set;
+import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
@@ -263,7 +263,7 @@ public class TabletMetadataBuilder implements Ample.TabletUpdates<TabletMetadata
   }
 
   @Override
-  public TabletMetadataBuilder deleteAll(Set<Key> keys) {
+  public TabletMetadataBuilder deleteAll(Iterable<Map.Entry<Key,Value>> keys) {
     throw new UnsupportedOperationException();
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMutatorBase.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMutatorBase.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.core.metadata.schema;
 
-import java.util.Set;
+import java.util.Map;
 
 import org.apache.accumulo.core.client.admin.TabletAvailability;
 import org.apache.accumulo.core.clientImpl.TabletAvailabilityUtil;
@@ -309,15 +309,17 @@ public abstract class TabletMutatorBase<T extends Ample.TabletUpdates<T>>
   }
 
   @Override
-  public T deleteAll(Set<Key> keys) {
+  public T deleteAll(Iterable<Map.Entry<Key,Value>> keys) {
     ByteSequence row = new ArrayByteSequence(mutation.getRow());
-    keys.forEach(key -> {
+    keys.forEach(entry -> {
+      var key = entry.getKey();
       Preconditions.checkArgument(key.getRowData().equals(row), "Unexpected row %s %s", row, key);
       Preconditions.checkArgument(key.getColumnVisibilityData().length() == 0,
           "Non empty column visibility %s", key);
     });
 
-    keys.forEach(key -> {
+    keys.forEach(entry -> {
+      var key = entry.getKey();
       mutation.putDelete(key.getColumnFamily(), key.getColumnQualifier());
     });
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
@@ -234,12 +234,12 @@ public class MetadataTableUtil {
   }
 
   private static Mutation createCloneMutation(TableId srcTableId, TableId tableId,
-      Map<Key,Value> tablet) {
+      Iterable<Entry<Key,Value>> tablet) {
 
-    KeyExtent ke = KeyExtent.fromMetaRow(tablet.keySet().iterator().next().getRow());
+    KeyExtent ke = KeyExtent.fromMetaRow(tablet.iterator().next().getKey().getRow());
     Mutation m = new Mutation(TabletsSection.encodeRow(tableId, ke.endRow()));
 
-    for (Entry<Key,Value> entry : tablet.entrySet()) {
+    for (Entry<Key,Value> entry : tablet) {
       if (entry.getKey().getColumnFamily().equals(DataFileColumnFamily.NAME)) {
         String cf = entry.getKey().getColumnQualifier().toString();
         if (!cf.startsWith("../") && !cf.contains(":")) {
@@ -375,7 +375,7 @@ public class MetadataTableUtil {
           // delete existing cloned tablet entry
           Mutation m = new Mutation(cloneTablet.getExtent().toMetaRow());
 
-          for (Entry<Key,Value> entry : cloneTablet.getKeyValues().entrySet()) {
+          for (Entry<Key,Value> entry : cloneTablet.getKeyValues()) {
             Key k = entry.getKey();
             m.putDelete(k.getColumnFamily(), k.getColumnQualifier(), k.getTimestamp());
           }

--- a/server/base/src/test/java/org/apache/accumulo/server/SetEncodingIteratorTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/SetEncodingIteratorTest.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.function.Function;
 
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
@@ -97,11 +98,19 @@ public class SetEncodingIteratorTest {
         .putFile(file4, new DataFileValue(100, 50)).putFile(file5, new DataFileValue(200, 75))
         .putFile(file6, new DataFileValue(300, 100)).putFlushId(7).build();
 
+    Function<Iterable<Map.Entry<Key,Value>>,SortedMap<Key,Value>> converter = entries -> {
+      SortedMap<Key,Value> map = new TreeMap<>();
+      for (var entry : entries) {
+        map.put(entry.getKey(), entry.getValue());
+      }
+      return map;
+    };
+
     // Convert TabletMetadata to a SortedMap
-    SortedMap<Key,Value> sortedMapNoFiles = new TreeMap<>(tmNoFiles.getKeyValues());
-    SortedMap<Key,Value> sortedMapOneFile = new TreeMap<>(tmOneFile.getKeyValues());
-    SortedMap<Key,Value> sortedMap = new TreeMap<>(tmMultipleFiles.getKeyValues());
-    SortedMap<Key,Value> sortedMap2 = new TreeMap<>(tmMultipleFiles2.getKeyValues());
+    SortedMap<Key,Value> sortedMapNoFiles = converter.apply(tmNoFiles.getKeyValues());
+    SortedMap<Key,Value> sortedMapOneFile = converter.apply(tmOneFile.getKeyValues());
+    SortedMap<Key,Value> sortedMap = converter.apply(tmMultipleFiles.getKeyValues());
+    SortedMap<Key,Value> sortedMap2 = converter.apply(tmMultipleFiles2.getKeyValues());
     // Add the second tablet metadata to the sortedMap
     sortedMap.putAll(sortedMap2);
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/DeleteTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/DeleteTablets.java
@@ -100,11 +100,11 @@ public class DeleteTablets extends ManagerRepo {
           break;
         }
 
-        tabletMeta.getKeyValues().keySet().forEach(key -> {
-          log.trace("{} deleting {}", fateId, key);
-        });
+        if (log.isTraceEnabled()) {
+          tabletMeta.getKeyValues().forEach(e -> log.trace("{} deleting {}", fateId, e.getKey()));
+        }
 
-        tabletMutator.deleteAll(tabletMeta.getKeyValues().keySet());
+        tabletMutator.deleteAll(tabletMeta.getKeyValues());
         // if the tablet no longer exists, then it was successful
         tabletMutator.submit(Ample.RejectionHandler.acceptAbsentTablet());
         submitted++;

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitIT.java
@@ -422,7 +422,9 @@ public class SplitIT extends AccumuloClusterHarness {
 
       // remove the srv:lock column for tests as this will change
       // because we are changing the metadata from the IT.
-      var original = new TreeMap<>(tabletMetadata.getKeyValues());
+      var original = new TreeMap<Key,Value>();
+      tabletMetadata.getKeyValues()
+          .forEach(entry -> original.put(entry.getKey(), entry.getValue()));
       assertTrue(original.keySet().removeIf(LOCK_COLUMN::hasColumns));
 
       // Split operation should fail because of the unexpected column.
@@ -436,7 +438,8 @@ public class SplitIT extends AccumuloClusterHarness {
       assertEquals(extent, tabletMetadata.getExtent());
 
       // tablet should have an operation id set, but nothing else changed
-      var kvCopy = new TreeMap<>(tabletMetadata2.getKeyValues());
+      var kvCopy = new TreeMap<Key,Value>();
+      tabletMetadata2.getKeyValues().forEach(entry -> kvCopy.put(entry.getKey(), entry.getValue()));
       assertTrue(kvCopy.keySet().removeIf(LOCK_COLUMN::hasColumns));
       assertTrue(kvCopy.keySet().removeIf(OPID_COLUMN::hasColumns));
       assertEquals(original, kvCopy);


### PR DESCRIPTION
Made two changes to speed up merge. First adjusted the sleep time for one of the Fate steps to consider how long a scan took.  For SplitMillionIT this resulted in ReserveTablets.isReady() sleeping for
around 30s instead of 60s.   Second when the merge code was deleting
tablets it was asking TabletMetadata to save key values and those saved
key values were being sorted, even though they did not need to be and
were actually already sorted. Changed code to not sort and the resulted
in DeleteTablets.call() going from 63s to 55s.  Below are the relevant
log messages from before and after runs w/ change to not sort.

```
2024-05-17T18:27:49,635 104 [fate.Fate] DEBUG: Running DeleteTablets.call() FATE:USER:9b3c9abe-a29a-4776-80ee-b0e6c0132d98 took 63328 ms and returned FinishTableRangeOp
```

```
2024-05-17T20:20:31,468 103 [fate.Fate] DEBUG: Running DeleteTablets.call() FATE:USER:3f566052-d88d-44dd-9e8b-ac34ed9ca445 took 54710 ms and returned FinishTableRangeO
```