### PR TITLE
Improves accumulo-cluster for start and stop commands

### DIFF
--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -23,16 +23,20 @@ function print_usage {
 Usage: accumulo-cluster <command> (<argument> ...)
 
 Commands:
-  create-config       Creates cluster config
-  restart             Restarts the Accumulo cluster
-  start               Starts Accumulo cluster
-  stop                Stops Accumulo cluster
-  kill                Kills Accumulo cluster
-  start-non-tservers  Starts all services except tservers
-  start-tservers      Starts all tservers on cluster
-  stop-tservers       Stops all tservers on cluster
-  start-here          Starts all services on this node
-  stop-here           Stops all services on this node
+  create-config              Creates cluster config
+  restart                    Restarts the Accumulo cluster
+  start                      Starts Accumulo cluster
+  stop                       Stops Accumulo cluster
+  kill                       Kills Accumulo cluster
+  start-non-tservers         Starts all services except tservers (Deprecated)
+  start-servers [--all|--tservers|--no-tservers|--sservers [group]|--compactors [queue]]
+                             Starts various server types, can optionally specify a queue or group
+  stop-servers [--all|--tservers| --no-tservers|--sservers [group]|--compactors [queue]]
+                             Starts various server types, can optionally specify a queue or group
+  start-tservers             Starts all tservers on cluster (Deprecated)
+  stop-tservers              Stops all tservers on cluster (Deprecated)
+  start-here                 Starts all services on this node
+  stop-here                  Stops all services on this node
 EOF
 }
 
