### PR TITLE
periodically clean up canceled futures in compaction job prioq

### DIFF
--- a/server/manager/src/test/java/org/apache/accumulo/manager/compaction/queue/CompactionJobQueuesTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/compaction/queue/CompactionJobQueuesTest.java
@@ -395,5 +395,6 @@ public class CompactionJobQueuesTest {
     assertEquals(extent1, future7.get().getTabletMetadata().getExtent());
     assertTrue(future5.isDone());
     assertTrue(future6.isCompletedExceptionally());
+    assertTrue(future6.isDone());
   }
 }


### PR DESCRIPTION
For the case where nothing is ever added to a compaction job prioq and futures are continually obtained and canceled these canceled futures would keep building up in memory.  This commit fixes that by periodically cleaning out canceled futures.