### PR TITLE
Update ScanServerRefFile format to sort on UUID

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/init/FileSystemInitializer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/FileSystemInitializer.java
@@ -218,9 +218,7 @@ public class FileSystemInitializer {
     TreeMap<Key,Value> sorted = new TreeMap<>();
     for (InitialTablet initialTablet : initialTablets) {
       // sort file contents in memory, then play back to the file
-      for (Map.Entry<Key,Value> entry : initialTablet.createEntries().entrySet()) {
-        sorted.putAll(initialTablet.createEntries());
-      }
+      sorted.putAll(initialTablet.createEntries());
     }
 
     for (Map.Entry<Key,Value> entry : sorted.entrySet()) {

--- a/server/base/src/main/java/org/apache/accumulo/server/init/InitialConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/InitialConfiguration.java
@@ -34,7 +34,7 @@ import org.apache.accumulo.server.constraints.MetadataConstraints;
 import org.apache.accumulo.server.iterators.MetadataBulkLoadFilter;
 import org.apache.hadoop.conf.Configuration;
 
-class InitialConfiguration {
+public class InitialConfiguration {
 
   // config only for root table
   private final HashMap<String,String> initialRootConf = new HashMap<>();
@@ -47,7 +47,7 @@ class InitialConfiguration {
   private final Configuration hadoopConf;
   private final SiteConfiguration siteConf;
 
-  InitialConfiguration(Configuration hadoopConf, SiteConfiguration siteConf) {
+  public InitialConfiguration(Configuration hadoopConf, SiteConfiguration siteConf) {
     this.hadoopConf = hadoopConf;
     this.siteConf = siteConf;
 

--- a/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
@@ -175,7 +175,7 @@ public class Initialize implements KeywordExecutable {
       if (!createDirs(fs, instanceId, initConfig.getVolumeUris())) {
         throw new IOException("Problem creating directories on " + fs.getVolumes());
       }
-      var fileSystemInitializer = new FileSystemInitializer(initConfig, zoo, instanceId);
+      var fileSystemInitializer = new FileSystemInitializer(initConfig);
       var rootVol = fs.choose(chooserEnv, initConfig.getVolumeUris());
       var rootPath = new Path(rootVol + SEPARATOR + TABLE_DIR + SEPARATOR
           + AccumuloTable.ROOT.tableId() + SEPARATOR + rootTabletDirName);

--- a/server/base/src/main/java/org/apache/accumulo/server/init/ZooKeeperInitializer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/ZooKeeperInitializer.java
@@ -118,10 +118,14 @@ public class ZooKeeperInitializer {
     TableManager.prepareNewNamespaceState(context, Namespace.ACCUMULO.id(),
         Namespace.ACCUMULO.name(), ZooUtil.NodeExistsPolicy.FAIL);
 
-    for (AccumuloTable table : AccumuloTable.values()) {
-      TableManager.prepareNewTableState(context, table.tableId(), Namespace.ACCUMULO.id(),
-          table.tableName(), TableState.ONLINE, ZooUtil.NodeExistsPolicy.FAIL);
-    }
+    TableManager.prepareNewTableState(context, AccumuloTable.ROOT.tableId(),
+        Namespace.ACCUMULO.id(), AccumuloTable.ROOT.tableName(), TableState.ONLINE,
+        ZooUtil.NodeExistsPolicy.FAIL);
+    TableManager.prepareNewTableState(context, AccumuloTable.METADATA.tableId(),
+        Namespace.ACCUMULO.id(), AccumuloTable.METADATA.tableName(), TableState.ONLINE,
+        ZooUtil.NodeExistsPolicy.FAIL);
+    // Call this separately so the upgrader code can handle the zk node creation for scan refs
+    initScanRefTableState(context);
 
     zoo.putPersistentData(zkInstanceRoot + Constants.ZTSERVERS, EMPTY_BYTE_ARRAY,
         ZooUtil.NodeExistsPolicy.FAIL);
@@ -186,6 +190,16 @@ public class ZooKeeperInitializer {
     rootTabletJson.update(mutation);
 
     return rootTabletJson.toJson().getBytes(UTF_8);
+  }
+
+  public void initScanRefTableState(ServerContext context) {
+    try {
+      TableManager.prepareNewTableState(context, AccumuloTable.SCAN_REF.tableId(),
+          Namespace.ACCUMULO.id(), AccumuloTable.SCAN_REF.tableName(), TableState.ONLINE,
+          ZooUtil.NodeExistsPolicy.FAIL);
+    } catch (KeeperException | InterruptedException e) {
+      throw new RuntimeException(e);
+    }
   }
 
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ScanServerRefStoreImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ScanServerRefStoreImpl.java
@@ -31,11 +31,10 @@ import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.clientImpl.ClientContext;
-import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.metadata.ScanServerRefStore;
 import org.apache.accumulo.core.metadata.ScanServerRefTabletFile;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,9 +54,7 @@ public class ScanServerRefStoreImpl implements ScanServerRefStore {
   public void put(Collection<ScanServerRefTabletFile> scanRefs) {
     try (BatchWriter writer = context.createBatchWriter(tableName)) {
       for (ScanServerRefTabletFile ref : scanRefs) {
-        Mutation m = new Mutation(ref.getRow());
-        m.put(ref.getServerAddress(), ref.getServerLockUUID(), ref.getValue());
-        writer.addMutation(m);
+        writer.addMutation(ref.putMutation());
       }
     } catch (MutationsRejectedException | TableNotFoundException e) {
       throw new IllegalStateException(
@@ -70,8 +67,7 @@ public class ScanServerRefStoreImpl implements ScanServerRefStore {
     try {
       Scanner scanner = context.createScanner(tableName, Authorizations.EMPTY);
       return scanner.stream().onClose(scanner::close)
-          .map(e -> new ScanServerRefTabletFile(e.getKey().getRowData().toString(),
-              e.getKey().getColumnFamily(), e.getKey().getColumnQualifier()));
+          .map(e -> new ScanServerRefTabletFile(e.getKey()));
     } catch (TableNotFoundException e) {
       throw new IllegalStateException(tableName + " not found!", e);
     }
@@ -82,12 +78,10 @@ public class ScanServerRefStoreImpl implements ScanServerRefStore {
     Objects.requireNonNull(serverAddress, "Server address must be supplied");
     Objects.requireNonNull(scanServerLockUUID, "Server uuid must be supplied");
     try (Scanner scanner = context.createScanner(tableName, Authorizations.EMPTY)) {
-      scanner.fetchColumn(new Text(serverAddress), new Text(scanServerLockUUID.toString()));
+      scanner.setRange(new Range(scanServerLockUUID.toString()));
 
       Set<ScanServerRefTabletFile> refsToDelete = StreamSupport.stream(scanner.spliterator(), false)
-          .map(e -> new ScanServerRefTabletFile(e.getKey().getRowData().toString(),
-              e.getKey().getColumnFamily(), e.getKey().getColumnQualifier()))
-          .collect(Collectors.toSet());
+          .map(e -> new ScanServerRefTabletFile(e.getKey())).collect(Collectors.toSet());
 
       if (!refsToDelete.isEmpty()) {
         this.delete(refsToDelete);
@@ -101,9 +95,7 @@ public class ScanServerRefStoreImpl implements ScanServerRefStore {
   public void delete(Collection<ScanServerRefTabletFile> refsToDelete) {
     try (BatchWriter writer = context.createBatchWriter(tableName)) {
       for (ScanServerRefTabletFile ref : refsToDelete) {
-        Mutation m = new Mutation(ref.getRow());
-        m.putDelete(ref.getServerAddress(), ref.getServerLockUUID());
-        writer.addMutation(m);
+        writer.addMutation(ref.putDeleteMutation());
       }
       log.debug("Deleted scan server file reference entries for files: {}", refsToDelete);
     } catch (MutationsRejectedException | TableNotFoundException e) {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ScanServerMetadataEntries.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ScanServerMetadataEntries.java
@@ -40,7 +40,7 @@ public class ScanServerMetadataEntries {
 
     // collect all uuids that are currently in the metadata table
     context.getAmple().scanServerRefs().list().forEach(ssrtf -> {
-      uuidsToDelete.add(UUID.fromString(ssrtf.getServerLockUUID().toString()));
+      uuidsToDelete.add(ssrtf.getServerLockUUID());
     });
 
     // gather the list of current live scan servers, its important that this is done after the above
@@ -57,7 +57,7 @@ public class ScanServerMetadataEntries {
 
       context.getAmple().scanServerRefs().list().forEach(ssrtf -> {
 
-        var uuid = UUID.fromString(ssrtf.getServerLockUUID().toString());
+        var uuid = ssrtf.getServerLockUUID();
 
         if (uuidsToDelete.contains(uuid)) {
           refsToDelete.add(ssrtf);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader11to12.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader11to12.java
@@ -53,7 +53,6 @@ import org.apache.accumulo.core.metadata.schema.RootTabletMetadata;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.TextUtil;
 import org.apache.accumulo.server.ServerContext;
-import org.apache.accumulo.server.fs.VolumeManagerImpl;
 import org.apache.accumulo.server.init.FileSystemInitializer;
 import org.apache.accumulo.server.init.InitialConfiguration;
 import org.apache.accumulo.server.init.ZooKeeperInitializer;
@@ -247,12 +246,10 @@ public class Upgrader11to12 implements Upgrader {
     ZooKeeperInitializer zkInit = new ZooKeeperInitializer();
     zkInit.initScanRefTableState(context);
 
-    try (var fs = VolumeManagerImpl.get(context.getSiteConfiguration(), context.getHadoopConf())) {
+    try {
       FileSystemInitializer initializer = new FileSystemInitializer(
           new InitialConfiguration(context.getHadoopConf(), context.getSiteConfiguration()));
-      FileSystemInitializer.InitialTablet scanRefTablet =
-          initializer.createScanRefTablet(context, fs);
-
+      FileSystemInitializer.InitialTablet scanRefTablet = initializer.createScanRefTablet(context);
       // Add references to the Metadata Table
       try (BatchWriter writer = context.createBatchWriter(AccumuloTable.METADATA.tableName())) {
         writer.addMutation(scanRefTablet.createMutation());

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader11to12.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader11to12.java
@@ -253,7 +253,6 @@ public class Upgrader11to12 implements Upgrader {
       // Add references to the Metadata Table
       try (BatchWriter writer = context.createBatchWriter(AccumuloTable.METADATA.tableName())) {
         writer.addMutation(scanRefTablet.createMutation());
-        writer.flush();
       } catch (MutationsRejectedException | TableNotFoundException e) {
         log.error("Failed to write tablet refs to metadata table");
         throw new RuntimeException(e);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader11to12.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader11to12.java
@@ -136,7 +136,6 @@ public class Upgrader11to12 implements Upgrader {
     log.debug("Upgrade root: upgrading to data version {}", METADATA_FILE_JSON_ENCODING);
     var rootName = Ample.DataLevel.METADATA.metaTable();
     upgradeTabletsMetadata(context, rootName);
-    removeScanServerRange(context, rootName);
   }
 
   @Override

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -630,8 +630,8 @@ public class ScanServer extends AbstractServer
 
       for (StoredTabletFile file : allFiles.keySet()) {
         if (!reservedFiles.containsKey(file)) {
-          refs.add(new ScanServerRefTabletFile(file.getNormalizedPathStr(), serverAddress,
-              serverLockUUID));
+          refs.add(new ScanServerRefTabletFile(serverLockUUID, serverAddress,
+              file.getNormalizedPathStr()));
           filesToReserve.add(file);
           tabletsToCheck.add(Objects.requireNonNull(allFiles.get(file)));
           LOG.trace("RFFS {} need to add scan ref for file {}", myReservationId, file);

--- a/test/src/main/java/org/apache/accumulo/test/upgrade/ScanServerUpgrade11to12TestIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/upgrade/ScanServerUpgrade11to12TestIT.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test.upgrade;
+
+import static org.apache.accumulo.harness.AccumuloITBase.MINI_CLUSTER_ONLY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.accumulo.core.client.Accumulo;
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.MutationsRejectedException;
+import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.metadata.ScanServerRefTabletFile;
+import org.apache.accumulo.core.metadata.schema.Ample;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.harness.MiniClusterConfigurationCallback;
+import org.apache.accumulo.harness.SharedMiniClusterBase;
+import org.apache.accumulo.manager.upgrade.Upgrader11to12;
+import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
+import org.apache.accumulo.server.ServerContext;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.net.HostAndPort;
+
+@Tag(MINI_CLUSTER_ONLY)
+public class ScanServerUpgrade11to12TestIT extends SharedMiniClusterBase {
+
+  public static final Logger log = LoggerFactory.getLogger(ScanServerUpgrade11to12TestIT.class);
+
+  private static class ScanServerUpgradeITConfiguration
+      implements MiniClusterConfigurationCallback {
+    @Override
+    public void configureMiniCluster(MiniAccumuloConfigImpl cfg,
+        org.apache.hadoop.conf.Configuration coreSite) {
+      cfg.setNumScanServers(0);
+    }
+  }
+
+  @BeforeAll
+  public static void start() throws Exception {
+    ScanServerUpgradeITConfiguration c = new ScanServerUpgradeITConfiguration();
+    SharedMiniClusterBase.startMiniClusterWithConfig(c);
+  }
+
+  @AfterAll
+  public static void stop() throws Exception {
+    stopMiniCluster();
+  }
+
+  private Stream<Map.Entry<Key,Value>> getOldScanServerRefs(String tableName) {
+    try {
+      Scanner scanner =
+          getCluster().getServerContext().createScanner(tableName, Authorizations.EMPTY);
+      scanner.setRange(Upgrader11to12.OLD_SCAN_SERVERS_RANGE);
+      return scanner.stream().onClose(scanner::close);
+    } catch (TableNotFoundException e) {
+      throw new IllegalStateException("Unable to find table " + tableName);
+    }
+  }
+
+  private void testMetadataScanServerRefRemoval(String tableName) {
+
+    HostAndPort server = HostAndPort.fromParts("127.0.0.1", 1234);
+    UUID serverLockUUID = UUID.randomUUID();
+
+    Set<ScanServerRefTabletFile> scanRefs = Stream.of("F0000070.rf", "F0000071.rf", "F0000072.rf")
+        .map(f -> "hdfs://localhost:8020/accumulo/tables/2a/default_tablet/" + f)
+        .map(f -> new ScanServerRefTabletFile(serverLockUUID, server.toString(), f))
+        .collect(Collectors.toSet());
+
+    ServerContext ctx = getCluster().getServerContext();
+    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
+      client.tableOperations().removeProperty(tableName,
+          Property.TABLE_CONSTRAINT_PREFIX.getKey() + "1");
+      log.info("Removed constraints from table {}", tableName);
+      Thread.sleep(10_000);
+    } catch (AccumuloException | AccumuloSecurityException | InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+
+    try (BatchWriter writer = ctx.createBatchWriter(tableName)) {
+      for (ScanServerRefTabletFile ref : scanRefs) {
+        Mutation m = new Mutation("~sserv" + ref.getServerLockUUID().toString());
+        m.put(ref.getServerAddress(), ref.getFilePath(), new Value(""));
+        writer.addMutation(m);
+      }
+      writer.flush();
+    } catch (TableNotFoundException | MutationsRejectedException e) {
+      log.warn("Failed to write mutations to metadata table");
+      throw new RuntimeException(e);
+    }
+
+    // Check that ample cannot find these scan server refs
+    assertEquals(0, ctx.getAmple().scanServerRefs().list().count());
+
+    // Ensure they exist on the metadata table
+    assertEquals(scanRefs.size(), getOldScanServerRefs(tableName).count());
+
+    var upgrader = new Upgrader11to12();
+    upgrader.removeScanServerRange(ctx, tableName);
+
+    // Ensure entries are now removed from the metadata table
+    assertEquals(0, getOldScanServerRefs(tableName).count());
+  }
+
+  @Test
+  public void testMetadataScanServerRefs() {
+    testMetadataScanServerRefRemoval(Ample.DataLevel.USER.metaTable());
+  }
+
+  @Test
+  public void testRootScanServerRefs() {
+    testMetadataScanServerRefRemoval(Ample.DataLevel.METADATA.metaTable());
+  }
+}

--- a/test/src/main/java/org/apache/accumulo/test/upgrade/ScanServerUpgrade11to12TestIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/upgrade/ScanServerUpgrade11to12TestIT.java
@@ -172,8 +172,4 @@ public class ScanServerUpgrade11to12TestIT extends SharedMiniClusterBase {
     testMetadataScanServerRefRemoval(Ample.DataLevel.USER.metaTable());
   }
 
-  @Test
-  public void testRootScanServerRefs() {
-    testMetadataScanServerRefRemoval(Ample.DataLevel.METADATA.metaTable());
-  }
 }


### PR DESCRIPTION
Updates the ScanServerRef format and moves the UUID entry forward so sorting is done on UUID instead of filename.
Also adds the removal of the scan serverref range from the metadata table

This PR is ensuring that the changes from #4682 are merged into main without introducing a large number of merge conflicts.

closes #4652 and #4493 
