### PR TITLE
fixes race condition w/ split,compaction relative to offline

### DIFF
--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -75,6 +75,7 @@ import org.apache.accumulo.core.lock.ServiceLockData;
 import org.apache.accumulo.core.lock.ServiceLockData.ServiceDescriptor;
 import org.apache.accumulo.core.lock.ServiceLockData.ServiceDescriptors;
 import org.apache.accumulo.core.lock.ServiceLockData.ThriftService;
+import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
@@ -200,6 +201,13 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
           // is running for some reason
           LOG.info("Cancelling compaction {} that no longer has a metadata entry at {}", ecid,
               extent);
+          JOB_HOLDER.cancel(job.getExternalCompactionId());
+          return;
+        }
+
+        var tableState = getContext().getTableState(extent.tableId());
+        if (tableState != TableState.ONLINE) {
+          LOG.info("Cancelling compaction {} because table state is {}", ecid, tableState);
           JOB_HOLDER.cancel(job.getExternalCompactionId());
           return;
         }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/TabletRefresher.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/TabletRefresher.java
@@ -23,9 +23,11 @@ import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -35,6 +37,7 @@ import java.util.function.Supplier;
 
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.dataImpl.thrift.TKeyExtent;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.metadata.TServerInstance;
@@ -106,8 +109,8 @@ public class TabletRefresher {
 
         // Ask tablet server to reload the metadata for these tablets. The tablet server returns
         // the list of extents it was hosting but was unable to refresh (the tablets could be in
-        // the process of loading). If it is not currently hosting the tablet it treats that as
-        // refreshed and does not return anything for it.
+        // the process of loading). If it is not currently hosting the tablet it does not return
+        // anything for it.
         Future<List<TKeyExtent>> future = threadPool
             .submit(() -> sendSyncRefreshRequest(context, logId, entry.getKey(), entry.getValue()));
 
@@ -139,6 +142,48 @@ public class TabletRefresher {
 
         refreshesNeeded.keySet()
             .removeIf(location -> !liveTservers.contains(location.getServerInstance()));
+      }
+
+      if (!refreshesNeeded.isEmpty()) {
+        // look for any tablets where the location changed, these tablets will no longer need a
+        // refresh because when the tablet loads at the new location it will see the new tablet
+        // metadata
+        HashMap<KeyExtent,TabletMetadata.Location> prevLocations = new HashMap<>();
+        refreshesNeeded.forEach((loc, extents) -> {
+          for (TKeyExtent te : extents) {
+            var extent = KeyExtent.fromThrift(te);
+            prevLocations.put(extent, loc);
+          }
+        });
+
+        // Build a map of tablets that exist and their current location. No need to includes tablets
+        // that no longer exists or do not have a location as later logic is ok w/ these being null.
+        HashMap<KeyExtent,TabletMetadata.Location> currLocations = new HashMap<>();
+        try (var tablets =
+            context.getAmple().readTablets().forTablets(prevLocations.keySet(), Optional.empty())
+                .fetch(ColumnType.LOCATION).build()) {
+          tablets.forEach(tablet -> {
+            if (tablet.getLocation() != null) {
+              currLocations.put(tablet.getExtent(), tablet.getLocation());
+            }
+          });
+        }
+
+        refreshesNeeded.clear();
+
+        var finalrefreshesNeeded = refreshesNeeded;
+        // rebuild refreshesNeeded only including those where the location is still the same
+        prevLocations.forEach((extent, prevLoc) -> {
+          var currLoc = currLocations.get(extent);
+          // currLoc may be null and this is ok because it should not be equal then
+          if (prevLoc.equals(currLoc)) {
+            finalrefreshesNeeded.computeIfAbsent(currLoc, k -> new ArrayList<>())
+                .add(extent.toThrift());
+          } else {
+            log.trace("The location of {} changed from {} to {}, so refresh no longer needed",
+                extent, prevLoc, currLoc);
+          }
+        });
       }
 
       if (!refreshesNeeded.isEmpty()) {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriver.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriver.java
@@ -46,6 +46,7 @@ import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.logging.TabletLogger;
+import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.core.metadata.AbstractTabletFile;
 import org.apache.accumulo.core.metadata.AccumuloTable;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
@@ -111,6 +112,11 @@ class CompactionDriver extends ManagerRepo {
       throw new AcceptableThriftTableOperationException(tableId.canonical(), null,
           TableOperation.COMPACT, TableOperationExceptionType.OTHER,
           TableOperationsImpl.TABLE_DELETED_MSG);
+    }
+
+    if (manager.getContext().getTableState(tableId) != TableState.ONLINE) {
+      throw new AcceptableThriftTableOperationException(tableId.canonical(), null,
+          TableOperation.COMPACT, TableOperationExceptionType.OFFLINE, "The table is not online.");
     }
 
     long t1 = System.currentTimeMillis();

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/AllocateDirsAndEnsureOnline.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/AllocateDirsAndEnsureOnline.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.manager.tableOps.split;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
+import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
+import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
+import org.apache.accumulo.core.fate.FateId;
+import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.manager.state.tables.TableState;
+import org.apache.accumulo.core.metadata.schema.Ample;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.metadata.schema.TabletOperationId;
+import org.apache.accumulo.core.metadata.schema.TabletOperationType;
+import org.apache.accumulo.manager.Manager;
+import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.server.tablets.TabletNameGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AllocateDirsAndEnsureOnline extends ManagerRepo {
+
+  private static final long serialVersionUID = 1L;
+  private static final Logger log = LoggerFactory.getLogger(PreSplit.class);
+
+  private final SplitInfo splitInfo;
+
+  public AllocateDirsAndEnsureOnline(SplitInfo splitInfo) {
+    this.splitInfo = splitInfo;
+  }
+
+  @Override
+  public Repo<Manager> call(FateId fateId, Manager manager) throws Exception {
+    // This check of table state is done after setting the operation id to avoid a race condition
+    // with the client code that waits for a table to go offline. That client code sets the table
+    // state and then scans the metadata table looking for split operations ids. If split checks
+    // tables state before setting the opid then there is race condition with the client. Setting it
+    // after ensures that in the case when the client does not see any split op id in the metadata
+    // table that it knows that any splits starting after that point in time will not complete. This
+    // order is needed because the split fate operation does not acquire a table lock in zookeeper.
+    if (manager.getContext().getTableState(splitInfo.getOriginal().tableId())
+        != TableState.ONLINE) {
+
+      var opid = TabletOperationId.from(TabletOperationType.SPLITTING, fateId);
+
+      // attempt to delete the operation id
+      try (var tabletsMutator = manager.getContext().getAmple().conditionallyMutateTablets()) {
+
+        Ample.RejectionHandler rejectionHandler = new Ample.RejectionHandler() {
+
+          @Override
+          public boolean callWhenTabletDoesNotExists() {
+            return true;
+          }
+
+          @Override
+          public boolean test(TabletMetadata tabletMetadata) {
+            // if the tablet no longer exists or our operation id is not set then consider a success
+            return tabletMetadata == null || !opid.equals(tabletMetadata.getOperationId());
+          }
+        };
+
+        tabletsMutator.mutateTablet(splitInfo.getOriginal()).requireOperation(opid)
+            .requireAbsentLocation().requireAbsentLogs().deleteOperation().submit(rejectionHandler);
+
+        var result = tabletsMutator.process().get(splitInfo.getOriginal());
+
+        if (result.getStatus() != Ample.ConditionalResult.Status.ACCEPTED) {
+          throw new IllegalStateException(
+              "Failed to delete operation id " + splitInfo.getOriginal());
+        }
+      }
+
+      throw new AcceptableThriftTableOperationException(
+          splitInfo.getOriginal().tableId().canonical(), null, TableOperation.SPLIT,
+          TableOperationExceptionType.OFFLINE,
+          "Unable to split tablet because the table is offline");
+    } else {
+      // Create the dir name here for the next step. If the next step fails it will always have the
+      // same dir name each time it runs again making it idempotent.
+      List<String> dirs = new ArrayList<>();
+
+      splitInfo.getSplits().forEach(split -> {
+        String dirName = TabletNameGenerator.createTabletDirectoryName(manager.getContext(), split);
+        dirs.add(dirName);
+        log.trace("{} allocated dir name {}", fateId, dirName);
+      });
+      return new UpdateTablets(splitInfo, dirs);
+    }
+  }
+}

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/SplitInfo.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/SplitInfo.java
@@ -37,7 +37,7 @@ public class SplitInfo implements Serializable {
   private final byte[] endRow;
   private final byte[][] splits;
 
-  SplitInfo(KeyExtent extent, SortedSet<Text> splits) {
+  public SplitInfo(KeyExtent extent, SortedSet<Text> splits) {
     this.tableId = extent.tableId();
     this.prevEndRow = extent.prevEndRow() == null ? null : TextUtil.getBytes(extent.prevEndRow());
     this.endRow = extent.endRow() == null ? null : TextUtil.getBytes(extent.endRow());


### PR DESCRIPTION
This commit wraps up #3412 and includes the following changes

 * compactors now cancel running compactions when the table state is no longer online, this avoids doing work that will never be used
 * coordinator will no longer start commiting compactions when the tablet is offline, this avoid race condition w/ offline+wait of table
 * fixed bug found in tablet refresher where it was not properly handling concurrent tablet unloads (found by testing concurrent compaction and offline)
 * compaction fate operation that drives table compaction will now fail when table is offline (this change may be needed in older versions)
 * reordered when the split fate operation checks for table offline to avoid race condition with offline+wait of table
 * added multiple ITs to test running split and compaction concurrently with offline table operation