### PR TITLE
Interrupt internal compaction thread if no longer enabled

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/HeapIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/HeapIterator.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.core.iteratorsImpl.system;
 
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.util.PriorityQueue;
 
 import org.apache.accumulo.core.data.Key;
@@ -70,6 +71,10 @@ public abstract class HeapIterator implements SortedKeyValueIterator<Key,Value> 
   public final void next() throws IOException {
     if (topIdx == null) {
       throw new IllegalStateException("Called next() when there is no top");
+    }
+
+    if (Thread.currentThread().isInterrupted()) {
+      throw new InterruptedIOException("thread interrupted while in next");
     }
 
     topIdx.next();

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/MultiIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/MultiIterator.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.core.iteratorsImpl.system;
 
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -105,6 +106,9 @@ public class MultiIterator extends HeapIterator {
     }
 
     for (SortedKeyValueIterator<Key,Value> skvi : iters) {
+      if (Thread.currentThread().isInterrupted()) {
+        throw new InterruptedIOException("thread interrupted while seeking");
+      }
       skvi.seek(range, columnFamilies, inclusive);
       addSource(skvi);
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/compaction/FileCompactor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/compaction/FileCompactor.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.server.compaction;
 
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
@@ -517,8 +518,10 @@ public class FileCompactor implements Callable<CompactionStats> {
         majCStats.add(lgMajcStats);
         writeSpan.end();
       }
-
     } catch (Exception e) {
+      if (e instanceof InterruptedIOException) {
+        throw new CompactionCanceledException();
+      }
       TraceUtil.setException(compactSpan, e, true);
       throw e;
     } finally {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
@@ -559,6 +559,7 @@ public class CompactableUtils {
       CompactableImpl.CompactionInfo cInfo, CompactionEnv cenv,
       Map<StoredTabletFile,DataFileValue> compactFiles, TabletFile tmpFileName)
       throws IOException, CompactionCanceledException {
+
     TableConfiguration tableConf = tablet.getTableConfiguration();
 
     AccumuloConfiguration compactionConfig = getCompactionConfig(tableConf,
@@ -568,6 +569,10 @@ public class CompactableUtils {
         compactFiles, tmpFileName, cInfo.propagateDeletes, cenv, cInfo.iters, compactionConfig,
         tableConf.getCryptoService());
 
+    if (Thread.currentThread().isInterrupted()) {
+      log.debug("Compaction for {} cancelled by interruption", tablet.getExtent());
+      throw new CompactionCanceledException();
+    }
     return compactor.call();
   }
 


### PR DESCRIPTION
This changes HeapIterator.next and MultiIterator.seek to throw an InterruptedIOException if the current Thread is interrupted, and modifies CompactableImpl.compact such that it creates a scheduled task to periodically check whether the majc should no longer be running and interrupts the thread.

Fixes #4485