### PR TITLE
sets error ref when compactor catches cancellation exception

### DIFF
--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -559,6 +559,7 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
         updateCompactionState(job, update2);
       } catch (FileCompactor.CompactionCanceledException cce) {
         LOG.debug("Compaction canceled {}", job.getExternalCompactionId());
+        err.set(cce);
       } catch (Exception e) {
         KeyExtent fromThriftExtent = KeyExtent.fromThrift(job.getExtent());
         LOG.error("Compaction failed: id: {}, extent: {}", job.getExternalCompactionId(),


### PR DESCRIPTION
The compactor was not setting an error reference when it caught a cancelation exception.  This could cause the compactor to report success back to the coordinator.