### PR TITLE
adds toggle for automatically setting lock on mutation

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
@@ -421,6 +421,12 @@ public interface Ample {
     T setUnSplittable(UnSplittableMetadata unSplittableMeta);
 
     T deleteUnSplittable();
+
+    /**
+     * By default the server lock is automatically added to mutations unless this method is set to
+     * false.
+     */
+    T automaticallyPutServerLock(boolean b);
   }
 
   interface TabletMutator extends TabletUpdates<TabletMutator> {

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadataBuilder.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadataBuilder.java
@@ -303,6 +303,11 @@ public class TabletMetadataBuilder implements Ample.TabletUpdates<TabletMetadata
     throw new UnsupportedOperationException();
   }
 
+  @Override
+  public TabletMetadataBuilder automaticallyPutServerLock(boolean b) {
+    throw new UnsupportedOperationException();
+  }
+
   /**
    * @param extraFetched Anything that was put on the builder will automatically be added to the
    *        fetched set. However, for the case where something was not put and it needs to be

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMutatorBase.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMutatorBase.java
@@ -64,6 +64,7 @@ public abstract class TabletMutatorBase<T extends Ample.TabletUpdates<T>>
   protected final Mutation mutation;
   protected AutoCloseable closeAfterMutate;
   protected boolean updatesEnabled = true;
+  protected boolean putServerLock = true;
 
   @SuppressWarnings("unchecked")
   private T getThis() {
@@ -357,6 +358,12 @@ public abstract class TabletMutatorBase<T extends Ample.TabletUpdates<T>>
   @Override
   public T deleteUnSplittable() {
     SplitColumnFamily.UNSPLITTABLE_COLUMN.putDelete(mutation);
+    return getThis();
+  }
+
+  @Override
+  public T automaticallyPutServerLock(boolean b) {
+    putServerLock = b;
     return getThis();
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ConditionalTabletMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ConditionalTabletMutatorImpl.java
@@ -295,7 +295,9 @@ public class ConditionalTabletMutatorImpl extends TabletMutatorBase<Ample.Condit
               .setValue(encodePrevEndRow(extent.prevEndRow()).get());
       mutation.addCondition(c);
     }
-    this.putZooLock(context.getZooKeeperRoot(), lock);
+    if (putServerLock) {
+      this.putZooLock(context.getZooKeeperRoot(), lock);
+    }
     getMutation();
     mutationConsumer.accept(mutation);
     rejectionHandlerConsumer.accept(extent, rejectionCheck);

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/RootTabletMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/RootTabletMutatorImpl.java
@@ -86,7 +86,9 @@ public class RootTabletMutatorImpl extends TabletMutatorBase<Ample.TabletMutator
   @Override
   public void mutate() {
 
-    this.putZooLock(this.context.getZooKeeperRoot(), lock);
+    if (putServerLock) {
+      this.putZooLock(this.context.getZooKeeperRoot(), lock);
+    }
     Mutation mutation = getMutation();
 
     MetadataConstraints metaConstraint = new MetadataConstraints();

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorImpl.java
@@ -45,7 +45,9 @@ class TabletMutatorImpl extends TabletMutatorBase<Ample.TabletMutator>
   @Override
   public void mutate() {
     try {
-      this.putZooLock(this.context.getZooKeeperRoot(), lock);
+      if (putServerLock) {
+        this.putZooLock(this.context.getZooKeeperRoot(), lock);
+      }
       writer.addMutation(getMutation());
 
       if (closeAfterMutate != null) {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/DeleteTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/DeleteTablets.java
@@ -107,6 +107,10 @@ public class DeleteTablets extends ManagerRepo {
         }
 
         tabletMutator.deleteAll(tabletMeta.getKeyValues().keySet());
+
+        // the entire tablet is being deleted, so do not want to add lock entry to the tablet
+        tabletMutator.automaticallyPutServerLock(false);
+
         // if the tablet no longer exists, then it was successful
         tabletMutator.submit(Ample.RejectionHandler.acceptAbsentTablet());
         submitted++;


### PR DESCRIPTION
Merging tables in a table deletes tablets.  When tablets were being deleted they were automatically setting a lock, which could leave junk in the metadata table.  Added a toggle to turn off setting these on mutations.