### PR TITLE
Filter metrics from micrometer

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/spi/metrics/FilteringLoggingMRFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/metrics/FilteringLoggingMRFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.spi.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.config.MeterFilter;
+
+public class FilteringLoggingMRFactory extends LoggingMeterRegistryFactory {
+
+  @Override
+  public MeterRegistry create(final InitParameters params) {
+    var meterRegistry = super.create(params);
+    MeterFilter myFilter = MeterFilter.denyNameStartsWith("accumulo.gc");
+    meterRegistry.config().meterFilter(myFilter);
+    return meterRegistry;
+  }
+}

--- a/core/src/main/java/org/apache/accumulo/core/spi/metrics/MeterRegistryFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/metrics/MeterRegistryFactory.java
@@ -69,4 +69,5 @@ public interface MeterRegistryFactory {
    * @return a Micrometer registry that will be added to the metrics configuration.
    */
   MeterRegistry create(final InitParameters params);
+
 }

--- a/core/src/test/java/org/apache/accumulo/core/spi/metrics/LoggingMeterRegistryFactoryTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/metrics/LoggingMeterRegistryFactoryTest.java
@@ -31,8 +31,8 @@ class LoggingMeterRegistryFactoryTest {
 
   @Test
   public void createTest() {
-    LoggingMeterRegistryFactory factory = new LoggingMeterRegistryFactory();
-    var reg = factory.create(new LoggingMetricsParams());
+    FilteringLoggingMRFactory factory = new FilteringLoggingMRFactory();
+    var reg = factory.filteredCreate(new LoggingMetricsParams());
     assertInstanceOf(LoggingMeterRegistry.class, reg);
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/metrics/MetricsInfoImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metrics/MetricsInfoImpl.java
@@ -279,7 +279,7 @@ public class MetricsInfoImpl implements MetricsInfo {
               org.apache.accumulo.core.spi.metrics.MeterRegistryFactory.class);
       org.apache.accumulo.core.spi.metrics.MeterRegistryFactory factory =
           clazz.getDeclaredConstructor().newInstance();
-      org.apache.accumulo.core.spi.metrics.MeterRegistryFactory.InitParameters initParameters =
+      org.apache.accumulo.core.spi.metrics.FilteringLoggingMRFactory.InitParameters initParameters =
           new MeterRegistryEnvPropImpl(context);
       return factory.create(initParameters);
     } catch (ClassCastException ex) {

--- a/test/src/main/java/org/apache/accumulo/test/metrics/MetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/metrics/MetricsIT.java
@@ -43,7 +43,7 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.metrics.MetricsProducer;
-import org.apache.accumulo.core.spi.metrics.LoggingMeterRegistryFactory;
+import org.apache.accumulo.core.spi.metrics.FilteringLoggingMRFactory;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.test.functional.ConfigurableMacBase;
 import org.apache.accumulo.test.metrics.TestStatsDSink.Metric;
@@ -85,8 +85,8 @@ public class MetricsIT extends ConfigurableMacBase implements MetricsProducer {
     cfg.setProperty(Property.GENERAL_MICROMETER_ENABLED, "true");
     cfg.setProperty(Property.GENERAL_MICROMETER_JVM_METRICS_ENABLED, "true");
     cfg.setProperty("general.custom.metrics.opts.logging.step", "1s");
-    String clazzList = LoggingMeterRegistryFactory.class.getName() + ","
-        + TestStatsDRegistryFactory.class.getName();
+    String clazzList =
+        FilteringLoggingMRFactory.class.getName() + "," + TestStatsDRegistryFactory.class.getName();
     cfg.setProperty(Property.GENERAL_MICROMETER_FACTORY, clazzList);
     Map<String,String> sysProps = Map.of(TestStatsDRegistryFactory.SERVER_HOST, "127.0.0.1",
         TestStatsDRegistryFactory.SERVER_PORT, Integer.toString(sink.getPort()));


### PR DESCRIPTION
closes [issue #4599 ](https://github.com/apache/accumulo/issues/4599)
Sub-classed `MeterRegistryFactory` and use Micrometer's `meterFilter` method to filter for metrics the user is interested in. 