@@ -115,15 +119,19 @@ function parse_config {
     echo "INFO: ${NUM_TSERVERS} tservers will be started per host"
   fi
 
-  # shellcheck disable=SC2153
-  if [[ -z $NUM_SSERVERS ]]; then
-    echo "INFO: ${NUM_SSERVERS} sservers will be started per host"
-  fi
+  for group in $SSERVER_GROUPS; do
+    var_name="NUM_SSERVERS_${group}"
+    if [[ -n ${!var_name} ]]; then
+      echo "INFO: ${!var_name} scan servers will be started per host for group ${group}"
+    fi
+  done
 
-  if [[ -z $NUM_COMPACTORS ]]; then
-    echo "INFO: ${NUM_COMPACTORS} compactors will be started per host"
-  fi
-
+  for queue in $COMPACTION_QUEUES; do
+    var_name="NUM_COMPACTORS_${queue}"
+    if [[ -n ${!var_name} ]]; then
+      echo "INFO: ${!var_name} compactors will be started per host for queue ${queue}"
+    fi
+  done
 }
 
 function control_service() {
@@ -138,10 +146,10 @@ function control_service() {
   [[ $service == "compactor" ]] && last_instance_id=${NUM_COMPACTORS:-1}
 
   for ((inst_id = 1; inst_id <= last_instance_id; inst_id++)); do
+    # Only increment the service name when more than one service is desired.
     ACCUMULO_SERVICE_INSTANCE=""
-    [[ $service == "tserver" && ${NUM_TSERVERS:-1} -gt 1 ]] && ACCUMULO_SERVICE_INSTANCE=${inst_id}
-    [[ $service == "compactor" ]] && ACCUMULO_SERVICE_INSTANCE="${inst_id}_${5}"
-    [[ $service == "sserver" ]] && ACCUMULO_SERVICE_INSTANCE="${inst_id}_${5}"
+    [[ last_instance_id -gt 1 ]] && ACCUMULO_SERVICE_INSTANCE="${inst_id}"
+    [[ $service == "compactor" || $service == "sserver" ]] && ACCUMULO_SERVICE_INSTANCE="${ACCUMULO_SERVICE_INSTANCE}_${5}"
 
     if [[ $host == localhost || $host == "$(hostname -s)" || $host == "$(hostname -f)" || "$(hostname -I)" =~ $host ]]; then
       #
@@ -166,6 +174,90 @@ function control_service() {
 
 function start_service() {
   control_service start "$@"
+}
+
+function start_compactors() {
+  echo -n "Starting compactor servers ..."
+  queues=$COMPACTION_QUEUES
+  if [[ -n $1 ]]; then
+    queues="$1"
+    echo "Only starting servers for group: ${queues}"
+  fi
+  for queue in $queues; do
+    var_name="NUM_COMPACTORS_${queue}"
+    [[ -n ${!var_name} ]] && NUM_COMPACTORS=${!var_name}
+    Q="COMPACTOR_HOSTS_${queue}"
+    if [[ -n ${!Q} ]]; then
+      for compactor in ${!Q}; do
+        start_service "$compactor" compactor "-q" "$queue"
+      done
+    else
+      echo "\"${queue}\" is not a valid queue ...exiting"
+    fi
+  done
+}
+
+function stop_compactors() {
+  echo "Stopping compactor servers ..."
+  queues=$COMPACTION_QUEUES
+  if [[ -n $1 ]]; then
+    queues="$1"
+    echo "Only stopping servers for group: ${queues}"
+  fi
+  for queue in $queues; do
+    var_name="NUM_COMPACTORS_${queue}"
+    [[ -n ${!var_name} ]] && NUM_COMPACTORS=${!var_name}
+    Q="COMPACTOR_HOSTS_${queue}"
+    if [[ -n ${!Q} ]]; then
+      for compactor in ${!Q}; do
+        stop_service "$compactor" compactor "-q" "$queue"
+      done
+    else
+      echo "$queue is not a valid compaction queue ...exiting"
+    fi
+  done
+}
+
+function start_sservers() {
+  echo "Starting scan servers ..."
+  groups=$SSERVER_GROUPS
+  if [[ -n $1 ]]; then
+    groups="$1"
+    echo "Only starting servers for group: ${groups}"
+  fi
+  for group in $groups; do
+    var_name="NUM_SSERVERS_${group}"
+    [[ -n ${!var_name} ]] && NUM_SSERVERS=${!var_name}
+    G="SSERVER_HOSTS_${group}"
+    if [[ -n ${!G} ]]; then
+      for sserver in ${!G}; do
+        start_service "$sserver" sserver "-g" "$group"
+      done
+    else
+      echo "\"${group} is not a valid resource group ...exiting"
+    fi
+  done
+}
+
+function stop_sservers() {
+  echo "Stopping scan servers ..."
+  groups=$SSERVER_GROUPS
+  if [[ -n $1 ]]; then
+    groups="$1"
+    echo "Only stopping servers for group: ${groups}"
+  fi
+  for group in $groups; do
+    var_name="NUM_SSERVERS_${group}"
+    [[ -n ${!var_name} ]] && NUM_SSERVERS=${!var_name}
+    G="SSERVER_HOSTS_${group}"
+    if [[ -n ${!G} ]]; then
+      for sserver in ${!G}; do
+        stop_service "$sserver" sserver "-g" "$group"
+      done
+    else
+      echo "$queue is not a valid resource group ...exiting"
+    fi
+  done
 }
 
 function start_tservers() {
@@ -202,6 +294,8 @@ function start_all() {
   done
 
   for group in $SSERVER_GROUPS; do
+    var_name="NUM_SSERVERS_${group}"
+    [[ -n ${!var_name} ]] && NUM_SSERVERS=${!var_name}
     G="SSERVER_HOSTS_${group}"
     for sserver in ${!G}; do
       start_service "$sserver" sserver "-g" "$group"
@@ -213,6 +307,8 @@ function start_all() {
   done
 
   for queue in $COMPACTION_QUEUES; do
+    var_name="NUM_COMPACTORS_${queue}"
+    [[ -n ${!var_name} ]] && NUM_COMPACTORS=${!var_name}
     Q="COMPACTOR_HOSTS_${queue}"
     for compactor in ${!Q}; do
       start_service "$compactor" compactor "-q" "$queue"
@@ -262,6 +358,8 @@ function start_here() {
   done
 
   for group in $SSERVER_GROUPS; do
+    var_name="NUM_SSERVERS_${group}"
+    [[ -n ${!var_name} ]] && NUM_SSERVERS=${!var_name}
     for host in $local_hosts; do
       G="SSERVER_HOSTS_${group}"
       for sserver in ${!G}; do
@@ -282,6 +380,8 @@ function start_here() {
 
   for queue in $COMPACTION_QUEUES; do
     for host in $local_hosts; do
+      var_name="NUM_COMPACTORS_${queue}"
+      [[ -n ${!var_name} ]] && NUM_COMPACTORS=${!var_name}
       Q="COMPACTOR_HOSTS_${queue}"
       for compactor in ${!Q}; do
         if echo "$compactor" | grep -q "^${host}\$"; then
@@ -339,6 +439,8 @@ function kill_all() {
   done
 
   for group in $SSERVER_GROUPS; do
+    var_name="NUM_SSERVERS_${group}"
+    [[ -n ${!var_name} ]] && NUM_SSERVERS=${!var_name}
     G="SSERVER_HOSTS_${group}"
     for sserver in ${!G}; do
       kill_service "$sserver" sserver "-g" "$group"
@@ -354,6 +456,8 @@ function kill_all() {
   done
 
   for queue in $COMPACTION_QUEUES; do
+    var_name="NUM_COMPACTORS_${queue}"
+    [[ -n ${!var_name} ]] && NUM_COMPACTORS=${!var_name}
     Q="COMPACTOR_HOSTS_${queue}"
     for compactor in ${!Q}; do
       kill_service "$compactor" compactor "-q" "$queue"
@@ -395,6 +499,8 @@ function stop_all() {
     done
 
     for group in $SSERVER_GROUPS; do
+      var_name="NUM_SSERVERS_${group}"
+      [[ -n ${!var_name} ]] && NUM_SSERVERS=${!var_name}
       G="SSERVER_HOSTS_${group}"
       for sserver in ${!G}; do
         end_service $end_cmd "$sserver" sserver "-g" "$group"
@@ -406,6 +512,8 @@ function stop_all() {
     done
 
     for queue in $COMPACTION_QUEUES; do
+      var_name="NUM_COMPACTORS_${queue}"
+      [[ -n ${!var_name} ]] && NUM_COMPACTORS=${!var_name}
       Q="COMPACTOR_HOSTS_${queue}"
       for compactor in ${!Q}; do
         end_service $end_cmd "$compactor" compactor "-q" "$queue"
@@ -443,12 +551,16 @@ function stop_here() {
         end_service $end_cmd "$host" $svc
       done
       for group in $SSERVER_GROUPS; do
+        var_name="NUM_SSERVERS_${group}"
+        [[ -n ${!var_name} ]] && NUM_SSERVERS=${!var_name}
         G="SSERVER_HOSTS_${group}"
         for sserver in ${!G}; do
           end_service $end_cmd "$sserver" sserver "-g" "$group"
         done
       done
       for queue in $COMPACTION_QUEUES; do
+        var_name="NUM_COMPACTORS_${queue}"
+        [[ -n ${!var_name} ]] && NUM_COMPACTORS=${!var_name}
         Q="COMPACTOR_HOSTS_${queue}"
         for compactor in ${!Q}; do
           end_service $end_cmd "$host" compactor "-q" "$queue"
@@ -520,8 +632,8 @@ tserver:
 # compactors_per_host.
 #
 tservers_per_host: 1
-sservers_per_host: 1
-compactors_per_host: 1
+#sservers_per_host: 1
+#compactors_per_host: 1
 
 EOF
       ;;
@@ -545,10 +657,12 @@ EOF
       kill_all
       ;;
     start-non-tservers)
+      echo "$1 is deprecated. Please use \`start-servers --no-tservers\` instead"
       parse_config
       start_all --no-tservers
       ;;
     start-tservers)
+      echo "$1 is deprecated. Please use \`start-servers --tservers\` instead"
       parse_config
       start_tservers
       ;;
@@ -557,12 +671,56 @@ EOF
       start_here
       ;;
     stop-tservers)
+      echo "$1 is deprecated. Please use \`stop-servers --tservers\` instead"
       parse_config
       stop_tservers
       ;;
     stop-here)
       parse_config
       stop_here
+      ;;
+    start-servers)
+      parse_config
+      case "$2" in
+        "--all" | "")
+          start_all
+          ;;
+        "--tservers")
+          start_tservers
+          ;;
+        "--no-tservers")
+          start_all --no-tservers
+          ;;
+        "--sservers")
+          start_sservers "${@:3}"
+          ;;
+        "--compactors")
+          start_compactors "${@:3}"
+          ;;
+        *)
+          invalid_args "'$2' is an invalid <command>"
+          ;;
+      esac
+      ;;
+    stop-servers)
+      parse_config
+      case "$2" in
+        "--all" | "")
+          stop_all
+          ;;
+        "--tservers")
+          stop_tservers
+          ;;
+        "--sservers")
+          stop_sservers "${@:3}"
+          ;;
+        "--compactors")
+          stop_compactors "${@:3}"
+          ;;
+        *)
+          invalid_args "'$2' is an invalid <command>"
+          ;;
+      esac
       ;;
     *)
       invalid_args "'$1' is an invalid <command>"

