### PR TITLE
WIP: Change scan server ref UUID

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/ScanServerRefTabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/ScanServerRefTabletFile.java
@@ -30,30 +30,30 @@ public class ScanServerRefTabletFile extends TabletFile {
 
   private final Value NULL_VALUE = new Value(new byte[0]);
   private final Text colf;
-  private final Text colq;
+  private final String uuid;
 
-  public ScanServerRefTabletFile(String file, String serverAddress, UUID serverLockUUID) {
+  public ScanServerRefTabletFile(UUID serverLockUUID, String serverAddress, String file) {
     super(new Path(URI.create(file)));
     this.colf = new Text(serverAddress);
-    this.colq = new Text(serverLockUUID.toString());
+    this.uuid = serverLockUUID.toString();
   }
 
-  public ScanServerRefTabletFile(String file, Text colf, Text colq) {
-    super(new Path(URI.create(file)));
+  public ScanServerRefTabletFile(String uuid, Text colf, Text file) {
+    super(new Path(URI.create(file.toString())));
     this.colf = colf;
-    this.colq = colq;
+    this.uuid = uuid;
   }
 
   public String getRowSuffix() {
-    return this.getPathStr();
+    return this.uuid;
+  }
+
+  public Text getFilePath() {
+    return new Text(getPath().toString());
   }
 
   public Text getServerAddress() {
     return this.colf;
-  }
-
-  public Text getServerLockUUID() {
-    return this.colq;
   }
 
   public Value getValue() {
@@ -65,7 +65,7 @@ public class ScanServerRefTabletFile extends TabletFile {
     final int prime = 31;
     int result = super.hashCode();
     result = prime * result + ((colf == null) ? 0 : colf.hashCode());
-    result = prime * result + ((colq == null) ? 0 : colq.hashCode());
+    result = prime * result + ((this.getRowSuffix() == null) ? 0 : this.getRowSuffix().hashCode());
     return result;
   }
 
@@ -81,13 +81,13 @@ public class ScanServerRefTabletFile extends TabletFile {
       return false;
     }
     ScanServerRefTabletFile other = (ScanServerRefTabletFile) obj;
-    return Objects.equals(colf, other.colf) && Objects.equals(colq, other.colq);
+    return Objects.equals(colf, other.colf) && Objects.equals(uuid, other.uuid);
   }
 
   @Override
   public String toString() {
-    return "ScanServerRefTabletFile [file=" + this.getRowSuffix() + ", server address=" + colf
-        + ", server lock uuid=" + colq + "]";
+    return "ScanServerRefTabletFile [file=" + this.getPath().toString() + ", server address=" + colf
+        + ", server lock uuid=" + this.uuid + "]";
   }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/util/UuidUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/UuidUtil.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.util;
+
+public class UuidUtil {
+  /**
+   * A fast method for verifying a suffix of a string looks like a uuid.
+   *
+   * @param offset location where the uuid starts. Its expected the uuid occupies the rest of the
+   *        string.
+   */
+  public static boolean isUUID(String uuid, int offset) {
+    if (uuid.length() - offset != 36) {
+      return false;
+    }
+    for (int i = 0; i < 36; i++) {
+      var c = uuid.charAt(i + offset);
+      if (i == 8 || i == 13 || i == 18 || i == 23) {
+        if (c != '-') {
+          // expect '-' char at above positions, did not see it
+          return false;
+        }
+      } else if (c < '0' || (c > '9' && c < 'A') || (c > 'F' && c < 'a') || c > 'f') {
+        // expected hex at all other positions, did not see hex chars
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
@@ -63,6 +63,7 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.ExternalCompactio
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.ScanServerFileReferenceSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.BulkFileColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.util.UuidUtil;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.hadoop.io.Text;
 import org.apache.zookeeper.KeeperException;
@@ -364,6 +365,7 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
       scanner.setRange(ScanServerFileReferenceSection.getRange());
       int pLen = ScanServerFileReferenceSection.getRowPrefix().length();
       return StreamSupport.stream(scanner.spliterator(), false)
+          .filter(e -> UuidUtil.isUUID(e.getKey().getRowData().toString(), pLen))
           .map(e -> new ScanServerRefTabletFile(e.getKey().getRowData().toString().substring(pLen),
               e.getKey().getColumnFamily(), e.getKey().getColumnQualifier()));
     } catch (TableNotFoundException e) {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ScanServerMetadataEntries.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ScanServerMetadataEntries.java
@@ -40,7 +40,7 @@ public class ScanServerMetadataEntries {
 
     // collect all uuids that are currently in the metadata table
     context.getAmple().getScanServerFileReferences().forEach(ssrtf -> {
-      uuidsToDelete.add(UUID.fromString(ssrtf.getServerLockUUID().toString()));
+      uuidsToDelete.add(UUID.fromString(ssrtf.getRowSuffix()));
     });
 
     // gather the list of current live scan servers, its important that this is done after the above
@@ -57,7 +57,7 @@ public class ScanServerMetadataEntries {
 
       context.getAmple().getScanServerFileReferences().forEach(ssrtf -> {
 
-        var uuid = UUID.fromString(ssrtf.getServerLockUUID().toString());
+        var uuid = UUID.fromString(ssrtf.getRowSuffix());
 
         if (uuidsToDelete.contains(uuid)) {
           refsToDelete.add(ssrtf);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ScanServerMetadataEntries.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ScanServerMetadataEntries.java
@@ -26,15 +26,12 @@ import java.util.stream.Collectors;
 import org.apache.accumulo.core.metadata.ScanServerRefTabletFile;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.cli.ServerUtilOpts;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This utility will remove scan server file references from the metadata table where the scan
  * server in the metadata entry is not currently running.
  */
 public class ScanServerMetadataEntries {
-  public static final Logger LOG = LoggerFactory.getLogger(ScanServerMetadataEntries.class);
 
   public static void clean(ServerContext context) {
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ScanServerMetadataEntries.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ScanServerMetadataEntries.java
@@ -43,7 +43,7 @@ public class ScanServerMetadataEntries {
 
     // collect all uuids that are currently in the metadata table
     context.getAmple().getScanServerFileReferences().forEach(ssrtf -> {
-        uuidsToDelete.add(UUID.fromString(ssrtf.getRowSuffix()));
+      uuidsToDelete.add(UUID.fromString(ssrtf.getRowSuffix()));
     });
 
     // gather the list of current live scan servers, its important that this is done after the above

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ScanServerMetadataEntries.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ScanServerMetadataEntries.java
@@ -43,12 +43,7 @@ public class ScanServerMetadataEntries {
 
     // collect all uuids that are currently in the metadata table
     context.getAmple().getScanServerFileReferences().forEach(ssrtf -> {
-      try {
         uuidsToDelete.add(UUID.fromString(ssrtf.getRowSuffix()));
-      } catch (Exception e) {
-        // Malformed entry on metadata table.
-        LOG.warn("Found Malformed Scan Server file ref: {}", ssrtf);
-      }
     });
 
     // gather the list of current live scan servers, its important that this is done after the above
@@ -64,13 +59,8 @@ public class ScanServerMetadataEntries {
       final Set<ScanServerRefTabletFile> refsToDelete = new HashSet<>();
 
       context.getAmple().getScanServerFileReferences().forEach(ssrtf -> {
-        UUID uuid = null;
-        try {
-          uuid = UUID.fromString(ssrtf.getRowSuffix());
-        } catch (Exception e) {
-          // Malformed entry on metadata table.
-          LOG.warn("Found Malformed Scan Server file ref: {}", ssrtf);
-        }
+
+        var uuid = UUID.fromString(ssrtf.getRowSuffix());
 
         if (uuidsToDelete.contains(uuid)) {
           refsToDelete.add(ssrtf);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -395,9 +395,13 @@ public class ScanServer extends AbstractServer
       LOG.info("Stopping Thrift Servers");
       address.server.stop();
 
-      LOG.info("Removing server scan references");
-      this.getContext().getAmple().deleteScanServerFileReferences(clientAddress.toString(),
-          serverLockUUID);
+      try {
+        LOG.info("Removing server scan references");
+        this.getContext().getAmple().deleteScanServerFileReferences(clientAddress.toString(),
+            serverLockUUID);
+      } catch (Exception e) {
+        LOG.warn("Failed to remove scan server refs from metadata location", e);
+      }
 
       try {
         LOG.debug("Closing filesystems");

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -590,7 +590,7 @@ public class ScanServer extends AbstractServer
 
       for (StoredTabletFile file : allFiles.keySet()) {
         if (!reservedFiles.containsKey(file)) {
-          refs.add(new ScanServerRefTabletFile(file.getPathStr(), serverAddress, serverLockUUID));
+          refs.add(new ScanServerRefTabletFile(serverLockUUID, serverAddress, file.getPathStr()));
           filesToReserve.add(file);
           tabletsToCheck.add(Objects.requireNonNull(allFiles.get(file)));
           LOG.trace("RFFS {} need to add scan ref for file {}", myReservationId, file);
@@ -799,7 +799,7 @@ public class ScanServer extends AbstractServer
             influxFiles.add(file);
             confirmed.add(file);
             refsToDelete
-                .add(new ScanServerRefTabletFile(file.getPathStr(), serverAddress, serverLockUUID));
+                .add(new ScanServerRefTabletFile(serverLockUUID, serverAddress, file.getPathStr()));
 
             // remove the entry from the map while holding the write lock ensuring no new
             // reservations are added to the map values while the metadata operation to delete is

--- a/test/src/main/java/org/apache/accumulo/test/ScanServerMetadataEntriesCleanIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ScanServerMetadataEntriesCleanIT.java
@@ -22,12 +22,25 @@ import static org.apache.accumulo.harness.AccumuloITBase.MINI_CLUSTER_ONLY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.accumulo.core.client.BatchDeleter;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.MutationsRejectedException;
+import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.metadata.ScanServerRefTabletFile;
+import org.apache.accumulo.core.metadata.schema.Ample;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.server.ServerContext;
@@ -48,6 +61,19 @@ public class ScanServerMetadataEntriesCleanIT extends SharedMiniClusterBase {
   @AfterAll
   public static void stop() throws Exception {
     stopMiniCluster();
+  }
+
+  private Set<Map.Entry<Key,Value>> currentScanRefs() {
+    // Scan the entire range and look for known entries
+    try (Scanner scanner = getCluster().getServerContext()
+        .createScanner(Ample.DataLevel.USER.metaTable(), Authorizations.EMPTY)) {
+      scanner.setRange(MetadataSchema.ScanServerFileReferenceSection.getRange());
+      return scanner.stream().collect(Collectors.toSet());
+
+    } catch (TableNotFoundException e) {
+      throw new IllegalStateException("Error reading scan server entries from metadata location "
+          + Ample.DataLevel.USER.metaTable(), e);
+    }
   }
 
   @Test
@@ -71,5 +97,56 @@ public class ScanServerMetadataEntriesCleanIT extends SharedMiniClusterBase {
 
     ScanServerMetadataEntries.clean(ctx);
     assertFalse(ctx.getAmple().getScanServerFileReferences().findAny().isPresent());
+  }
+
+  @Test
+  public void testMalformedScanServerRefs() {
+    HostAndPort server = HostAndPort.fromParts("127.0.0.1", 1234);
+    UUID serverLockUUID = UUID.randomUUID();
+
+    Set<ScanServerRefTabletFile> scanRefs = Stream.of("F0001270.rf", "F0001271.rf")
+        .map(f -> "hdfs://localhost:8020/accumulo/tables/2a/test_tablet/" + f)
+        .map(f -> new ScanServerRefTabletFile(serverLockUUID, server.toString(), f))
+        .collect(Collectors.toSet());
+
+    ServerContext ctx = getCluster().getServerContext();
+    ctx.getAmple().putScanServerFileReferences(scanRefs);
+
+    // Ensure that ample returns the same number as a direct scanner
+    assertEquals(scanRefs.size(), currentScanRefs().size());
+    assertEquals(scanRefs.size(), ctx.getAmple().getScanServerFileReferences().count());
+
+    // Add malformed entries
+    try (BatchWriter writer = ctx.createBatchWriter(Ample.DataLevel.USER.metaTable())) {
+      String prefix = MetadataSchema.ScanServerFileReferenceSection.getRowPrefix();
+      for (String filepath : Stream.of("F0001243.rf", "F0006512.rf")
+          .map(f -> "hdfs://localhost:8020/accumulo/tables/2a/test_tablet/" + f)
+          .collect(Collectors.toSet())) {
+        Mutation m = new Mutation(prefix + filepath);
+        m.put(server.toString(), serverLockUUID.toString(), "");
+        writer.addMutation(m);
+      }
+      writer.flush();
+    } catch (MutationsRejectedException | TableNotFoundException e) {
+      throw new IllegalStateException(
+          "Error inserting scan server file references into " + Ample.DataLevel.USER.metaTable(),
+          e);
+    }
+
+    // Ample ignores the malformed entries, so the counts are still the same.
+    assertEquals(scanRefs.size(), ctx.getAmple().getScanServerFileReferences().count());
+
+    // However, a direct scan will find the malformed entries.
+    assertEquals(scanRefs.size() + 2, currentScanRefs().size());
+
+    // Delete Malformed References
+    try (BatchDeleter batchDeleter =
+        ctx.createBatchDeleter(Ample.DataLevel.USER.metaTable(), Authorizations.EMPTY, 1)) {
+      batchDeleter.setRanges(List.of(MetadataSchema.ScanServerFileReferenceSection.getRange()));
+      batchDeleter.delete();
+    } catch (TableNotFoundException | MutationsRejectedException e) {
+      throw new RuntimeException(e);
+    }
+    assertEquals(0, currentScanRefs().size());
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/ScanServerMetadataEntriesCleanIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ScanServerMetadataEntriesCleanIT.java
@@ -57,7 +57,7 @@ public class ScanServerMetadataEntriesCleanIT extends SharedMiniClusterBase {
 
     Set<ScanServerRefTabletFile> scanRefs = Stream.of("F0000070.rf", "F0000071.rf")
         .map(f -> "hdfs://localhost:8020/accumulo/tables/2a/default_tablet/" + f)
-        .map(f -> new ScanServerRefTabletFile(f, server.toString(), serverLockUUID))
+        .map(f -> new ScanServerRefTabletFile(serverLockUUID, server.toString(), f))
         .collect(Collectors.toSet());
 
     ServerContext ctx = getCluster().getServerContext();

--- a/test/src/main/java/org/apache/accumulo/test/ScanServerMetadataEntriesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ScanServerMetadataEntriesIT.java
@@ -111,7 +111,7 @@ public class ScanServerMetadataEntriesIT extends SharedMiniClusterBase {
 
     Set<ScanServerRefTabletFile> scanRefs = Stream.of("F0000070.rf", "F0000071.rf")
         .map(f -> "hdfs://localhost:8020/accumulo/tables/2a/default_tablet/" + f)
-        .map(f -> new ScanServerRefTabletFile(f, server.toString(), serverLockUUID))
+        .map(f -> new ScanServerRefTabletFile(serverLockUUID, server.toString(), f))
         .collect(Collectors.toSet());
 
     ServerContext ctx = getCluster().getServerContext();
@@ -243,7 +243,7 @@ public class ScanServerMetadataEntriesIT extends SharedMiniClusterBase {
         metadataEntries.forEach(m -> {
           String row = m.getKey().getRow().toString();
           assertTrue(row.startsWith("~sserv"));
-          String file = row.substring(ScanServerFileReferenceSection.getRowPrefix().length());
+          String file = m.getKey().getColumnQualifier().toString();
           metadataScanFileRefs.add(file);
         });
         assertEquals(fileCount, metadataScanFileRefs.size());

--- a/test/src/main/java/org/apache/accumulo/test/upgrade/SServerUpgrade9to10TestIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/upgrade/SServerUpgrade9to10TestIT.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test.upgrade;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.client.Accumulo;
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.MutationsRejectedException;
+import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.fate.zookeeper.ServiceLock;
+import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
+import org.apache.accumulo.core.metadata.ScanServerRefTabletFile;
+import org.apache.accumulo.core.metadata.schema.Ample;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.security.TablePermission;
+import org.apache.accumulo.core.util.HostAndPort;
+import org.apache.accumulo.manager.upgrade.Upgrader9to10;
+import org.apache.accumulo.minicluster.ServerType;
+import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
+import org.apache.accumulo.miniclusterImpl.ProcessNotFoundException;
+import org.apache.accumulo.test.functional.ConfigurableMacBase;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.RawLocalFileSystem;
+import org.apache.zookeeper.KeeperException;
+import org.junit.jupiter.api.Test;
+
+public class SServerUpgrade9to10TestIT extends ConfigurableMacBase {
+
+  private static final String OUR_SECRET = "itsreallysecret";
+  private static final Upgrader9to10 upgrader = new Upgrader9to10();
+
+  @Override
+  protected Duration defaultTimeout() {
+    return Duration.ofMinutes(5);
+  }
+
+  @Override
+  public void configure(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
+    cfg.setProperty(Property.INSTANCE_ZK_TIMEOUT, "15s");
+    cfg.setProperty(Property.INSTANCE_SECRET, OUR_SECRET);
+    cfg.setProperty(Property.GC_CYCLE_START, "1000"); // gc will be killed before it is run
+
+    // use raw local file system so walogs sync and flush will work
+    hadoopCoreSite.set("fs.file.impl", RawLocalFileSystem.class.getName());
+  }
+
+  private void killMacGc() throws ProcessNotFoundException, InterruptedException, KeeperException {
+    // kill gc started by MAC
+    getCluster().killProcess(ServerType.GARBAGE_COLLECTOR,
+        getCluster().getProcesses().get(ServerType.GARBAGE_COLLECTOR).iterator().next());
+    // delete lock in zookeeper if there, this will allow next GC to start quickly
+    var path = ServiceLock.path(getServerContext().getZooKeeperRoot() + Constants.ZGC_LOCK);
+    ZooReaderWriter zk = getServerContext().getZooReaderWriter();
+    try {
+      ServiceLock.deleteLock(zk, path);
+    } catch (IllegalStateException e) {
+      log.error("Unable to delete ZooLock for mini accumulo-gc", e);
+    }
+
+    assertNull(getCluster().getProcesses().get(ServerType.GARBAGE_COLLECTOR));
+  }
+
+  @Test
+  public void sserverRemoveMetadataTableRefsIT() throws Exception {
+    deleteScanServerRange(Ample.DataLevel.METADATA);
+  }
+
+  @Test
+  public void sserverRemoveUserTableRefsIT() throws Exception {
+    deleteScanServerRange(Ample.DataLevel.USER);
+  }
+
+  public void deleteScanServerRange(Ample.DataLevel level) throws Exception {
+    killMacGc();// we do not want anything deleted
+
+    var table = level.metaTable();
+    HostAndPort server = HostAndPort.fromParts("127.0.0.1", 1234);
+    UUID serverLockUUID = UUID.randomUUID();
+
+    log.info("Testing removal of scan server refs for upgrade {}", table);
+    try (AccumuloClient client = Accumulo.newClient().from(getClientProperties()).build()) {
+      client.securityOperations().grantTablePermission(client.whoami(), table,
+          TablePermission.WRITE);
+
+      try (BatchWriter writer = client.createBatchWriter(table)) {
+        String prefix = MetadataSchema.ScanServerFileReferenceSection.getRowPrefix();
+        Set<ScanServerRefTabletFile> scanRefs =
+            Stream.of("F0001370.rf", "F0001371.rf", "F0001270.rf", "F0001271.rf")
+                .map(f -> "hdfs://localhost:8020/accumulo/tables/2a/test_tablet/" + f)
+                .map(f -> new ScanServerRefTabletFile(serverLockUUID, server.toString(), f))
+                .collect(Collectors.toSet());
+
+        for (ScanServerRefTabletFile scanRef : scanRefs) {
+          Mutation m = new Mutation(prefix + scanRef.getRowSuffix());
+          m.put(scanRef.getServerAddress().toString(), scanRef.getFilePath().toString(), "");
+          writer.addMutation(m);
+        }
+        for (String filepath : Stream.of("F0001243.rf", "F0006512.rf", "F00452.rf", "F0002345.rf")
+            .map(f -> "hdfs://localhost:8020/accumulo/tables/1a/test_tablet/" + f)
+            .collect(Collectors.toSet())) {
+          Mutation m = new Mutation(prefix + filepath);
+          m.put(server.toString(), serverLockUUID.toString(), "");
+          writer.addMutation(m);
+        }
+
+        writer.flush();
+      } catch (MutationsRejectedException | TableNotFoundException e) {
+        throw new IllegalStateException("Error inserting scan server file references into " + table,
+            e);
+      }
+
+      try (Scanner scanner = client.createScanner(table, Authorizations.EMPTY)) {
+        scanner.setRange(MetadataSchema.ScanServerFileReferenceSection.getRange());
+        assertEquals(8, scanner.stream().count());
+        upgrader.removeAllScanServerRefs(getServerContext(), level);
+        assertEquals(0, scanner.stream().count());
+      } catch (TableNotFoundException e) {
+        throw new RuntimeException(e);
+      }
+
+    } catch (AccumuloException | AccumuloSecurityException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+}


### PR DESCRIPTION
After performing scale testing we found that scan servers encounter write contention if the scan server refs start with the file path. 

Found that moving the UUID to the beginning of the reference removes the contention issue.

Creating this as a WIP since this needs additional tests and validation of the upgrade code to ensure that the entire sserv range is removed on upgrade.

I'm thinking about adding a issue ticket for a scan server "delete" admin command that would wipe the range. 
That can be performed today with a `deletemany -f` shell command, but incurs risk of mistyping the range.