### PR TITLE
Adds completable futures to compaction queue

### DIFF
--- a/server/manager/src/test/java/org/apache/accumulo/manager/compaction/queue/CompactionJobPriorityQueueTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/compaction/queue/CompactionJobPriorityQueueTest.java
@@ -19,9 +19,7 @@
 package org.apache.accumulo.manager.compaction.queue;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashSet;
 import java.util.List;
@@ -206,58 +204,6 @@ public class CompactionJobPriorityQueueTest {
     job = queue.poll();
     assertNull(job);
     assertEquals(2, queue.getDequeuedJobs());
-
-  }
-
-  @Test
-  public void testAddAfterClose() {
-
-    CompactableFile file1 = EasyMock.createMock(CompactableFileImpl.class);
-    CompactableFile file2 = EasyMock.createMock(CompactableFileImpl.class);
-    CompactableFile file3 = EasyMock.createMock(CompactableFileImpl.class);
-    CompactableFile file4 = EasyMock.createMock(CompactableFileImpl.class);
-
-    KeyExtent extent = new KeyExtent(TableId.of("1"), new Text("z"), new Text("a"));
-    TabletMetadata tm = EasyMock.createMock(TabletMetadata.class);
-    EasyMock.expect(tm.getExtent()).andReturn(extent).anyTimes();
-
-    CompactionJob cj1 = EasyMock.createMock(CompactionJob.class);
-    EasyMock.expect(cj1.getGroup()).andReturn(GROUP).anyTimes();
-    EasyMock.expect(cj1.getPriority()).andReturn((short) 10).anyTimes();
-    EasyMock.expect(cj1.getFiles()).andReturn(Set.of(file1)).anyTimes();
-
-    CompactionJob cj2 = EasyMock.createMock(CompactionJob.class);
-    EasyMock.expect(cj2.getGroup()).andReturn(GROUP).anyTimes();
-    EasyMock.expect(cj2.getPriority()).andReturn((short) 5).anyTimes();
-    EasyMock.expect(cj2.getFiles()).andReturn(Set.of(file2, file3, file4)).anyTimes();
-
-    EasyMock.replay(tm, cj1, cj2);
-
-    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, 2);
-    assertEquals(2, queue.add(tm, List.of(cj1, cj2), 1L));
-
-    assertFalse(queue.closeIfEmpty());
-
-    EasyMock.verify(tm, cj1, cj2);
-
-    assertEquals(5L, queue.getLowestPriority());
-    assertEquals(2, queue.getMaxSize());
-    assertEquals(0, queue.getDequeuedJobs());
-    assertEquals(0, queue.getRejectedJobs());
-    assertEquals(2, queue.getQueuedJobs());
-    MetaJob job = queue.poll();
-    assertEquals(cj1, job.getJob());
-    assertEquals(tm, job.getTabletMetadata());
-    assertEquals(1, queue.getDequeuedJobs());
-
-    MetaJob job2 = queue.poll();
-    assertEquals(cj2, job2.getJob());
-    assertEquals(tm, job2.getTabletMetadata());
-    assertEquals(2, queue.getDequeuedJobs());
-
-    assertTrue(queue.closeIfEmpty());
-
-    assertEquals(-1, queue.add(tm, List.of(cj1, cj2), 1L));
 
   }
 

--- a/server/manager/src/test/java/org/apache/accumulo/manager/compaction/queue/CompactionJobQueuesTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/compaction/queue/CompactionJobQueuesTest.java
@@ -385,6 +385,6 @@ public class CompactionJobQueuesTest {
     // since future5 was canceled, this addition should go to future6
     jobQueues.add(tm1, List.of(newJob((short) 1, 5, cg1)));
     assertTrue(future6.isDone());
-    assertEquals(extent1, future6.getNow(null).getTabletMetadata().getExtent());
+    assertEquals(extent1, future6.get().getTabletMetadata().getExtent());
   }
 }

