### PR TITLE
signal event after bulk import to trigger compaction check

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
@@ -264,7 +264,7 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
     }
 
     EventHandler() {
-      rangesToProcess = new ArrayBlockingQueue<>(3000);
+      rangesToProcess = new ArrayBlockingQueue<>(10000);
 
       Threads
           .createThread("TGW [" + store.name() + "] event range processor", new RangeProccessor())

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
@@ -294,6 +294,8 @@ class LoadFiles extends ManagerRepo {
       results.forEach((extent, condResult) -> {
         if (condResult.getStatus() == Status.ACCEPTED) {
           loadingFiles.get(extent).forEach(file -> TabletLogger.bulkImported(extent, file));
+          // Trigger a check for compaction now that new files were added via bulk load
+          manager.getEventCoordinator().event(extent, "Bulk load completed on tablet %s", extent);
         } else {
           seenFailure.set(true);
           var metadata = condResult.readMetadata();


### PR DESCRIPTION
Adds a singal event after a tablet successfully bulk imports into a tablet.  This event will tigger the tablet group watcher to check if the tablet needs a compaction.  This change will lower the latency for compacting newly arrived bulk import files which can benefit scans.