### PR TITLE
cleans up some todos

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -444,9 +444,8 @@ public enum Property {
       "The number of threads used to inspect tablets files to find split points.", "4.0.0"),
 
   MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_SIZE("manager.compaction.major.service.queue.size",
-      // ELASTICITY_TODO: It might be good to note that there is a priority queue per compactor
-      // resource group
-      "10000", PropertyType.COUNT, "The max size of the priority queue.", "4.0"),
+      "10000", PropertyType.COUNT,
+      "The max size of each resource groups compaction job priority queue.", "4.0"),
   SPLIT_PREFIX("split.", null, PropertyType.PREFIX,
       "System wide properties related to splitting tablets.", "3.1.0"),
   SPLIT_MAXOPEN("split.files.max", "300", PropertyType.COUNT,

--- a/server/base/src/main/java/org/apache/accumulo/server/AccumuloDataVersion.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/AccumuloDataVersion.java
@@ -82,7 +82,7 @@ public class AccumuloDataVersion {
     return CURRENT_VERSION;
   }
 
-  // ELASTICITY_TODO get upgrade working
+  // ELASTICITY_TODO get upgrade working #4587
   // public static final Set<Integer> CAN_RUN = Set.of(ROOT_TABLET_META_CHANGES,
   // REMOVE_DEPRECATIONS_FOR_VERSION_3, METADATA_FILE_JSON_ENCODING, CURRENT_VERSION);
   public static final Set<Integer> CAN_RUN = Set.of(CURRENT_VERSION);

--- a/server/base/src/test/java/org/apache/accumulo/server/ServerContextTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/ServerContextTest.java
@@ -134,7 +134,7 @@ public class ServerContextTest {
   @Test
   public void testCanRun() {
     final int oldestSupported = AccumuloDataVersion.oldestUpgradeableVersion();
-    // ELASTICITY_TODO basically disable check until upgrade is working. Should be:
+    // ELASTICITY_TODO #4587 basically disable check until upgrade is working. Should be:
     // assertEquals(10, oldestSupported); // make sure it hasn't changed accidentally
     final int currentVersion = AccumuloDataVersion.get();
     IntConsumer shouldPass = ServerContext::ensureDataVersionCompatible;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
@@ -158,7 +158,7 @@ public class CompactionCoordinator
       new ConcurrentHashMap<>();
 
   /* Map of group name to last time compactor called to get a compaction job */
-  // ELASTICITY_TODO need to clean out groups that are no longer configured..
+  // ELASTICITY_TODO #4403 need to clean out groups that are no longer configured..
   private final Map<CompactorGroupId,Long> TIME_COMPACTOR_LAST_CHECKED = new ConcurrentHashMap<>();
 
   private final ServerContext ctx;

--- a/test/src/main/java/org/apache/accumulo/test/UnusedWALIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/UnusedWALIT.java
@@ -47,7 +47,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.RawLocalFileSystem;
 import org.junit.jupiter.api.Test;
 
-// ELASTICITY_TODO When reviewing the changes for ACCUMULO-3423, kturner suggested
+// When reviewing the changes for ACCUMULO-3423, kturner suggested
 // "tablets will now have log references that contain no data,
 // so it may be marked with 3 WALs, the first with data, the 2nd without, a 3rd with data.
 // It would be useful to have an IT that will test this situation.


### PR DESCRIPTION
Cleaned up a few TODOs in the elasticity branch.  Added issues to some, implemented an easy one, and removed one that was erroneously added.  The TODO in UnusedWALIT.java was erroneously added to an old comment from 2015.