### PR TITLE
Add new compactor busy metric to unexpected list - fixes MetricsIT failure

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/metrics/MetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/metrics/MetricsIT.java
@@ -102,6 +102,7 @@ public class MetricsIT extends ConfigurableMacBase implements MetricsProducer {
     // @formatter:off
     Set<String> unexpectedMetrics =
             Set.of(METRICS_COMPACTOR_MAJC_STUCK,
+                    METRICS_COMPACTOR_BUSY,
                     METRICS_REPLICATION_QUEUE,
                     METRICS_SCAN_YIELDS,
                     METRICS_UPDATE_ERRORS);


### PR DESCRIPTION
MetricsIT was failing because it did not see this metric. The test does not run a compactor so it has been added to the set of unexpected metrics.