### PR TITLE
Update places where one fate store is used when both should be

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/functional/FateConcurrencyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FateConcurrencyIT.java
@@ -262,13 +262,13 @@ public class FateConcurrencyIT extends AccumuloClusterHarness {
 
         InstanceId instanceId = context.getInstanceID();
         ZooReaderWriter zk = context.getZooReader().asWriter(secret);
-        MetaFateStore<String> zs =
+        MetaFateStore<String> mfs =
             new MetaFateStore<>(ZooUtil.getRoot(instanceId) + Constants.ZFATE, zk);
         var lockPath =
             ServiceLock.path(ZooUtil.getRoot(instanceId) + Constants.ZTABLE_LOCKS + "/" + tableId);
         UserFateStore<String> ufs = new UserFateStore<>(context);
         Map<FateInstanceType,ReadOnlyFateStore<String>> fateStores =
-            Map.of(FateInstanceType.META, zs, FateInstanceType.USER, ufs);
+            Map.of(FateInstanceType.META, mfs, FateInstanceType.USER, ufs);
 
         withLocks = admin.getStatus(fateStores, zk, lockPath, null, null, null);
 
@@ -356,11 +356,11 @@ public class FateConcurrencyIT extends AccumuloClusterHarness {
 
       InstanceId instanceId = context.getInstanceID();
       ZooReaderWriter zk = context.getZooReader().asWriter(secret);
-      MetaFateStore<String> zs =
+      MetaFateStore<String> mfs =
           new MetaFateStore<>(ZooUtil.getRoot(instanceId) + Constants.ZFATE, zk);
       var lockPath =
           ServiceLock.path(ZooUtil.getRoot(instanceId) + Constants.ZTABLE_LOCKS + "/" + tableId);
-      AdminUtil.FateStatus fateStatus = admin.getStatus(zs, zk, lockPath, null, null, null);
+      AdminUtil.FateStatus fateStatus = admin.getStatus(mfs, zk, lockPath, null, null, null);
 
       log.trace("current fates: {}", fateStatus.getTransactions().size());
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/FunctionalTestUtils.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FunctionalTestUtils.java
@@ -60,7 +60,10 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.fate.AdminUtil;
 import org.apache.accumulo.core.fate.AdminUtil.FateStatus;
+import org.apache.accumulo.core.fate.FateInstanceType;
 import org.apache.accumulo.core.fate.MetaFateStore;
+import org.apache.accumulo.core.fate.ReadOnlyFateStore;
+import org.apache.accumulo.core.fate.user.UserFateStore;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.lock.ServiceLock;
 import org.apache.accumulo.core.metadata.AccumuloTable;
@@ -231,10 +234,13 @@ public class FunctionalTestUtils {
       AdminUtil<String> admin = new AdminUtil<>(false);
       ServerContext context = cluster.getServerContext();
       ZooReaderWriter zk = context.getZooReaderWriter();
-      MetaFateStore<String> zs =
+      MetaFateStore<String> mfs =
           new MetaFateStore<>(context.getZooKeeperRoot() + Constants.ZFATE, zk);
+      UserFateStore<String> ufs = new UserFateStore<>(context);
+      Map<FateInstanceType,ReadOnlyFateStore<String>> fateStores =
+          Map.of(FateInstanceType.META, mfs, FateInstanceType.USER, ufs);
       var lockPath = ServiceLock.path(context.getZooKeeperRoot() + Constants.ZTABLE_LOCKS);
-      return admin.getStatus(zs, zk, lockPath, null, null, null);
+      return admin.getStatus(fateStores, zk, lockPath, null, null, null);
     } catch (KeeperException | InterruptedException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
closes #4647

- `UpgradeCoordinator.abortIfFateTransactions()` now uses both stores
- `FunctionalTestUtils.getFateStatus()` now uses both stores. As this method is currently only used in `assertNoDanglingFateLocks()`, technically only the `MetaFateStore` is needed, but based on the method name and if it is used for other purposes in the future, both stores should be used.

I also attempted to change the FATE metrics to include both types of transactions (currently only includes META) (issue: https://github.com/apache/accumulo/issues/4534), but I ran into an issue I couldn't resolve. Including the `UserFateStore` in the map passed to `AdminUtil.getTransactionStatus()` resulted in `getTransactionStatus()` never completing (see `FateMetricValues.getFromZooKeeper()`). It would get hung up whenever a terminal op was applied to the stream aquired from UserFateStores `store.list()`. I could not figure out why this was occurring and could not resolve this, so this PR does not fix https://github.com/apache/accumulo/issues/4534 but fixes the other places where both fate stores should be used but aren't.