### PR TITLE
Added namespace support to Utils.checkTableNameDoesNotExist

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
@@ -23,6 +23,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.locks.Lock;
@@ -30,7 +32,9 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 
 import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.client.NamespaceNotFoundException;
 import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
+import org.apache.accumulo.core.clientImpl.Namespace;
 import org.apache.accumulo.core.clientImpl.Namespaces;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
@@ -43,6 +47,7 @@ import org.apache.accumulo.core.fate.zookeeper.FateLock;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.fate.zookeeper.ZooReservation;
 import org.apache.accumulo.core.util.FastFormat;
+import org.apache.accumulo.core.util.tables.TableNameUtil;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.hadoop.fs.FileSystem;
@@ -62,15 +67,41 @@ public class Utils {
   public static void checkTableNameDoesNotExist(ServerContext context, String tableName,
       TableId tableId, TableOperation operation) throws AcceptableThriftTableOperationException {
 
+    final Map<NamespaceId,String> namespaces = new HashMap<>();
+    final boolean namespaceInTableName = tableName.contains(".");
     try {
       for (String tid : context.getZooReader()
           .getChildren(context.getZooKeeperRoot() + Constants.ZTABLES)) {
-        String zTablePath = context.getZooKeeperRoot() + Constants.ZTABLES + "/" + tid;
+        final String zTablePath = context.getZooKeeperRoot() + Constants.ZTABLES + "/" + tid;
         try {
-          byte[] tname = context.getZooReader().getData(zTablePath + Constants.ZTABLE_NAME);
+          final byte[] tname = context.getZooReader().getData(zTablePath + Constants.ZTABLE_NAME);
           Preconditions.checkState(tname != null, "Malformed table entry in ZooKeeper at %s",
               zTablePath);
-          if (tableName.equals(new String(tname, UTF_8))) {
+
+          String namespaceName = Namespace.DEFAULT.name();
+          if (namespaceInTableName) {
+            final byte[] nId =
+                context.getZooReader().getData(zTablePath + Constants.ZTABLE_NAMESPACE);
+            if (nId != null) {
+              final NamespaceId namespaceId = NamespaceId.of(new String(nId, UTF_8));
+              if (!namespaceId.equals(Namespace.DEFAULT.id())) {
+                namespaceName = namespaces.get(namespaceId);
+                if (namespaceName == null) {
+                  try {
+                    namespaceName = Namespaces.getNamespaceName(context, namespaceId);
+                    namespaces.put(namespaceId, namespaceName);
+                  } catch (NamespaceNotFoundException e) {
+                    throw new AcceptableThriftTableOperationException(null, tableName,
+                        TableOperation.CREATE, TableOperationExceptionType.OTHER,
+                        "Table (" + tableId.canonical() + ") contains reference to namespace ("
+                            + namespaceId + ") that doesn't exist");
+                  }
+                }
+              }
+            }
+          }
+
+          if (tableName.equals(TableNameUtil.qualified(new String(tname, UTF_8), namespaceName))) {
             throw new AcceptableThriftTableOperationException(tid, tableName, operation,
                 TableOperationExceptionType.EXISTS, null);
           }

--- a/test/src/main/java/org/apache/accumulo/test/CreateTableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/CreateTableIT.java
@@ -50,7 +50,7 @@ public class CreateTableIT extends SharedMiniClusterBase {
   public void testCreateLotsOfTables() throws Exception {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
 
-      String[] tableNames = getUniqueNames(1000);
+      String[] tableNames = getUniqueNames(500);
 
       for (int i = 0; i < tableNames.length; i++) {
         // Create waits for the Fate operation to complete
@@ -58,9 +58,9 @@ public class CreateTableIT extends SharedMiniClusterBase {
         client.tableOperations().create(tableNames[i]);
         System.out.println("Table creation took: " + (System.currentTimeMillis() - start) + "ms");
       }
-      // Confirm all 1000 user tables exist in addition to Root, Metadata,
+      // Confirm all 500 user tables exist in addition to Root, Metadata,
       // and ScanRef tables
-      assertEquals(1003, client.tableOperations().list().size());
+      assertEquals(503, client.tableOperations().list().size());
     }
   }
 


### PR DESCRIPTION
Method was changed in #4685, but that changed missed the namespace handling that was being performed in TableMap. This was causing NamespacesIT.cloneTable to fail. Also lowered the number of tables being created in CreateTableIT because it's timing out in the IT builds but is passing locally.