### PR TITLE
Timeout value addd to wait for scans servers

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelector.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelector.java
@@ -84,7 +84,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * example could have some scans use expensive high memory VMs and others use cheaper burstable
  * VMs.</li>
  * <li><b>timeToWaitForScanServers : </b> When there are no scans servers, this setting determines
- * how long to wait for scan servers to load before falling back to tablet servers is desired.
+ * how long to wait for scan servers to become available before falling back to tablet servers.
  * Falling back to tablet servers may cause tablets to be loaded that are not currently loaded. When
  * this setting is given a wait time and there are no scan servers, it will wait for scan servers to
  * be available. This setting avoids loading tablets on tablet servers when scans servers are
@@ -98,10 +98,10 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * <li>"ms" for milliseconds</li>
  * </ul>
  * If duration is not specified this setting defaults to 0s, and will disable the wait for scan
- * servers. When set to a large value, the selector will effectively wait for scan servers to become
- * available before falling back to tablet servers. To ensure the selector never falls back to
- * scanning tablet servers an unrealistic wait time can be set. For instance 10000d should be
- * sufficient. Setting Waiting for scan servers is done via
+ * servers and will fall back to tablet servers immediately. When set to a large value, the selector
+ * will effectively wait for scan servers to become available before falling back to tablet servers.
+ * To ensure the selector never falls back to scanning tablet servers an unrealistic wait time can
+ * be set. For instance 10000d should be sufficient. Setting Waiting for scan servers is done via
  * {@link org.apache.accumulo.core.spi.scan.ScanServerSelector.SelectorParameters#waitUntil(Supplier, Duration, String)}</li>
  * <li><b>attemptPlans : </b> A list of configuration to use for each scan attempt. Each list object
  * has the following fields:

--- a/core/src/main/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelector.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelector.java
@@ -98,9 +98,9 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * <li>"ms" for milliseconds</li>
  * </ul>
  * If duration is not specified this setting defaults to 0s, and will disable the wait for scan
- * servers. When set to a large value, the system will effectively wait for scan servers to become
- * available before falling back to tablet servers. To ensure the scan servers does not fall back to
- * tablet servers and continuously waits for scan servers a wait time of 10000d should be
+ * servers. When set to a large value, the selector will effectively wait for scan servers to become
+ * available before falling back to tablet servers. To ensure the selector never falls back to scanning
+ * tablet servers an unrealistic wait time can be set. For instance 10000d should be
  * sufficient. Setting Waiting for scan servers is done via
  * {@link org.apache.accumulo.core.spi.scan.ScanServerSelector.SelectorParameters#waitUntil(Supplier, Duration, String)}</li>
  * <li><b>attemptPlans : </b> A list of configuration to use for each scan attempt. Each list object

--- a/core/src/main/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelector.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelector.java
@@ -99,8 +99,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * </ul>
  * If duration is not specified this setting defaults to 0s, and will disable the wait for scan
  * servers. When set to a large value, the selector will effectively wait for scan servers to become
- * available before falling back to tablet servers. To ensure the selector never falls back to scanning
- * tablet servers an unrealistic wait time can be set. For instance 10000d should be
+ * available before falling back to tablet servers. To ensure the selector never falls back to
+ * scanning tablet servers an unrealistic wait time can be set. For instance 10000d should be
  * sufficient. Setting Waiting for scan servers is done via
  * {@link org.apache.accumulo.core.spi.scan.ScanServerSelector.SelectorParameters#waitUntil(Supplier, Duration, String)}</li>
  * <li><b>attemptPlans : </b> A list of configuration to use for each scan attempt. Each list object

--- a/core/src/test/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelectorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelectorTest.java
@@ -490,7 +490,7 @@ public class ConfigurableScanServerSelectorTest {
     // will wait for scan servers
 
     String defaultProfile =
-        "{'isDefault':true,'maxBusyTimeout':'5m','busyTimeoutMultiplier':4,'timeToWaitForScanServers':120ms,"
+        "{'isDefault':true,'maxBusyTimeout':'5m','busyTimeoutMultiplier':4,'timeToWaitForScanServers':120s,"
             + "'attemptPlans':[{'servers':'100%', 'busyTimeout':'60s'}]}";
 
     var opts = Map.of("profiles", "[" + defaultProfile + "]".replace('\'', '"'));

--- a/core/src/test/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelectorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelectorTest.java
@@ -490,7 +490,7 @@ public class ConfigurableScanServerSelectorTest {
     // will wait for scan servers
 
     String defaultProfile =
-        "{'isDefault':true,'maxBusyTimeout':'5m','busyTimeoutMultiplier':4,'enableTabletServerFallback':false,"
+        "{'isDefault':true,'maxBusyTimeout':'5m','busyTimeoutMultiplier':4,'timeToWaitForScanServers':120ms,"
             + "'attemptPlans':[{'servers':'100%', 'busyTimeout':'60s'}]}";
 
     var opts = Map.of("profiles", "[" + defaultProfile + "]".replace('\'', '"'));

--- a/core/src/test/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelectorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelectorTest.java
@@ -490,7 +490,7 @@ public class ConfigurableScanServerSelectorTest {
     // will wait for scan servers
 
     String defaultProfile =
-        "{'isDefault':true,'maxBusyTimeout':'5m','busyTimeoutMultiplier':4,'timeToWaitForScanServers':120s,"
+        "{'isDefault':true,'maxBusyTimeout':'5m','busyTimeoutMultiplier':4,'timeToWaitForScanServers':'120s',"
             + "'attemptPlans':[{'servers':'100%', 'busyTimeout':'60s'}]}";
 
     var opts = Map.of("profiles", "[" + defaultProfile + "]".replace('\'', '"'));

--- a/test/src/main/java/org/apache/accumulo/test/ScanServerIT_NoServers.java
+++ b/test/src/main/java/org/apache/accumulo/test/ScanServerIT_NoServers.java
@@ -139,7 +139,7 @@ public class ScanServerIT_NoServers extends SharedMiniClusterBase {
     var clientProps = new Properties();
     clientProps.putAll(getClientProps());
     String scanServerSelectorProfiles = "[{'isDefault':true,'maxBusyTimeout':'5m',"
-        + "'busyTimeoutMultiplier':8, 'scanTypeActivations':[], 'timeToWaitForScanServers':120s,"
+        + "'busyTimeoutMultiplier':8, 'scanTypeActivations':[], 'timeToWaitForScanServers':'120s',"
         + "'attemptPlans':[{'servers':'3', 'busyTimeout':'1s'}]}]";
     clientProps.put("scan.server.selector.impl", ConfigurableScanServerSelector.class.getName());
     clientProps.put("scan.server.selector.opts.profiles",
@@ -167,7 +167,7 @@ public class ScanServerIT_NoServers extends SharedMiniClusterBase {
     var clientProps = new Properties();
     clientProps.putAll(getClientProps());
     String scanServerSelectorProfiles = "[{'isDefault':true,'maxBusyTimeout':'5m',"
-        + "'busyTimeoutMultiplier':8, 'scanTypeActivations':[], 'timeToWaitForScanServers':120s,"
+        + "'busyTimeoutMultiplier':8, 'scanTypeActivations':[], 'timeToWaitForScanServers':'120s',"
         + "'attemptPlans':[{'servers':'3', 'busyTimeout':'1s'}]}]";
     clientProps.put("scan.server.selector.impl", ConfigurableScanServerSelector.class.getName());
     clientProps.put("scan.server.selector.opts.profiles",

--- a/test/src/main/java/org/apache/accumulo/test/ScanServerIT_NoServers.java
+++ b/test/src/main/java/org/apache/accumulo/test/ScanServerIT_NoServers.java
@@ -139,7 +139,7 @@ public class ScanServerIT_NoServers extends SharedMiniClusterBase {
     var clientProps = new Properties();
     clientProps.putAll(getClientProps());
     String scanServerSelectorProfiles = "[{'isDefault':true,'maxBusyTimeout':'5m',"
-        + "'busyTimeoutMultiplier':8, 'scanTypeActivations':[], 'timeToWaitForScanServers':120ms,"
+        + "'busyTimeoutMultiplier':8, 'scanTypeActivations':[], 'timeToWaitForScanServers':120s,"
         + "'attemptPlans':[{'servers':'3', 'busyTimeout':'1s'}]}]";
     clientProps.put("scan.server.selector.impl", ConfigurableScanServerSelector.class.getName());
     clientProps.put("scan.server.selector.opts.profiles",
@@ -167,7 +167,7 @@ public class ScanServerIT_NoServers extends SharedMiniClusterBase {
     var clientProps = new Properties();
     clientProps.putAll(getClientProps());
     String scanServerSelectorProfiles = "[{'isDefault':true,'maxBusyTimeout':'5m',"
-        + "'busyTimeoutMultiplier':8, 'scanTypeActivations':[], 'timeToWaitForScanServers':120ms,"
+        + "'busyTimeoutMultiplier':8, 'scanTypeActivations':[], 'timeToWaitForScanServers':120s,"
         + "'attemptPlans':[{'servers':'3', 'busyTimeout':'1s'}]}]";
     clientProps.put("scan.server.selector.impl", ConfigurableScanServerSelector.class.getName());
     clientProps.put("scan.server.selector.opts.profiles",

--- a/test/src/main/java/org/apache/accumulo/test/ScanServerIT_NoServers.java
+++ b/test/src/main/java/org/apache/accumulo/test/ScanServerIT_NoServers.java
@@ -139,7 +139,7 @@ public class ScanServerIT_NoServers extends SharedMiniClusterBase {
     var clientProps = new Properties();
     clientProps.putAll(getClientProps());
     String scanServerSelectorProfiles = "[{'isDefault':true,'maxBusyTimeout':'5m',"
-        + "'busyTimeoutMultiplier':8, 'scanTypeActivations':[], 'enableTabletServerFallback':false,"
+        + "'busyTimeoutMultiplier':8, 'scanTypeActivations':[], 'timeToWaitForScanServers':120ms,"
         + "'attemptPlans':[{'servers':'3', 'busyTimeout':'1s'}]}]";
     clientProps.put("scan.server.selector.impl", ConfigurableScanServerSelector.class.getName());
     clientProps.put("scan.server.selector.opts.profiles",
@@ -167,7 +167,7 @@ public class ScanServerIT_NoServers extends SharedMiniClusterBase {
     var clientProps = new Properties();
     clientProps.putAll(getClientProps());
     String scanServerSelectorProfiles = "[{'isDefault':true,'maxBusyTimeout':'5m',"
-        + "'busyTimeoutMultiplier':8, 'scanTypeActivations':[], 'enableTabletServerFallback':false,"
+        + "'busyTimeoutMultiplier':8, 'scanTypeActivations':[], 'timeToWaitForScanServers':120ms,"
         + "'attemptPlans':[{'servers':'3', 'busyTimeout':'1s'}]}]";
     clientProps.put("scan.server.selector.impl", ConfigurableScanServerSelector.class.getName());
     clientProps.put("scan.server.selector.opts.profiles",

--- a/test/src/main/java/org/apache/accumulo/test/functional/OnDemandTabletUnloadingIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/OnDemandTabletUnloadingIT.java
@@ -190,7 +190,7 @@ public class OnDemandTabletUnloadingIT extends SharedMiniClusterBase {
 
   public static final String SCAN_SERVER_SELECTOR_CONFIG =
       "[{'isDefault':true,'maxBusyTimeout':'5m',"
-          + "'busyTimeoutMultiplier':8, 'scanTypeActivations':[], 'timeToWaitForScanServers':120ms"
+          + "'busyTimeoutMultiplier':8, 'scanTypeActivations':[], 'timeToWaitForScanServers':120s"
           + "'attemptPlans':[{'servers':'3', 'busyTimeout':'33ms', 'salt':'one'},"
           + "{'servers':'13', 'busyTimeout':'33ms', 'salt':'two'},"
           + "{'servers':'100%', 'busyTimeout':'33ms'}]}]";
@@ -204,7 +204,7 @@ public class OnDemandTabletUnloadingIT extends SharedMiniClusterBase {
     var clientProps = new Properties();
     clientProps.putAll(getClientProps());
     String scanServerSelectorProfiles = "[{'isDefault':true,'maxBusyTimeout':'5m',"
-        + "'busyTimeoutMultiplier':8, 'scanTypeActivations':[], 'timeToWaitForScanServers':120ms,"
+        + "'busyTimeoutMultiplier':8, 'scanTypeActivations':[], 'timeToWaitForScanServers':120s,"
         + "'attemptPlans':[{'servers':'3', 'busyTimeout':'1s'}]}]";
     clientProps.put("scan.server.selector.impl", ConfigurableScanServerSelector.class.getName());
     clientProps.put("scan.server.selector.opts.profiles",

--- a/test/src/main/java/org/apache/accumulo/test/functional/OnDemandTabletUnloadingIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/OnDemandTabletUnloadingIT.java
@@ -190,7 +190,7 @@ public class OnDemandTabletUnloadingIT extends SharedMiniClusterBase {
 
   public static final String SCAN_SERVER_SELECTOR_CONFIG =
       "[{'isDefault':true,'maxBusyTimeout':'5m',"
-          + "'busyTimeoutMultiplier':8, 'scanTypeActivations':[], 'timeToWaitForScanServers':120s"
+          + "'busyTimeoutMultiplier':8, 'scanTypeActivations':[], 'timeToWaitForScanServers':'120s',"
           + "'attemptPlans':[{'servers':'3', 'busyTimeout':'33ms', 'salt':'one'},"
           + "{'servers':'13', 'busyTimeout':'33ms', 'salt':'two'},"
           + "{'servers':'100%', 'busyTimeout':'33ms'}]}]";
@@ -204,7 +204,7 @@ public class OnDemandTabletUnloadingIT extends SharedMiniClusterBase {
     var clientProps = new Properties();
     clientProps.putAll(getClientProps());
     String scanServerSelectorProfiles = "[{'isDefault':true,'maxBusyTimeout':'5m',"
-        + "'busyTimeoutMultiplier':8, 'scanTypeActivations':[], 'timeToWaitForScanServers':120s,"
+        + "'busyTimeoutMultiplier':8, 'scanTypeActivations':[], 'timeToWaitForScanServers':'120s',"
         + "'attemptPlans':[{'servers':'3', 'busyTimeout':'1s'}]}]";
     clientProps.put("scan.server.selector.impl", ConfigurableScanServerSelector.class.getName());
     clientProps.put("scan.server.selector.opts.profiles",

--- a/test/src/main/java/org/apache/accumulo/test/functional/OnDemandTabletUnloadingIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/OnDemandTabletUnloadingIT.java
@@ -190,7 +190,7 @@ public class OnDemandTabletUnloadingIT extends SharedMiniClusterBase {
 
   public static final String SCAN_SERVER_SELECTOR_CONFIG =
       "[{'isDefault':true,'maxBusyTimeout':'5m',"
-          + "'busyTimeoutMultiplier':8, 'scanTypeActivations':[], 'enableTabletServerFallback':false"
+          + "'busyTimeoutMultiplier':8, 'scanTypeActivations':[], 'timeToWaitForScanServers':120ms"
           + "'attemptPlans':[{'servers':'3', 'busyTimeout':'33ms', 'salt':'one'},"
           + "{'servers':'13', 'busyTimeout':'33ms', 'salt':'two'},"
           + "{'servers':'100%', 'busyTimeout':'33ms'}]}]";
@@ -204,7 +204,7 @@ public class OnDemandTabletUnloadingIT extends SharedMiniClusterBase {
     var clientProps = new Properties();
     clientProps.putAll(getClientProps());
     String scanServerSelectorProfiles = "[{'isDefault':true,'maxBusyTimeout':'5m',"
-        + "'busyTimeoutMultiplier':8, 'scanTypeActivations':[], 'enableTabletServerFallback':false,"
+        + "'busyTimeoutMultiplier':8, 'scanTypeActivations':[], 'timeToWaitForScanServers':120ms,"
         + "'attemptPlans':[{'servers':'3', 'busyTimeout':'1s'}]}]";
     clientProps.put("scan.server.selector.impl", ConfigurableScanServerSelector.class.getName());
     clientProps.put("scan.server.selector.opts.profiles",


### PR DESCRIPTION
Closes [issue#4532](https://github.com/apache/accumulo/issues/4532) 

Changed `enableTabletServerFallback` to `timeToWaitForScanServers` and made it a timeout value. Please take a look at the class description and see if the explanation `timeToWaitForScanServers`  is sufficient enough. This update will need to be added into 2.1 as well.