### PR TITLE
Add new scan metrics to flaky list in MetricsIT

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/metrics/MetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/metrics/MetricsIT.java
@@ -104,6 +104,7 @@ public class MetricsIT extends ConfigurableMacBase implements MetricsProducer {
     // add sserver as flaky until scan server included in mini tests.
     Set<String> flakyMetrics = Set.of(METRICS_GC_WAL_ERRORS, METRICS_FATE_TYPE_IN_PROGRESS,
         METRICS_SCAN_BUSY_TIMEOUT_COUNTER, METRICS_SCAN_RESERVATION_TOTAL_TIMER,
+        METRICS_SCAN_RESERVATION_WRITEOUT_TIMER, METRICS_SCAN_RESERVATION_CONFLICT_COUNTER,
         METRICS_SCAN_TABLET_METADATA_CACHE);
 
     Map<String,String> expectedMetricNames = this.getMetricFields();


### PR DESCRIPTION
 - METRICS_SCAN_RESERVATION_WRITEOUT_TIMER
 - METRICS_SCAN_RESERVATION_CONFLICT_COUNTER

metrics were added in #4577 