### PR TITLE
Back ported Timeout value to 2.1

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java
@@ -36,11 +36,13 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.client.AccumuloException;
@@ -502,7 +504,7 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
 
   private void doLookups(Map<String,Map<KeyExtent,List<Range>>> binnedRanges,
       final ResultReceiver receiver, List<Column> columns) {
-
+    long startTime = System.currentTimeMillis();
     int maxTabletsPerRequest = Integer.MAX_VALUE;
 
     long busyTimeout = 0;
@@ -510,7 +512,7 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
     Map<String,ScanServerAttemptReporter> reporters = Map.of();
 
     if (options.getConsistencyLevel().equals(ConsistencyLevel.EVENTUAL)) {
-      var scanServerData = rebinToScanServers(binnedRanges);
+      var scanServerData = rebinToScanServers(binnedRanges, startTime);
       busyTimeout = scanServerData.actions.getBusyTimeout().toMillis();
       reporters = scanServerData.reporters;
       scanServerSelectorDelay = scanServerData.actions.getDelay();
@@ -603,7 +605,8 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
     Map<String,ScanServerAttemptReporter> reporters;
   }
 
-  private ScanServerData rebinToScanServers(Map<String,Map<KeyExtent,List<Range>>> binnedRanges) {
+  private ScanServerData rebinToScanServers(Map<String,Map<KeyExtent,List<Range>>> binnedRanges,
+      long startTime) {
     ScanServerSelector ecsm = context.getScanServerSelector();
 
     List<TabletIdImpl> tabletIds =
@@ -612,6 +615,9 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
 
     // get a snapshot of this once,not each time the plugin request it
     var scanAttemptsSnapshot = scanAttempts.snapshot();
+
+    Duration timeoutLeft = Duration.ofMillis(retryTimeout)
+        .minus(Duration.ofMillis(System.currentTimeMillis() - startTime));
 
     ScanServerSelector.SelectorParameters params = new ScanServerSelector.SelectorParameters() {
       @Override
@@ -627,6 +633,13 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
       @Override
       public Map<String,String> getHints() {
         return options.executionHints;
+      }
+
+      @Override
+      public <T> Optional<T> waitUntil(Supplier<Optional<T>> condition, Duration maxWaitTime,
+          String description) {
+        return ThriftScanner.waitUntil(condition, maxWaitTime, description, timeoutLeft, context,
+            tableId, log);
       }
     };
 

--- a/core/src/main/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelector.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelector.java
@@ -84,7 +84,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * example could have some scans use expensive high memory VMs and others use cheaper burstable
  * VMs.</li>
  * <li><b>timeToWaitForScanServers : </b> When there are no scans servers, this setting determines
- * how long to wait for scan servers to load before falling back to tablet servers is desired.
+ * how long to wait for scan servers to become available before falling back to tablet servers.
  * Falling back to tablet servers may cause tablets to be loaded that are not currently loaded. When
  * this setting is given a wait time and there are no scan servers, it will wait for scan servers to
  * be available. This setting avoids loading tablets on tablet servers when scans servers are
@@ -98,10 +98,10 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * <li>"ms" for milliseconds</li>
  * </ul>
  * If duration is not specified this setting defaults to 0s, and will disable the wait for scan
- * servers. When set to a large value, the selector will effectively wait for scan servers to become
- * available before falling back to tablet servers. To ensure the selector never falls back to
- * scanning tablet servers an unrealistic wait time can be set. For instance 10000d should be
- * sufficient. Setting Waiting for scan servers is done via
+ * servers and will fall back to tablet servers immediately. When set to a large value, the selector
+ * will effectively wait for scan servers to become available before falling back to tablet servers.
+ * To ensure the selector never falls back scanning tablet servers an unrealistic wait time can be
+ * set. For instanced should be sufficient. Setting Waiting for scan servers is done via
  * {@link org.apache.accumulo.core.spi.scan.ScanServerSelector.SelectorParameters#waitUntil(Supplier, Duration, String)}</li>
  * <li><b>attemptPlans : </b> A list of configuration to use for each scan attempt. Each list object
  * has the following fields:

--- a/core/src/test/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelectorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelectorTest.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.core.spi.scan;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -29,7 +30,9 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -39,6 +42,7 @@ import org.apache.accumulo.core.data.TabletId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.dataImpl.TabletIdImpl;
 import org.apache.accumulo.core.spi.common.ServiceEnvironment;
+import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.Test;
 
@@ -47,7 +51,7 @@ public class ConfigurableScanServerSelectorTest {
   static class InitParams implements ScanServerSelector.InitParameters {
 
     private final Map<String,String> opts;
-    private final Map<String,String> scanServers;
+    private final Supplier<Map<String,String>> scanServers;
 
     InitParams(Set<String> scanServers) {
       this(scanServers, Map.of());
@@ -55,12 +59,18 @@ public class ConfigurableScanServerSelectorTest {
 
     InitParams(Set<String> scanServers, Map<String,String> opts) {
       this.opts = opts;
-      this.scanServers = new HashMap<>();
+      var scanServersMap = new HashMap<String,String>();
       scanServers.forEach(
-          sserv -> this.scanServers.put(sserv, ScanServerSelector.DEFAULT_SCAN_SERVER_GROUP_NAME));
+          sserv -> scanServersMap.put(sserv, ScanServerSelector.DEFAULT_SCAN_SERVER_GROUP_NAME));
+      this.scanServers = () -> scanServersMap;
     }
 
     InitParams(Map<String,String> scanServers, Map<String,String> opts) {
+      this.opts = opts;
+      this.scanServers = () -> scanServers;
+    }
+
+    InitParams(Supplier<Map<String,String>> scanServers, Map<String,String> opts) {
       this.opts = opts;
       this.scanServers = scanServers;
     }
@@ -77,7 +87,7 @@ public class ConfigurableScanServerSelectorTest {
 
     @Override
     public Supplier<Collection<ScanServerInfo>> getScanServers() {
-      return () -> scanServers.entrySet().stream().map(entry -> new ScanServerInfo() {
+      return () -> scanServers.get().entrySet().stream().map(entry -> new ScanServerInfo() {
 
         @Override
         public String getAddress() {
@@ -126,6 +136,13 @@ public class ConfigurableScanServerSelectorTest {
     public Map<String,String> getHints() {
       return hints;
     }
+
+    @Override
+    public <T> Optional<T> waitUntil(Supplier<Optional<T>> condition, Duration maxWaitTime,
+        String description) {
+      throw new UnsupportedOperationException();
+    }
+
   }
 
   static class TestScanServerAttempt implements ScanServerAttempt {
@@ -466,5 +483,50 @@ public class ConfigurableScanServerSelectorTest {
     }
 
     assertEquals(Set.of("ss1:1", "ss2:2", "ss3:3"), servers);
+  }
+
+  @Test
+  public void testWaitForScanServers() {
+    // this test ensures that when there are no scan servers that the ConfigurableScanServerSelector
+    // will wait for scan servers
+
+    String defaultProfile =
+        "{'isDefault':true,'maxBusyTimeout':'5m','busyTimeoutMultiplier':4,'timeToWaitForScanServers':'120s',"
+            + "'attemptPlans':[{'servers':'100%', 'busyTimeout':'60s'}]}";
+
+    var opts = Map.of("profiles", "[" + defaultProfile + "]".replace('\'', '"'));
+
+    ConfigurableScanServerSelector selector = new ConfigurableScanServerSelector();
+
+    AtomicReference<Map<String,String>> scanServers = new AtomicReference<>(Map.of());
+
+    selector.init(new InitParams(scanServers::get, opts));
+
+    var tabletId = nti("1", "m");
+
+    var dg = ScanServerSelector.DEFAULT_SCAN_SERVER_GROUP_NAME;
+
+    var params = new SelectorParams(tabletId, Map.of(), Map.of()) {
+      @Override
+      public <T> Optional<T> waitUntil(Supplier<Optional<T>> condition, Duration maxWaitTime,
+          String description) {
+        // make some scan servers available now that wait was called
+        scanServers.set(Map.of("ss1:1", dg, "ss2:2", dg, "ss3:3", dg));
+
+        Optional<T> optional = condition.get();
+
+        while (optional.isEmpty()) {
+          UtilWaitThread.sleep(10);
+          optional = condition.get();
+        }
+
+        return optional;
+      }
+    };
+
+    ScanServerSelections actions = selector.selectServers(params);
+
+    assertTrue(Set.of("ss1:1", "ss2:2", "ss3:3").contains(actions.getScanServer(tabletId)));
+    assertFalse(scanServers.get().isEmpty());
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/ScanServerIT_NoServers.java
+++ b/test/src/main/java/org/apache/accumulo/test/ScanServerIT_NoServers.java
@@ -25,16 +25,20 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchScanner;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.ScannerBase.ConsistencyLevel;
-import org.apache.accumulo.core.client.TableOfflineException;
+import org.apache.accumulo.core.client.TimedOutException;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.spi.scan.ConfigurableScanServerSelector;
 import org.apache.accumulo.harness.MiniClusterConfigurationCallback;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
@@ -123,16 +127,55 @@ public class ScanServerIT_NoServers extends SharedMiniClusterBase {
   }
 
   @Test
-  public void testScanOfflineTable() throws Exception {
-    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
+  public void testScanWithNoTserverFallback() throws Exception {
+
+    var clientProps = new Properties();
+    clientProps.putAll(getClientProps());
+    String scanServerSelectorProfiles = "[{'isDefault':true,'maxBusyTimeout':'5m',"
+        + "'busyTimeoutMultiplier':8, 'scanTypeActivations':[], 'timeToWaitForScanServers':'120s',"
+        + "'attemptPlans':[{'servers':'3', 'busyTimeout':'1s'}]}]";
+    clientProps.put("scan.server.selector.impl", ConfigurableScanServerSelector.class.getName());
+    clientProps.put("scan.server.selector.opts.profiles",
+        scanServerSelectorProfiles.replace("'", "\""));
+
+    try (AccumuloClient client = Accumulo.newClient().from(clientProps).build()) {
       String tableName = getUniqueNames(1)[0];
 
       createTableAndIngest(client, tableName, null, 10, 10, "colf");
       client.tableOperations().offline(tableName, true);
 
-      assertThrows(TableOfflineException.class, () -> {
+      assertThrows(TimedOutException.class, () -> {
         try (Scanner scanner = client.createScanner(tableName, Authorizations.EMPTY)) {
           scanner.setRange(new Range());
+          scanner.setTimeout(1, TimeUnit.SECONDS);
+          scanner.setConsistencyLevel(ConsistencyLevel.EVENTUAL);
+          assertEquals(100, Iterables.size(scanner));
+        } // when the scanner is closed, all open sessions should be closed
+      });
+    }
+  }
+
+  @Test
+  public void testBatchScanWithNoTserverFallback() throws Exception {
+
+    var clientProps = new Properties();
+    clientProps.putAll(getClientProps());
+    String scanServerSelectorProfiles = "[{'isDefault':true,'maxBusyTimeout':'5m',"
+        + "'busyTimeoutMultiplier':8, 'scanTypeActivations':[], 'timeToWaitForScanServers':'120s',"
+        + "'attemptPlans':[{'servers':'3', 'busyTimeout':'1s'}]}]";
+    clientProps.put("scan.server.selector.impl", ConfigurableScanServerSelector.class.getName());
+    clientProps.put("scan.server.selector.opts.profiles",
+        scanServerSelectorProfiles.replace("'", "\""));
+
+    try (AccumuloClient client = Accumulo.newClient().from(clientProps).build()) {
+      String tableName = getUniqueNames(1)[0];
+
+      createTableAndIngest(client, tableName, null, 10, 10, "colf");
+
+      assertThrows(TimedOutException.class, () -> {
+        try (BatchScanner scanner = client.createBatchScanner(tableName, Authorizations.EMPTY)) {
+          scanner.setRanges(List.of(new Range()));
+          scanner.setTimeout(1, TimeUnit.SECONDS);
           scanner.setConsistencyLevel(ConsistencyLevel.EVENTUAL);
           assertEquals(100, Iterables.size(scanner));
         } // when the scanner is closed, all open sessions should be closed

--- a/test/src/main/java/org/apache/accumulo/test/ScanServerIT_NoServers.java
+++ b/test/src/main/java/org/apache/accumulo/test/ScanServerIT_NoServers.java
@@ -142,7 +142,6 @@ public class ScanServerIT_NoServers extends SharedMiniClusterBase {
       String tableName = getUniqueNames(1)[0];
 
       createTableAndIngest(client, tableName, null, 10, 10, "colf");
-      client.tableOperations().offline(tableName, true);
 
       assertThrows(TimedOutException.class, () -> {
         try (Scanner scanner = client.createScanner(tableName, Authorizations.EMPTY)) {


### PR DESCRIPTION
This PR is inline with [pull #4638 ](https://github.com/apache/accumulo/pull/4638), where it is adding the client option to wait for scan servers 