### PR TITLE
FateSummaryIT Jenkins failure fix attempt

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/FateSummaryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/FateSummaryIT.java
@@ -179,7 +179,8 @@ public class FateSummaryIT extends ConfigurableMacBase {
 
     String[] commandsToTest = {"--print", "--summary"};
     final int numTxns = 500;
-    final List<String> tableNames = new ArrayList<>(Arrays.asList(getUniqueNames(commandsToTest.length)));
+    final List<String> tableNames =
+        new ArrayList<>(Arrays.asList(getUniqueNames(commandsToTest.length)));
 
     // Occasionally, the summary/print cmds will see a COMMIT_COMPACTION transaction which was
     // initiated on starting the manager, causing the test to fail. Stopping the compactor fixes

--- a/test/src/main/java/org/apache/accumulo/test/FateSummaryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/FateSummaryIT.java
@@ -28,8 +28,10 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
@@ -177,7 +179,7 @@ public class FateSummaryIT extends ConfigurableMacBase {
 
     String[] commandsToTest = {"--print", "--summary"};
     final int numTxns = 500;
-    final String table = getUniqueNames(1)[0];
+    final List<String> tableNames = new ArrayList<>(Arrays.asList(getUniqueNames(commandsToTest.length)));
 
     // Occasionally, the summary/print cmds will see a COMMIT_COMPACTION transaction which was
     // initiated on starting the manager, causing the test to fail. Stopping the compactor fixes
@@ -187,6 +189,7 @@ public class FateSummaryIT extends ConfigurableMacBase {
 
     try (AccumuloClient client = Accumulo.newClient().from(getClientProperties()).build()) {
       for (String command : commandsToTest) {
+        final String table = tableNames.remove(0);
         IteratorSetting is = new IteratorSetting(1, SlowIterator.class);
         is.addOption("sleepTime", "2");
 


### PR DESCRIPTION
part of https://github.com/apache/accumulo/issues/4614

This is an attempt to fix the Jenkins build failure for this test. Locally, I have not been able to reproduce this test timeout (only takes about 1 minute locally and passes). So, I could not test that these changes fix the problem. If anyone knows how I can better test these changes, that would be great.

Since it was timing out at the deletion of the table, I thought this might be caused by creating, using, and deleting a table with the same name twice. I can't think of any other reason this might be timing out here...