### PR TITLE
Improve ActiveCompactionHelper retrieval methods

### DIFF
--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ListCompactionsCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ListCompactionsCommand.java
@@ -55,7 +55,7 @@ public class ListCompactionsCommand extends Command {
       activeCompactionStream = ActiveCompactionHelper
           .activeCompactionsForServer(cl.getOptionValue(tserverOption.getOpt()), instanceOps);
     } else {
-      activeCompactionStream = ActiveCompactionHelper.stream(instanceOps);
+      activeCompactionStream = ActiveCompactionHelper.activeCompactions(instanceOps);
     }
 
     if (cl.hasOption(filterOption.getOpt())) {


### PR DESCRIPTION
* remove the need to create lists and just use a single stream per method
* create `static final Comparator` for reuse in both methods. Improve age comparison
* rename `stream()` to `activeCompactions()` for consistency