--- a/server/manager/src/test/java/org/apache/accumulo/manager/compaction/queue/CompactionJobQueuesTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/compaction/queue/CompactionJobQueuesTest.java
@@ -19,7 +19,9 @@
 package org.apache.accumulo.manager.compaction.queue;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -331,5 +333,58 @@ public class CompactionJobQueuesTest {
 
     // The background threads should have seen every job that was added
     assertEquals(numToAdd, totalSeen);
+  }
+
+  @Test
+  public void testGetAsync() throws URISyntaxException {
+    CompactionJobQueues jobQueues = new CompactionJobQueues(100);
+
+    var tid = TableId.of("1");
+    var extent1 = new KeyExtent(tid, new Text("z"), new Text("q"));
+    var extent2 = new KeyExtent(tid, new Text("q"), new Text("l"));
+    var extent3 = new KeyExtent(tid, new Text("l"), new Text("c"));
+    var extent4 = new KeyExtent(tid, new Text("c"), new Text("a"));
+
+    var tm1 = TabletMetadata.builder(extent1).build();
+    var tm2 = TabletMetadata.builder(extent2).build();
+    var tm3 = TabletMetadata.builder(extent3).build();
+    var tm4 = TabletMetadata.builder(extent4).build();
+
+    var cg1 = CompactorGroupId.of("CG1");
+
+    var future1 = jobQueues.getAsync(cg1);
+    var future2 = jobQueues.getAsync(cg1);
+
+    assertFalse(future1.isDone());
+    assertFalse(future2.isDone());
+
+    jobQueues.add(tm1, List.of(newJob((short) 1, 5, cg1)));
+    jobQueues.add(tm2, List.of(newJob((short) 2, 6, cg1)));
+    jobQueues.add(tm3, List.of(newJob((short) 3, 7, cg1)));
+    jobQueues.add(tm4, List.of(newJob((short) 4, 8, cg1)));
+
+    var future3 = jobQueues.getAsync(cg1);
+    var future4 = jobQueues.getAsync(cg1);
+
+    assertTrue(future1.isDone());
+    assertTrue(future2.isDone());
+    assertTrue(future3.isDone());
+    assertTrue(future4.isDone());
+
+    assertEquals(extent1, future1.getNow(null).getTabletMetadata().getExtent());
+    assertEquals(extent2, future2.getNow(null).getTabletMetadata().getExtent());
+    assertEquals(extent4, future3.getNow(null).getTabletMetadata().getExtent());
+    assertEquals(extent3, future4.getNow(null).getTabletMetadata().getExtent());
+
+    // test cancelling a future
+    var future5 = jobQueues.getAsync(cg1);
+    assertFalse(future5.isDone());
+    future5.cancel(false);
+    var future6 = jobQueues.getAsync(cg1);
+    assertFalse(future6.isDone());
+    // since future5 was canceled, this addition should go to future6
+    jobQueues.add(tm1, List.of(newJob((short) 1, 5, cg1)));
+    assertTrue(future6.isDone());
+    assertEquals(extent1, future6.getNow(null).getTabletMetadata().getExtent());
   }
 }

--- a/server/manager/src/test/java/org/apache/accumulo/manager/compaction/queue/CompactionJobQueuesTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/compaction/queue/CompactionJobQueuesTest.java
@@ -336,7 +336,7 @@ public class CompactionJobQueuesTest {
   }
 
   @Test
-  public void testGetAsync() throws URISyntaxException {
+  public void testGetAsync() throws Exception {
     CompactionJobQueues jobQueues = new CompactionJobQueues(100);
 
     var tid = TableId.of("1");
@@ -371,10 +371,10 @@ public class CompactionJobQueuesTest {
     assertTrue(future3.isDone());
     assertTrue(future4.isDone());
 
-    assertEquals(extent1, future1.getNow(null).getTabletMetadata().getExtent());
-    assertEquals(extent2, future2.getNow(null).getTabletMetadata().getExtent());
-    assertEquals(extent4, future3.getNow(null).getTabletMetadata().getExtent());
-    assertEquals(extent3, future4.getNow(null).getTabletMetadata().getExtent());
+    assertEquals(extent1, future1.get().getTabletMetadata().getExtent());
+    assertEquals(extent2, future2.get().getTabletMetadata().getExtent());
+    assertEquals(extent4, future3.get().getTabletMetadata().getExtent());
+    assertEquals(extent3, future4.get().getTabletMetadata().getExtent());
 
     // test cancelling a future
     var future5 = jobQueues.getAsync(cg1);


### PR DESCRIPTION
Adds completeable futures to the queue of compaction jobs.  This allows for async notification when something is added to the queue.

The compaction queues code would drop queues that became empty.  The concept of queues being empty became more complex with this change. A queue would be considered empty when there were no futures and the queue was empty.  This increased complexity of empty would have made the code for dropping empty queues more complex.  Instead of increasing the complexity of this code chose to drop removing empty queues.  This means that if a compaction group is used and then no longer used that it will have a small empty datastructure sitting around in map for the process lifetime.  That is unlikely to cause memory issues.  Therefore decided the increased complexity was not worthwhile given it was unlikely to cause memory problems.