### PR TITLE
fixes ManagerAssignmentIT test failure

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/availability/SetTabletAvailability.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/availability/SetTabletAvailability.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.manager.tableOps.availability;
 
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
@@ -90,7 +91,9 @@ public class SetTabletAvailability extends ManagerRepo {
     Consumer<Ample.ConditionalResult> resultsConsumer = result -> {
       if (result.getStatus() != Ample.ConditionalResult.Status.ACCEPTED) {
         notAccepted.incrementAndGet();
-        LOG.debug("{} failed to set tablet availability for {}", fateId, result.getExtent());
+        LOG.debug("{} failed to set tablet availability for {} '{}'", fateId, result.getExtent(),
+            Optional.ofNullable(result.readMetadata()).map(TabletMetadata::getOperationId)
+                .orElse(null));
       }
     };
 


### PR DESCRIPTION
ManagerAssignmentIT had a test that would manually set an operation id on a tablet and then attempt to set the tablet availibility on the tablet using public API.  The changes in #4636 caused this public API call to block because an opid was present.  Modified the test to directly set tablet availability in the API.  Modifed the fate operation to log the opid that is blocking it.