### PR TITLE
acquires two locks in correct order in tablet close

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
@@ -350,7 +350,7 @@ class DatafileManager {
     try {
       // Should not hold the tablet lock while trying to acquire the log lock because this could
       // lead to deadlock. However there is a path in the code that does this. See #3759
-      tablet.getLogLock().lock();
+      var logLock = tablet.lockLogLock();
       // do not place any code here between lock and try
       try {
         // The following call pairs with tablet.finishClearingUnusedLogs() later in this block. If
@@ -405,7 +405,7 @@ class DatafileManager {
 
         tablet.finishClearingUnusedLogs();
       } finally {
-        tablet.getLogLock().unlock();
+        logLock.unlock();
       }
 
       do {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
@@ -348,8 +348,6 @@ class DatafileManager {
     metadataUpdateCount.updateAndGet(MetadataUpdateCount::incrementStart);
     // do not place any code here between above stmt and following try{}finally
     try {
-      // Should not hold the tablet lock while trying to acquire the log lock because this could
-      // lead to deadlock. However there is a path in the code that does this. See #3759
       var logLock = tablet.lockLogLock();
       // do not place any code here between lock and try
       try {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
@@ -348,7 +348,7 @@ class DatafileManager {
     metadataUpdateCount.updateAndGet(MetadataUpdateCount::incrementStart);
     // do not place any code here between above stmt and following try{}finally
     try {
-      var logLock = tablet.lockLogLock();
+      final var logLock = tablet.lockLogLock();
       // do not place any code here between lock and try
       try {
         // The following call pairs with tablet.finishClearingUnusedLogs() later in this block. If

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -903,7 +903,12 @@ public class Tablet extends TabletBase {
   @Override
   public void close(boolean saveState) throws IOException {
     initiateClose(saveState);
-    completeClose(saveState, true);
+    var lock = lockLogLock();
+    try {
+      completeClose(saveState, true);
+    } finally {
+      lock.unlock();
+    }
     log.info("Tablet {} closed.", this.extent);
   }
 
@@ -1018,6 +1023,11 @@ public class Tablet extends TabletBase {
   private boolean closeCompleting = false;
 
   synchronized void completeClose(boolean saveState, boolean completeClose) throws IOException {
+
+    // The lockLog must be acuired before the tablet lock. Later in this function the log lock may
+    // be acquired during minor compaction. It will fail if the tablet lock is held and not the log
+    // lock. Fail sooner here and always, not only the case when a minor compaction is needed.
+    Preconditions.checkState(logLock.isHeldByCurrentThread());
 
     if (!isClosing() || isCloseComplete() || closeCompleting) {
       throw new IllegalStateException("Bad close state " + closeState + " on tablet " + extent);
@@ -1631,61 +1641,68 @@ public class Tablet extends TabletBase {
     Map<TabletFile,FileUtil.FileInfo> firstAndLastRows = FileUtil.tryToGetFirstAndLastRows(context,
         tableConfiguration, getDatafileManager().getFiles());
 
-    synchronized (this) {
-      // java needs tuples ...
-      TreeMap<KeyExtent,TabletData> newTablets = new TreeMap<>();
+    // This must be acquired before the tablet lock AND completeClose expects it to be acquired when
+    // called.
+    var lock = lockLogLock();
+    try {
+      synchronized (this) {
+        // java needs tuples ...
+        TreeMap<KeyExtent,TabletData> newTablets = new TreeMap<>();
 
-      long t1 = System.currentTimeMillis();
+        long t1 = System.currentTimeMillis();
 
-      closeState = CloseState.CLOSING;
-      completeClose(true, false);
+        closeState = CloseState.CLOSING;
+        completeClose(true, false);
 
-      Text midRow = splitPoint.row;
-      double splitRatio = splitPoint.splitRatio;
+        Text midRow = splitPoint.row;
+        double splitRatio = splitPoint.splitRatio;
 
-      KeyExtent low = new KeyExtent(extent.tableId(), midRow, extent.prevEndRow());
-      KeyExtent high = new KeyExtent(extent.tableId(), extent.endRow(), midRow);
+        KeyExtent low = new KeyExtent(extent.tableId(), midRow, extent.prevEndRow());
+        KeyExtent high = new KeyExtent(extent.tableId(), extent.endRow(), midRow);
 
-      String lowDirectoryName = createTabletDirectoryName(context, midRow);
+        String lowDirectoryName = createTabletDirectoryName(context, midRow);
 
-      // write new tablet information to MetadataTable
-      SortedMap<StoredTabletFile,DataFileValue> lowDatafileSizes = new TreeMap<>();
-      SortedMap<StoredTabletFile,DataFileValue> highDatafileSizes = new TreeMap<>();
-      List<StoredTabletFile> highDatafilesToRemove = new ArrayList<>();
+        // write new tablet information to MetadataTable
+        SortedMap<StoredTabletFile,DataFileValue> lowDatafileSizes = new TreeMap<>();
+        SortedMap<StoredTabletFile,DataFileValue> highDatafileSizes = new TreeMap<>();
+        List<StoredTabletFile> highDatafilesToRemove = new ArrayList<>();
 
-      MetadataTableUtil.splitDatafiles(midRow, splitRatio, firstAndLastRows,
-          getDatafileManager().getDatafileSizes(), lowDatafileSizes, highDatafileSizes,
-          highDatafilesToRemove);
+        MetadataTableUtil.splitDatafiles(midRow, splitRatio, firstAndLastRows,
+            getDatafileManager().getDatafileSizes(), lowDatafileSizes, highDatafileSizes,
+            highDatafilesToRemove);
 
-      log.debug("Files for low split {} {}", low, lowDatafileSizes.keySet());
-      log.debug("Files for high split {} {}", high, highDatafileSizes.keySet());
+        log.debug("Files for low split {} {}", low, lowDatafileSizes.keySet());
+        log.debug("Files for high split {} {}", high, highDatafileSizes.keySet());
 
-      MetadataTime time = tabletTime.getMetadataTime();
+        MetadataTime time = tabletTime.getMetadataTime();
 
-      HashSet<ExternalCompactionId> ecids = new HashSet<>();
-      compactable.getExternalCompactionIds(ecids::add);
+        HashSet<ExternalCompactionId> ecids = new HashSet<>();
+        compactable.getExternalCompactionIds(ecids::add);
 
-      MetadataTableUtil.splitTablet(high, extent.prevEndRow(), splitRatio,
-          getTabletServer().getContext(), getTabletServer().getLock(), ecids);
-      ManagerMetadataUtil.addNewTablet(getTabletServer().getContext(), low, lowDirectoryName,
-          getTabletServer().getTabletSession(), lowDatafileSizes, bulkImported, time,
-          lastFlushID.get(), lastCompactID.get(), getTabletServer().getLock());
-      MetadataTableUtil.finishSplit(high, highDatafileSizes, highDatafilesToRemove,
-          getTabletServer().getContext(), getTabletServer().getLock());
+        MetadataTableUtil.splitTablet(high, extent.prevEndRow(), splitRatio,
+            getTabletServer().getContext(), getTabletServer().getLock(), ecids);
+        ManagerMetadataUtil.addNewTablet(getTabletServer().getContext(), low, lowDirectoryName,
+            getTabletServer().getTabletSession(), lowDatafileSizes, bulkImported, time,
+            lastFlushID.get(), lastCompactID.get(), getTabletServer().getLock());
+        MetadataTableUtil.finishSplit(high, highDatafileSizes, highDatafilesToRemove,
+            getTabletServer().getContext(), getTabletServer().getLock());
 
-      TabletLogger.split(extent, low, high, getTabletServer().getTabletSession());
+        TabletLogger.split(extent, low, high, getTabletServer().getTabletSession());
 
-      newTablets.put(high, new TabletData(dirName, highDatafileSizes, time, lastFlushID.get(),
-          lastCompactID.get(), lastLocation, bulkImported));
-      newTablets.put(low, new TabletData(lowDirectoryName, lowDatafileSizes, time,
-          lastFlushID.get(), lastCompactID.get(), lastLocation, bulkImported));
+        newTablets.put(high, new TabletData(dirName, highDatafileSizes, time, lastFlushID.get(),
+            lastCompactID.get(), lastLocation, bulkImported));
+        newTablets.put(low, new TabletData(lowDirectoryName, lowDatafileSizes, time,
+            lastFlushID.get(), lastCompactID.get(), lastLocation, bulkImported));
 
-      long t2 = System.currentTimeMillis();
+        long t2 = System.currentTimeMillis();
 
-      log.debug(String.format("offline split time : %6.2f secs", (t2 - t1) / 1000.0));
+        log.debug(String.format("offline split time : %6.2f secs", (t2 - t1) / 1000.0));
 
-      closeState = CloseState.COMPLETE;
-      return newTablets;
+        closeState = CloseState.COMPLETE;
+        return newTablets;
+      }
+    } finally {
+      lock.unlock();
     }
   }
 
@@ -1928,7 +1945,12 @@ public class Tablet extends TabletBase {
     }
   }
 
-  ReentrantLock getLogLock() {
+  ReentrantLock lockLogLock() {
+    // It is expected that the log lock is acquired before the tablet lock. If they are acquired in
+    // reverse order it could lead to deadlock. So if the current thread does not hold the log lock,
+    // then it should also not hold the tablet lock.
+    Preconditions.checkState(!Thread.holdsLock(this) || logLock.isHeldByCurrentThread());
+    logLock.lock();
     return logLock;
   }
 
@@ -1996,10 +2018,7 @@ public class Tablet extends TabletBase {
 
     boolean releaseLock = true;
 
-    // Should not hold the tablet lock while trying to acquire the log lock because this could lead
-    // to deadlock. However there is a path in the code that does this. See #3759
-    logLock.lock();
-
+    var lock = lockLogLock();
     try {
       synchronized (this) {
 
@@ -2055,7 +2074,7 @@ public class Tablet extends TabletBase {
       }
     } finally {
       if (releaseLock) {
-        logLock.unlock();
+        lock.unlock();
       }
     }
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -1024,9 +1024,9 @@ public class Tablet extends TabletBase {
 
   synchronized void completeClose(boolean saveState, boolean completeClose) throws IOException {
 
-    // The lockLog must be acuired before the tablet lock. Later in this function the log lock may
+    // The lockLock must be acquired before the tablet lock. Later in this function the log lock may
     // be acquired during minor compaction. It will fail if the tablet lock is held and not the log
-    // lock. Fail sooner here and always, not only the case when a minor compaction is needed.
+    // lock. Fail sooner here and always, not only in the case when a minor compaction is needed.
     Preconditions.checkState(logLock.isHeldByCurrentThread());
 
     if (!isClosing() || isCloseComplete() || closeCompleting) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -903,7 +903,7 @@ public class Tablet extends TabletBase {
   @Override
   public void close(boolean saveState) throws IOException {
     initiateClose(saveState);
-    var lock = lockLogLock();
+    final var lock = lockLogLock();
     try {
       completeClose(saveState, true);
     } finally {
@@ -1643,7 +1643,7 @@ public class Tablet extends TabletBase {
 
     // This must be acquired before the tablet lock AND completeClose expects it to be acquired when
     // called.
-    var lock = lockLogLock();
+    final var lock = lockLogLock();
     try {
       synchronized (this) {
         // java needs tuples ...
@@ -2018,7 +2018,7 @@ public class Tablet extends TabletBase {
 
     boolean releaseLock = true;
 
-    var lock = lockLogLock();
+    final var lock = lockLogLock();
     try {
       synchronized (this) {
 


### PR DESCRIPTION
The tablet close code was acuiring the log lock after the tablet lock, which is the opposite order of other code.  This could cause deadlock.  Reversed the acuisition order.

Also added validation of the lock acquisition order.

Fixes #3759