### PR TITLE
moves static metadata util methods to only places using them

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
@@ -31,11 +31,9 @@ import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -57,14 +55,11 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.gc.ReferenceFile;
 import org.apache.accumulo.core.lock.ServiceLock;
 import org.apache.accumulo.core.metadata.AccumuloTable;
-import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.Ample;
-import org.apache.accumulo.core.metadata.schema.Ample.TabletMutator;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ClonedColumnFamily;
@@ -72,7 +67,6 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.Cu
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LastLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
-import org.apache.accumulo.core.metadata.schema.MetadataTime;
 import org.apache.accumulo.core.metadata.schema.TabletDeletedException;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
@@ -101,53 +95,6 @@ public class MetadataTableUtil {
   public static void putLockID(ServerContext context, ServiceLock zooLock, Mutation m) {
     ServerColumnFamily.LOCK_COLUMN.put(m,
         new Value(zooLock.getLockID().serialize(context.getZooKeeperRoot() + "/")));
-  }
-
-  public static void update(ServerContext context, ServiceLock zooLock, Mutation m,
-      KeyExtent extent) {
-
-    if (zooLock != null) {
-      putLockID(context, zooLock, m);
-    }
-
-    String metaTable = Ample.DataLevel.of(extent.tableId()).metaTable();
-    while (true) {
-      try (BatchWriter writer = context.createBatchWriter(metaTable)) {
-        writer.addMutation(m);
-        writer.flush();
-        return;
-      } catch (MutationsRejectedException e) {
-
-        if (!e.getConstraintViolationSummaries().isEmpty()) {
-          // retrying when a CVE occurs is probably futile and can cause problems, see ACCUMULO-3096
-          throw new IllegalArgumentException(e);
-        }
-      } catch (TableNotFoundException e) {
-        logUpdateFailure(m, extent, e);
-      }
-
-      sleepUninterruptibly(1, TimeUnit.SECONDS);
-    }
-  }
-
-  private static void logUpdateFailure(Mutation m, KeyExtent extent, Exception e) {
-    log.error("Failed to write metadata updates for extent {} {}", extent, m.prettyPrint(), e);
-  }
-
-  public static Map<StoredTabletFile,DataFileValue> updateTabletDataFile(FateId fateId,
-      KeyExtent extent, Map<ReferencedTabletFile,DataFileValue> estSizes, MetadataTime time,
-      ServerContext context, ServiceLock zooLock) {
-    TabletMutator tablet = context.getAmple().mutateTablet(extent);
-    tablet.putTime(time);
-
-    Map<StoredTabletFile,DataFileValue> newFiles = new HashMap<>(estSizes.size());
-    estSizes.forEach((tf, dfv) -> {
-      tablet.putFile(tf, dfv);
-      tablet.putBulkFile(tf, fateId);
-      newFiles.put(tf.insert(), dfv);
-    });
-    tablet.mutate();
-    return newFiles;
   }
 
   public static void deleteTable(TableId tableId, boolean insertDeletes, ServerContext context,

--- a/test/src/main/java/org/apache/accumulo/test/MetaConstraintRetryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MetaConstraintRetryIT.java
@@ -33,8 +33,8 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.AccumuloTable;
 import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
+import org.apache.accumulo.manager.upgrade.SplitRecovery12to13;
 import org.apache.accumulo.server.ServerContext;
-import org.apache.accumulo.server.util.MetadataTableUtil;
 import org.junit.jupiter.api.Test;
 
 public class MetaConstraintRetryIT extends AccumuloClusterHarness {
@@ -58,7 +58,7 @@ public class MetaConstraintRetryIT extends AccumuloClusterHarness {
       // unknown columns should cause constraint violation
       m.put("badcolfam", "badcolqual", "3");
       var iae = assertThrows(IllegalArgumentException.class,
-          () -> MetadataTableUtil.update(context, null, m, extent));
+          () -> SplitRecovery12to13.update(context, null, m, extent));
       assertEquals(MutationsRejectedException.class, iae.getCause().getClass());
       var mre = (MutationsRejectedException) iae.getCause();
       assertFalse(mre.getConstraintViolationSummaries().isEmpty());


### PR DESCRIPTION
While investigating #3858, noticed these utility metadata utility methods that were not widely used.  Moved the static method where they are actually used to clean up the code.

This refactoring was done using IDE. Planning to merge this PR if GH actions build passes because it was an automated change.