### PR TITLE
fixes create table when fate step runs twice

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
@@ -59,6 +59,9 @@ public class Utils {
   private static final byte[] ZERO_BYTE = {'0'};
   private static final Logger log = LoggerFactory.getLogger(Utils.class);
 
+  /**
+   * Checks that a table name is only used by the specified table id or not used at all.
+   */
   public static void checkTableNameDoesNotExist(ServerContext context, String tableName,
       TableId tableId, TableOperation operation) throws AcceptableThriftTableOperationException {
 
@@ -70,7 +73,7 @@ public class Utils {
           byte[] tname = context.getZooReader().getData(zTablePath + Constants.ZTABLE_NAME);
           Preconditions.checkState(tname != null, "Malformed table entry in ZooKeeper at %s",
               zTablePath);
-          if (tableName.equals(new String(tname, UTF_8))) {
+          if (tableName.equals(new String(tname, UTF_8)) && !tableId.equals(TableId.of(tid))) {
             throw new AcceptableThriftTableOperationException(tid, tableName, operation,
                 TableOperationExceptionType.EXISTS, null);
           }


### PR DESCRIPTION
When a create table fate step ran twice it would detect its table name as in use.  However the table name was reserved by the first run of the fate step.  Made the code idempotent.  Some ITs were failing that ran fate steps multiple times.