### PR TITLE
adds code to generate data for upgrade test

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/ComprehensiveIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ComprehensiveIT.java
@@ -115,7 +115,7 @@ import com.google.common.collect.Sets;
 public class ComprehensiveIT extends SharedMiniClusterBase {
 
   public static final String DOG_AND_CAT = "DOG&CAT";
-  static final Authorizations AUTHORIZATIONS = new Authorizations("CAT", "DOG");
+  public static final Authorizations AUTHORIZATIONS = new Authorizations("CAT", "DOG");
 
   private static final Logger log = LoggerFactory.getLogger(ComprehensiveIT.class);
 
@@ -1148,7 +1148,7 @@ public class ComprehensiveIT extends SharedMiniClusterBase {
     }
   }
 
-  static class TestRecord {
+  public static class TestRecord {
     final int row;
     final int fam;
     final int qual;
@@ -1164,7 +1164,7 @@ public class ComprehensiveIT extends SharedMiniClusterBase {
     }
   }
 
-  static String row(int r) {
+  public static String row(int r) {
     return String.format("%06d", r);
   }
 
@@ -1180,16 +1180,24 @@ public class ComprehensiveIT extends SharedMiniClusterBase {
     return String.format("%09d", v);
   }
 
-  static SortedMap<Key,Value> generateKeys(int minRow, int maxRow) {
+  public static SortedSet<Text> createSplits(int minRow, int maxRow, int step) {
+    TreeSet<Text> splits = new TreeSet<>();
+    for (int r = minRow + step; r < maxRow; r += step) {
+      splits.add(new Text(row(r)));
+    }
+    return splits;
+  }
+
+  public static SortedMap<Key,Value> generateKeys(int minRow, int maxRow) {
     return generateKeys(minRow, maxRow, tr -> true);
   }
 
-  static SortedMap<Key,Value> generateKeys(int minRow, int maxRow,
+  public static SortedMap<Key,Value> generateKeys(int minRow, int maxRow,
       Predicate<TestRecord> predicate) {
     return generateKeys(minRow, maxRow, 0, predicate);
   }
 
-  static SortedMap<Key,Value> generateKeys(int minRow, int maxRow, int salt,
+  public static SortedMap<Key,Value> generateKeys(int minRow, int maxRow, int salt,
       Predicate<TestRecord> predicate) {
     TreeMap<Key,Value> data = new TreeMap<>();
     var mutations = generateMutations(minRow, maxRow, salt, predicate);
@@ -1205,12 +1213,12 @@ public class ComprehensiveIT extends SharedMiniClusterBase {
     return data;
   }
 
-  static Collection<Mutation> generateMutations(int minRow, int maxRow,
+  public static Collection<Mutation> generateMutations(int minRow, int maxRow,
       Predicate<TestRecord> predicate) {
     return generateMutations(minRow, maxRow, 0, predicate);
   }
 
-  static Collection<Mutation> generateMutations(int minRow, int maxRow, int salt,
+  public static Collection<Mutation> generateMutations(int minRow, int maxRow, int salt,
       Predicate<TestRecord> predicate) {
 
     List<Mutation> mutations = new ArrayList<>();

--- a/test/src/main/java/org/apache/accumulo/test/upgrade/UpgradeGenerateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/upgrade/UpgradeGenerateIT.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test.upgrade;
+
+import static org.apache.accumulo.core.conf.Property.GENERAL_PROCESS_BIND_ADDRESS;
+import static org.apache.accumulo.core.conf.Property.TABLE_MAJC_RATIO;
+import static org.apache.accumulo.harness.AccumuloITBase.MINI_CLUSTER_ONLY;
+import static org.apache.accumulo.test.ComprehensiveIT.AUTHORIZATIONS;
+import static org.apache.accumulo.test.ComprehensiveIT.createSplits;
+import static org.apache.accumulo.test.ComprehensiveIT.generateMutations;
+import static org.apache.accumulo.test.upgrade.UpgradeTestUtils.getTestDir;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.client.Accumulo;
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.admin.CompactionConfig;
+import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl;
+import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
+import org.apache.accumulo.test.functional.SlowIterator;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.RawLocalFileSystem;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * <p>
+ * This IT supports manual upgrade testing via the following process.
+ *
+ * <ol>
+ * <li>Run this IT in version N of accumulo to generate data</li>
+ * <li>Checkout version N+1 of accumulo.</li>
+ * <li>Run {@code mvn package -DskipTests} to update the accumulo version in source. Do not run mvn
+ * clean as the persisted data is in test/target and would be wiped.</li>
+ * <li>Run UpgradeIT which will upgrade and verify the persisted data created by this test.</li>
+ * </ol>
+ *
+ *
+ */
+
+@Disabled
+@Tag(MINI_CLUSTER_ONLY)
+public class UpgradeGenerateIT {
+
+  private MiniAccumuloClusterImpl cluster;
+
+  private void setupUpgradeTest(String testName) throws Exception {
+
+    UpgradeTestUtils.deleteTest(Constants.VERSION, testName);
+    File testDir = getTestDir(Constants.VERSION, testName);
+
+    MiniAccumuloConfigImpl config =
+        new MiniAccumuloConfigImpl(testDir, UpgradeTestUtils.ROOT_PASSWORD);
+    config.setProperty(GENERAL_PROCESS_BIND_ADDRESS, "localhost");
+    cluster = new MiniAccumuloClusterImpl(config);
+    Configuration haddopConfig = new Configuration(false);
+    haddopConfig.set("fs.file.impl", RawLocalFileSystem.class.getName());
+    File csFile = new File(Objects.requireNonNull(config.getConfDir()), "core-site.xml");
+    try (OutputStream out =
+        new BufferedOutputStream(new FileOutputStream(csFile.getAbsolutePath()))) {
+      haddopConfig.writeXml(out);
+    }
+
+    cluster.start();
+  }
+
+  @Test
+  public void genBasic() throws Exception {
+
+    setupUpgradeTest("basic");
+    try (AccumuloClient c = Accumulo.newClient().from(cluster.getClientProperties()).build()) {
+
+      c.securityOperations().changeUserAuthorizations("root", AUTHORIZATIONS);
+
+      var table1 = "ut1";
+
+      c.tableOperations().create(table1);
+      try (var writer = c.createBatchWriter(table1)) {
+        var mutations = generateMutations(0, 1000, 3, tr -> true);
+        int written = 0;
+        for (var mutation : mutations) {
+          writer.addMutation(mutation);
+          written++;
+          if (written == 50) {
+            // generate multiple files in the table
+            writer.flush();
+            c.tableOperations().flush(table1, null, null, true);
+          }
+        }
+      }
+      c.tableOperations().flush(table1, null, null, true);
+
+      c.tableOperations().setProperty(table1, TABLE_MAJC_RATIO.getKey(), "3.14");
+
+      // create an empty table
+      var table2 = "ut2";
+      c.tableOperations().create(table2);
+
+      // create a table with splits
+      var table3 = "ut3";
+      c.tableOperations().create(table3);
+      c.tableOperations().addSplits(table3, createSplits(0, 1000, 13));
+      try (var writer = c.createBatchWriter(table3)) {
+        var mutations = generateMutations(0, 1000, 7, tr -> true);
+        for (var mutation : mutations) {
+          writer.addMutation(mutation);
+        }
+      }
+
+      c.tableOperations().setProperty(table3, TABLE_MAJC_RATIO.getKey(), "2.72");
+
+      cluster.getClusterControl().adminStopAll();
+    } finally {
+      cluster.stop();
+    }
+  }
+
+  @Test
+  public void genFate() throws Exception {
+    setupUpgradeTest("fate");
+    try (AccumuloClient c = Accumulo.newClient().from(cluster.getClientProperties()).build()) {
+      var table1 = "ut1";
+
+      c.tableOperations().create(table1);
+      try (var writer = c.createBatchWriter(table1)) {
+        var mutations = generateMutations(0, 1000, 3, tr -> true);
+        for (var mutation : mutations) {
+          writer.addMutation(mutation);
+        }
+      }
+
+      // Create a compaction operation that will not complete before the cluster is stopped. This
+      // will create a fate operation that should cause upgrade to fail.
+      CompactionConfig compactionConfig = new CompactionConfig();
+      IteratorSetting iteratorSetting = new IteratorSetting(100, SlowIterator.class);
+      SlowIterator.setSleepTime(iteratorSetting, 1000);
+      compactionConfig.setIterators(List.of(iteratorSetting));
+      compactionConfig.setWait(false);
+
+      c.tableOperations().compact(table1, compactionConfig);
+
+    } finally {
+      cluster.stop();
+    }
+  }
+}

--- a/test/src/main/java/org/apache/accumulo/test/upgrade/UpgradeTestUtils.java
+++ b/test/src/main/java/org/apache/accumulo/test/upgrade/UpgradeTestUtils.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test.upgrade;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class UpgradeTestUtils {
+
+  public static final String BACKUP_DIR = "/target/upgrade-tests/backup/";
+  public static final String WORK_DIR = "/target/upgrade-tests/work/";
+  public static final String ROOT_PASSWORD = "979d55ae-98fd-4d22-9b1c-2d5723546a5e";
+
+  public static final Logger log = LoggerFactory.getLogger(UpgradeTestUtils.class);
+
+  public static File getTestDir(String version, String testName) {
+    return new File(System.getProperty("user.dir") + WORK_DIR + testName + "/" + version);
+  }
+
+  public static File getBackupDir(String version, String testName) {
+    return new File(System.getProperty("user.dir") + BACKUP_DIR + testName + "/" + version);
+  }
+
+  /**
+   * For a given test name finds all the versions of all dirs created using
+   * {@link #getTestDir(String, String)}
+   */
+  public static List<String> findVersions(String testName) {
+    var testRoot = new File(System.getProperty("user.dir") + WORK_DIR + testName);
+    var files = testRoot.listFiles();
+    if (files == null) {
+      return List.of();
+    }
+    return Arrays.stream(files).filter(File::isDirectory).map(File::getName)
+        .collect(Collectors.toList());
+  }
+
+  public static void deleteTest(String version, String testName) {
+    FileUtils.deleteQuietly(getTestDir(version, testName));
+    FileUtils.deleteQuietly(getBackupDir(version, testName));
+  }
+
+  /**
+   * This method facilitates running upgrade test multiple times. Upgrade will change persisted data
+   * making it impossible to run an upgrade test a second time. Using this method an upgrade test
+   * can backup and restore persisted data before running a test.
+   */
+  public static void backupOrRestore(String version, String testName) throws IOException {
+
+    File testDir = getTestDir(version, testName);
+    File backupDir = getBackupDir(version, testName);
+
+    if (backupDir.exists()) {
+      log.info("Restoring backup {} -> {}", backupDir, testDir);
+      FileUtils.deleteQuietly(testDir);
+      FileUtils.copyDirectory(backupDir, testDir);
+    } else {
+      log.info("Creating backup {} -> {}", testDir, backupDir);
+      FileUtils.copyDirectory(testDir, backupDir);
+    }
+  }
+
+}


### PR DESCRIPTION
Adds a disabled integration test that will generate data for an upgrade test.  This is intended to be used manually in the following way.

 1. Checkout version 3.1.x
 2. Run UpgradeGenerateIT which will generate instances test/target/upgrade-test
 3. Checkout version 4.0.x
 4. Run mvn package (not clean)
 5. Run UpgradeIT which will upgrade and verify the instances in test/target/upgrade-test

UpgradeIT does not exist in this commit, its added in #4719