### PR TITLE
Parallelize split seeding in TableOperationImpl.addSplits()

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -529,11 +529,9 @@ public class TableOperationsImpl extends TableOperationsHelper {
         futures.add(future);
       }
 
-      List<Pair<TFateId,List<Text>>> opids =
-          futures.stream().map(CompletableFuture::join).collect(Collectors.toList());
-
       // after all operations have been started, wait for them to complete
-      for (Pair<TFateId,List<Text>> entry : opids) {
+      for (CompletableFuture<Pair<TFateId,List<Text>>> future : futures) {
+        Pair<TFateId,List<Text>> entry = future.join();
         final TFateId opid = entry.getFirst();
         final List<Text> completedSplits = entry.getSecond();
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -486,7 +486,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
 
     ClientTabletCache tabLocator = ClientTabletCache.getInstance(context, tableId);
 
-    SortedSet<Text> splitsTodo = new TreeSet<>(splits);
+    SortedSet<Text> splitsTodo = Collections.synchronizedSortedSet(new TreeSet<>(splits));
 
     final ByteBuffer EMPTY = ByteBuffer.allocate(0);
 
@@ -536,9 +536,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
             String status = handleFateOperation(() -> waitForFateOperation(opid), tableName);
 
             if (SPLIT_SUCCESS_MSG.equals(status)) {
-              synchronized (splitsTodo) {
-                completedSplits.forEach(splitsTodo::remove);
-              }
+              completedSplits.forEach(splitsTodo::remove);
             }
           } catch (TableExistsException | NamespaceExistsException | NamespaceNotFoundException
               | AccumuloSecurityException | TableNotFoundException | AccumuloException e) {


### PR DESCRIPTION
This is a follow on of #4697.

In this PR the begin and execute steps of the add splits fate operations have been wrapped in `Future`s and executed in a thread pool. This further speeds up the addSplits operation.

I benchmarked these changes on elasticty before #4697 was merged, after it was merged, and after the changes in this PR. Below are the results from [this IT](https://github.com/apache/accumulo/pull/4697#issuecomment-2187560469) averaged over two runs:

| Branch                                    | Time to Seed 587 (ms) | Time to Add 1000 Splits (ms) |
|-------------------------------------------|-----------------------|------------------------------|
| Current Changes                           | 2690                  | 6348                         |
| Elasticity (13c8ccf1fbd90fc552c9a0f9a6cd0e37918b98a2) | 5562 (~106% slower)                 | 7639 (~20% slower)                        |
| Elasticity pre #4697 (11c060be893998aa5ae894bcf96a479883617995) | N/A                   | 42770 (~574% slower)                        |

