### PR TITLE
Fix Compactors table on EC Monitor page

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/ec.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/ec.js
@@ -61,7 +61,7 @@ $(document).ready(function () {
         "data": "server"
       },
       {
-        "data": "queueName"
+        "data": "groupName"
       },
       {
         "data": "lastContact"

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/ec.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/ec.ftl
@@ -49,7 +49,7 @@
               <thead>
                 <tr>
                   <th class="firstcell" title="The hostname the compactor is running on.">Server</th>
-                  <th title="The name of the queue this compactor is assigned.">Queue</th>
+                  <th title="The name of the group this compactor is assigned.">Group</th>
                   <th class="duration" title="Last time data was fetched. Server fetches on refresh, at most every minute.">Last Contact</th>
                 </tr>
               </thead>


### PR DESCRIPTION
compactor.queue was renamed to compactor.group in #3591 and this updates the Monitor to use the new name so Compactors can be displayed correctly in the table on the external compations page. Before this change there the table was empty and there were errors in the javascript console.