--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -164,9 +164,9 @@ function control_service() {
     else
       if [[ $# -gt 3 ]]; then
         EXTRA_ARGS="${*:4}"
-        $SSH "$host" "bash -c 'ACCUMULO_SERVICE_INSTANCE=${ACCUMULO_SERVICE_INSTANCE} ${bin}/accumulo-service \"$service\" \"$control_cmd\" \"-a\" \"$host\" $EXTRA_ARGS '"
+        $SSH "$host" "bash -c 'ACCUMULO_SERVICE_INSTANCE=${ACCUMULO_SERVICE_INSTANCE} ${bin}/accumulo-service \"$service\" \"$control_cmd\" \"-a\" \"$host\" $EXTRA_ARGS '&"
       else
-        $SSH "$host" "bash -c 'ACCUMULO_SERVICE_INSTANCE=${ACCUMULO_SERVICE_INSTANCE} ${bin}/accumulo-service \"$service\" \"$control_cmd\" \"-a\" \"$host\"'"
+        $SSH "$host" "bash -c 'ACCUMULO_SERVICE_INSTANCE=${ACCUMULO_SERVICE_INSTANCE} ${bin}/accumulo-service \"$service\" \"$control_cmd\" \"-a\" \"$host\"'&"
       fi
     fi
   done

--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -164,9 +164,9 @@ function control_service() {
     else
       if [[ $# -gt 3 ]]; then
         EXTRA_ARGS="${*:4}"
-        $SSH "$host" "bash -c 'ACCUMULO_SERVICE_INSTANCE=${ACCUMULO_SERVICE_INSTANCE} ${bin}/accumulo-service \"$service\" \"$control_cmd\" \"-a\" \"$host\" $EXTRA_ARGS '&"
+        $SSH "$host" "bash -c 'ACCUMULO_SERVICE_INSTANCE=${ACCUMULO_SERVICE_INSTANCE} ${bin}/accumulo-service \"$service\" \"$control_cmd\" \"-a\" \"$host\" $EXTRA_ARGS '"
       else
-        $SSH "$host" "bash -c 'ACCUMULO_SERVICE_INSTANCE=${ACCUMULO_SERVICE_INSTANCE} ${bin}/accumulo-service \"$service\" \"$control_cmd\" \"-a\" \"$host\"'&"
+        $SSH "$host" "bash -c 'ACCUMULO_SERVICE_INSTANCE=${ACCUMULO_SERVICE_INSTANCE} ${bin}/accumulo-service \"$service\" \"$control_cmd\" \"-a\" \"$host\"'"
       fi
     fi
   done

--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -149,7 +149,7 @@ function control_service() {
     # Only increment the service name when more than one service is desired.
     ACCUMULO_SERVICE_INSTANCE=""
     [[ last_instance_id -gt 1 ]] && ACCUMULO_SERVICE_INSTANCE="${inst_id}"
-    [[ $service == "compactor" || $service == "sserver" ]] && ACCUMULO_SERVICE_INSTANCE="${ACCUMULO_SERVICE_INSTANCE}_${5}"
+    [[ $service =~ ^compactor|sserver$ ]] && ACCUMULO_SERVICE_INSTANCE="${ACCUMULO_SERVICE_INSTANCE}_${5}"
 
     if [[ $host == localhost || $host == "$(hostname -s)" || $host == "$(hostname -f)" || "$(hostname -I)" =~ $host ]]; then
       #

--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -632,8 +632,11 @@ tserver:
 # compactors_per_host.
 #
 tservers_per_host: 1
-#sservers_per_host: 1
-#compactors_per_host: 1
+#sservers_per_host: 
+# - default: 1
+#compactors_per_host:
+# - q1: 1
+# - q2: 1 
 
 EOF
       ;;

--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -28,13 +28,13 @@ Commands:
   start                      Starts Accumulo cluster
   stop                       Stops Accumulo cluster
   kill                       Kills Accumulo cluster
-  start-non-tservers         Starts all services except tservers (Deprecated)
+  start-non-tservers         Deprecated. Starts all services except tservers
   start-servers [--all|--tservers|--no-tservers|--sservers [group]|--compactors [queue]]
                              Starts various server types, can optionally specify a queue or group
   stop-servers [--all|--tservers| --no-tservers|--sservers [group]|--compactors [queue]]
                              Starts various server types, can optionally specify a queue or group
-  start-tservers             Starts all tservers on cluster (Deprecated)
-  stop-tservers              Stops all tservers on cluster (Deprecated)
+  start-tservers             Deprecated. Starts all tservers on cluster
+  stop-tservers              Deprecated. Stops all tservers on cluster
   start-here                 Starts all services on this node
   stop-here                  Stops all services on this node
 EOF
@@ -192,7 +192,7 @@ function start_compactors() {
         start_service "$compactor" compactor "-q" "$queue"
       done
     else
-      echo "\"${queue}\" is not a valid queue ...exiting"
+      echo "${queue} is not a valid queue ...exiting"
     fi
   done
 }
@@ -213,7 +213,7 @@ function stop_compactors() {
         stop_service "$compactor" compactor "-q" "$queue"
       done
     else
-      echo "$queue is not a valid compaction queue ...exiting"
+      echo "${queue} is not a valid compaction queue ...exiting"
     fi
   done
 }
@@ -234,7 +234,7 @@ function start_sservers() {
         start_service "$sserver" sserver "-g" "$group"
       done
     else
-      echo "\"${group} is not a valid resource group ...exiting"
+      echo "${group} is not a valid resource group ...exiting"
     fi
   done
 }
@@ -255,7 +255,7 @@ function stop_sservers() {
         stop_service "$sserver" sserver "-g" "$group"
       done
     else
-      echo "$queue is not a valid resource group ...exiting"
+      echo "${queue} is not a valid resource group ...exiting"
     fi
   done
 }
@@ -593,7 +593,7 @@ function main() {
   case "$1" in
     create-config)
       if [[ -f "$conf"/cluster.yaml ]]; then
-        echo "ERROR : $conf/cluster.yaml already exists, not overwriting"
+        echo "ERROR : ${conf}/cluster.yaml already exists, not overwriting"
         exit 1
       fi
       cat <<EOF >"$conf"/cluster.yaml

--- a/assemble/bin/accumulo-service
+++ b/assemble/bin/accumulo-service
@@ -33,9 +33,10 @@ Services:
   sserver                Accumulo scan server (experimental)
 
 Commands:
-  start       Starts service
-  stop        Stops service
-  kill        Kills service
+  start                   Starts service(s)
+  stop [--all | [<name>]] Stops service(s)
+  kill [--all | [<name>]] Kills service(s)
+  list                    List running service(s)
 
 EOF
 }
@@ -72,7 +73,6 @@ function start_service() {
   if [[ $service == "manager" ]]; then
     "${bin}/accumulo" org.apache.accumulo.manager.state.SetGoalState NORMAL
   fi
-
   outfile="${ACCUMULO_LOG_DIR}/${service}${ACCUMULO_SERVICE_INSTANCE}_${host}.out"
   errfile="${ACCUMULO_LOG_DIR}/${service}${ACCUMULO_SERVICE_INSTANCE}_${host}.err"
   rotate_log "$outfile"
@@ -91,26 +91,77 @@ function start_service() {
   fi
 }
 
-function stop_service() {
+function control_process() {
+  kill_code=${1}
   if [[ -f $pid_file ]]; then
     echo "Stopping $service on $host"
-    kill -s TERM "$(cat "$pid_file")" 2>/dev/null
+    kill -s "$kill_code" "$(cat "$pid_file")" 2>/dev/null
     rm -f "${pid_file}" 2>/dev/null
   fi
 }
 
-function kill_service() {
-  if [[ -f $pid_file ]]; then
-    echo "Killing $service on $host"
-    kill -s KILL "$(cat "$pid_file")" 2>/dev/null
-    rm -f "${pid_file}" 2>/dev/null
+function stop_service() {
+  if [[ -n $1 ]]; then
+    case $1 in
+      "--all")
+        find_processes
+        for process in "${RUNNING_PROCESSES[@]}"; do
+          pid_file="${ACCUMULO_PID_DIR}/accumulo-${process}.pid"
+          control_process "TERM"
+        done
+        ;;
+      *"$service"*)
+        echo "Stopping service process: $1"
+        pid_file="${ACCUMULO_PID_DIR}/accumulo-${1}.pid"
+        ;;
+    esac
   fi
+  control_process "TERM"
+}
+
+function kill_service() {
+  if [[ -n $1 ]]; then
+    case $1 in
+      "--all")
+        find_processes
+        for process in "${RUNNING_PROCESSES[@]}"; do
+          pid_file="${ACCUMULO_PID_DIR}/accumulo-${process}.pid"
+          control_process "KILL"
+        done
+        ;;
+      *"$service"*)
+        pid_file="${ACCUMULO_PID_DIR}/accumulo-${1}.pid"
+        ;;
+    esac
+  fi
+  control_process "KILL"
+}
+
+function find_processes() {
+  files=$(echo "${ACCUMULO_PID_DIR}"/*)
+  for file in $files; do
+    if [[ $file == *$service* ]]; then
+      stripped_file=${file%.pid}
+      RUNNING_PROCESSES+=("${stripped_file##*accumulo-}")
+    fi
+  done
+}
+
+function list_processes() {
+  find_processes
+  echo "Currently running ${service} processes:"
+  for process in "${RUNNING_PROCESSES[@]}"; do
+    echo "$process"
+  done
 }
 
 function main() {
   if [[ -z $1 ]]; then
     invalid_args "<service> cannot be empty"
   fi
+
+  # Create a global array for process tracking
+  declare -a RUNNING_PROCESSES
 
   # Resolve base directory
   SOURCE="${BASH_SOURCE[0]}"
@@ -159,10 +210,13 @@ function main() {
           start_service "${@:3}"
           ;;
         stop)
-          stop_service
+          stop_service "${@:3:1}"
           ;;
         kill)
-          kill_service
+          kill_service "${@:3:1}"
+          ;;
+        list)
+          list_processes
           ;;
         *)
           invalid_args "'$2' is an invalid <command>"

--- a/assemble/bin/accumulo-service
+++ b/assemble/bin/accumulo-service
@@ -61,39 +61,39 @@ function rotate_log() {
 }
 
 function start_service() {
- local service_type=$1
- local service_name=$2
- shift 2;
+  local service_type=$1
+  local service_name=$2
+  shift 2
 
- local pid_file="${ACCUMULO_PID_DIR}/accumulo-${service_name}.pid"
- if [[ -f $pid_file ]]; then
-   pid=$(cat "$pid_file")
-   if kill -0 "$pid" 2>/dev/null; then
-     echo "$HOST : ${service_name} already running (${pid})"
-     exit 0
-   fi
- fi
- echo "Starting $service_name on $HOST"
+  local pid_file="${ACCUMULO_PID_DIR}/accumulo-${service_name}.pid"
+  if [[ -f $pid_file ]]; then
+    pid=$(cat "$pid_file")
+    if kill -0 "$pid" 2>/dev/null; then
+      echo "$HOST : ${service_name} already running (${pid})"
+      exit 0
+    fi
+  fi
+  echo "Starting $service_name on $HOST"
 
- if [[ ${service_type} == "manager" ]]; then
-   "${bin}/accumulo" org.apache.accumulo.manager.state.SetGoalState NORMAL
- fi
- outfile="${ACCUMULO_LOG_DIR}/${service_name}_${HOST}.out"
- errfile="${ACCUMULO_LOG_DIR}/${service_name}_${HOST}.err"
- rotate_log "$outfile"
- rotate_log "$errfile"
+  if [[ ${service_type} == "manager" ]]; then
+    "${bin}/accumulo" org.apache.accumulo.manager.state.SetGoalState NORMAL
+  fi
+  outfile="${ACCUMULO_LOG_DIR}/${service_name}_${HOST}.out"
+  errfile="${ACCUMULO_LOG_DIR}/${service_name}_${HOST}.err"
+  rotate_log "$outfile"
+  rotate_log "$errfile"
 
- nohup "${bin}/accumulo" "$service_type" "$@" >"$outfile" 2>"$errfile" </dev/null &
- echo "$!" >"${pid_file}"
+  nohup "${bin}/accumulo" "$service_type" "$@" >"$outfile" 2>"$errfile" </dev/null &
+  echo "$!" >"${pid_file}"
 
- # Check the max open files limit and selectively warn
- max_files_open=$(ulimit -n)
- if [[ -n $max_files_open ]]; then
-   max_files_recommended=32768
-   if ((max_files_open < max_files_recommended)); then
-     echo "WARN : Max open files on $HOST is $max_files_open, recommend $max_files_recommended" >&2
-   fi
- fi
+  # Check the max open files limit and selectively warn
+  max_files_open=$(ulimit -n)
+  if [[ -n $max_files_open ]]; then
+    max_files_recommended=32768
+    if ((max_files_open < max_files_recommended)); then
+      echo "WARN : Max open files on $HOST is $max_files_open, recommend $max_files_recommended" >&2
+    fi
+  fi
 }
 
 function control_process() {
@@ -140,10 +140,10 @@ function kill_service() {
   local all_flag=$3
   if $all_flag; then
     find_processes "$service_type"
-      for process in "${RUNNING_PROCESSES[@]}"; do
-        local pid_file="${ACCUMULO_PID_DIR}/accumulo-${process}.pid"
-        control_process "KILL" "$process" "$pid_file"
-      done
+    for process in "${RUNNING_PROCESSES[@]}"; do
+      local pid_file="${ACCUMULO_PID_DIR}/accumulo-${process}.pid"
+      control_process "KILL" "$process" "$pid_file"
+    done
   else
     local pid_file="${ACCUMULO_PID_DIR}/accumulo-${service_name}.pid"
     control_process "KILL" "$service_name" "$pid_file"
@@ -199,7 +199,7 @@ function main() {
 
   local service_type="$1"
   local command_name="$2"
-  shift 2;
+  shift 2
   local service_name="unknown"
   local all_flag=false
 
@@ -211,8 +211,8 @@ function main() {
   # Check and see if accumulo-cluster is calling this script
   if [ -z ${ACCUMULO_SERVICE_INSTANCE+x} ]; then
     # The rest of the arguments are from a user
-    if [[ "$1" == "--all" ]]; then
-      all_flag=true;
+    if [[ $1 == "--all" ]]; then
+      all_flag=true
     else
       # A named service has been specified
       service_name="$1"

--- a/assemble/bin/accumulo-service
+++ b/assemble/bin/accumulo-service
@@ -138,8 +138,8 @@ function kill_service() {
 }
 
 function find_processes() {
-  files=$(echo "${ACCUMULO_PID_DIR}"/*)
-  for file in $files; do
+  local file
+  for file in $ACCUMULO_PID_DIR/*; do
     if [[ $file == *$service* ]]; then
       stripped_file=${file%.pid}
       RUNNING_PROCESSES+=("${stripped_file##*accumulo-}")

--- a/assemble/bin/accumulo-service
+++ b/assemble/bin/accumulo-service
@@ -61,94 +61,99 @@ function rotate_log() {
 }
 
 function start_service() {
-  if [[ -f $pid_file ]]; then
-    pid=$(cat "$pid_file")
-    if kill -0 "$pid" 2>/dev/null; then
-      echo "$host : $service already running (${pid})"
-      exit 0
-    fi
-  fi
-  echo "Starting $service on $host"
+ local service_type=$1
+ local service_name=$2
+ shift 2;
 
-  if [[ $service == "manager" ]]; then
-    "${bin}/accumulo" org.apache.accumulo.manager.state.SetGoalState NORMAL
-  fi
-  outfile="${ACCUMULO_LOG_DIR}/${service}${ACCUMULO_SERVICE_INSTANCE}_${host}.out"
-  errfile="${ACCUMULO_LOG_DIR}/${service}${ACCUMULO_SERVICE_INSTANCE}_${host}.err"
-  rotate_log "$outfile"
-  rotate_log "$errfile"
+ local pid_file="${ACCUMULO_PID_DIR}/accumulo-${service_name}.pid"
+ if [[ -f $pid_file ]]; then
+   pid=$(cat "$pid_file")
+   if kill -0 "$pid" 2>/dev/null; then
+     echo "$HOST : ${service_name} already running (${pid})"
+     exit 0
+   fi
+ fi
+ echo "Starting $service_name on $HOST"
 
-  nohup "${bin}/accumulo" "$service" "$@" >"$outfile" 2>"$errfile" </dev/null &
-  echo "$!" >"${pid_file}"
+ if [[ ${service_type} == "manager" ]]; then
+   "${bin}/accumulo" org.apache.accumulo.manager.state.SetGoalState NORMAL
+ fi
+ outfile="${ACCUMULO_LOG_DIR}/${service_name}_${HOST}.out"
+ errfile="${ACCUMULO_LOG_DIR}/${service_name}_${HOST}.err"
+ rotate_log "$outfile"
+ rotate_log "$errfile"
 
-  # Check the max open files limit and selectively warn
-  max_files_open=$(ulimit -n)
-  if [[ -n $max_files_open ]]; then
-    max_files_recommended=32768
-    if ((max_files_open < max_files_recommended)); then
-      echo "WARN : Max open files on $host is $max_files_open, recommend $max_files_recommended" >&2
-    fi
-  fi
+ nohup "${bin}/accumulo" "$service_type" "$@" >"$outfile" 2>"$errfile" </dev/null &
+ echo "$!" >"${pid_file}"
+
+ # Check the max open files limit and selectively warn
+ max_files_open=$(ulimit -n)
+ if [[ -n $max_files_open ]]; then
+   max_files_recommended=32768
+   if ((max_files_open < max_files_recommended)); then
+     echo "WARN : Max open files on $HOST is $max_files_open, recommend $max_files_recommended" >&2
+   fi
+ fi
 }
 
 function control_process() {
   local kill_code=$1
+  local service_name=$2
+  local pid_file=$3
   if [[ -f $pid_file ]]; then
-    echo "Stopping $service on $host"
+    echo "Stopping $service_name on $HOST"
     kill -s "$kill_code" "$(cat "$pid_file")" 2>/dev/null
     rm -f "${pid_file}" 2>/dev/null
   fi
 }
 
 function find_processes() {
+  local service_type=$1
   local file
   for file in "$ACCUMULO_PID_DIR"/*; do
-    if file=$(expr "$file" : '^.*/accumulo-\('"$service"'.*\)[.]pid$'); then
+    if file=$(expr "$file" : '^.*/accumulo-\('"$service_type"'.*\)[.]pid$'); then
       RUNNING_PROCESSES+=("$file")
     fi
   done
 }
 
 function stop_service() {
-  if [[ -n $1 ]]; then
-    case $1 in
-      "--all")
-        find_processes
-        for process in "${RUNNING_PROCESSES[@]}"; do
-          pid_file="${ACCUMULO_PID_DIR}/accumulo-${process}.pid"
-          control_process "TERM"
-        done
-        ;;
-      *"$service"*)
-        echo "Stopping service process: $1"
-        pid_file="${ACCUMULO_PID_DIR}/accumulo-${1}.pid"
-        ;;
-    esac
+  local service_type=$1
+  local service_name=$2
+  local all_flag=$3
+  if $all_flag; then
+    find_processes "$service_type"
+    for process in "${RUNNING_PROCESSES[@]}"; do
+      local pid_file="${ACCUMULO_PID_DIR}/accumulo-${process}.pid"
+      control_process "TERM" "$process" "$pid_file"
+    done
+  else
+    echo "Stopping service process: $service_name"
+    local pid_file="${ACCUMULO_PID_DIR}/accumulo-${service_name}.pid"
+    control_process "TERM" "$service_name" "$pid_file"
   fi
-  control_process "TERM"
 }
 
 function kill_service() {
-  if [[ -n $1 ]]; then
-    case $1 in
-      "--all")
-        find_processes
-        for process in "${RUNNING_PROCESSES[@]}"; do
-          pid_file="${ACCUMULO_PID_DIR}/accumulo-${process}.pid"
-          control_process "KILL"
-        done
-        ;;
-      *"$service"*)
-        pid_file="${ACCUMULO_PID_DIR}/accumulo-${1}.pid"
-        ;;
-    esac
+  local service_type=$1
+  local service_name=$2
+  local all_flag=$3
+  if $all_flag; then
+    find_processes "$service_type"
+      for process in "${RUNNING_PROCESSES[@]}"; do
+        local pid_file="${ACCUMULO_PID_DIR}/accumulo-${process}.pid"
+        control_process "KILL" "$process" "$pid_file"
+      done
+  else
+    local pid_file="${ACCUMULO_PID_DIR}/accumulo-${service_name}.pid"
+    control_process "KILL" "$service_name" "$pid_file"
   fi
-  control_process "KILL"
 }
 
 function list_processes() {
-  find_processes
-  echo "Currently running ${service} processes:"
+  local service_type=$1
+  find_processes "$service_type"
+  echo "Currently running ${service_type} processes:"
   for process in "${RUNNING_PROCESSES[@]}"; do
     echo "$process"
   done
@@ -187,43 +192,61 @@ function main() {
   mkdir -p "$ACCUMULO_LOG_DIR" 2>/dev/null
   mkdir -p "$ACCUMULO_PID_DIR" 2>/dev/null
 
-  host="$(hostname)"
-  if [[ -z $host ]]; then
-    host=$(ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
+  HOST="$(hostname)"
+  if [[ -z $HOST ]]; then
+    HOST=$(ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
   fi
-  service="$1"
 
-  if [[ $service == "master" ]]; then
+  local service_type="$1"
+  local command_name="$2"
+  shift 2;
+  local service_name="unknown"
+  local all_flag=false
+
+  if [[ $service_type == "master" ]]; then
     echo "WARN : Use of 'master' service name is deprecated; use 'manager' instead."
-    service="manager"
+    service_type="manager"
   fi
 
-  pid_file="${ACCUMULO_PID_DIR}/accumulo-${service}${ACCUMULO_SERVICE_INSTANCE}.pid"
-  case "$service" in
+  # Check and see if accumulo-cluster is calling this script
+  if [ -z ${ACCUMULO_SERVICE_INSTANCE+x} ]; then
+    # The rest of the arguments are from a user
+    if [[ "$1" == "--all" ]]; then
+      all_flag=true;
+    else
+      # A named service has been specified
+      service_name="$1"
+    fi
+  # Use the special bash env var from accumulo-cluster
+  else
+    service_name=${service_type}${ACCUMULO_SERVICE_INSTANCE}
+  fi
+
+  case "$service_type" in
     gc | manager | monitor | tserver | compaction-coordinator | compactor | sserver)
-      if [[ -z $2 ]]; then
+      if [ -z ${command_name+z} ]; then
         invalid_args "<command> cannot be empty"
       fi
-      case "$2" in
+      case "$command_name" in
         start)
-          start_service "${@:3}"
+          start_service "$service_type" "$service_name" "$@"
           ;;
         stop)
-          stop_service "${@:3:1}"
+          stop_service "$service_type" "$service_name" $all_flag
           ;;
         kill)
-          kill_service "${@:3:1}"
+          kill_service "$service_type" "$service_name" $all_flag
           ;;
         list)
-          list_processes
+          list_processes "$service_type"
           ;;
         *)
