### PR TITLE
Update MetricsIT

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/metrics/MetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/metrics/MetricsIT.java
@@ -99,13 +99,10 @@ public class MetricsIT extends ConfigurableMacBase implements MetricsProducer {
     doWorkToGenerateMetrics();
     cluster.stop();
 
-    Set<String> unexpectedMetrics =
-        Set.of(METRICS_SCAN_YIELDS, METRICS_UPDATE_ERRORS, METRICS_COMPACTOR_MAJC_STUCK,
-            METRICS_SCAN_BUSY_TIMEOUT_COUNTER, METRICS_SCAN_PAUSED_FOR_MEM,
-            METRICS_SCAN_RETURN_FOR_MEM, METRICS_MINC_PAUSED, METRICS_MAJC_PAUSED);
-    Set<String> flakyMetrics = Set.of(METRICS_GC_WAL_ERRORS, METRICS_FATE_TYPE_IN_PROGRESS,
-        METRICS_SCAN_BUSY_TIMEOUT_COUNTER, METRICS_SCAN_RESERVATION_TIMER,
-        METRICS_SCAN_TABLET_METADATA_CACHE);
+    Set<String> unexpectedMetrics = Set.of(METRICS_COMPACTOR_MAJC_STUCK, METRICS_SCAN_YIELDS);
+    Set<String> flakyMetrics =
+        Set.of(METRICS_FATE_TYPE_IN_PROGRESS, METRICS_GC_WAL_ERRORS, METRICS_SCAN_RESERVATION_TIMER,
+            METRICS_SCAN_BUSY_TIMEOUT_COUNTER, METRICS_SCAN_TABLET_METADATA_CACHE);
 
     Map<String,String> expectedMetricNames = this.getMetricFields();
     flakyMetrics.forEach(expectedMetricNames::remove); // might not see these


### PR DESCRIPTION
Changes to counters are now publishing metrics that may have not seen before:
  - METRICS_MAJC_PAUSED
  - METRICS_MINC_PAUSED
  - METRICS_SCAN_PAUSED_FOR_MEM
  - METRICS_SCAN_RETURN_FOR_MEM
  - METRICS_UPDATE_ERRORS

Also sorted metrics excludes list to make things easier to find.