### PR TITLE
Backport fix to make Import tablet idempotent

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/MoveExportedFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/MoveExportedFiles.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -71,24 +72,27 @@ class MoveExportedFiles extends ManagerRepo {
 
       Function<FileStatus,String> fileStatusName = fstat -> fstat.getPath().getName();
 
-      Set<String> importing = Arrays.stream(exportedFiles).map(fileStatusName)
-          .map(fileNameMappings::get).collect(Collectors.toSet());
+      Set<Path> importing =
+          Arrays.stream(exportedFiles).map(fileStatusName).map(fileNameMappings::get)
+              .filter(Objects::nonNull).map(Path::new).collect(Collectors.toSet());
 
-      Set<String> imported =
-          Arrays.stream(importedFiles).map(fileStatusName).collect(Collectors.toSet());
+      Set<Path> imported =
+          Arrays.stream(importedFiles).map(FileStatus::getPath).collect(Collectors.toSet());
 
       if (log.isDebugEnabled()) {
         log.debug("{} files already present in imported (target) directory: {}", fmtTid,
-            String.join(",", imported));
+            imported.stream().map(Path::getName).collect(Collectors.joining(",")));
       }
 
-      Set<String> missingFiles = Sets.difference(new HashSet<>(fileNameMappings.values()),
+      Set<Path> missingFiles = Sets.difference(
+          fileNameMappings.values().stream().map(Path::new).collect(Collectors.toSet()),
           new HashSet<>(Sets.union(importing, imported)));
 
       if (!missingFiles.isEmpty()) {
         throw new AcceptableThriftTableOperationException(tableInfo.tableId.canonical(),
             tableInfo.tableName, TableOperation.IMPORT, TableOperationExceptionType.OTHER,
-            "Missing source files corresponding to files " + String.join(",", missingFiles));
+            "Missing source files corresponding to files "
+                + missingFiles.stream().map(Path::getName).collect(Collectors.joining(",")));
       }
 
       for (FileStatus fileStatus : exportedFiles) {


### PR DESCRIPTION
This backports the fix from #4646 to make MoveExportedFiles fate step idempotent.

This closes #4655

Note: ComprehensiveIT does not exist in 2.1 so those changes that were part of #4646 were not backported.  I think there are other ITs that exist for table import though, so I wasn't sure if we wanted to test this in some other way or bring back that test and the flaky comprehensive test too. The test does exist in main so we could maybe add it there. 