### PR TITLE
Modifications to make compaction queue size dynamic

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -449,7 +449,7 @@ public enum Property {
       "manager.compaction.major.service.queue.initial.size", "10000", PropertyType.COUNT,
       "The initial size of each resource groups compaction job priority queue.", "4.0.0"),
   MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_SIZE_FACTOR(
-      "manager.compaction.major.service.queue.size.factor", "1.5", PropertyType.FRACTION,
+      "manager.compaction.major.service.queue.size.factor", "3.0", PropertyType.FRACTION,
       "The dynamic resizing of the compaction job priority queue is based on"
           + " the number of compactors for the group multiplied by this factor.",
       "4.0.0"),
@@ -1440,7 +1440,6 @@ public enum Property {
 
       // compaction coordiantor properties
       MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_INITIAL_SIZE,
-      MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_SIZE_FACTOR,
 
       // block cache options
       TSERV_CACHE_MANAGER_IMPL, TSERV_DATACACHE_SIZE, TSERV_INDEXCACHE_SIZE,

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -445,9 +445,14 @@ public enum Property {
   MANAGER_SPLIT_WORKER_THREADS("manager.split.inspection.threadpool.size", "8", PropertyType.COUNT,
       "The number of threads used to inspect tablets files to find split points.", "4.0.0"),
 
-  MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_SIZE("manager.compaction.major.service.queue.size",
-      "10000", PropertyType.COUNT,
-      "The max size of each resource groups compaction job priority queue.", "4.0"),
+  MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_INITIAL_SIZE(
+      "manager.compaction.major.service.queue.initial.size", "10000", PropertyType.COUNT,
+      "The initial size of each resource groups compaction job priority queue.", "4.0.0"),
+  MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_SIZE_FACTOR(
+      "manager.compaction.major.service.queue.size.factor", "1.5", PropertyType.FRACTION,
+      "The dynamic resizing of the compaction job priority queue is based on"
+          + " the number of compactors for the group multiplied by this factor.",
+      "4.0.0"),
   SPLIT_PREFIX("split.", null, PropertyType.PREFIX,
       "System wide properties related to splitting tablets.", "3.1.0"),
   SPLIT_MAXOPEN("split.files.max", "300", PropertyType.COUNT,
@@ -1432,6 +1437,10 @@ public enum Property {
 
       // max message options
       RPC_MAX_MESSAGE_SIZE,
+
+      // compaction coordiantor properties
+      MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_INITIAL_SIZE,
+      MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_SIZE_FACTOR,
 
       // block cache options
       TSERV_CACHE_MANAGER_IMPL, TSERV_DATACACHE_SIZE, TSERV_INDEXCACHE_SIZE,

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
@@ -188,8 +188,8 @@ public class MiniAccumuloConfigImpl {
 
       mergeProp(Property.COMPACTOR_PORTSEARCH.getKey(), "true");
 
-      mergeProp(Property.MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_SIZE.getKey(),
-          Property.MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_SIZE.getDefaultValue());
+      mergeProp(Property.MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_INITIAL_SIZE.getKey(),
+          Property.MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_INITIAL_SIZE.getDefaultValue());
       mergeProp(Property.COMPACTION_SERVICE_DEFAULT_PLANNER.getKey(),
           Property.COMPACTION_SERVICE_DEFAULT_PLANNER.getDefaultValue());
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -1103,8 +1103,7 @@ public class Manager extends AbstractServer
     // Start the Manager's Fate Service
     fateServiceHandler = new FateServiceHandler(this);
     managerClientHandler = new ManagerClientServiceHandler(this);
-    compactionCoordinator =
-        new CompactionCoordinator(context, security, fateRefs, getResourceGroup(), this);
+    compactionCoordinator = new CompactionCoordinator(context, security, fateRefs, this);
 
     // Start the Manager's Client service
     // Ensure that calls before the manager gets the lock fail

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
@@ -117,6 +117,7 @@ import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.compaction.coordinator.commit.CommitCompaction;
 import org.apache.accumulo.manager.compaction.coordinator.commit.CompactionCommitData;
 import org.apache.accumulo.manager.compaction.coordinator.commit.RenameCompactionFile;
+import org.apache.accumulo.manager.compaction.queue.CompactionJobPriorityQueue;
 import org.apache.accumulo.manager.compaction.queue.CompactionJobQueues;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.compaction.CompactionConfigStorage;
@@ -183,7 +184,7 @@ public class CompactionCoordinator
   private final Manager manager;
 
   private final LoadingCache<String,Integer> compactorCounts;
-  private final double queueSizeFactor;
+  private final int jobQueueInitialSize;
 
   public CompactionCoordinator(ServerContext ctx, SecurityOperation security,
       AtomicReference<Map<FateInstanceType,Fate<Manager>>> fateInstances, Manager manager) {
@@ -192,11 +193,10 @@ public class CompactionCoordinator
     this.security = security;
     this.manager = Objects.requireNonNull(manager);
 
-    this.jobQueues = new CompactionJobQueues(ctx.getConfiguration()
-        .getCount(Property.MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_INITIAL_SIZE));
+    this.jobQueueInitialSize = ctx.getConfiguration()
+        .getCount(Property.MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_INITIAL_SIZE);
 
-    this.queueSizeFactor = ctx.getConfiguration()
-        .getFraction(Property.MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_SIZE_FACTOR);
+    this.jobQueues = new CompactionJobQueues(jobQueueInitialSize);
 
     this.queueMetrics = new QueueMetrics(jobQueues);
 
@@ -1068,7 +1068,9 @@ public class CompactionCoordinator
   private void cleanUpCompactors() {
     final String compactorQueuesPath = this.ctx.getZooKeeperRoot() + Constants.ZCOMPACTORS;
 
-    var zoorw = this.ctx.getZooReaderWriter();
+    final var zoorw = this.ctx.getZooReaderWriter();
+    final double queueSizeFactor = ctx.getConfiguration()
+        .getFraction(Property.MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_SIZE_FACTOR);
 
     try {
       var groups = zoorw.getChildren(compactorQueuesPath);
@@ -1082,7 +1084,11 @@ public class CompactionCoordinator
           deleteEmpty(zoorw, qpath);
           // Group has no compactors, we can clear its
           // associated priority queue of jobs
-          getJobQueues().getQueue(cgid).clear();
+          CompactionJobPriorityQueue queue = getJobQueues().getQueue(cgid);
+          if (queue != null) {
+            queue.clear();
+            queue.setMaxSize(this.jobQueueInitialSize);
+          }
         } else {
           int aliveCompactorsForGroup = 0;
           for (String compactor : compactors) {
@@ -1094,8 +1100,12 @@ public class CompactionCoordinator
               aliveCompactorsForGroup++;
             }
           }
-          getJobQueues().getQueue(cgid).setMaxSize(
-              Math.min((int) (aliveCompactorsForGroup * queueSizeFactor), Integer.MAX_VALUE));
+          CompactionJobPriorityQueue queue = getJobQueues().getQueue(cgid);
+          if (queue != null) {
+            queue.setMaxSize(
+                Math.min((int) (aliveCompactorsForGroup * queueSizeFactor), Integer.MAX_VALUE));
+          }
+
         }
 
       }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/queue/CompactionJobPriorityQueue.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/queue/CompactionJobPriorityQueue.java
@@ -202,7 +202,7 @@ public class CompactionJobPriorityQueue {
     return jobsAdded;
   }
 
-  public int getMaxSize() {
+  public synchronized int getMaxSize() {
     return maxSize.get();
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/queue/CompactionJobQueues.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/queue/CompactionJobQueues.java
@@ -164,7 +164,7 @@ public class CompactionJobQueues {
    */
   public CompletableFuture<MetaJob> getAsync(CompactorGroupId groupId) {
     var pq = priorityQueues.computeIfAbsent(groupId,
-        gid -> new CompactionJobPriorityQueue(gid, queueSize));
+        gid -> new CompactionJobPriorityQueue(gid, () -> queueSize));
     return pq.getAsync();
   }
 
@@ -187,7 +187,7 @@ public class CompactionJobQueues {
     }
 
     var pq = priorityQueues.computeIfAbsent(groupId,
-        gid -> new CompactionJobPriorityQueue(gid, queueSize));
+        gid -> new CompactionJobPriorityQueue(gid, () -> queueSize));
     pq.add(tabletMetadata, jobs,
         currentGenerations.get(DataLevel.of(tabletMetadata.getTableId())).get());
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/queue/CompactionJobQueues.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/queue/CompactionJobQueues.java
@@ -164,7 +164,7 @@ public class CompactionJobQueues {
    */
   public CompletableFuture<MetaJob> getAsync(CompactorGroupId groupId) {
     var pq = priorityQueues.computeIfAbsent(groupId,
-        gid -> new CompactionJobPriorityQueue(gid, () -> queueSize));
+        gid -> new CompactionJobPriorityQueue(gid, queueSize));
     return pq.getAsync();
   }
 
@@ -187,7 +187,7 @@ public class CompactionJobQueues {
     }
 
     var pq = priorityQueues.computeIfAbsent(groupId,
-        gid -> new CompactionJobPriorityQueue(gid, () -> queueSize));
+        gid -> new CompactionJobPriorityQueue(gid, queueSize));
     pq.add(tabletMetadata, jobs,
         currentGenerations.get(DataLevel.of(tabletMetadata.getTableId())).get());
   }

--- a/server/manager/src/test/java/org/apache/accumulo/manager/compaction/CompactionCoordinatorTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/compaction/CompactionCoordinatorTest.java
@@ -130,7 +130,7 @@ public class CompactionCoordinatorTest {
 
     public TestCoordinator(ServerContext ctx, SecurityOperation security,
         List<RunningCompaction> runningCompactions, Manager manager) {
-      super(ctx, security, fateInstances, "TEST_GROUP", manager);
+      super(ctx, security, fateInstances, manager);
       this.runningCompactions = runningCompactions;
     }
 

--- a/server/manager/src/test/java/org/apache/accumulo/manager/compaction/queue/CompactionJobPriorityQueueTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/compaction/queue/CompactionJobPriorityQueueTest.java
@@ -71,7 +71,7 @@ public class CompactionJobPriorityQueueTest {
 
     EasyMock.replay(tm, cj1, cj2);
 
-    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, 2);
+    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, () -> 2);
     assertEquals(1, queue.add(tm, List.of(cj1), 1L));
 
     MetaJob job = queue.peek();
@@ -126,7 +126,7 @@ public class CompactionJobPriorityQueueTest {
 
     EasyMock.replay(tm, cj1, cj2);
 
-    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, 2);
+    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, () -> 2);
     assertEquals(2, queue.add(tm, List.of(cj1, cj2), 1L));
 
     EasyMock.verify(tm, cj1, cj2);
@@ -183,7 +183,7 @@ public class CompactionJobPriorityQueueTest {
 
     EasyMock.replay(tm, cj1, cj2, cj3);
 
-    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, 2);
+    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, () -> 2);
     assertEquals(2, queue.add(tm, List.of(cj1, cj2, cj3), 1L));
 
     EasyMock.verify(tm, cj1, cj2, cj3);
@@ -239,7 +239,7 @@ public class CompactionJobPriorityQueueTest {
 
     TreeSet<CompactionJob> expected = new TreeSet<>(CompactionJobPrioritizer.JOB_COMPARATOR);
 
-    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, 100);
+    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, () -> 100);
 
     // create and add 1000 jobs
     for (int x = 0; x < 1000; x++) {
@@ -273,7 +273,7 @@ public class CompactionJobPriorityQueueTest {
    */
   @Test
   public void testAsyncCancelCleanup() {
-    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, 100);
+    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, () -> 100);
 
     List<CompletableFuture<MetaJob>> futures = new ArrayList<>();
 
@@ -300,4 +300,13 @@ public class CompactionJobPriorityQueueTest {
         < 2 * (CompactionJobPriorityQueue.FUTURE_CHECK_THRESHOLD + CANCEL_THRESHOLD));
     assertTrue(maxFuturesSize > 2 * CompactionJobPriorityQueue.FUTURE_CHECK_THRESHOLD);
   }
+
+  @Test
+  public void testChangeMaxSize() {
+    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, () -> 100);
+    assertEquals(100, queue.getMaxSize());
+    queue.setMaxSize(50);
+    assertEquals(50, queue.getMaxSize());
+  }
+
 }

