### PR TITLE
Fix ReturnValueIgnored on IdleProcessMetricsIT

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/functional/IdleProcessMetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/IdleProcessMetricsIT.java
@@ -18,11 +18,13 @@
  */
 package org.apache.accumulo.test.functional;
 
+import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.MAX_DATA;
 import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.QUEUE1;
 import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.compact;
 import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.createTable;
 import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.verify;
 import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.writeData;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
@@ -30,7 +32,6 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Function;
 
 import org.apache.accumulo.compactor.Compactor;
 import org.apache.accumulo.coordinator.CompactionCoordinator;
@@ -220,7 +221,7 @@ public class IdleProcessMetricsIT extends SharedMiniClusterBase {
 
       try (Scanner scanner = client.createScanner(table1, Authorizations.EMPTY)) {
         scanner.setConsistencyLevel(ScannerBase.ConsistencyLevel.EVENTUAL);
-        scanner.stream().forEach(Function.identity()::apply); // iterate and ignore
+        assertEquals(MAX_DATA, scanner.stream().count()); // Ensure that data exists
       }
 
       log.info("Waiting for sserver to be not idle after starting a scan");


### PR DESCRIPTION
Fixes the compliation error with IdleProcessMetricsIT for not using the return value of the stream.