### PR TITLE
Fixed bug with USER compaction hints showing on SYSTEM compactions

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
@@ -1281,6 +1281,10 @@ public class CompactableImpl implements Compactable {
 
       cInfo.localHelper = this.chelper;
       cInfo.localCompactionCfg = this.compactionConfig;
+      // don't include execution hints, which may have been previously set, for system compactions
+      if (job.getKind() == CompactionKind.SYSTEM) {
+        cInfo.localCompactionCfg.setExecutionHints(Collections.emptyMap());
+      }
     }
 
     // Check to ensure the tablet actually has these files now that they are reserved. Compaction

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
@@ -1277,14 +1277,10 @@ public class CompactableImpl implements Compactable {
       if (job.getKind() == CompactionKind.USER) {
         cInfo.iters = compactionConfig.getIterators();
         cInfo.checkCompactionId = this.compactionId;
+        cInfo.localCompactionCfg = this.compactionConfig;
       }
 
       cInfo.localHelper = this.chelper;
-      cInfo.localCompactionCfg = this.compactionConfig;
-      // don't include execution hints, which may have been previously set, for system compactions
-      if (job.getKind() == CompactionKind.SYSTEM) {
-        cInfo.localCompactionCfg.setExecutionHints(Collections.emptyMap());
-      }
     }
 
     // Check to ensure the tablet actually has these files now that they are reserved. Compaction


### PR DESCRIPTION
Closes #4460
- Confirmed that these changes fix the issue: no longer shows hints on SYSTEM compactions which follow a USER compaction that had hints
- This may not be the best way to fix this issue but this keeps the amount of code changes small. Figured filtering them out at the time they are logged may not be the best approach in case these incorrect hints would be seen/used deeper in the code. But also didn't filter them out at the deepest level where they are set. This would have required larger refactoring.
- This issue made me think that maybe these execution hints would carry over to new USER compactions. For example, if a user compaction is initiated with execution hints "hints1", and later another user compaction was initiated with no execution hints, we may still see "hints1". I confirmed that this is not the case.