### PR TITLE
Add metrics for scan server reservation write out time and collisions

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metrics/MetricsProducer.java
+++ b/core/src/main/java/org/apache/accumulo/core/metrics/MetricsProducer.java
@@ -341,7 +341,7 @@ import io.micrometer.core.instrument.MeterRegistry;
  * <tr>
  * <th>N/A</th>
  * <th>N/A</th>
- * <th>{@value #METRICS_SCAN_RESERVATION_TIMER}</th>
+ * <th>{@value #METRICS_SCAN_RESERVATION_TOTAL_TIMER}</th>
  * <th>Timer</th>
  * <th>Time to reserve a tablets files for scan</th>
  * </tr>
@@ -629,8 +629,12 @@ public interface MetricsProducer {
   String METRICS_SCAN_START = METRICS_SCAN_PREFIX + "start";
   String METRICS_SCAN_CONTINUE = METRICS_SCAN_PREFIX + "continue";
   String METRICS_SCAN_CLOSE = METRICS_SCAN_PREFIX + "close";
+  String METRICS_SCAN_RESERVATION_TOTAL_TIMER = METRICS_SCAN_PREFIX + "reservation.total.timer";
+  String METRICS_SCAN_RESERVATION_WRITEOUT_TIMER =
+      METRICS_SCAN_PREFIX + "reservation.writeout.timer";
   String METRICS_SCAN_BUSY_TIMEOUT_COUNTER = METRICS_SCAN_PREFIX + "busy.timeout.count";
-  String METRICS_SCAN_RESERVATION_TIMER = METRICS_SCAN_PREFIX + "reservation.timer";
+  String METRICS_SCAN_RESERVATION_COLLISION_COUNTER =
+      METRICS_SCAN_PREFIX + "reservation.collision.count";
   String METRICS_SCAN_QUERIES = METRICS_SCAN_PREFIX + "queries";
   String METRICS_SCAN_QUERY_SCAN_RESULTS = METRICS_SCAN_PREFIX + "query.results";
   String METRICS_SCAN_QUERY_SCAN_RESULTS_BYTES = METRICS_SCAN_PREFIX + "query.results.bytes";

--- a/core/src/main/java/org/apache/accumulo/core/metrics/MetricsProducer.java
+++ b/core/src/main/java/org/apache/accumulo/core/metrics/MetricsProducer.java
@@ -633,8 +633,8 @@ public interface MetricsProducer {
   String METRICS_SCAN_RESERVATION_WRITEOUT_TIMER =
       METRICS_SCAN_PREFIX + "reservation.writeout.timer";
   String METRICS_SCAN_BUSY_TIMEOUT_COUNTER = METRICS_SCAN_PREFIX + "busy.timeout.count";
-  String METRICS_SCAN_RESERVATION_COLLISION_COUNTER =
-      METRICS_SCAN_PREFIX + "reservation.collision.count";
+  String METRICS_SCAN_RESERVATION_CONFLICT_COUNTER =
+      METRICS_SCAN_PREFIX + "reservation.conflict.count";
   String METRICS_SCAN_QUERIES = METRICS_SCAN_PREFIX + "queries";
   String METRICS_SCAN_QUERY_SCAN_RESULTS = METRICS_SCAN_PREFIX + "query.results";
   String METRICS_SCAN_QUERY_SCAN_RESULTS_BYTES = METRICS_SCAN_PREFIX + "query.results.bytes";

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -602,13 +602,8 @@ public class ScanServer extends AbstractServer
       }
 
       if (!filesToReserve.isEmpty()) {
-        long reservationWriteStart = System.nanoTime();
-        try {
-          getContext().getAmple().putScanServerFileReferences(refs);
-        } finally {
-          long elapsed = System.nanoTime() - reservationWriteStart;
-          scanServerMetrics.recordWriteOutReservationTime(Duration.ofNanos(elapsed));
-        }
+        scanServerMetrics.recordWriteOutReservationTime(
+            () -> getContext().getAmple().putScanServerFileReferences(refs));
 
         // After we insert the scan server refs we need to check and see if the tablet is still
         // using the file. As long as the tablet is still using the files then the Accumulo GC

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -642,7 +642,7 @@ public class ScanServer extends AbstractServer
           LOG.info("RFFS {} tablet files changed while attempting to reference files {}",
               myReservationId, filesToReserve);
           getContext().getAmple().deleteScanServerFileReferences(refs);
-          scanServerMetrics.incrementCollisions();
+          scanServerMetrics.incrementReservationConflictCount();
           return null;
         }
       }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServerMetrics.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServerMetrics.java
@@ -18,6 +18,9 @@
  */
 package org.apache.accumulo.tserver;
 
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metrics.MetricsProducer;
@@ -25,14 +28,17 @@ import org.apache.accumulo.core.metrics.MetricsProducer;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics;
 
 public class ScanServerMetrics implements MetricsProducer {
 
-  private Timer reservationTimer;
+  private Timer totalReservationTimer;
+  private Timer writeOutReservationTimer;
   private Counter busyTimeoutCount;
+  private final AtomicLong collisionCount = new AtomicLong(0);
 
   private final LoadingCache<KeyExtent,TabletMetadata> tabletMetadataCache;
 
@@ -42,18 +48,34 @@ public class ScanServerMetrics implements MetricsProducer {
 
   @Override
   public void registerMetrics(MeterRegistry registry) {
-    reservationTimer = Timer.builder(MetricsProducer.METRICS_SCAN_RESERVATION_TIMER)
+    totalReservationTimer = Timer.builder(MetricsProducer.METRICS_SCAN_RESERVATION_TOTAL_TIMER)
         .description("Time to reserve a tablets files for scan").register(registry);
+    writeOutReservationTimer =
+        Timer.builder(MetricsProducer.METRICS_SCAN_RESERVATION_WRITEOUT_TIMER)
+            .description("Time to write out a tablets files for scan").register(registry);
     busyTimeoutCount = Counter.builder(METRICS_SCAN_BUSY_TIMEOUT_COUNTER)
         .description("The number of scans where a busy timeout happened").register(registry);
+    FunctionCounter
+        .builder(METRICS_SCAN_RESERVATION_COLLISION_COUNTER, collisionCount, AtomicLong::get)
+        .description("The number of scans where a collision happened while trying to reserve files")
+        .register(registry);
+
     CaffeineCacheMetrics.monitor(registry, tabletMetadataCache, METRICS_SCAN_TABLET_METADATA_CACHE);
   }
 
-  public Timer getReservationTimer() {
-    return reservationTimer;
+  public void recordTotalReservationTime(Duration time) {
+    totalReservationTimer.record(time);
+  }
+
+  public void recordWriteOutReservationTime(Duration time) {
+    writeOutReservationTimer.record(time);
   }
 
   public void incrementBusy() {
     busyTimeoutCount.increment();
+  }
+
+  public void incrementCollisions() {
+    collisionCount.getAndIncrement();
   }
 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServerMetrics.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServerMetrics.java
@@ -51,9 +51,9 @@ public class ScanServerMetrics implements MetricsProducer {
   public void registerMetrics(MeterRegistry registry) {
     totalReservationTimer = Timer.builder(MetricsProducer.METRICS_SCAN_RESERVATION_TOTAL_TIMER)
         .description("Time to reserve a tablets files for scan").register(registry);
-    writeOutReservationTimer =
-        Timer.builder(MetricsProducer.METRICS_SCAN_RESERVATION_WRITEOUT_TIMER)
-            .description("Time to write out a tablets files for scan").register(registry);
+    writeOutReservationTimer = Timer
+        .builder(MetricsProducer.METRICS_SCAN_RESERVATION_WRITEOUT_TIMER)
+        .description("Time to write out a tablets file reservations for scan").register(registry);
     busyTimeoutCount = Counter.builder(METRICS_SCAN_BUSY_TIMEOUT_COUNTER)
         .description("The number of scans where a busy timeout happened").register(registry);
     FunctionCounter
@@ -72,7 +72,7 @@ public class ScanServerMetrics implements MetricsProducer {
     totalReservationTimer.record(time);
   }
 
-  public void recordWriteOutReservationTime(Duration time) {
+  public void recordWriteOutReservationTime(Runnable time) {
     writeOutReservationTimer.record(time);
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServerMetrics.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServerMetrics.java
@@ -38,7 +38,7 @@ public class ScanServerMetrics implements MetricsProducer {
   private Timer totalReservationTimer;
   private Timer writeOutReservationTimer;
   private Counter busyTimeoutCount;
-  private final AtomicLong collisionCount = new AtomicLong(0);
+  private final AtomicLong reservationConflictCount = new AtomicLong(0);
 
   private final LoadingCache<KeyExtent,TabletMetadata> tabletMetadataCache;
 
@@ -56,8 +56,10 @@ public class ScanServerMetrics implements MetricsProducer {
     busyTimeoutCount = Counter.builder(METRICS_SCAN_BUSY_TIMEOUT_COUNTER)
         .description("The number of scans where a busy timeout happened").register(registry);
     FunctionCounter
-        .builder(METRICS_SCAN_RESERVATION_COLLISION_COUNTER, collisionCount, AtomicLong::get)
-        .description("The number of scans where a collision happened while trying to reserve files")
+        .builder(METRICS_SCAN_RESERVATION_CONFLICT_COUNTER, reservationConflictCount,
+            AtomicLong::get)
+        .description(
+            "Counts instances where file reservation attempts for scans encountered conflicts")
         .register(registry);
 
     CaffeineCacheMetrics.monitor(registry, tabletMetadataCache, METRICS_SCAN_TABLET_METADATA_CACHE);
@@ -75,7 +77,7 @@ public class ScanServerMetrics implements MetricsProducer {
     busyTimeoutCount.increment();
   }
 
-  public void incrementCollisions() {
-    collisionCount.getAndIncrement();
+  public void incrementReservationConflictCount() {
+    reservationConflictCount.getAndIncrement();
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/metrics/MetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/metrics/MetricsIT.java
@@ -103,7 +103,7 @@ public class MetricsIT extends ConfigurableMacBase implements MetricsProducer {
         METRICS_REPLICATION_QUEUE, METRICS_COMPACTOR_MAJC_STUCK, METRICS_SCAN_BUSY_TIMEOUT_COUNTER);
     // add sserver as flaky until scan server included in mini tests.
     Set<String> flakyMetrics = Set.of(METRICS_GC_WAL_ERRORS, METRICS_FATE_TYPE_IN_PROGRESS,
-        METRICS_SCAN_BUSY_TIMEOUT_COUNTER, METRICS_SCAN_RESERVATION_TIMER,
+        METRICS_SCAN_BUSY_TIMEOUT_COUNTER, METRICS_SCAN_RESERVATION_TOTAL_TIMER,
         METRICS_SCAN_TABLET_METADATA_CACHE);
 
     Map<String,String> expectedMetricNames = this.getMetricFields();


### PR DESCRIPTION
Fixes #4509

This PR adds two new metrics:
1. `accumulo.scan.reservation.writeout.timer` which records the amount of time it takes for reservations to be added to the metadata table
2. `accumulo.scan.reservation.collision.count` which adds a `FunctionCounter` that gets incremented if a scan is held up waiting for files that are in flux

I also renamed `accumulo.scan.reservation.timer` to `accumulo.scan.reservation.total.timer`.

supersedes #4541 