### PR TITLE
replaces sorted map w/ list for key vals in tablet metadata

### DIFF
--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
@@ -40,6 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Constructor;
+import java.util.AbstractMap;
 import java.util.EnumSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -160,7 +161,9 @@ public class TabletMetadataTest {
     assertEquals(Set.of(tf1, tf2), Set.copyOf(tm.getFiles()));
     assertEquals(Map.of(tf1, dfv1, tf2, dfv2), tm.getFilesMap());
     assertEquals(6L, tm.getFlushId().getAsLong());
-    assertEquals(rowMap, tm.getKeyValues());
+    TreeMap<Key,Value> actualRowMap = new TreeMap<>();
+    tm.getKeyValues().forEach(entry -> actualRowMap.put(entry.getKey(), entry.getValue()));
+    assertEquals(rowMap, actualRowMap);
     assertEquals(Map.of(new StoredTabletFile(bf1), 56L, new StoredTabletFile(bf2), 59L),
         tm.getLoaded());
     assertEquals(HostAndPort.fromParts("server1", 8555), tm.getLocation().getHostAndPort());
@@ -388,7 +391,7 @@ public class TabletMetadataTest {
     b.log(LogEntry.fromPath("localhost+8020/" + UUID.randomUUID()));
     b.scan(stf);
     b.loadedFile(stf, 0L);
-    b.keyValue(new Key(), new Value());
+    b.keyValue(new AbstractMap.SimpleImmutableEntry<>(new Key(), new Value()));
     var tm2 = b.build(EnumSet.allOf(ColumnType.class));
 
     assertEquals(1, tm2.getExternalCompactions().size());
@@ -407,8 +410,7 @@ public class TabletMetadataTest {
     assertEquals(1, tm2.getLoaded().size());
     assertThrows(UnsupportedOperationException.class, () -> tm2.getLoaded().put(stf, 0L));
     assertEquals(1, tm2.getKeyValues().size());
-    assertThrows(UnsupportedOperationException.class,
-        () -> tm2.getKeyValues().put(new Key(), new Value()));
+    assertThrows(UnsupportedOperationException.class, () -> tm2.getKeyValues().remove(null));
 
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
@@ -398,12 +398,12 @@ public class MetadataTableUtil {
   }
 
   private static Mutation createCloneMutation(TableId srcTableId, TableId tableId,
-      Map<Key,Value> tablet) {
+      Iterable<Entry<Key,Value>> tablet) {
 
-    KeyExtent ke = KeyExtent.fromMetaRow(tablet.keySet().iterator().next().getRow());
+    KeyExtent ke = KeyExtent.fromMetaRow(tablet.iterator().next().getKey().getRow());
     Mutation m = new Mutation(TabletsSection.encodeRow(tableId, ke.endRow()));
 
-    for (Entry<Key,Value> entry : tablet.entrySet()) {
+    for (Entry<Key,Value> entry : tablet) {
       if (entry.getKey().getColumnFamily().equals(DataFileColumnFamily.NAME)) {
         String cf = entry.getKey().getColumnQualifier().toString();
         if (!cf.startsWith("../") && !cf.contains(":")) {
@@ -538,7 +538,7 @@ public class MetadataTableUtil {
         // delete existing cloned tablet entry
         Mutation m = new Mutation(cloneTablet.getExtent().toMetaRow());
 
-        for (Entry<Key,Value> entry : cloneTablet.getKeyValues().entrySet()) {
+        for (Entry<Key,Value> entry : cloneTablet.getKeyValues()) {
           Key k = entry.getKey();
           m.putDelete(k.getColumnFamily(), k.getColumnQualifier(), k.getTimestamp());
         }


### PR DESCRIPTION
This change was made in elasticity as part of a larger change to speedup merge, see #4574.  Backported just the part that replaced a sortedmap w/ a list in TabletMetadata to speed up the code that tracks a tablets key/values.