### PR TITLE
ignores failures to set future location

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletStateStore.java
@@ -18,10 +18,7 @@
  */
 package org.apache.accumulo.server.manager.state;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
@@ -65,8 +62,11 @@ public interface TabletStateStore {
 
   /**
    * Store the assigned locations in the data store.
+   *
+   * @return the failures, the extents that a future location could not be set for
    */
-  void setFutureLocations(Collection<Assignment> assignments) throws DistributedStoreException;
+  Set<KeyExtent> setFutureLocations(Collection<Assignment> assignments)
+      throws DistributedStoreException;
 
   /**
    * Tablet servers will update the data store with the location when they bring the tablet online

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/ZooTabletStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/ZooTabletStateStore.java
@@ -22,17 +22,14 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.AbstractMap;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.iteratorsImpl.system.SortedMapIterator;
 import org.apache.accumulo.core.manager.state.TabletManagement;
@@ -154,10 +151,10 @@ class ZooTabletStateStore extends AbstractTabletStateStore implements TabletStat
   }
 
   @Override
-  public void setFutureLocations(Collection<Assignment> assignments)
+  public Set<KeyExtent> setFutureLocations(Collection<Assignment> assignments)
       throws DistributedStoreException {
     validateAssignments(assignments);
-    super.setFutureLocations(assignments);
+    return super.setFutureLocations(assignments);
   }
 
   @Override


### PR DESCRIPTION
When TabletGroupWatcher failed to set a future location it would still ask the tablet server to load the tablet.  The tablet server would get the request and fail causing noise in its logs.  This change avoids uneeded work and noise in the logs.