### PR TITLE
Fixed NPE in ScanServerMetrics

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServerMetrics.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServerMetrics.java
@@ -63,9 +63,12 @@ public class ScanServerMetrics implements MetricsProducer {
             "Counts instances where file reservation attempts for scans encountered conflicts")
         .register(registry);
 
-    Preconditions.checkState(tabletMetadataCache.policy().isRecordingStats(),
-        "Attempted to instrument cache that is not recording stats.");
-    CaffeineCacheMetrics.monitor(registry, tabletMetadataCache, METRICS_SCAN_TABLET_METADATA_CACHE);
+    if (tabletMetadataCache != null) {
+      Preconditions.checkState(tabletMetadataCache.policy().isRecordingStats(),
+          "Attempted to instrument cache that is not recording stats.");
+      CaffeineCacheMetrics.monitor(registry, tabletMetadataCache,
+          METRICS_SCAN_TABLET_METADATA_CACHE);
+    }
   }
 
   public void recordTotalReservationTime(Duration time) {


### PR DESCRIPTION
A NPE was being raised in ScanServerMetrics.registerMetrics when the SSERV_CACHED_TABLET_METADATA_EXPIRATION value was zero, which disables the tablet metadata caching and leaves the variable tabletMetadataCache referencing null. A test was failing in ScanServerConcurrentTabletScanIT that led to this discovery.