### PR TITLE
addSplits() improvement - start all fate ops before waiting on any

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -67,11 +67,8 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -382,29 +379,16 @@ public class TableOperationsImpl extends TableOperationsHelper {
     }
   }
 
-  String doFateOperation(FateOperation op, List<ByteBuffer> args, Map<String,String> opts,
-      String tableOrNamespaceName)
-      throws AccumuloSecurityException, TableExistsException, TableNotFoundException,
-      AccumuloException, NamespaceExistsException, NamespaceNotFoundException {
-    return doFateOperation(op, args, opts, tableOrNamespaceName, true);
+  @FunctionalInterface
+  public interface FateOperationExecutor<T> {
+    T execute() throws Exception;
   }
 
-  String doFateOperation(FateOperation op, List<ByteBuffer> args, Map<String,String> opts,
-      String tableOrNamespaceName, boolean wait)
+  private <T> T handleFateOperation(FateOperationExecutor<T> executor, String tableOrNamespaceName)
       throws AccumuloSecurityException, TableExistsException, TableNotFoundException,
       AccumuloException, NamespaceExistsException, NamespaceNotFoundException {
-    TFateId opid = null;
-
     try {
-      TFateInstanceType t =
-          FateInstanceType.fromNamespaceOrTableName(tableOrNamespaceName).toThrift();
-      opid = beginFateOperation(t);
-      executeFateOperation(opid, op, args, opts, !wait);
-      if (!wait) {
-        opid = null;
-        return null;
-      }
-      return waitForFateOperation(opid);
+      return executor.execute();
     } catch (ThriftSecurityException e) {
       switch (e.getCode()) {
         case TABLE_DOESNT_EXIST:
@@ -437,12 +421,41 @@ public class TableOperationsImpl extends TableOperationsHelper {
       }
     } catch (Exception e) {
       throw new AccumuloException(e.getMessage(), e);
+    }
+  }
+
+  String doFateOperation(FateOperation op, List<ByteBuffer> args, Map<String,String> opts,
+      String tableOrNamespaceName)
+      throws AccumuloSecurityException, TableExistsException, TableNotFoundException,
+      AccumuloException, NamespaceExistsException, NamespaceNotFoundException {
+    return doFateOperation(op, args, opts, tableOrNamespaceName, true);
+  }
+
+  String doFateOperation(FateOperation op, List<ByteBuffer> args, Map<String,String> opts,
+      String tableOrNamespaceName, boolean wait)
+      throws AccumuloSecurityException, TableExistsException, TableNotFoundException,
+      AccumuloException, NamespaceExistsException, NamespaceNotFoundException {
+    AtomicReference<TFateId> opid = new AtomicReference<>();
+
+    try {
+      return handleFateOperation(() -> {
+        TFateInstanceType t =
+            FateInstanceType.fromNamespaceOrTableName(tableOrNamespaceName).toThrift();
+        final TFateId fateId = beginFateOperation(t);
+        opid.set(fateId);
+        executeFateOperation(fateId, op, args, opts, !wait);
+        if (!wait) {
+          opid.set(null);
+          return null;
+        }
+        return waitForFateOperation(fateId);
+      }, tableOrNamespaceName);
     } finally {
       context.clearTableListCache();
       // always finish table op, even when exception
-      if (opid != null) {
+      if (opid.get() != null) {
         try {
-          finishFateOperation(opid);
+          finishFateOperation(opid.get());
         } catch (Exception e) {
           log.warn("Exception thrown while finishing fate table operation", e);
         }
@@ -472,59 +485,66 @@ public class TableOperationsImpl extends TableOperationsHelper {
     ClientTabletCache tabLocator = ClientTabletCache.getInstance(context, tableId);
 
     SortedSet<Text> splitsTodo = new TreeSet<>(splits);
-    ExecutorService executor =
-        context.threadPools().getPoolBuilder("addSplits").numCoreThreads(16).build();
 
-    try {
-      while (!splitsTodo.isEmpty()) {
+    while (!splitsTodo.isEmpty()) {
 
-        tabLocator.invalidateCache();
+      tabLocator.invalidateCache();
 
-        Map<KeyExtent,List<Text>> tabletSplits =
-            mapSplitsToTablets(tableName, tableId, tabLocator, splitsTodo);
+      Map<KeyExtent,List<Text>> tabletSplits =
+          mapSplitsToTablets(tableName, tableId, tabLocator, splitsTodo);
 
-        List<Future<List<Text>>> splitTasks = new ArrayList<>();
+      ArrayList<Pair<TFateId,List<Text>>> opids = new ArrayList<>(tabletSplits.size());
 
-        for (Entry<KeyExtent,List<Text>> splitsForTablet : tabletSplits.entrySet()) {
-          Callable<List<Text>> splitTask = createSplitTask(tableName, splitsForTablet);
-          splitTasks.add(executor.submit(splitTask));
+      final ByteBuffer EMPTY = ByteBuffer.allocate(0);
+
+      // begin the fate operation for each tablet without waiting for the operation to complete
+      for (Entry<KeyExtent,List<Text>> splitsForTablet : tabletSplits.entrySet()) {
+        var extent = splitsForTablet.getKey();
+
+        List<ByteBuffer> args = new ArrayList<>();
+        args.add(ByteBuffer.wrap(extent.tableId().canonical().getBytes(UTF_8)));
+        args.add(extent.endRow() == null ? EMPTY : TextUtil.getByteBuffer(extent.endRow()));
+        args.add(extent.prevEndRow() == null ? EMPTY : TextUtil.getByteBuffer(extent.prevEndRow()));
+        splitsForTablet.getValue().forEach(split -> args.add(TextUtil.getByteBuffer(split)));
+
+        try {
+          handleFateOperation(() -> {
+            TFateInstanceType t = FateInstanceType.fromNamespaceOrTableName(tableName).toThrift();
+            TFateId opid = beginFateOperation(t);
+            executeFateOperation(opid, FateOperation.TABLE_SPLIT, args, Map.of(), false);
+            opids.add(new Pair<>(opid, splitsForTablet.getValue()));
+            return null;
+          }, tableName);
+        } catch (TableExistsException | NamespaceExistsException | NamespaceNotFoundException e) {
+          throw new RuntimeException(e);
         }
+      }
 
-        for (var future : splitTasks) {
-          try {
-            var completedSplits = future.get();
+      // after all operations have been started, wait for them to complete
+      for (Pair<TFateId,List<Text>> entry : opids) {
+        final TFateId opid = entry.getFirst();
+        final List<Text> completedSplits = entry.getSecond();
+
+        try {
+          String status = handleFateOperation(() -> waitForFateOperation(opid), tableName);
+
+          if (SPLIT_SUCCESS_MSG.equals(status)) {
             completedSplits.forEach(splitsTodo::remove);
-          } catch (ExecutionException ee) {
-            Throwable excep = ee.getCause();
-            // Below all exceptions are wrapped and rethrown. This is done so that the user knows
-            // what code path got them here. If the wrapping was not done, the user would only
-            // have the stack trace for the background thread.
-            if (excep instanceof TableNotFoundException) {
-              TableNotFoundException tnfe = (TableNotFoundException) excep;
-              throw new TableNotFoundException(tableId.canonical(), tableName,
-                  "Table not found by background thread", tnfe);
-            } else if (excep instanceof TableOfflineException) {
-              log.debug(
-                  "TableOfflineException occurred in background thread. Throwing new exception",
-                  excep);
-              throw new TableOfflineException(tableId, tableName);
-            } else if (excep instanceof AccumuloSecurityException) {
-              // base == background accumulo security exception
-              AccumuloSecurityException base = (AccumuloSecurityException) excep;
-              throw new AccumuloSecurityException(base.getUser(),
-                  base.asThriftException().getCode(), base.getTableInfo(), excep);
-            } else if (excep instanceof AccumuloServerException) {
-              throw new AccumuloServerException((AccumuloServerException) excep);
-            } else {
-              throw new AccumuloException(excep);
+          }
+        } catch (TableExistsException | NamespaceExistsException | NamespaceNotFoundException e) {
+          throw new RuntimeException(e);
+        } finally {
+          context.clearTableListCache();
+          // always finish table op, even when exception
+          if (opid != null) {
+            try {
+              finishFateOperation(opid);
+            } catch (Exception e) {
+              log.warn("Exception thrown while finishing fate table operation", e);
             }
-          } catch (InterruptedException e) {
-            throw new IllegalStateException(e);
           }
         }
       }
-    } finally {
-      executor.shutdownNow();
     }
   }
 
@@ -567,35 +587,6 @@ public class TableOperationsImpl extends TableOperationsHelper {
       }
     }
     return tabletSplits;
-  }
-
-  private Callable<List<Text>> createSplitTask(String tableName,
-      Entry<KeyExtent,List<Text>> splitsForTablet) {
-    Callable<List<Text>> splitTask = () -> {
-      var extent = splitsForTablet.getKey();
-
-      ByteBuffer EMPTY = ByteBuffer.allocate(0);
-
-      List<ByteBuffer> args = new ArrayList<>();
-      args.add(ByteBuffer.wrap(extent.tableId().canonical().getBytes(UTF_8)));
-      args.add(extent.endRow() == null ? EMPTY : TextUtil.getByteBuffer(extent.endRow()));
-      args.add(extent.prevEndRow() == null ? EMPTY : TextUtil.getByteBuffer(extent.prevEndRow()));
-      splitsForTablet.getValue().forEach(split -> args.add(TextUtil.getByteBuffer(split)));
-
-      try {
-        String status = doFateOperation(FateOperation.TABLE_SPLIT, args, Map.of(), tableName);
-        if (SPLIT_SUCCESS_MSG.equals(status)) {
-          // the fate operation successfully created the splits, so these splits are done
-          return splitsForTablet.getValue();
-        } else {
-          // splits did not succeed
-          return List.of();
-        }
-      } catch (TableExistsException | NamespaceExistsException | NamespaceNotFoundException e) {
-        throw new RuntimeException(e);
-      }
-    };
-    return splitTask;
   }
 
   @Override


### PR DESCRIPTION
Fixes #4633 

This PR changes the way split fate operations are carried out in `addSplits()`. Before these changes, `addSplits()` would call `doFateOperation()` for each split which would start then wait for it to finish. The changes in this PR start all of the fate ops and then once all have started, wait for them all to finish.

So that error handling was not duplicated, I created a new method that executes a lambda within the original try-catch block from `doFateOperation()`

I did some crude benchmarking using `SplitMillionIT` and saw a decrease in time taken per 10,000 splits in the test. Per 10,000 splits, over 5 runs I saw an average time of 827.8ms on elasticity and 822.4ms on this branch. This difference seems negligible but I at least did not notice a performance decrease.