### PR TITLE
Metadata table bulk file columns deleted on upgrade

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataSchema.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataSchema.java
@@ -347,7 +347,6 @@ public class MetadataSchema {
       }
 
       public static FateId getBulkLoadTid(String vs) {
-        // ELASTICITY_TODO issue 4044 - May need to introduce code in upgrade to handle old format.
         return FateId.from(vs);
       }
     }


### PR DESCRIPTION
Deletes the bulk file columns from the metadata table on upgrade to 4.x, if they exist.
closes #4637, related to #4587