### PR TITLE
Add prettyPrint method to ConditionalMutatoin

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/data/ConditionalMutation.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/ConditionalMutation.java
@@ -19,12 +19,14 @@
 package org.apache.accumulo.core.data;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.hadoop.io.Text;
 
 /**
@@ -80,6 +82,49 @@ public class ConditionalMutation extends Mutation {
 
   public List<Condition> getConditions() {
     return Collections.unmodifiableList(conditions);
+  }
+
+  private String toString(ByteSequence bs) {
+    if (bs == null) {
+      return null;
+    }
+    return new String(bs.toArray(), UTF_8);
+  }
+
+  public String prettyPrint() {
+    StringBuilder sb = new StringBuilder(super.prettyPrint());
+    for (Condition c : conditions) {
+      sb.append(" condition: ");
+      sb.append(toString(c.getFamily()));
+      sb.append(":");
+      sb.append(toString(c.getQualifier()));
+      if (c.getValue() != null && !toString(c.getValue()).isBlank()) {
+        sb.append(" value: ");
+        sb.append(toString(c.getValue()));
+      }
+      if (c.getVisibility() != null && !toString(c.getVisibility()).isBlank()) {
+        sb.append(" visibility: '");
+        sb.append(toString(c.getVisibility()));
+        sb.append("'");
+      }
+      if (c.getTimestamp() != null) {
+        sb.append(" timestamp: ");
+        sb.append("'");
+        sb.append(c.getTimestamp());
+        sb.append("'");
+      }
+      if (c.getIterators().length != 0) {
+        sb.append(" iterator: ");
+        IteratorSetting[] iterators = c.getIterators();
+        for (IteratorSetting its : iterators) {
+          sb.append("'");
+          sb.append(its.toString());
+          sb.append("' ");
+        }
+      }
+      sb.append("\n");
+    }
+    return sb.toString();
   }
 
   @Override


### PR DESCRIPTION
Added prettyPrint method to ConditionalMutation. The method outputs the expected information that is currently provided when prettyPrint is called on a mutation, but adds additional condition information for the provided conditinalMutation.

Unit testing was also added.

Closes #4675