-          invalid_args "'$2' is an invalid <command>"
+          invalid_args "'$command_name' is an invalid <command>"
           ;;
       esac
       ;;
     *)
-      invalid_args "'$service' is an invalid <service>"
+      invalid_args "'$service_type' is an invalid <service>"
       ;;
   esac
 }

--- a/assemble/bin/accumulo-service
+++ b/assemble/bin/accumulo-service
@@ -209,7 +209,7 @@ function main() {
   fi
 
   # Check and see if accumulo-cluster is calling this script
-  if [ -z ${ACCUMULO_SERVICE_INSTANCE+x} ]; then
+  if [[ -z $ACCUMULO_SERVICE_INSTANCE ]]; then
     # The rest of the arguments are from a user
     if [[ $1 == "--all" ]]; then
       all_flag=true
@@ -224,7 +224,7 @@ function main() {
 
   case "$service_type" in
     gc | manager | monitor | tserver | compaction-coordinator | compactor | sserver)
-      if [ -z ${command_name+z} ]; then
+      if [[ -z $command_name ]]; then
         invalid_args "<command> cannot be empty"
       fi
       case "$command_name" in

--- a/assemble/bin/accumulo-service
+++ b/assemble/bin/accumulo-service
@@ -26,7 +26,7 @@ Services:
   gc                     Accumulo garbage collector
   monitor                Accumulo monitor
   manager                Accumulo manager
-  master                 Accumulo master (Deprecated)
+  master                 Deprecated. Accumulo master
   tserver                Accumulo tserver
   compaction-coordinator Accumulo compaction coordinator (experimental)
   compactor              Accumulo compactor (experimental)
@@ -92,12 +92,21 @@ function start_service() {
 }
 
 function control_process() {
-  kill_code=${1}
+  local kill_code=$1
   if [[ -f $pid_file ]]; then
     echo "Stopping $service on $host"
     kill -s "$kill_code" "$(cat "$pid_file")" 2>/dev/null
     rm -f "${pid_file}" 2>/dev/null
   fi
+}
+
+function find_processes() {
+  local file
+  for file in "$ACCUMULO_PID_DIR"/*; do
+    if file=$(expr "$file" : '^.*/accumulo-\('"$service"'.*\)[.]pid$'); then
+      RUNNING_PROCESSES+=("$file")
+    fi
+  done
 }
 
 function stop_service() {
@@ -135,16 +144,6 @@ function kill_service() {
     esac
   fi
   control_process "KILL"
-}
-
-function find_processes() {
-  local file
-  for file in $ACCUMULO_PID_DIR/*; do
-    if [[ $file == *$service* ]]; then
-      stripped_file=${file%.pid}
-      RUNNING_PROCESSES+=("${stripped_file##*accumulo-}")
-    fi
-  done
 }
 
 function list_processes() {

--- a/core/src/test/java/org/apache/accumulo/core/conf/cluster/ClusterConfigParserTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/cluster/ClusterConfigParserTest.java
@@ -85,7 +85,7 @@ public class ClusterConfigParserTest {
     Map<String,String> contents =
         ClusterConfigParser.parseConfiguration(new File(configFile.toURI()).getAbsolutePath());
 
-    assertEquals(13, contents.size());
+    assertEquals(16, contents.size());
     assertTrue(contents.containsKey("manager"));
     assertEquals("localhost1 localhost2", contents.get("manager"));
     assertTrue(contents.containsKey("monitor"));
@@ -111,10 +111,16 @@ public class ClusterConfigParserTest {
     assertEquals("burstyvm1 burstyvm2", contents.get("sserver.cheap"));
     assertTrue(contents.containsKey("tservers_per_host"));
     assertEquals("2", contents.get("tservers_per_host"));
-    assertTrue(contents.containsKey("sservers_per_host"));
-    assertEquals("2", contents.get("sservers_per_host"));
-    assertTrue(contents.containsKey("compactors_per_host"));
-    assertEquals("3", contents.get("compactors_per_host"));
+    assertTrue(contents.containsKey("sservers_per_host.default"));
+    assertEquals("1", contents.get("sservers_per_host.default"));
+    assertTrue(contents.containsKey("sservers_per_host.highmem"));
+    assertEquals("2", contents.get("sservers_per_host.highmem"));
+    assertTrue(contents.containsKey("sservers_per_host.cheap"));
+    assertEquals("3", contents.get("sservers_per_host.cheap"));
+    assertTrue(contents.containsKey("compactors_per_host.q1"));
+    assertEquals("3", contents.get("compactors_per_host.q1"));
+    assertTrue(contents.containsKey("compactors_per_host.q2"));
+    assertEquals("1", contents.get("compactors_per_host.q2"));
   }
 
   @Test
@@ -172,8 +178,6 @@ public class ClusterConfigParserTest {
     expected.put("GC_HOSTS", "localhost");
     expected.put("TSERVER_HOSTS", "localhost1 localhost2 localhost3 localhost4");
     expected.put("NUM_TSERVERS", "${NUM_TSERVERS:=1}");
-    expected.put("NUM_SSERVERS", "${NUM_SSERVERS:=1}");
-    expected.put("NUM_COMPACTORS", "${NUM_COMPACTORS:=1}");
 
     expected.replaceAll((k, v) -> '"' + v + '"');
 
@@ -231,8 +235,11 @@ public class ClusterConfigParserTest {
     expected.put("SSERVER_HOSTS_highmem", "hmvm1 hmvm2 hmvm3");
     expected.put("SSERVER_HOSTS_cheap", "burstyvm1 burstyvm2");
     expected.put("NUM_TSERVERS", "${NUM_TSERVERS:=2}");
-    expected.put("NUM_SSERVERS", "${NUM_SSERVERS:=2}");
-    expected.put("NUM_COMPACTORS", "${NUM_COMPACTORS:=3}");
+    expected.put("NUM_COMPACTORS_q1", "3");
+    expected.put("NUM_COMPACTORS_q2", "1");
+    expected.put("NUM_SSERVERS_default", "1");
+    expected.put("NUM_SSERVERS_highmem", "2");
+    expected.put("NUM_SSERVERS_cheap", "3");
 
     expected.replaceAll((k, v) -> {
       return '"' + v + '"';

--- a/core/src/test/resources/org/apache/accumulo/core/conf/cluster/cluster-with-optional-services.yaml
+++ b/core/src/test/resources/org/apache/accumulo/core/conf/cluster/cluster-with-optional-services.yaml
@@ -59,5 +59,10 @@ compaction:
         - localhost4
 
 tservers_per_host: 2
-sservers_per_host: 2
-compactors_per_host: 3
+sservers_per_host:
+  - default : 1
+  - highmem : 2
+  - cheap : 3
+compactors_per_host:
+  - q1 : 3
+  - q2 : 1


### PR DESCRIPTION
Adds the ability to start and stop compactors and scan servers by compaction queue or scan server group.

This is important when attempting to run scan servers or compactors and not want to stop/start other accumulo services (gc, monitor, manager, compaction-coordinator). 
