### PR TITLE
Conditional writer creation now always includes the client properties

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
@@ -786,9 +786,7 @@ public class ClientContext implements AccumuloClient {
 
   @Override
   public ConditionalWriter createConditionalWriter(String tableName) throws TableNotFoundException {
-    ensureOpen();
-    return new ConditionalWriterImpl(this, requireNotOffline(getTableId(tableName), tableName),
-        tableName, new ConditionalWriterConfig());
+    return createConditionalWriter(tableName, null);
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
@@ -90,7 +90,9 @@ import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class ConditionalWriterImpl implements ConditionalWriter {
+import com.google.common.annotations.VisibleForTesting;
+
+public class ConditionalWriterImpl implements ConditionalWriter {
 
   private static final Logger log = LoggerFactory.getLogger(ConditionalWriterImpl.class);
 
@@ -106,6 +108,7 @@ class ConditionalWriterImpl implements ConditionalWriter {
   private long timeout;
   private final Durability durability;
   private final String classLoaderContext;
+  private final ConditionalWriterConfig config;
 
   private static class ServerQueue {
     BlockingQueue<TabletServerMutations<QCMutation>> queue = new LinkedBlockingQueue<>();
@@ -371,6 +374,7 @@ class ConditionalWriterImpl implements ConditionalWriter {
 
   ConditionalWriterImpl(ClientContext context, TableId tableId, String tableName,
       ConditionalWriterConfig config) {
+    this.config = config;
     this.context = context;
     this.auths = config.getAuthorizations();
     this.ve = new VisibilityEvaluator(config.getAuthorizations());
@@ -823,6 +827,11 @@ class ConditionalWriterImpl implements ConditionalWriter {
     } catch (VisibilityParseException | BadArgumentException e) {
       return false;
     }
+  }
+
+  @VisibleForTesting
+  public ConditionalWriterConfig getConfig() {
+    return config;
   }
 
   @Override

--- a/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
@@ -1555,14 +1555,15 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
       try (
           ConditionalWriterImpl cw1 =
               (ConditionalWriterImpl) client.createConditionalWriter(tableName);
-          ConditionalWriterImpl cw2 = (ConditionalWriterImpl) client
-              .createConditionalWriter(tableName, new ConditionalWriterConfig())) {
+          ConditionalWriterImpl cw2 =
+              (ConditionalWriterImpl) client.createConditionalWriter(tableName,
+                  new ConditionalWriterConfig().setMaxWriteThreads(200))) {
         // verify we see the non-default prop values
         assertEquals(99, cw1.getConfig().getTimeout(TimeUnit.SECONDS));
         assertEquals(101, cw1.getConfig().getMaxWriteThreads());
         assertEquals(Durability.NONE, cw1.getConfig().getDurability());
         assertEquals(99, cw2.getConfig().getTimeout(TimeUnit.SECONDS));
-        assertEquals(101, cw2.getConfig().getMaxWriteThreads());
+        assertEquals(200, cw2.getConfig().getMaxWriteThreads());
         assertEquals(Durability.NONE, cw2.getConfig().getDurability());
       }
     }

--- a/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
@@ -58,6 +58,7 @@ import org.apache.accumulo.core.client.ConditionalWriter;
 import org.apache.accumulo.core.client.ConditionalWriter.Result;
 import org.apache.accumulo.core.client.ConditionalWriter.Status;
 import org.apache.accumulo.core.client.ConditionalWriterConfig;
+import org.apache.accumulo.core.client.Durability;
 import org.apache.accumulo.core.client.IsolatedScanner;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.RowIterator;
@@ -68,6 +69,8 @@ import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.TableOfflineException;
 import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
+import org.apache.accumulo.core.clientImpl.ConditionalWriterImpl;
+import org.apache.accumulo.core.conf.ClientProperty;
 import org.apache.accumulo.core.data.ArrayByteSequence;
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Condition;
@@ -1532,6 +1535,35 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
         cm1.put("data", "x", "a");
 
         assertThrows(IllegalArgumentException.class, () -> cw.write(cm1));
+      }
+    }
+  }
+
+  @Test
+  public void testCreateConditionalWriterUsesClientProps() throws Exception {
+    // Tests that creating a conditional writer includes the client properties that were set
+    String tableName = getUniqueNames(1)[0];
+    var clientProps = getClientProps();
+    // Set non-default values for all conditional writer props
+    clientProps.setProperty(ClientProperty.CONDITIONAL_WRITER_TIMEOUT_MAX.getKey(), "99");
+    clientProps.setProperty(ClientProperty.CONDITIONAL_WRITER_THREADS_MAX.getKey(), "101");
+    clientProps.setProperty(ClientProperty.CONDITIONAL_WRITER_DURABILITY.getKey(),
+        Durability.NONE.name());
+    try (AccumuloClient client = Accumulo.newClient().from(clientProps).build()) {
+      client.tableOperations().create(tableName);
+
+      try (
+          ConditionalWriterImpl cw1 =
+              (ConditionalWriterImpl) client.createConditionalWriter(tableName);
+          ConditionalWriterImpl cw2 = (ConditionalWriterImpl) client
+              .createConditionalWriter(tableName, new ConditionalWriterConfig())) {
+        // verify we see the non-default prop values
+        assertEquals(99, cw1.getConfig().getTimeout(TimeUnit.SECONDS));
+        assertEquals(101, cw1.getConfig().getMaxWriteThreads());
+        assertEquals(Durability.NONE, cw1.getConfig().getDurability());
+        assertEquals(99, cw2.getConfig().getTimeout(TimeUnit.SECONDS));
+        assertEquals(101, cw2.getConfig().getMaxWriteThreads());
+        assertEquals(Durability.NONE, cw2.getConfig().getDurability());
       }
     }
   }


### PR DESCRIPTION
Closes #4708
- Fixed `ClientContext.createConditionalWriter(String)` to include client props
- Added `testCreateConditionalWriterUsesClientProps` to `ConditionalWriterIT` (verified to fail before changes and pass after)