--- a/server/manager/src/test/java/org/apache/accumulo/manager/compaction/queue/CompactionJobPriorityQueueTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/compaction/queue/CompactionJobPriorityQueueTest.java
@@ -71,7 +71,7 @@ public class CompactionJobPriorityQueueTest {
 
     EasyMock.replay(tm, cj1, cj2);
 
-    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, () -> 2);
+    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, 2);
     assertEquals(1, queue.add(tm, List.of(cj1), 1L));
 
     MetaJob job = queue.peek();
@@ -126,7 +126,7 @@ public class CompactionJobPriorityQueueTest {
 
     EasyMock.replay(tm, cj1, cj2);
 
-    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, () -> 2);
+    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, 2);
     assertEquals(2, queue.add(tm, List.of(cj1, cj2), 1L));
 
     EasyMock.verify(tm, cj1, cj2);
@@ -183,7 +183,7 @@ public class CompactionJobPriorityQueueTest {
 
     EasyMock.replay(tm, cj1, cj2, cj3);
 
-    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, () -> 2);
+    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, 2);
     assertEquals(2, queue.add(tm, List.of(cj1, cj2, cj3), 1L));
 
     EasyMock.verify(tm, cj1, cj2, cj3);
@@ -239,7 +239,7 @@ public class CompactionJobPriorityQueueTest {
 
     TreeSet<CompactionJob> expected = new TreeSet<>(CompactionJobPrioritizer.JOB_COMPARATOR);
 
-    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, () -> 100);
+    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, 100);
 
     // create and add 1000 jobs
     for (int x = 0; x < 1000; x++) {
@@ -273,7 +273,7 @@ public class CompactionJobPriorityQueueTest {
    */
   @Test
   public void testAsyncCancelCleanup() {
-    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, () -> 100);
+    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, 100);
 
     List<CompletableFuture<MetaJob>> futures = new ArrayList<>();
 
@@ -303,7 +303,7 @@ public class CompactionJobPriorityQueueTest {
 
   @Test
   public void testChangeMaxSize() {
-    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, () -> 100);
+    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, 100);
     assertEquals(100, queue.getMaxSize());
     queue.setMaxSize(50);
     assertEquals(50, queue.getMaxSize());

--- a/test/src/main/java/org/apache/accumulo/test/compaction/CompactionPriorityQueueMetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/CompactionPriorityQueueMetricsIT.java
@@ -196,7 +196,7 @@ public class CompactionPriorityQueueMetricsIT extends SharedMiniClusterBase {
           Property.COMPACTION_SERVICE_PREFIX.getKey() + QUEUE1_SERVICE + ".planner.opts.groups",
           "[{'group':'" + QUEUE1 + "'}]");
 
-      cfg.setProperty(Property.MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_SIZE, "6");
+      cfg.setProperty(Property.MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_INITIAL_SIZE, "6");
       cfg.getClusterServerConfiguration().addCompactorResourceGroup(QUEUE1, 0);
 
       // This test waits for dead compactors to be absent in zookeeper. The following setting will


### PR DESCRIPTION
Modified the logic in CompactionCoordinator to clear the priority queue for a compactor group when there are no compactors remaining or to set the max size based on the number of remaining compactors multiplied by some factor set by the user.

Closes #3635