### PR TITLE
adds validation of file clipping to split code

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/UpdateTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/UpdateTablets.java
@@ -138,10 +138,10 @@ public class UpdateTablets extends ManagerRepo {
         fileRange = new Range(fileInfo.getFirstRow(), fileInfo.getLastRow());
         if (!file.getRange().isInfiniteStartKey() || !file.getRange().isInfiniteStopKey()) {
           // Its expected that if a file has a range that the first row and last row will be clipped
-          // to be within that range. For that reason this code does not check the file range when
-          // making decisions about whether a file should go to a tablet, because its assumed this
-          // fileRange will cover that case. Since the range is not being checked this code
-          // validates the assumption.
+          // to be within that range. For that reason this code does not check file.getRange() when
+          // making decisions about whether a file should go to a tablet, because its assumed that
+          // fileRange will cover that case. Since file.getRange() is not being checked directly
+          // this code validates the assumption that fileRange is within file.getRange()
           Preconditions.checkState(
               file.getRange().clip(new Range(fileInfo.getFirstRow()), false) != null,
               "First row % computed for file % did not fall in its range", fileInfo.getFirstRow(),

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/UpdateTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/UpdateTablets.java
@@ -144,11 +144,11 @@ public class UpdateTablets extends ManagerRepo {
           // this code validates the assumption that fileRange is within file.getRange()
           Preconditions.checkState(
               file.getRange().clip(new Range(fileInfo.getFirstRow()), false) != null,
-              "First row % computed for file % did not fall in its range", fileInfo.getFirstRow(),
+              "First row %s computed for file %s did not fall in its range", fileInfo.getFirstRow(),
               file);
           Preconditions.checkState(
               file.getRange().clip(new Range(fileInfo.getLastRow()), false) != null,
-              "Last row % computed for file % did not fall in its range", fileInfo.getLastRow(),
+              "Last row %s computed for file %s did not fall in its range", fileInfo.getLastRow(),
               file);
         }
       } else {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/UpdateTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/UpdateTablets.java
@@ -136,6 +136,21 @@ public class UpdateTablets extends ManagerRepo {
       Range fileRange;
       if (fileInfo != null) {
         fileRange = new Range(fileInfo.getFirstRow(), fileInfo.getLastRow());
+        if (!file.getRange().isInfiniteStartKey() || !file.getRange().isInfiniteStopKey()) {
+          // Its expected that if a file has a range that the first row and last row will be clipped
+          // to be within that range. For that reason this code does not check the file range when
+          // making decisions about whether a file should go to a tablet, because its assumed this
+          // fileRange will cover that case. Since the range is not being checked this code
+          // validates the assumption.
+          Preconditions.checkState(
+              file.getRange().clip(new Range(fileInfo.getFirstRow()), false) != null,
+              "First row % computed for file % did not fall in its range", fileInfo.getFirstRow(),
+              file);
+          Preconditions.checkState(
+              file.getRange().clip(new Range(fileInfo.getLastRow()), false) != null,
+              "Last row % computed for file % did not fall in its range", fileInfo.getLastRow(),
+              file);
+        }
       } else {
         fileRange = new Range();
       }


### PR DESCRIPTION
When the split code examined files to determine if they should go to a child tablet it did not directly look at any ranges associated with the file becasue it assumed other code would clip.  Added validation that clipping was done since the file ranges are not directly examined by split.

Ran ComprehensiveIT.testMergeAndSplit() to test this change because it does split->merge-split->merge while will cause split of tablets w/ fenced files.