### PR TITLE
Add metrics for User fate transactions

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/FateMetricValues.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/FateMetricValues.java
@@ -24,11 +24,7 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import org.apache.accumulo.core.fate.AdminUtil;
-import org.apache.accumulo.core.fate.FateInstanceType;
 import org.apache.accumulo.core.fate.ReadOnlyFateStore;
-import org.apache.accumulo.server.ServerContext;
-import org.apache.zookeeper.KeeperException;
-import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,39 +32,26 @@ import org.slf4j.LoggerFactory;
  * Immutable class that holds a snapshot of fate metric values - use builder to instantiate an
  * instance.
  */
-class FateMetricValues {
+public abstract class FateMetricValues {
 
   private static final Logger log = LoggerFactory.getLogger(FateMetricValues.class);
 
-  private final long updateTime;
-  private final long currentFateOps;
-  private final long zkFateChildOpsTotal;
-  private final long zkConnectionErrors;
+  protected final long updateTime;
+  protected final long currentFateOps;
 
-  private final Map<String,Long> txStateCounters;
-  private final Map<String,Long> opTypeCounters;
+  protected final Map<String,Long> txStateCounters;
+  protected final Map<String,Long> opTypeCounters;
 
-  private FateMetricValues(final long updateTime, final long currentFateOps,
-      final long zkFateChildOpsTotal, final long zkConnectionErrors,
+  protected FateMetricValues(final long updateTime, final long currentFateOps,
       final Map<String,Long> txStateCounters, final Map<String,Long> opTypeCounters) {
     this.updateTime = updateTime;
     this.currentFateOps = currentFateOps;
-    this.zkFateChildOpsTotal = zkFateChildOpsTotal;
-    this.zkConnectionErrors = zkConnectionErrors;
     this.txStateCounters = txStateCounters;
     this.opTypeCounters = opTypeCounters;
   }
 
-  long getCurrentFateOps() {
+  public long getCurrentFateOps() {
     return currentFateOps;
-  }
-
-  long getZkFateChildOpsTotal() {
-    return zkFateChildOpsTotal;
-  }
-
-  long getZkConnectionErrors() {
-    return zkConnectionErrors;
   }
 
   /**
@@ -76,7 +59,7 @@ class FateMetricValues {
    *
    * @return a map of transaction status counters.
    */
-  Map<String,Long> getTxStateCounters() {
+  public Map<String,Long> getTxStateCounters() {
     return txStateCounters;
   }
 
@@ -87,107 +70,62 @@ class FateMetricValues {
    *
    * @return a map of operation type counters.
    */
-  Map<String,Long> getOpTypeCounters() {
+  public Map<String,Long> getOpTypeCounters() {
     return opTypeCounters;
   }
 
-  /**
-   * The FATE transaction stores the transaction type as a debug string in the transaction zknode.
-   * This method returns a map of counters of the current occurrences of each operation type that is
-   * IN_PROGRESS
-   *
-   * @param context Accumulo context
-   * @param fateRootPath the zookeeper path to fate info
-   * @param metaFateStore a readonly MetaFateStore
-   * @return the current FATE metric values.
-   */
-  public static FateMetricValues getFromZooKeeper(final ServerContext context,
-      final String fateRootPath, final ReadOnlyFateStore<FateMetrics> metaFateStore) {
+  protected static <T extends AbstractBuilder<T,U>,U extends FateMetricValues> T
+      getFateMetrics(final ReadOnlyFateStore<FateMetrics<U>> fateStore, T builder) {
 
-    FateMetricValues.Builder builder = FateMetricValues.builder();
+    AdminUtil<FateMetrics<U>> admin = new AdminUtil<>(false);
 
-    AdminUtil<FateMetrics> admin = new AdminUtil<>(false);
+    List<AdminUtil.TransactionStatus> currFates =
+        admin.getTransactionStatus(Map.of(fateStore.type(), fateStore), null, null, null);
 
-    try {
+    builder.withCurrentFateOps(currFates.size());
 
-      List<AdminUtil.TransactionStatus> currFates = admin
-          .getTransactionStatus(Map.of(FateInstanceType.META, metaFateStore), null, null, null);
-
-      builder.withCurrentFateOps(currFates.size());
-
-      // states are enumerated - create new map with counts initialized to 0.
-      Map<String,Long> states = new TreeMap<>();
-      for (ReadOnlyFateStore.TStatus t : ReadOnlyFateStore.TStatus.values()) {
-        states.put(t.name(), 0L);
-      }
-
-      // op types are dynamic, no count initialization needed - clearing prev values will
-      // need to be handled by the caller - this is just the counts for current op types.
-      Map<String,Long> opTypeCounters = new TreeMap<>();
-
-      for (AdminUtil.TransactionStatus tx : currFates) {
-
-        String stateName = tx.getStatus().name();
-
-        // incr count for state
-        states.merge(stateName, 1L, Long::sum);
-
-        // incr count for op type for for in_progress transactions.
-        if (ReadOnlyFateStore.TStatus.IN_PROGRESS.equals(tx.getStatus())) {
-          String opType = tx.getTxName();
-          if (opType == null || opType.isEmpty()) {
-            opType = "UNKNOWN";
-          }
-          opTypeCounters.merge(opType, 1L, Long::sum);
-        }
-      }
-
-      builder.withTxStateCounters(states);
-      builder.withOpTypeCounters(opTypeCounters);
-
-      Stat node = context.getZooReaderWriter().getZooKeeper().exists(fateRootPath, false);
-      builder.withZkFateChildOpsTotal(node.getCversion());
-
-      if (log.isTraceEnabled()) {
-        log.trace(
-            "ZkNodeStat: {czxid: {}, mzxid: {}, pzxid: {}, ctime: {}, mtime: {}, "
-                + "version: {}, cversion: {}, num children: {}",
-            node.getCzxid(), node.getMzxid(), node.getPzxid(), node.getCtime(), node.getMtime(),
-            node.getVersion(), node.getCversion(), node.getNumChildren());
-      }
-
-    } catch (KeeperException ex) {
-      log.debug("Error connecting to ZooKeeper", ex);
-      builder.incrZkConnectionErrors();
-    } catch (InterruptedException ex) {
-      Thread.currentThread().interrupt();
+    // states are enumerated - create new map with counts initialized to 0.
+    Map<String,Long> states = new TreeMap<>();
+    for (ReadOnlyFateStore.TStatus t : ReadOnlyFateStore.TStatus.values()) {
+      states.put(t.name(), 0L);
     }
 
-    return builder.build();
+    // op types are dynamic, no count initialization needed - clearing prev values will
+    // need to be handled by the caller - this is just the counts for current op types.
+    Map<String,Long> opTypeCounters = new TreeMap<>();
+
+    for (AdminUtil.TransactionStatus tx : currFates) {
+
+      String stateName = tx.getStatus().name();
+
+      // incr count for state
+      states.merge(stateName, 1L, Long::sum);
+
+      // incr count for op type for for in_progress transactions.
+      if (ReadOnlyFateStore.TStatus.IN_PROGRESS.equals(tx.getStatus())) {
+        String opType = tx.getTxName();
+        if (opType == null || opType.isEmpty()) {
+          opType = "UNKNOWN";
+        }
+        opTypeCounters.merge(opType, 1L, Long::sum);
+      }
+    }
+
+    builder.withTxStateCounters(states);
+    builder.withOpTypeCounters(opTypeCounters);
+
+    return builder;
   }
 
-  @Override
-  public String toString() {
-    return "FateMetricValues{updateTime=" + updateTime + ", currentFateOps=" + currentFateOps
-        + ", zkFateChildOpsTotal=" + zkFateChildOpsTotal + ", zkConnectionErrors="
-        + zkConnectionErrors + '}';
-  }
+  @SuppressWarnings("unchecked")
+  protected static abstract class AbstractBuilder<T extends AbstractBuilder<T,U>,
+      U extends FateMetricValues> {
 
-  public static Builder builder() {
-    return new Builder();
-  }
+    protected long currentFateOps = 0;
+    protected final Map<String,Long> txStateCounters;
+    protected Map<String,Long> opTypeCounters;
 
-  static class Builder {
-
-    private long currentFateOps = 0;
-    private long zkFateChildOpsTotal = 0;
-    private long zkConnectionErrors = 0;
-
-    private final Map<String,Long> txStateCounters;
-    private Map<String,Long> opTypeCounters;
-
-    Builder() {
-
+    protected AbstractBuilder() {
       // states are enumerated - create new map with counts initialized to 0.
       txStateCounters = new TreeMap<>();
       for (ReadOnlyFateStore.TStatus t : ReadOnlyFateStore.TStatus.values()) {
@@ -197,39 +135,21 @@ class FateMetricValues {
       opTypeCounters = Collections.emptyMap();
     }
 
-    Builder withCurrentFateOps(final long value) {
+    public T withCurrentFateOps(final long value) {
       this.currentFateOps = value;
-      return this;
+      return (T) this;
     }
 
-    Builder withZkFateChildOpsTotal(final long value) {
-      this.zkFateChildOpsTotal = value;
-      return this;
-    }
-
-    Builder incrZkConnectionErrors() {
-      this.zkConnectionErrors += 1L;
-      return this;
-    }
-
-    Builder withZkConnectionErrors(final long value) {
-      this.zkConnectionErrors = value;
-      return this;
-    }
-
-    Builder withTxStateCounters(final Map<String,Long> txStateCounters) {
+    public T withTxStateCounters(final Map<String,Long> txStateCounters) {
       this.txStateCounters.putAll(txStateCounters);
-      return this;
+      return (T) this;
     }
 
-    Builder withOpTypeCounters(final Map<String,Long> opTypeCounters) {
+    public T withOpTypeCounters(final Map<String,Long> opTypeCounters) {
       this.opTypeCounters = new TreeMap<>(opTypeCounters);
-      return this;
+      return (T) this;
     }
 
-    FateMetricValues build() {
-      return new FateMetricValues(System.currentTimeMillis(), currentFateOps, zkFateChildOpsTotal,
-          zkConnectionErrors, txStateCounters, opTypeCounters);
-    }
+    protected abstract U build();
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/FateMetrics.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/FateMetrics.java
@@ -20,18 +20,16 @@ package org.apache.accumulo.manager.metrics.fate;
 
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.apache.accumulo.core.Constants;
-import org.apache.accumulo.core.fate.MetaFateStore;
 import org.apache.accumulo.core.fate.ReadOnlyFateStore;
 import org.apache.accumulo.core.metrics.MetricsProducer;
 import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.server.ServerContext;
-import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,7 +38,7 @@ import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 
-public class FateMetrics implements MetricsProducer {
+public abstract class FateMetrics<T extends FateMetricValues> implements MetricsProducer {
 
   private static final Logger log = LoggerFactory.getLogger(FateMetrics.class);
 
@@ -49,48 +47,35 @@ public class FateMetrics implements MetricsProducer {
 
   private static final String OP_TYPE_TAG = "op.type";
 
-  private final ServerContext context;
-  private final ReadOnlyFateStore<FateMetrics> fateStore;
-  private final String fateRootPath;
-  private final long refreshDelay;
+  protected final ServerContext context;
+  protected final ReadOnlyFateStore<FateMetrics<T>> fateStore;
+  protected final long refreshDelay;
 
-  private AtomicLong totalCurrentOpsGauge = new AtomicLong(0);
-  private AtomicLong totalOpsGauge = new AtomicLong(0);
-  private AtomicLong fateErrorsGauge = new AtomicLong(0);
-  private AtomicLong newTxGauge = new AtomicLong(0);
-  private AtomicLong submittedTxGauge = new AtomicLong(0);
-  private AtomicLong inProgressTxGauge = new AtomicLong(0);
-  private AtomicLong failedInProgressTxGauge = new AtomicLong(0);
-  private AtomicLong failedTxGauge = new AtomicLong(0);
-  private AtomicLong successfulTxGauge = new AtomicLong(0);
-  private AtomicLong unknownTxGauge = new AtomicLong(0);
+  protected final AtomicLong totalCurrentOpsGauge = new AtomicLong(0);
+  protected final AtomicLong newTxGauge = new AtomicLong(0);
+  protected final AtomicLong submittedTxGauge = new AtomicLong(0);
+  protected final AtomicLong inProgressTxGauge = new AtomicLong(0);
+  protected final AtomicLong failedInProgressTxGauge = new AtomicLong(0);
+  protected final AtomicLong failedTxGauge = new AtomicLong(0);
+  protected final AtomicLong successfulTxGauge = new AtomicLong(0);
+  protected final AtomicLong unknownTxGauge = new AtomicLong(0);
 
   public FateMetrics(final ServerContext context, final long minimumRefreshDelay) {
-
     this.context = context;
-    this.fateRootPath = context.getZooKeeperRoot() + Constants.ZFATE;
     this.refreshDelay = Math.max(DEFAULT_MIN_REFRESH_DELAY, minimumRefreshDelay);
-
-    try {
-      this.fateStore = new MetaFateStore<>(fateRootPath, context.getZooReaderWriter());
-    } catch (KeeperException ex) {
-      throw new IllegalStateException(
-          "FATE Metrics - Failed to create zoo store - metrics unavailable", ex);
-    } catch (InterruptedException ex) {
-      Thread.currentThread().interrupt();
-      throw new IllegalStateException(
-          "FATE Metrics - Interrupt received while initializing zoo store");
-    }
-
+    this.fateStore = Objects.requireNonNull(buildStore(context));
   }
 
-  private void update() {
-    FateMetricValues metricValues =
-        FateMetricValues.getFromZooKeeper(context, fateRootPath, fateStore);
+  protected abstract ReadOnlyFateStore<FateMetrics<T>> buildStore(ServerContext context);
 
+  protected abstract T getMetricValues();
+
+  protected void update() {
+    update(getMetricValues());
+  }
+
+  protected void update(T metricValues) {
     totalCurrentOpsGauge.set(metricValues.getCurrentFateOps());
-    totalOpsGauge.set(metricValues.getZkFateChildOpsTotal());
-    fateErrorsGauge.set(metricValues.getZkConnectionErrors());
 
     for (Entry<String,Long> vals : metricValues.getTxStateCounters().entrySet()) {
       switch (ReadOnlyFateStore.TStatus.valueOf(vals.getKey())) {
@@ -126,44 +111,56 @@ public class FateMetrics implements MetricsProducer {
 
   @Override
   public void registerMetrics(final MeterRegistry registry) {
+    var type = fateStore.type().name().toLowerCase();
+    var instanceTypeTag = Tag.of("instanceType", type);
+
     registry.gauge(METRICS_FATE_OPS, totalCurrentOpsGauge);
-    registry.gauge(METRICS_FATE_OPS_ACTIVITY, totalOpsGauge);
-    registry.gauge(METRICS_FATE_ERRORS, List.of(Tag.of("type", "zk.connection")), fateErrorsGauge);
+
+    registry.gauge(METRICS_FATE_TX, List
+        .of(Tag.of("state", ReadOnlyFateStore.TStatus.NEW.name().toLowerCase()), instanceTypeTag),
+        newTxGauge);
     registry.gauge(METRICS_FATE_TX,
-        List.of(Tag.of("state", ReadOnlyFateStore.TStatus.NEW.name().toLowerCase())), newTxGauge);
-    registry.gauge(METRICS_FATE_TX,
-        List.of(Tag.of("state", ReadOnlyFateStore.TStatus.SUBMITTED.name().toLowerCase())),
+        List.of(Tag.of("state", ReadOnlyFateStore.TStatus.SUBMITTED.name().toLowerCase()),
+            instanceTypeTag),
         submittedTxGauge);
     registry.gauge(METRICS_FATE_TX,
-        List.of(Tag.of("state", ReadOnlyFateStore.TStatus.IN_PROGRESS.name().toLowerCase())),
+        List.of(Tag.of("state", ReadOnlyFateStore.TStatus.IN_PROGRESS.name().toLowerCase()),
+            instanceTypeTag),
         inProgressTxGauge);
     registry.gauge(METRICS_FATE_TX,
-        List.of(Tag.of("state", ReadOnlyFateStore.TStatus.FAILED_IN_PROGRESS.name().toLowerCase())),
+        List.of(Tag.of("state", ReadOnlyFateStore.TStatus.FAILED_IN_PROGRESS.name().toLowerCase()),
+            instanceTypeTag),
         failedInProgressTxGauge);
     registry.gauge(METRICS_FATE_TX,
-        List.of(Tag.of("state", ReadOnlyFateStore.TStatus.FAILED.name().toLowerCase())),
+        List.of(Tag.of("state", ReadOnlyFateStore.TStatus.FAILED.name().toLowerCase()),
+            instanceTypeTag),
         failedTxGauge);
     registry.gauge(METRICS_FATE_TX,
-        List.of(Tag.of("state", ReadOnlyFateStore.TStatus.SUCCESSFUL.name().toLowerCase())),
+        List.of(Tag.of("state", ReadOnlyFateStore.TStatus.SUCCESSFUL.name().toLowerCase()),
+            instanceTypeTag),
         successfulTxGauge);
     registry.gauge(METRICS_FATE_TX,
-        List.of(Tag.of("state", ReadOnlyFateStore.TStatus.UNKNOWN.name().toLowerCase())),
+        List.of(Tag.of("state", ReadOnlyFateStore.TStatus.UNKNOWN.name().toLowerCase()),
+            instanceTypeTag),
         unknownTxGauge);
 
-    update();
-
     // get fate status is read only operation - no reason to be nice on shutdown.
-    ScheduledExecutorService scheduler =
-        ThreadPools.getServerThreadPools().createScheduledExecutorService(1, "fateMetricsPoller");
+    ScheduledExecutorService scheduler = ThreadPools.getServerThreadPools()
+        .createScheduledExecutorService(1, type + "FateMetricsPoller");
     Runtime.getRuntime().addShutdownHook(new Thread(scheduler::shutdownNow));
 
+    // Only update as part of the scheduler thread.
+    // We have to call update() in a new thread because this method to
+    // register metrics is called on start up in the Manager before it's finished
+    // initializing, so we can't scan the User fate store until after startup is done.
+    // If we called update() here in this method directly we would get stuck forever.
     ScheduledFuture<?> future = scheduler.scheduleAtFixedRate(() -> {
       try {
         update();
       } catch (Exception ex) {
-        log.info("Failed to update fate metrics due to exception", ex);
+        log.info("Failed to update {}fate metrics due to exception", type, ex);
       }
-    }, refreshDelay, refreshDelay, TimeUnit.MILLISECONDS);
+    }, 0, refreshDelay, TimeUnit.MILLISECONDS);
     ThreadPools.watchNonCriticalScheduledTask(future);
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/meta/MetaFateMetricValues.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/meta/MetaFateMetricValues.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.manager.metrics.fate.meta;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.accumulo.core.fate.FateInstanceType;
+import org.apache.accumulo.core.fate.ReadOnlyFateStore;
+import org.apache.accumulo.manager.metrics.fate.FateMetricValues;
+import org.apache.accumulo.manager.metrics.fate.FateMetrics;
+import org.apache.accumulo.server.ServerContext;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+
+public class MetaFateMetricValues extends FateMetricValues {
+
+  private static final Logger log = LoggerFactory.getLogger(MetaFateMetricValues.class);
+
+  private final long zkFateChildOpsTotal;
+  private final long zkConnectionErrors;
+
+  protected MetaFateMetricValues(final long updateTime, final long currentFateOps,
+      final long zkFateChildOpsTotal, final long zkConnectionErrors,
+      final Map<String,Long> txStateCounters, final Map<String,Long> opTypeCounters) {
+    super(updateTime, currentFateOps, txStateCounters, opTypeCounters);
+
+    this.zkFateChildOpsTotal = zkFateChildOpsTotal;
+    this.zkConnectionErrors = zkConnectionErrors;
+
+  }
+
+  long getZkFateChildOpsTotal() {
+    return zkFateChildOpsTotal;
+  }
+
+  long getZkConnectionErrors() {
+    return zkConnectionErrors;
+  }
+
+  /**
+   * The FATE transaction stores the transaction type as a debug string in the transaction zknode.
+   * This method returns a map of counters of the current occurrences of each operation type that is
+   * IN_PROGRESS
+   *
+   * @param context Accumulo context
+   * @param fateRootPath the zookeeper path to fate info
+   * @param metaFateStore a readonly MetaFateStore
+   * @return the current FATE metric values.
+   */
+  public static MetaFateMetricValues getMetaStoreMetrics(final ServerContext context,
+      final String fateRootPath,
+      final ReadOnlyFateStore<FateMetrics<MetaFateMetricValues>> metaFateStore) {
+    Preconditions.checkArgument(metaFateStore.type() == FateInstanceType.META,
+        "Fate store must be of type %s", FateInstanceType.META);
+
+    Builder builder = null;
+
+    try {
+      builder = getFateMetrics(metaFateStore, new Builder());
+
+      Stat node = context.getZooReaderWriter().getZooKeeper().exists(fateRootPath, false);
+      builder.withZkFateChildOpsTotal(node.getCversion());
+
+      if (log.isTraceEnabled()) {
+        log.trace(
+            "ZkNodeStat: {czxid: {}, mzxid: {}, pzxid: {}, ctime: {}, mtime: {}, "
+                + "version: {}, cversion: {}, num children: {}",
+            node.getCzxid(), node.getMzxid(), node.getPzxid(), node.getCtime(), node.getMtime(),
+            node.getVersion(), node.getCversion(), node.getNumChildren());
+      }
+
+    } catch (KeeperException ex) {
+      log.debug("Error connecting to ZooKeeper", ex);
+      Optional.ofNullable(builder).ifPresent(Builder::incrZkConnectionErrors);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+    }
+
+    return builder.build();
+  }
+
+  @Override
+  public String toString() {
+    return "MetaFateMetricValues{updateTime=" + updateTime + ", currentFateOps=" + currentFateOps
+        + ", zkFateChildOpsTotal=" + zkFateChildOpsTotal + ", zkConnectionErrors="
+        + zkConnectionErrors + '}';
+  }
+
+  static Builder builder() {
+    return new Builder();
+  }
+
+  static class Builder extends AbstractBuilder<Builder,MetaFateMetricValues> {
+
+    private long zkFateChildOpsTotal = 0;
+    private long zkConnectionErrors = 0;
+
+    Builder() {
+
+    }
+
+    Builder withZkFateChildOpsTotal(final long value) {
+      this.zkFateChildOpsTotal = value;
+      return this;
+    }
+
+    Builder incrZkConnectionErrors() {
+      this.zkConnectionErrors += 1L;
+      return this;
+    }
+
+    Builder withZkConnectionErrors(final long value) {
+      this.zkConnectionErrors = value;
+      return this;
+    }
+
+    @Override
+    protected MetaFateMetricValues build() {
+      return new MetaFateMetricValues(System.currentTimeMillis(), currentFateOps,
+          zkFateChildOpsTotal, zkConnectionErrors, txStateCounters, opTypeCounters);
+    }
+  }
+}

--- a/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/meta/MetaFateMetrics.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/meta/MetaFateMetrics.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.manager.metrics.fate.meta;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.fate.MetaFateStore;
+import org.apache.accumulo.core.fate.ReadOnlyFateStore;
+import org.apache.accumulo.manager.metrics.fate.FateMetrics;
+import org.apache.accumulo.server.ServerContext;
+import org.apache.zookeeper.KeeperException;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+
+public class MetaFateMetrics extends FateMetrics<MetaFateMetricValues> {
+
+  private final String fateRootPath;
+  private final AtomicLong totalOpsGauge = new AtomicLong(0);
+  private final AtomicLong fateErrorsGauge = new AtomicLong(0);
+
+  public MetaFateMetrics(ServerContext context, long minimumRefreshDelay) {
+    super(context, minimumRefreshDelay);
+    this.fateRootPath = getFateRootPath(context);
+  }
+
+  @Override
+  protected void update(MetaFateMetricValues metricValues) {
+    super.update(metricValues);
+    totalOpsGauge.set(metricValues.getZkFateChildOpsTotal());
+    fateErrorsGauge.set(metricValues.getZkConnectionErrors());
+  }
+
+  @Override
+  public void registerMetrics(MeterRegistry registry) {
+    super.registerMetrics(registry);
+    registry.gauge(METRICS_FATE_OPS_ACTIVITY, totalOpsGauge);
+    registry.gauge(METRICS_FATE_ERRORS, List.of(Tag.of("type", "zk.connection")), fateErrorsGauge);
+  }
+
+  @Override
+  protected ReadOnlyFateStore<FateMetrics<MetaFateMetricValues>> buildStore(ServerContext context) {
+    try {
+      return new MetaFateStore<>(getFateRootPath(context), context.getZooReaderWriter());
+    } catch (KeeperException ex) {
+      throw new IllegalStateException(
+          "FATE Metrics - Failed to create zoo store - metrics unavailable", ex);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException(
+          "FATE Metrics - Interrupt received while initializing zoo store");
+    }
+  }
+
+  @Override
+  protected MetaFateMetricValues getMetricValues() {
+    return MetaFateMetricValues.getMetaStoreMetrics(context, fateRootPath, fateStore);
+  }
+
+  private static String getFateRootPath(ServerContext context) {
+    return context.getZooKeeperRoot() + Constants.ZFATE;
+  }
+}

--- a/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/user/UserFateMetricValues.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/user/UserFateMetricValues.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.manager.metrics.fate.user;
+
+import java.util.Map;
+
+import org.apache.accumulo.core.fate.FateInstanceType;
+import org.apache.accumulo.core.fate.ReadOnlyFateStore;
+import org.apache.accumulo.manager.metrics.fate.FateMetricValues;
+import org.apache.accumulo.manager.metrics.fate.FateMetrics;
+
+import com.google.common.base.Preconditions;
+
+public class UserFateMetricValues extends FateMetricValues {
+
+  protected UserFateMetricValues(long updateTime, long currentFateOps,
+      Map<String,Long> txStateCounters, Map<String,Long> opTypeCounters) {
+    super(updateTime, currentFateOps, txStateCounters, opTypeCounters);
+  }
+
+  public static UserFateMetricValues getUserStoreMetrics(
+      final ReadOnlyFateStore<FateMetrics<UserFateMetricValues>> userFateStore) {
+    Preconditions.checkArgument(userFateStore.type() == FateInstanceType.USER,
+        "Fate store must be of type %s", FateInstanceType.USER);
+    Builder builder = getFateMetrics(userFateStore, UserFateMetricValues.builder());
+    return builder.build();
+  }
+
+  @Override
+  public String toString() {
+    return "MetaFateMetricValues{updateTime=" + updateTime + ", currentFateOps=" + currentFateOps
+        + '}';
+  }
+
+  static Builder builder() {
+    return new Builder();
+  }
+
+  static class Builder extends AbstractBuilder<Builder,UserFateMetricValues> {
+
+    @Override
+    protected UserFateMetricValues build() {
+      return new UserFateMetricValues(System.currentTimeMillis(), currentFateOps, txStateCounters,
+          opTypeCounters);
+    }
+  }
+}

--- a/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/user/UserFateMetrics.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/user/UserFateMetrics.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.manager.metrics.fate.user;
+
+import org.apache.accumulo.core.fate.ReadOnlyFateStore;
+import org.apache.accumulo.core.fate.user.UserFateStore;
+import org.apache.accumulo.manager.metrics.fate.FateMetrics;
+import org.apache.accumulo.server.ServerContext;
+
+public class UserFateMetrics extends FateMetrics<UserFateMetricValues> {
+
+  public UserFateMetrics(ServerContext context, long minimumRefreshDelay) {
+    super(context, minimumRefreshDelay);
+  }
+
+  @Override
+  protected ReadOnlyFateStore<FateMetrics<UserFateMetricValues>> buildStore(ServerContext context) {
+    return new UserFateStore<>(context);
+  }
+
+  @Override
+  protected UserFateMetricValues getMetricValues() {
+    return UserFateMetricValues.getUserStoreMetrics(fateStore);
+  }
+}

--- a/server/manager/src/test/java/org/apache/accumulo/manager/metrics/fate/meta/MetaFateMetricValuesTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/metrics/fate/meta/MetaFateMetricValuesTest.java
@@ -16,18 +16,18 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.manager.metrics.fate;
+package org.apache.accumulo.manager.metrics.fate.meta;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
-public class FateMetricValuesTest {
+public class MetaFateMetricValuesTest {
 
   @Test
   public void defaultValueTest() {
 
-    FateMetricValues v = FateMetricValues.builder().build();
+    MetaFateMetricValues v = MetaFateMetricValues.builder().build();
 
     assertEquals(0, v.getCurrentFateOps());
     assertEquals(0, v.getZkFateChildOpsTotal());
@@ -37,9 +37,9 @@ public class FateMetricValuesTest {
   @Test
   public void valueTest() {
 
-    FateMetricValues.Builder builder = FateMetricValues.builder();
+    MetaFateMetricValues.Builder builder = MetaFateMetricValues.builder();
 
-    FateMetricValues v =
+    MetaFateMetricValues v =
         builder.withCurrentFateOps(1).withZkFateChildOpsTotal(2).withZkConnectionErrors(3).build();
 
     assertEquals(1, v.getCurrentFateOps());

--- a/test/src/main/java/org/apache/accumulo/test/metrics/MetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/metrics/MetricsIT.java
@@ -47,6 +47,8 @@ import org.apache.accumulo.core.client.admin.CompactionConfig;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.fate.FateInstanceType;
+import org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus;
 import org.apache.accumulo.core.metrics.MetricsProducer;
 import org.apache.accumulo.core.spi.metrics.LoggingMeterRegistryFactory;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
@@ -306,8 +308,11 @@ public class MetricsIT extends ConfigurableMacBase implements MetricsProducer {
             // Checking the value would be hard to test because the metrics are updated on a timer
             // and fate transactions get cleaned up when finished so the current state is a bit
             // non-deterministic
-            assertNotNull(a.getTags().get("state"));
-            assertNotNull(a.getTags().get("instanceType"));
+            TStatus status = TStatus.valueOf(a.getTags().get("state").toUpperCase());
+            assertNotNull(status);
+            FateInstanceType type =
+                FateInstanceType.valueOf(a.getTags().get("instanceType").toUpperCase());
+            assertNotNull(type);
           });
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/metrics/MetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/metrics/MetricsIT.java
@@ -266,7 +266,7 @@ public class MetricsIT extends ConfigurableMacBase implements MetricsProducer {
       statsDMetrics.stream().filter(line -> line.startsWith("accumulo"))
           .map(TestStatsDSink::parseStatsDMetric).forEach(a -> {
             var t = a.getTags();
-            log.trace("METRICS, received from statsd - name: '{}' num tags: {}, tags: {} = {}",
+            log.info("METRICS, received from statsd - name: '{}' num tags: {}, tags: {} = {}",
                 a.getName(), t.size(), t, a.getValue());
             // check hostname is always set and is valid
             assertNotEquals("0.0.0.0", a.getTags().get("host"));
@@ -284,6 +284,30 @@ public class MetricsIT extends ConfigurableMacBase implements MetricsProducer {
             // check the length of the tag value is sane
             final int MAX_EXPECTED_TAG_LEN = 128;
             a.getTags().forEach((k, v) -> assertTrue(v.length() < MAX_EXPECTED_TAG_LEN));
+          });
+    }
+  }
+
+  @Test
+  public void fateMetrics() throws Exception {
+    doWorkToGenerateMetrics();
+    cluster.stop();
+
+    List<String> statsDMetrics;
+
+    while (!(statsDMetrics = sink.getLines()).isEmpty()) {
+      statsDMetrics.stream().filter(line -> line.startsWith("accumulo.fate.tx"))
+          .map(TestStatsDSink::parseStatsDMetric).forEach(a -> {
+            var t = a.getTags();
+            log.debug("METRICS, received from statsd - name: '{}' num tags: {}, tags: {} = {}",
+                a.getName(), t.size(), t, a.getValue());
+
+            // Verify the fate metrics contain state and instanceType
+            // Checking the value would be hard to test because the metrics are updated on a timer
+            // and fate transactions get cleaned up when finished so the current state is a bit
+            // non-deterministic
+            assertNotNull(a.getTags().get("state"));
+            assertNotNull(a.getTags().get("instanceType"));
           });
     }
   }


### PR DESCRIPTION
This commit updates the fate metrics that are published to include the user fate transactions and not just Meta (zookeeper). The metric names are the same and a tag is now added to the metrics to indicate the fate instance type of either user or meta.

This closes #4534

I ended up refactoring the metrics classes to share common code in an abstract class between both types. There's a couple extra metrics for ZK only so I wanted to separate that out. I didn't add any new metrics for the User metrics that might be different than from Meta but we could always add some in the future. I noticed the MetricsIT already scans all the metrics to make sure they are published and I added one new test there to check that the instance type tag was being set properly. Actually testing the values of the metrics would be difficult since both Fate and the metrics updates are a bit non-deterministic as they run async on timers. There wasn't any previous tests for fate metrics so this at least adds something.