### PR TITLE
Simplify idle check used for idle process metric in Compactor

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/AbstractServer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/AbstractServer.java
@@ -21,7 +21,6 @@ package org.apache.accumulo.server;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Supplier;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.classloader.ClassLoaderUtil;
@@ -68,8 +67,14 @@ public abstract class AbstractServer implements AutoCloseable, MetricsProducer, 
         context.getConfiguration().getTimeInMillis(Property.GENERAL_IDLE_PROCESS_INTERVAL));
   }
 
-  protected void idleProcessCheck(Supplier<Boolean> idleCondition) {
-    boolean isIdle = idleCondition.get();
+  /**
+   * Updates the idle status of the server to set the idle process metric. The server must be idle
+   * for multiple calls over a specified period for the metric to reflect the idle state. If the
+   * server is busy or the idle period hasn't started, it resets the idle tracking.
+   *
+   * @param isIdle whether the server is idle
+   */
+  protected void updateIdleStatus(boolean isIdle) {
     boolean shouldResetIdlePeriod = !isIdle || idleReportingPeriodNanos == 0;
     boolean isIdlePeriodNotStarted = idlePeriodStartNanos == 0;
     boolean hasExceededIdlePeriod =

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -705,7 +705,7 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
       while (!shutdown) {
 
         // mark compactor as idle while not in the compaction loop
-        idleProcessCheck(() -> true);
+        updateIdleStatus(true);
 
         currentCompactionId.set(null);
         err.set(null);
@@ -745,7 +745,7 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
 
         try {
           // mark compactor as busy while compacting
-          idleProcessCheck(() -> false);
+          updateIdleStatus(false);
 
           // Need to call FileCompactorRunnable.initialize after calling JOB_HOLDER.set
           fcr.initialize();
@@ -860,7 +860,7 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
           currentCompactionId.set(null);
 
           // mark compactor as idle after compaction completes
-          idleProcessCheck(() -> true);
+          updateIdleStatus(true);
 
           // In the case where there is an error in the foreground code the background compaction
           // may still be running. Must cancel it before starting another iteration of the loop to

--- a/server/compactor/src/test/java/org/apache/accumulo/compactor/CompactorTest.java
+++ b/server/compactor/src/test/java/org/apache/accumulo/compactor/CompactorTest.java
@@ -323,7 +323,7 @@ public class CompactorTest {
     PowerMock.resetAll();
     PowerMock.suppress(PowerMock.methods(Halt.class, "halt"));
     PowerMock.suppress(PowerMock.constructor(AbstractServer.class));
-    PowerMock.suppress(PowerMock.methods(AbstractServer.class, "idleProcessCheck"));
+    PowerMock.suppress(PowerMock.methods(AbstractServer.class, "updateIdleStatus"));
 
     ServerAddress client = PowerMock.createNiceMock(ServerAddress.class);
     HostAndPort address = HostAndPort.fromString("localhost:10240");
@@ -374,7 +374,7 @@ public class CompactorTest {
     PowerMock.resetAll();
     PowerMock.suppress(PowerMock.methods(Halt.class, "halt"));
     PowerMock.suppress(PowerMock.constructor(AbstractServer.class));
-    PowerMock.suppress(PowerMock.methods(AbstractServer.class, "idleProcessCheck"));
+    PowerMock.suppress(PowerMock.methods(AbstractServer.class, "updateIdleStatus"));
 
     ServerAddress client = PowerMock.createNiceMock(ServerAddress.class);
     HostAndPort address = HostAndPort.fromString("localhost:10240");
@@ -426,7 +426,7 @@ public class CompactorTest {
     PowerMock.resetAll();
     PowerMock.suppress(PowerMock.methods(Halt.class, "halt"));
     PowerMock.suppress(PowerMock.constructor(AbstractServer.class));
-    PowerMock.suppress(PowerMock.methods(AbstractServer.class, "idleProcessCheck"));
+    PowerMock.suppress(PowerMock.methods(AbstractServer.class, "updateIdleStatus"));
 
     ServerAddress client = PowerMock.createNiceMock(ServerAddress.class);
     HostAndPort address = HostAndPort.fromString("localhost:10240");

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -420,8 +420,8 @@ public class ScanServer extends AbstractServer
     try {
       while (!serverStopRequested) {
         UtilWaitThread.sleep(1000);
-        idleProcessCheck(() -> sessionManager.getActiveScans().isEmpty()
-            && tabletMetadataCache.estimatedSize() == 0);
+        updateIdleStatus(
+            sessionManager.getActiveScans().isEmpty() && tabletMetadataCache.estimatedSize() == 0);
       }
     } finally {
       LOG.info("Stopping Thrift Servers");

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -872,7 +872,7 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
     HostAndPort managerHost;
     while (!serverStopRequested) {
 
-      idleProcessCheck(() -> getOnlineTablets().isEmpty());
+      updateIdleStatus(getOnlineTablets().isEmpty());
 
       // send all of the pending messages
       try {
@@ -884,7 +884,7 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
           // was requested
           while (mm == null && !serverStopRequested) {
             mm = managerMessages.poll(1, TimeUnit.SECONDS);
-            idleProcessCheck(() -> getOnlineTablets().isEmpty());
+            updateIdleStatus(getOnlineTablets().isEmpty());
           }
 
           // have a message to send to the manager, so grab a
@@ -912,7 +912,7 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
             // if any messages are immediately available grab em and
             // send them
             mm = managerMessages.poll();
-            idleProcessCheck(() -> getOnlineTablets().isEmpty());
+            updateIdleStatus(getOnlineTablets().isEmpty());
           }
 
         } finally {

--- a/test/src/main/java/org/apache/accumulo/test/functional/IdleProcessMetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/IdleProcessMetricsIT.java
@@ -75,6 +75,8 @@ public class IdleProcessMetricsIT extends SharedMiniClusterBase {
       cfg.setProperty(Property.GENERAL_IDLE_PROCESS_INTERVAL,
           idleProcessInterval.toSeconds() + "s");
 
+      // need to set this to a low value since one of the idle conditions for the scan server is an
+      // empty cache
       cfg.setProperty(Property.SSERV_CACHED_TABLET_METADATA_EXPIRATION, "1s");
 
       // Tell the server processes to use a StatsDMeterRegistry that will be configured

--- a/test/src/main/java/org/apache/accumulo/test/functional/IdleProcessMetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/IdleProcessMetricsIT.java
@@ -183,7 +183,7 @@ public class IdleProcessMetricsIT extends SharedMiniClusterBase {
             .filter(a -> a.getTags().get("process.name").equals("compactor"))
             .peek(a -> log.info("Compactor idle metric: {}", a))
             .anyMatch(a -> Integer.parseInt(a.getValue()) == expectedValue),
-        60_000, 2000, "Compactor did not go idle");
+        60_000, 2000, "Compactor idle metric value did not reach expected value: " + expectedValue);
   }
 
 }

--- a/test/src/main/java/org/apache/accumulo/test/functional/IdleProcessMetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/IdleProcessMetricsIT.java
@@ -19,16 +19,25 @@
 package org.apache.accumulo.test.functional;
 
 import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.QUEUE1;
+import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.compact;
+import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.createTable;
+import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.verify;
+import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.writeData;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.accumulo.compactor.Compactor;
 import org.apache.accumulo.coordinator.CompactionCoordinator;
+import org.apache.accumulo.core.client.Accumulo;
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.iterators.IteratorUtil;
 import org.apache.accumulo.core.metrics.MetricsProducer;
 import org.apache.accumulo.harness.MiniClusterConfigurationCallback;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
@@ -125,6 +134,56 @@ public class IdleProcessMetricsIT extends SharedMiniClusterBase {
           });
       return sawCompactor.get() && sawSServer.get() && sawTServer.get();
     });
+  }
+
+  @Test
+  public void idleCompactorTest() throws Exception {
+    try (AccumuloClient client =
+        Accumulo.newClient().from(getCluster().getClientProperties()).build()) {
+
+      getCluster().getClusterControl().startCoordinator(CompactionCoordinator.class);
+      getCluster().getClusterControl().startCompactors(Compactor.class, 1, QUEUE1);
+
+      // should emit the idle metric after the configured duration of GENERAL_IDLE_PROCESS_INTERVAL
+      Thread.sleep(idleProcessInterval.toMillis());
+
+      log.info("Waiting for compactor to go idle");
+      waitForCompactorIdleMetricToBe(1);
+
+      // once we see the idle compactor metric, start a compaction and wait for the metric to go
+      // back to not idle
+
+      String table1 = getUniqueNames(1)[0];
+      createTable(client, table1, "cs1");
+      writeData(client, table1);
+
+      IteratorSetting setting = new IteratorSetting(50, "Slow", SlowIterator.class);
+      SlowIterator.setSleepTime(setting, 5);
+      client.tableOperations().attachIterator(table1, setting,
+          EnumSet.of(IteratorUtil.IteratorScope.majc));
+
+      compact(client, table1, 2, QUEUE1, false);
+
+      log.info("Waiting for compactor to be not idle after starting compaction");
+      waitForCompactorIdleMetricToBe(0);
+
+      log.info("Waiting for compactor to go idle once compaction completes");
+      waitForCompactorIdleMetricToBe(1);
+
+      verify(client, table1, 2);
+    }
+
+  }
+
+  private static void waitForCompactorIdleMetricToBe(int expectedValue) {
+    Wait.waitFor(
+        () -> sink.getLines().stream()
+            .filter(line -> line.startsWith(MetricsProducer.METRICS_SERVER_IDLE))
+            .map(TestStatsDSink::parseStatsDMetric)
+            .filter(a -> a.getTags().get("process.name").equals("compactor"))
+            .peek(a -> log.info("Compactor idle metric: {}", a))
+            .anyMatch(a -> Integer.parseInt(a.getValue()) == expectedValue),
+        60_000, 2000, "Compactor did not go idle");
   }
 
 }

--- a/test/src/main/java/org/apache/accumulo/test/functional/IdleProcessMetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/IdleProcessMetricsIT.java
@@ -99,6 +99,10 @@ public class IdleProcessMetricsIT extends SharedMiniClusterBase {
     SharedMiniClusterBase.stopMiniCluster();
   }
 
+  /**
+   * Test that the idle process metrics are emitted correctly for the compactor, scan server and
+   * tserver.
+   */
   @Test
   public void testIdleStopMetrics() throws Exception {
 
@@ -136,6 +140,10 @@ public class IdleProcessMetricsIT extends SharedMiniClusterBase {
     });
   }
 
+  /**
+   * Test that before during and after a compaction, the compactor will emit the appropriate value
+   * for the idle metric.
+   */
   @Test
   public void idleCompactorTest() throws Exception {
     try (AccumuloClient client =


### PR DESCRIPTION
This PR simplifies the check for the Compactor that is used to determine when to change the idle process metric for the Compactor. The new code just returns true when no compaction is running and false when one is. It defers the time checking portion to the upstream logic in `AbstractServer`.

The old method was to check how much time has passed since the last compaction was completed. There are at least two issues with this:
1. There is logic that makes sure the amount of time since the last compaction happened is at least `idleReportingPeriodNanos`. This check also happens upstream when the `Supplier<boolean>` is read in `AbstractServer` so we are getting rid of that duplicate check in the new code.
2. There is a check that the `System.nanoTime()` value of the last completed compaction is not negative. This is not a safe check to make since `System.nanoTime()` may provide a negative value. (This bug was identified [here](https://github.com/apache/accumulo/pull/4737#discussion_r1672754943))