### PR TITLE
Admin service status server lock changes

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/util/ServiceStatusCmd.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ServiceStatusCmd.java
@@ -19,6 +19,8 @@
 package org.apache.accumulo.server.util;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.accumulo.core.lock.ServiceLockData.ThriftService.TABLET_SCAN;
+import static org.apache.accumulo.core.lock.ServiceLockData.ThriftService.TSERV;
 
 import java.util.Collection;
 import java.util.Map;
@@ -29,6 +31,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.fate.zookeeper.ZooReader;
+import org.apache.accumulo.core.lock.ServiceLockData;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.util.serviceStatus.ServiceStatusReport;
@@ -40,6 +43,7 @@ import org.slf4j.LoggerFactory;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.gson.Gson;
 
 public class ServiceStatusCmd {
 
@@ -47,6 +51,8 @@ public class ServiceStatusCmd {
   public static final String NO_GROUP_TAG = "NO_GROUP";
 
   private static final Logger LOG = LoggerFactory.getLogger(ServiceStatusCmd.class);
+
+  private static final Gson gson = new Gson();
 
   public ServiceStatusCmd() {}
 
@@ -85,7 +91,7 @@ public class ServiceStatusCmd {
 
   /**
    * The manager paths in ZooKeeper are: {@code /accumulo/[IID]/managers/lock/zlock#[NUM]} with the
-   * lock data providing host:port.
+   * lock data providing a service descriptor with host and port.
    */
   @VisibleForTesting
   StatusSummary getManagerStatus(final ZooReader zooReader, String zRootPath) {
@@ -95,7 +101,7 @@ public class ServiceStatusCmd {
 
   /**
    * The monitor paths in ZooKeeper are: {@code /accumulo/[IID]/monitor/lock/zlock#[NUM]} with the
-   * lock data providing host:port.
+   * lock data providing a service descriptor with host and port.
    */
   @VisibleForTesting
   StatusSummary getMonitorStatus(final ZooReader zooReader, String zRootPath) {
@@ -110,7 +116,7 @@ public class ServiceStatusCmd {
   @VisibleForTesting
   StatusSummary getTServerStatus(final ZooReader zooReader, String zRootPath) {
     String lockPath = zRootPath + Constants.ZTSERVERS;
-    return getServerHostStatus(zooReader, lockPath, ServiceStatusReport.ReportKey.T_SERVER);
+    return getServerHostStatus(zooReader, lockPath, ServiceStatusReport.ReportKey.T_SERVER, TSERV);
   }
 
   /**
@@ -120,7 +126,8 @@ public class ServiceStatusCmd {
   @VisibleForTesting
   StatusSummary getScanServerStatus(final ZooReader zooReader, String zRootPath) {
     String lockPath = zRootPath + Constants.ZSSERVERS;
-    return getServerHostStatus(zooReader, lockPath, ServiceStatusReport.ReportKey.S_SERVER);
+    return getServerHostStatus(zooReader, lockPath, ServiceStatusReport.ReportKey.S_SERVER,
+        TABLET_SCAN);
   }
 
   /**
@@ -128,7 +135,7 @@ public class ServiceStatusCmd {
    * {@code /accumulo/IID/[tservers | sservers]/HOST:PORT/[LOCK]}
    */
   private StatusSummary getServerHostStatus(final ZooReader zooReader, String basePath,
-      ServiceStatusReport.ReportKey displayNames) {
+      ServiceStatusReport.ReportKey displayNames, ServiceLockData.ThriftService serviceType) {
     AtomicInteger errorSum = new AtomicInteger(0);
 
     // Set<String> hostNames = new TreeSet<>();
@@ -137,25 +144,26 @@ public class ServiceStatusCmd {
 
     var nodeNames = readNodeNames(zooReader, basePath);
 
-    nodeNames.getHosts().forEach(host -> {
+    nodeNames.getData().forEach(host -> {
       var lock = readNodeNames(zooReader, basePath + "/" + host);
-      lock.getHosts().forEach(l -> {
+      lock.getData().forEach(l -> {
         var nodeData = readNodeData(zooReader, basePath + "/" + host + "/" + l);
         int err = nodeData.getErrorCount();
         if (err > 0) {
           errorSum.addAndGet(nodeData.getErrorCount());
         } else {
-          // process resource groups
-          String[] tokens = nodeData.getHosts().split(",");
-          if (tokens.length == 2) {
-            String groupName = tokens[1];
-            groupNames.add(groupName);
-            hostsByGroups.computeIfAbsent(groupName, s -> new TreeSet<>()).add(host);
-          } else {
-            hostsByGroups.computeIfAbsent(NO_GROUP_TAG, s -> new TreeSet<>()).add(host);
-          }
-        }
 
+          ServiceLockData.ServiceDescriptors sld =
+              gson.fromJson(nodeData.getData(), ServiceLockData.ServiceDescriptors.class);
+
+          sld.getServices().forEach(sd -> {
+            if (serviceType == sd.getService()) {
+              groupNames.add(sd.getGroup());
+              hostsByGroups.computeIfAbsent(sd.getGroup(), set -> new TreeSet<>())
+                  .add(sd.getAddress());
+            }
+          });
+        }
       });
       errorSum.addAndGet(lock.getFirst());
     });
@@ -203,8 +211,15 @@ public class ServiceStatusCmd {
       ZooReader zooReader, String lockPath) {
     var result = readAllNodesData(zooReader, lockPath);
     Map<String,Set<String>> byGroup = new TreeMap<>();
-    byGroup.put(NO_GROUP_TAG, result.getHosts());
-    return new StatusSummary(displayNames, Set.of(), byGroup, result.getErrorCount());
+    result.getData().forEach(data -> {
+      ServiceLockData.ServiceDescriptors sld =
+          gson.fromJson(data, ServiceLockData.ServiceDescriptors.class);
+      var services = sld.getServices();
+      services.forEach(sd -> {
+        byGroup.computeIfAbsent(sd.getGroup(), set -> new TreeSet<>()).add(sd.getAddress());
+      });
+    });
+    return new StatusSummary(displayNames, byGroup.keySet(), byGroup, result.getErrorCount());
   }
 
   /**
@@ -218,12 +233,12 @@ public class ServiceStatusCmd {
     // get group names
     Result<Integer,Set<String>> queueNodes = readNodeNames(zooReader, zRootPath);
     errors.addAndGet(queueNodes.getErrorCount());
-    Set<String> queues = new TreeSet<>(queueNodes.getHosts());
+    Set<String> queues = new TreeSet<>(queueNodes.getData());
 
     queues.forEach(group -> {
       var hostNames = readNodeNames(zooReader, zRootPath + "/" + group);
       errors.addAndGet(hostNames.getErrorCount());
-      Collection<String> hosts = hostNames.getHosts();
+      Collection<String> hosts = hostNames.getData();
       hosts.forEach(host -> {
         hostsByGroups.computeIfAbsent(group, set -> new TreeSet<>()).add(host);
       });
@@ -286,7 +301,7 @@ public class ServiceStatusCmd {
    */
   @VisibleForTesting
   Result<Integer,Set<String>> readAllNodesData(final ZooReader zooReader, final String path) {
-    Set<String> hosts = new TreeSet<>();
+    Set<String> data = new TreeSet<>();
     final AtomicInteger errorCount = new AtomicInteger(0);
     try {
       var locks = zooReader.getChildren(path);
@@ -296,7 +311,7 @@ public class ServiceStatusCmd {
         if (err > 0) {
           errorCount.addAndGet(nodeData.getErrorCount());
         } else {
-          hosts.add(nodeData.getHosts());
+          data.add(nodeData.getData());
         }
       });
     } catch (KeeperException | InterruptedException ex) {
@@ -307,7 +322,7 @@ public class ServiceStatusCmd {
       LOG.info("Could not read node names from ZooKeeper for path {}", path, ex);
       errorCount.incrementAndGet();
     }
-    return new Result<>(errorCount.get(), hosts);
+    return new Result<>(errorCount.get(), data);
   }
 
   @Parameters(commandDescription = "show service status")
@@ -335,7 +350,7 @@ public class ServiceStatusCmd {
       return getFirst();
     }
 
-    public B getHosts() {
+    public B getData() {
       return getSecond();
     }
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ServiceStatusCmd.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ServiceStatusCmd.java
@@ -52,8 +52,6 @@ public class ServiceStatusCmd {
 
   private static final Logger LOG = LoggerFactory.getLogger(ServiceStatusCmd.class);
 
-  // private static final Gson gson = new Gson();
-
   public ServiceStatusCmd() {}
 
   /**

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ServiceStatusCmd.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ServiceStatusCmd.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.server.util;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.core.lock.ServiceLockData.ThriftService.TABLET_SCAN;
 import static org.apache.accumulo.core.lock.ServiceLockData.ThriftService.TSERV;
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
 
 import java.util.Collection;
 import java.util.Map;
@@ -43,7 +44,6 @@ import org.slf4j.LoggerFactory;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.gson.Gson;
 
 public class ServiceStatusCmd {
 
@@ -52,7 +52,7 @@ public class ServiceStatusCmd {
 
   private static final Logger LOG = LoggerFactory.getLogger(ServiceStatusCmd.class);
 
-  private static final Gson gson = new Gson();
+  // private static final Gson gson = new Gson();
 
   public ServiceStatusCmd() {}
 
@@ -154,7 +154,7 @@ public class ServiceStatusCmd {
         } else {
 
           ServiceLockData.ServiceDescriptors sld =
-              gson.fromJson(nodeData.getData(), ServiceLockData.ServiceDescriptors.class);
+              GSON.get().fromJson(nodeData.getData(), ServiceLockData.ServiceDescriptors.class);
 
           sld.getServices().forEach(sd -> {
             if (serviceType == sd.getService()) {
@@ -213,7 +213,7 @@ public class ServiceStatusCmd {
     Map<String,Set<String>> byGroup = new TreeMap<>();
     result.getData().forEach(data -> {
       ServiceLockData.ServiceDescriptors sld =
-          gson.fromJson(data, ServiceLockData.ServiceDescriptors.class);
+          GSON.get().fromJson(data, ServiceLockData.ServiceDescriptors.class);
       var services = sld.getServices();
       services.forEach(sd -> {
         byGroup.computeIfAbsent(sd.getGroup(), set -> new TreeSet<>()).add(sd.getAddress());

--- a/server/base/src/main/java/org/apache/accumulo/server/util/serviceStatus/ServiceStatusReport.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/serviceStatus/ServiceStatusReport.java
@@ -18,10 +18,13 @@
  */
 package org.apache.accumulo.server.util.serviceStatus;
 
+import static org.apache.accumulo.core.lock.ServiceLockData.ServiceDescriptor.DEFAULT_GROUP_NAME;
+
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,12 +86,12 @@ public class ServiceStatusReport {
         .reduce(Integer::sum).orElse(0);
     sb.append("ZooKeeper read errors: ").append(zkErrors).append("\n");
 
-    fmtServiceStatus(sb, ReportKey.MANAGER, summaries.get(ReportKey.MANAGER), noHosts);
-    fmtServiceStatus(sb, ReportKey.MONITOR, summaries.get(ReportKey.MONITOR), noHosts);
-    fmtServiceStatus(sb, ReportKey.GC, summaries.get(ReportKey.GC), noHosts);
-    fmtServiceStatus(sb, ReportKey.T_SERVER, summaries.get(ReportKey.T_SERVER), noHosts);
+    fmtResourceGroups(sb, ReportKey.MANAGER, summaries.get(ReportKey.MANAGER), noHosts);
+    fmtResourceGroups(sb, ReportKey.MONITOR, summaries.get(ReportKey.MONITOR), noHosts);
+    fmtResourceGroups(sb, ReportKey.GC, summaries.get(ReportKey.GC), noHosts);
+    fmtResourceGroups(sb, ReportKey.T_SERVER, summaries.get(ReportKey.T_SERVER), noHosts);
     fmtResourceGroups(sb, ReportKey.S_SERVER, summaries.get(ReportKey.S_SERVER), noHosts);
-    fmtServiceStatus(sb, ReportKey.COORDINATOR, summaries.get(ReportKey.COORDINATOR), noHosts);
+    fmtResourceGroups(sb, ReportKey.COORDINATOR, summaries.get(ReportKey.COORDINATOR), noHosts);
     fmtResourceGroups(sb, ReportKey.COMPACTOR, summaries.get(ReportKey.COMPACTOR), noHosts);
 
     sb.append("\n");
@@ -96,6 +99,12 @@ public class ServiceStatusReport {
     return sb.toString();
   }
 
+  /**
+   * This method can be used instead of
+   * {@link #fmtResourceGroups(StringBuilder, ReportKey, StatusSummary, boolean)} if there are
+   * services that do not make sense to group by a resource group. With the data in ServiceLock, all
+   * services has at least the default group.
+   */
   private void fmtServiceStatus(final StringBuilder sb, final ReportKey displayNames,
       final StatusSummary summary, boolean noHosts) {
     if (summary == null) {
@@ -109,9 +118,10 @@ public class ServiceStatusReport {
     if (noHosts) {
       return;
     }
+    sb.append(I2).append("resource group: (default)").append("\n");
     if (summary.getServiceCount() > 0) {
       var hosts = summary.getServiceByGroups();
-      hosts.values().forEach(s -> s.forEach(h -> sb.append(I2).append(h).append("\n")));
+      hosts.values().forEach(s -> s.forEach(h -> sb.append(I4).append(h).append("\n")));
     }
   }
 
@@ -130,6 +140,12 @@ public class ServiceStatusReport {
       sb.append(reportKey).append(": unavailable").append("\n");
       return;
     }
+    // only default group is present, omit grouping from report
+    if (!summary.getResourceGroups().isEmpty()
+        && summary.getResourceGroups().equals(Set.of(DEFAULT_GROUP_NAME))) {
+      fmtServiceStatus(sb, reportKey, summary, noHosts);
+      return;
+    }
 
     fmtCounts(sb, summary);
 
@@ -139,6 +155,7 @@ public class ServiceStatusReport {
     }
 
     if (!summary.getResourceGroups().isEmpty()) {
+
       sb.append(I2).append("resource groups:\n");
       summary.getResourceGroups().forEach(g -> sb.append(I4).append(g).append("\n"));
 

--- a/server/base/src/test/java/org/apache/accumulo/server/util/serviceStatus/ServiceStatusReportTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/serviceStatus/ServiceStatusReportTest.java
@@ -103,29 +103,29 @@ public class ServiceStatusReportTest {
     final Map<ServiceStatusReport.ReportKey,StatusSummary> services = new TreeMap<>();
 
     Map<String,Set<String>> managerByGroup = new TreeMap<>();
-    managerByGroup.put(NO_GROUP_TAG, new TreeSet<>(List.of("host1:8080", "host2:9090")));
-    StatusSummary managerSummary = new StatusSummary(MANAGER, Set.of(), managerByGroup, 1);
+    managerByGroup.put("default", new TreeSet<>(List.of("host1:8080", "host2:9090")));
+    StatusSummary managerSummary = new StatusSummary(MANAGER, Set.of("default"), managerByGroup, 1);
     services.put(MANAGER, managerSummary);
 
     Map<String,Set<String>> monitorByGroup = new TreeMap<>();
-    monitorByGroup.put(NO_GROUP_TAG, new TreeSet<>(List.of("host1:8080", "host2:9090")));
-    StatusSummary monitorSummary =
-        new StatusSummary(ServiceStatusReport.ReportKey.MONITOR, Set.of(), monitorByGroup, 0);
+    monitorByGroup.put("default", new TreeSet<>(List.of("host1:8080", "host2:9090")));
+    StatusSummary monitorSummary = new StatusSummary(ServiceStatusReport.ReportKey.MONITOR,
+        Set.of("default"), monitorByGroup, 0);
     services.put(ServiceStatusReport.ReportKey.MONITOR, monitorSummary);
 
     Map<String,Set<String>> gcByGroup = new TreeMap<>();
-    gcByGroup.put(NO_GROUP_TAG, new TreeSet<>(List.of("host1:8080", "host2:9090")));
+    gcByGroup.put("default", new TreeSet<>(List.of("host1:8080", "host2:9090")));
 
     StatusSummary gcSummary =
-        new StatusSummary(ServiceStatusReport.ReportKey.GC, Set.of(), gcByGroup, 0);
+        new StatusSummary(ServiceStatusReport.ReportKey.GC, Set.of("default"), gcByGroup, 0);
     services.put(ServiceStatusReport.ReportKey.GC, gcSummary);
 
     Map<String,Set<String>> tserverByGroup = new TreeMap<>();
-    tserverByGroup.put(NO_GROUP_TAG,
+    tserverByGroup.put("default",
         new TreeSet<>(List.of("host2:9090", "host4:9091", "host1:8080", "host3:9091")));
 
-    StatusSummary tserverSummary =
-        new StatusSummary(ServiceStatusReport.ReportKey.T_SERVER, Set.of(), tserverByGroup, 1);
+    StatusSummary tserverSummary = new StatusSummary(ServiceStatusReport.ReportKey.T_SERVER,
+        Set.of("default"), tserverByGroup, 1);
     services.put(ServiceStatusReport.ReportKey.T_SERVER, tserverSummary);
 
     Map<String,Set<String>> sserverByGroup = new TreeMap<>();
@@ -138,7 +138,7 @@ public class ServiceStatusReportTest {
     services.put(ServiceStatusReport.ReportKey.S_SERVER, scanServerSummary);
 
     Map<String,Set<String>> coordinatorByGroup = new TreeMap<>();
-    coordinatorByGroup.put(NO_GROUP_TAG, new TreeSet<>(List.of("host4:9090", "host2:9091")));
+    coordinatorByGroup.put("default", new TreeSet<>(List.of("host4:9090", "host2:9091")));
     StatusSummary coordinatorSummary = new StatusSummary(ServiceStatusReport.ReportKey.COORDINATOR,
         Set.of(), coordinatorByGroup, 0);
     services.put(ServiceStatusReport.ReportKey.COORDINATOR, coordinatorSummary);


### PR DESCRIPTION
The service host information stored in ZooKeeper changed between 2.1 and 3.1.x.  3.1.x uses ServiceLockData and ServiceDescriptors.  These changes adopt the admin serviceStatus command to use the new data formats.

Fixes #4603 