### PR TITLE
improves fate execution of in progress transactions

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/FateCleaner.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/FateCleaner.java
@@ -104,7 +104,7 @@ public class FateCleaner<T> {
   }
 
   public void ageOff() {
-    store.list().filter(ids -> AGE_OFF_STATUSES.contains(ids.getStatus()))
+    store.list(AGE_OFF_STATUSES)
         .forEach(idStatus -> store.tryReserve(idStatus.getFateId()).ifPresent(txStore -> {
           try {
             AgeOffInfo ageOffInfo = readAgeOffInfo(txStore);

--- a/core/src/main/java/org/apache/accumulo/core/fate/ReadOnlyFateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/ReadOnlyFateStore.java
@@ -19,11 +19,14 @@
 package org.apache.accumulo.core.fate;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.accumulo.core.util.Pair;
@@ -53,7 +56,10 @@ public interface ReadOnlyFateStore<T> {
     /** Unrecognized or unknown transaction state */
     UNKNOWN,
     /** Transaction that is eligible to be executed */
-    SUBMITTED
+    SUBMITTED;
+
+    public static final Set<TStatus> ALL_STATUSES =
+        Arrays.stream(values()).collect(Collectors.toUnmodifiableSet());
   }
 
   /**
@@ -137,6 +143,13 @@ public interface ReadOnlyFateStore<T> {
    * @return all outstanding transactions, including those reserved by others.
    */
   Stream<FateIdStatus> list();
+
+  /**
+   * list all transaction ids in store that have a current status that is in the provided set
+   *
+   * @return all outstanding transactions, including those reserved by others.
+   */
+  Stream<FateIdStatus> list(Set<TStatus> statuses);
 
   /**
    * list transaction in the store that have a given fate key type.

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/FateStatusFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/FateStatusFilter.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.fate.user;
+
+import static org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus.ALL_STATUSES;
+
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.ScannerBase;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.fate.ReadOnlyFateStore;
+import org.apache.accumulo.core.iterators.Filter;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+
+public class FateStatusFilter extends Filter {
+
+  private EnumSet<ReadOnlyFateStore.TStatus> valuesToAccept;
+
+  @Override
+  public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options,
+      IteratorEnvironment env) throws IOException {
+    super.init(source, options, env);
+    valuesToAccept = EnumSet.noneOf(ReadOnlyFateStore.TStatus.class);
+    var option = options.get("statuses");
+    if (!option.isBlank()) {
+      for (var status : option.split(",")) {
+        valuesToAccept.add(ReadOnlyFateStore.TStatus.valueOf(status));
+      }
+    }
+  }
+
+  @Override
+  public boolean accept(Key k, Value v) {
+    var tstatus = ReadOnlyFateStore.TStatus.valueOf(v.toString());
+    return valuesToAccept.contains(tstatus);
+  }
+
+  public static void configureScanner(ScannerBase scanner,
+      Set<ReadOnlyFateStore.TStatus> statuses) {
+    // only filter when getting a subset of statuses
+    if (!statuses.equals(ALL_STATUSES)) {
+      String statusesStr = statuses.stream().map(Enum::name).collect(Collectors.joining(","));
+      var iterSettings = new IteratorSetting(100, "statuses", FateStatusFilter.class);
+      iterSettings.addOption("statuses", statusesStr);
+      scanner.addScanIterator(iterSettings);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/UserFateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/UserFateStore.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -151,10 +152,11 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
   }
 
   @Override
-  protected Stream<FateIdStatus> getTransactions() {
+  protected Stream<FateIdStatus> getTransactions(Set<TStatus> statuses) {
     try {
       Scanner scanner = context.createScanner(tableName, Authorizations.EMPTY);
       scanner.setRange(new Range());
+      FateStatusFilter.configureScanner(scanner, statuses);
       TxColumnFamily.STATUS_COLUMN.fetch(scanner);
       return scanner.stream().onClose(scanner::close).map(e -> {
         String txUUIDStr = e.getKey().getRow().toString();
@@ -176,6 +178,7 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
     try {
       Scanner scanner = context.createScanner(tableName, Authorizations.EMPTY);
       scanner.setRange(new Range());
+      // TODO push iterator down to filter
       TxColumnFamily.TX_KEY_COLUMN.fetch(scanner);
       return scanner.stream().onClose(scanner::close)
           .map(e -> FateKey.deserialize(e.getValue().get()))

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/UserFateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/UserFateStore.java
@@ -178,7 +178,6 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
     try {
       Scanner scanner = context.createScanner(tableName, Authorizations.EMPTY);
       scanner.setRange(new Range());
-      // TODO push iterator down to filter
       TxColumnFamily.TX_KEY_COLUMN.fetch(scanner);
       return scanner.stream().onClose(scanner::close)
           .map(e -> FateKey.deserialize(e.getValue().get()))

--- a/core/src/main/java/org/apache/accumulo/core/logging/FateLogger.java
+++ b/core/src/main/java/org/apache/accumulo/core/logging/FateLogger.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.core.logging;
 
 import java.io.Serializable;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -118,6 +119,11 @@ public class FateLogger {
       @Override
       public Stream<FateIdStatus> list() {
         return store.list();
+      }
+
+      @Override
+      public Stream<FateIdStatus> list(Set<TStatus> statuses) {
+        return store.list(statuses);
       }
 
       @Override

--- a/core/src/test/java/org/apache/accumulo/core/fate/TestStore.java
+++ b/core/src/test/java/org/apache/accumulo/core/fate/TestStore.java
@@ -217,6 +217,11 @@ public class TestStore implements FateStore<String> {
   }
 
   @Override
+  public Stream<FateIdStatus> list(Set<TStatus> statuses) {
+    return list().filter(fis -> statuses.contains(fis.getStatus()));
+  }
+
+  @Override
   public Stream<FateKey> list(FateKey.FateKeyType type) {
     throw new UnsupportedOperationException();
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/init/InitialConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/InitialConfiguration.java
@@ -25,6 +25,7 @@ import java.util.function.Predicate;
 
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.conf.SiteConfiguration;
+import org.apache.accumulo.core.fate.user.schema.FateSchema;
 import org.apache.accumulo.core.iterators.user.VersioningIterator;
 import org.apache.accumulo.core.metadata.AccumuloTable;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
@@ -85,6 +86,11 @@ class InitialConfiguration {
 
     initialFateTableConf.putAll(commonConfig);
     initialFateTableConf.put(Property.TABLE_SPLIT_THRESHOLD.getKey(), "256M");
+    // Create a locality group that contains status so its fast to scan. When fate looks for work is
+    // scans this family.
+    initialFateTableConf.put(Property.TABLE_LOCALITY_GROUP_PREFIX.getKey() + "status",
+        FateSchema.TxColumnFamily.STR_NAME);
+    initialFateTableConf.put(Property.TABLE_LOCALITY_GROUPS.getKey(), "status");
 
     int max = hadoopConf.getInt("dfs.replication.max", 512);
     // Hadoop 0.23 switched the min value configuration name

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/PreSplit.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/PreSplit.java
@@ -69,11 +69,6 @@ public class PreSplit extends ManagerRepo {
   public long isReady(FateId fateId, Manager manager) throws Exception {
     var opid = TabletOperationId.from(TabletOperationType.SPLITTING, fateId);
 
-    // ELASTICITY_TODO does FATE prioritize running Fate txs that have already started? If not would
-    // be good to look into this so we can finish things that are started before running new txs
-    // that have not completed their first step. Once splits starts running, would like it to move
-    // through as quickly as possible.
-
     var tabletMetadata = manager.getContext().getAmple().readTablet(splitInfo.getOriginal(),
         PREV_ROW, LOCATION, OPID, LOGS);
 

--- a/test/src/main/java/org/apache/accumulo/test/fate/FateInterleavingIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FateInterleavingIT.java
@@ -1,0 +1,396 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test.fate;
+
+import static org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus.SUBMITTED;
+import static org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus.SUCCESSFUL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.AbstractMap;
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.apache.accumulo.core.client.Accumulo;
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.MutationsRejectedException;
+import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
+import org.apache.accumulo.core.client.admin.TabletAvailability;
+import org.apache.accumulo.core.conf.ConfigurationCopy;
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.fate.Fate;
+import org.apache.accumulo.core.fate.Fate.TxInfo;
+import org.apache.accumulo.core.fate.FateId;
+import org.apache.accumulo.core.fate.FateStore;
+import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.harness.SharedMiniClusterBase;
+import org.apache.accumulo.server.ServerContext;
+import org.apache.hadoop.io.Text;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.Iterators;
+
+public abstract class FateInterleavingIT extends SharedMiniClusterBase
+    implements FateTestRunner<FateInterleavingIT.FilTestEnv> {
+
+  public static class FilTestEnv extends TestEnv {
+    private final AccumuloClient client;
+
+    public FilTestEnv(AccumuloClient client) {
+      this.client = client;
+    }
+
+    AccumuloClient getClient() {
+      return client;
+    }
+  }
+
+  public static class FirstOp implements Repo<FateInterleavingIT.FilTestEnv> {
+
+    private static final long serialVersionUID = 1L;
+
+    protected boolean isTrackingDataSet(FateId tid, FilTestEnv env, String step) throws Exception {
+      try (Scanner scanner = env.getClient().createScanner(FATE_TRACKING_TABLE)) {
+        return scanner.stream()
+            .anyMatch(e -> e.getKey().getColumnFamily().toString().equals(tid.canonical())
+                && e.getValue().toString().equals(step));
+      }
+    }
+
+    protected static void insertTrackingData(FateId tid, FilTestEnv env, String step)
+        throws TableNotFoundException, MutationsRejectedException {
+      try (BatchWriter bw = env.getClient().createBatchWriter(FATE_TRACKING_TABLE)) {
+        Mutation mut = new Mutation(Long.toString(System.currentTimeMillis()));
+        mut.put(tid.canonical(), "", step);
+        bw.addMutation(mut);
+      }
+    }
+
+    @Override
+    public long isReady(FateId tid, FilTestEnv env) throws Exception {
+      Thread.sleep(50);
+      var step = this.getName() + "::isReady";
+      if (isTrackingDataSet(tid, env, step)) {
+        return 0;
+      } else {
+        insertTrackingData(tid, env, step);
+        return 100;
+      }
+    }
+
+    @Override
+    public String getName() {
+      return this.getClass().getSimpleName();
+    }
+
+    @Override
+    public Repo<FilTestEnv> call(FateId tid, FilTestEnv env) throws Exception {
+      Thread.sleep(50);
+      insertTrackingData(tid, env, this.getName() + "::call");
+      return new SecondOp();
+    }
+
+    @Override
+    public void undo(FateId fateId, FilTestEnv environment) throws Exception {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getReturn() {
+      return "";
+    }
+  }
+
+  public static class SecondOp extends FirstOp {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public Repo<FilTestEnv> call(FateId tid, FilTestEnv environment) throws Exception {
+      super.call(tid, environment);
+      return new LastOp();
+    }
+
+  }
+
+  public static class LastOp extends FirstOp {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public Repo<FilTestEnv> call(FateId tid, FilTestEnv environment) throws Exception {
+      super.call(tid, environment);
+      return null;
+    }
+  }
+
+  private static final String FATE_TRACKING_TABLE = "fate_tracking";
+
+  @BeforeAll
+  public static void setup() throws Exception {
+    SharedMiniClusterBase.startMiniCluster();
+    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
+      NewTableConfiguration ntc = new NewTableConfiguration();
+      ntc.withInitialTabletAvailability(TabletAvailability.HOSTED);
+      client.tableOperations().create(FATE_TRACKING_TABLE, ntc);
+    }
+  }
+
+  @AfterAll
+  public static void teardown() throws Exception {
+    SharedMiniClusterBase.stopMiniCluster();
+  }
+
+  @BeforeEach
+  public void before() throws Exception {
+    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
+      client.tableOperations().deleteRows(FATE_TRACKING_TABLE, null, null);
+    }
+  }
+
+  private void waitFor(FateStore<FilTestEnv> store, FateId txid) throws Exception {
+    while (store.read(txid).getStatus() != SUCCESSFUL) {
+      Thread.sleep(50);
+    }
+  }
+
+  protected Fate<FilTestEnv> initializeFate(AccumuloClient client, FateStore<FilTestEnv> store) {
+    ConfigurationCopy config = new ConfigurationCopy();
+    config.set(Property.GENERAL_THREADPOOL_SIZE, "2");
+    config.set(Property.MANAGER_FATE_THREADPOOL_SIZE, "1");
+    return new Fate<>(new FilTestEnv(client), store, r -> r + "", config);
+  }
+
+  private static Entry<String,String> toIdStep(Entry<Key,Value> e) {
+    return new AbstractMap.SimpleImmutableEntry<>(e.getKey().getColumnFamily().toString(),
+        e.getValue().toString());
+  }
+
+  @Test
+  public void testInterleaving() throws Exception {
+    executeTest(this::testInterleaving);
+  }
+
+  protected void testInterleaving(FateStore<FilTestEnv> store, ServerContext sctx)
+      throws Exception {
+
+    // This test verifies that fates will interleave in time when their isReady() returns >0 and
+    // then 0.
+
+    FateId[] fateIds = new FateId[3];
+
+    for (int i = 0; i < 3; i++) {
+      fateIds[i] = store.create();
+      var txStore = store.reserve(fateIds[i]);
+      try {
+        txStore.push(new FirstOp());
+        txStore.setTransactionInfo(TxInfo.TX_NAME, "TEST_" + i);
+        txStore.setStatus(SUBMITTED);
+      } finally {
+        txStore.unreserve(0, TimeUnit.SECONDS);
+      }
+    }
+
+    Fate<FilTestEnv> fate = null;
+
+    // The execution order of the transactions is not according to their insertion
+    // order. However, we do know that the first step of each transaction will be
+    // executed before the second steps.
+    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
+
+      fate = initializeFate(client, store);
+
+      for (var fateId : fateIds) {
+        waitFor(store, fateId);
+      }
+
+      var expectedIds =
+          Set.of(fateIds[0].canonical(), fateIds[1].canonical(), fateIds[2].canonical());
+
+      Scanner scanner = client.createScanner(FATE_TRACKING_TABLE);
+      Iterator<Entry<String,String>> iter = scanner.stream().map(FateInterleavingIT::toIdStep)
+          .filter(e -> e.getValue().contains("::call")).iterator();
+
+      SortedMap<String,String> subset = new TreeMap<>();
+
+      Iterators.limit(iter, 3).forEachRemaining(e -> subset.put(e.getKey(), e.getValue()));
+
+      // Should see the call() for the first steps of all three fates come first in time
+      assertTrue(subset.values().stream().allMatch(v -> v.startsWith("FirstOp")));
+      assertEquals(expectedIds, subset.keySet());
+
+      subset.clear();
+
+      Iterators.limit(iter, 3).forEachRemaining(e -> subset.put(e.getKey(), e.getValue()));
+
+      // Should see the call() for the second steps of all three fates come second in time
+      assertTrue(subset.values().stream().allMatch(v -> v.startsWith("SecondOp")));
+      assertEquals(expectedIds, subset.keySet());
+
+      subset.clear();
+
+      Iterators.limit(iter, 3).forEachRemaining(e -> subset.put(e.getKey(), e.getValue()));
+
+      // Should see the call() for the last steps of all three fates come last in time
+      assertTrue(subset.values().stream().allMatch(v -> v.startsWith("LastOp")));
+      assertEquals(expectedIds, subset.keySet());
+
+      assertFalse(iter.hasNext());
+
+    } finally {
+      if (fate != null) {
+        fate.shutdown(10, TimeUnit.MINUTES);
+      }
+    }
+  }
+
+  public static class FirstNonInterleavingOp extends FirstOp {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public long isReady(FateId tid, FilTestEnv env) throws Exception {
+      Thread.sleep(50);
+      insertTrackingData(tid, env, this.getName() + "::isReady");
+      return 0;
+    }
+
+    @Override
+    public Repo<FilTestEnv> call(FateId tid, FilTestEnv manager) throws Exception {
+      Thread.sleep(50);
+      insertTrackingData(tid, manager, this.getName() + "::call");
+      return new SecondNonInterleavingOp();
+    }
+  }
+
+  public static class SecondNonInterleavingOp extends FirstNonInterleavingOp {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public Repo<FilTestEnv> call(FateId tid, FilTestEnv environment) throws Exception {
+      super.call(tid, environment);
+      return new LastNonInterleavingOp();
+    }
+
+  }
+
+  public static class LastNonInterleavingOp extends FirstNonInterleavingOp {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public Repo<FilTestEnv> call(FateId tid, FilTestEnv environment) throws Exception {
+      super.call(tid, environment);
+      return null;
+    }
+
+  }
+
+  @Test
+  public void testNonInterleaving() throws Exception {
+    executeTest(this::testNonInterleaving);
+  }
+
+  protected void testNonInterleaving(FateStore<FilTestEnv> store, ServerContext sctx)
+      throws Exception {
+
+    // This test ensures that when isReady() always returns zero that all the fate steps will
+    // execute immediately
+
+    FateId[] fateIds = new FateId[3];
+
+    for (int i = 0; i < 3; i++) {
+      fateIds[i] = store.create();
+      var txStore = store.reserve(fateIds[i]);
+      try {
+        txStore.push(new FirstNonInterleavingOp());
+        txStore.setTransactionInfo(TxInfo.TX_NAME, "TEST_" + i);
+        txStore.setStatus(SUBMITTED);
+      } finally {
+        txStore.unreserve(0, TimeUnit.SECONDS);
+      }
+    }
+
+    Fate<FilTestEnv> fate = null;
+
+    // The execution order of the transactions is not according to their insertion
+    // order. In this case, without interleaving, a transaction will run start to finish
+    // before moving on to the next transaction
+    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
+
+      fate = initializeFate(client, store);
+
+      for (var fateId : fateIds) {
+        waitFor(store, fateId);
+      }
+
+      Scanner scanner = client.createScanner(FATE_TRACKING_TABLE);
+      Iterator<Entry<Key,Value>> iter = scanner.iterator();
+
+      SortedMap<Key,Value> subset = new TreeMap<>();
+
+      // should see one fate op execute all of it steps
+      var seenId1 = verifySameIds(iter, subset);
+      // should see another fate op execute all of it steps
+      var seenId2 = verifySameIds(iter, subset);
+      // should see another fate op execute all of it steps
+      var seenId3 = verifySameIds(iter, subset);
+
+      assertEquals(Set.of(fateIds[0], fateIds[1], fateIds[2]), Set.of(seenId1, seenId2, seenId3));
+
+      assertFalse(iter.hasNext());
+
+    } finally {
+      if (fate != null) {
+        fate.shutdown(10, TimeUnit.MINUTES);
+      }
+    }
+  }
+
+  private FateId verifySameIds(Iterator<Entry<Key,Value>> iter, SortedMap<Key,Value> subset) {
+    subset.clear();
+    Iterators.limit(iter, 6).forEachRemaining(e -> subset.put(e.getKey(), e.getValue()));
+
+    Text fateId = subset.keySet().iterator().next().getColumnFamily();
+    assertTrue(subset.keySet().stream().allMatch(k -> k.getColumnFamily().equals(fateId)));
+
+    var expectedVals = Set.of("FirstNonInterleavingOp::isReady", "FirstNonInterleavingOp::call",
+        "SecondNonInterleavingOp::isReady", "SecondNonInterleavingOp::call",
+        "LastNonInterleavingOp::isReady", "LastNonInterleavingOp::call");
+    var actualVals = subset.values().stream().map(Value::toString).collect(Collectors.toSet());
+    assertEquals(expectedVals, actualVals);
+
+    return FateId.from(fateId.toString());
+  }
+
+}

--- a/test/src/main/java/org/apache/accumulo/test/fate/meta/MetaFateInterleavingIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/meta/MetaFateInterleavingIT.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test.fate.meta;
+
+import java.util.UUID;
+
+import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.fate.AbstractFateStore;
+import org.apache.accumulo.core.fate.MetaFateStore;
+import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
+import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.test.fate.FateInterleavingIT;
+
+public class MetaFateInterleavingIT extends FateInterleavingIT {
+
+  // put the fate data for the test in a different location than what accumulo is using
+  private static final String ZK_ROOT = "/accumulo/" + UUID.randomUUID();
+
+  @Override
+  public void executeTest(FateTestExecutor<FilTestEnv> testMethod, int maxDeferred,
+      AbstractFateStore.FateIdGenerator fateIdGenerator) throws Exception {
+    ServerContext sctx = getCluster().getServerContext();
+    String path = ZK_ROOT + Constants.ZFATE;
+    ZooReaderWriter zk = sctx.getZooReaderWriter();
+    zk.mkdirs(ZK_ROOT);
+    testMethod.execute(new MetaFateStore<>(path, zk), sctx);
+  }
+}

--- a/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateInterleavingIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateInterleavingIT.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test.fate.user;
+
+import static org.apache.accumulo.test.fate.user.UserFateStoreIT.createFateTable;
+
+import org.apache.accumulo.core.client.Accumulo;
+import org.apache.accumulo.core.clientImpl.ClientContext;
+import org.apache.accumulo.core.fate.AbstractFateStore;
+import org.apache.accumulo.core.fate.user.UserFateStore;
+import org.apache.accumulo.test.fate.FateInterleavingIT;
+
+public class UserFateInterleavingIT extends FateInterleavingIT {
+  @Override
+  public void executeTest(FateTestExecutor<FilTestEnv> testMethod, int maxDeferred,
+      AbstractFateStore.FateIdGenerator fateIdGenerator) throws Exception {
+    var table = getUniqueNames(1)[0];
+    try (ClientContext client =
+        (ClientContext) Accumulo.newClient().from(getClientProps()).build()) {
+      createFateTable(client, table);
+      testMethod.execute(new UserFateStore<>(client, table, maxDeferred, fateIdGenerator),
+          getCluster().getServerContext());
+      client.tableOperations().delete(table);
+    }
+  }
+}


### PR DESCRIPTION
There are a few improvments to FATE in this PR.  The first is that Fate now continues to execute a transaction as long as its ready. Before it would do one step of a transaction and then persist the result and stop, meaning the next step would not run until the next full scan.

The second change was to make finding runnable transactions look for in progress transaction first in the persisted store followed by the non inprogress ones.  This change causes the search for runnable transactions to scan the store twice. To make this more efficient a locality group and filtering iterator were added.  This should make the scans looking for fate transactions with a certain status much more efficient.

These two improvements should make fate a bit more responsive for getting existing work done.

remove todo