### PR TITLE
uses new accumulo-access API for empty authorization

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/security/Authorizations.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/Authorizations.java
@@ -386,9 +386,6 @@ public class Authorizations implements Iterable<byte[]>, Serializable, Authoriza
     return sb.toString();
   }
 
-  private static final org.apache.accumulo.access.Authorizations EMPTY_ACCESS_AUTH =
-      org.apache.accumulo.access.Authorizations.of(Set.of());
-
   /**
    * Converts to an Accumulo Access Authorizations object.
    *
@@ -396,7 +393,7 @@ public class Authorizations implements Iterable<byte[]>, Serializable, Authoriza
    */
   public org.apache.accumulo.access.Authorizations toAccessAuthorizations() {
     if (auths.isEmpty()) {
-      return EMPTY_ACCESS_AUTH;
+      return org.apache.accumulo.access.Authorizations.of();
     } else {
       Set<String> auths = new HashSet<>(authsList.size());
       for (var auth : authsList) {


### PR DESCRIPTION
After the changes in #4743 can now use a new API from accumulo-access that is only present in the snapshot version.  This new API efficiently returns an empty accumulo-access Authorization object.   Can call this new API and drop a bit of custom code that did the same thing.