### PR TITLE
Fix issue when SERVICE_INSTANCE is empty string

### DIFF
--- a/assemble/bin/accumulo-service
+++ b/assemble/bin/accumulo-service
@@ -200,7 +200,7 @@ function main() {
   local service_type="$1"
   local command_name="$2"
   shift 2
-  local service_name="unknown"
+  local service_name=$service_type
   local all_flag=false
 
   if [[ $service_type == "master" ]]; then
@@ -215,7 +215,9 @@ function main() {
       all_flag=true
     else
       # A named service has been specified
-      service_name="$1"
+      if [[ $1 != "-a" ]]; then
+        service_name="$1"
+      fi
     fi
   # Use the special bash env var from accumulo-cluster
   else


### PR DESCRIPTION
When ACCUMULO_SERVICE_INSTANCE is an empty string the service_name is set to the next OPT "-a". 

This causes an issue with the run files being named "accumulo--a.pid"

This change checks to make sure it's not "-a" and sets the service name correctly.
