### PR TITLE
Add getData methods to Key that populate ArrayByteSequence

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/data/Key.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Key.java
@@ -658,9 +658,10 @@ public class Key implements WritableComparable<Key>, Cloneable {
   }
 
   /**
-   * Writes the row ID into the given <code>ArrayByteSequence</code>. This method gives users
-   * control over allocation of ArrayByteSequence objects by copying into the passed in
-   * ArrayByteSequence.
+   * Writes the row ID into the given <code>ArrayByteSequence</code> without allocating new object
+   * by using {@link org.apache.accumulo.core.data.ArrayByteSequence#reset(byte[], int, int)}
+   * method. Using this updates existing ArrayByteSequence object with reference to row data, rather
+   * than copying row data.
    *
    * @param r <code>ArrayByteSequence</code> object to copy into
    * @return the <code>ArrayByteSequence</code> that was passed in
@@ -701,9 +702,10 @@ public class Key implements WritableComparable<Key>, Cloneable {
   }
 
   /**
-   * Writes the column family into the given <code>ArrayByteSequence</code>. This method gives users
-   * control over allocation of ArrayByteSequence objects by copying into the passed in
-   * ArrayByteSequence.
+   * Writes the column family into the given <code>ArrayByteSequence</code> without allocating new
+   * object by using {@link org.apache.accumulo.core.data.ArrayByteSequence#reset(byte[], int, int)}
+   * method. Using this updates existing ArrayByteSequence object with reference to column family
+   * data, rather than copying column family data.
    *
    * @param cf <code>ArrayByteSequence</code> object to copy into
    * @return the <code>ArrayByteSequence</code> that was passed in
@@ -758,9 +760,11 @@ public class Key implements WritableComparable<Key>, Cloneable {
   }
 
   /**
-   * Writes the column qualifier into the given <code>ArrayByteSequence</code>. This method gives
-   * users control over allocation of ArrayByteSequence objects by copying into the passed in
-   * ArrayByteSequence.
+   * Writes the column qualifier into the given <code>ArrayByteSequence</code> without allocating
+   * new object by using
+   * {@link org.apache.accumulo.core.data.ArrayByteSequence#reset(byte[], int, int)} method. Using
+   * this updates existing ArrayByteSequence object with reference to column qualifier data, rather
+   * than copying column qualifier data.
    *
    * @param cq <code>ArrayByteSequence</code> object to copy into
    * @return the <code>ArrayByteSequence</code> that was passed in

--- a/core/src/main/java/org/apache/accumulo/core/data/Key.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Key.java
@@ -854,9 +854,11 @@ public class Key implements WritableComparable<Key>, Cloneable {
   }
 
   /**
-   * Writes the column visibility into the given <code>ArrayByteSequence</code>. This method gives
-   * users control over allocation of ArrayByteSequence objects by copying into the passed in
-   * ArrayByteSequence.
+   * Writes the column visibility into the given <code>ArrayByteSequence</code> without allocating
+   * new object by using
+   * {@link org.apache.accumulo.core.data.ArrayByteSequence#reset(byte[], int, int)} method. Using
+   * this updates existing ArrayByteSequence object with reference to column visibility data, rather
+   * than copying column visibility data.
    *
    * @param cv <code>ArrayByteSequence</code> object to copy into
    * @return the <code>ArrayByteSequence</code> that was passed in

--- a/core/src/main/java/org/apache/accumulo/core/data/Key.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Key.java
@@ -658,6 +658,20 @@ public class Key implements WritableComparable<Key>, Cloneable {
   }
 
   /**
+   * Writes the row ID into the given <code>ArrayByteSequence</code>. This method gives users
+   * control over allocation of ArrayByteSequence objects by copying into the passed in
+   * ArrayByteSequence.
+   *
+   * @param r <code>ArrayByteSequence</code> object to copy into
+   * @return the <code>ArrayByteSequence</code> that was passed in
+   * @since 3.1.0
+   */
+  public ArrayByteSequence getRowData(ArrayByteSequence r) {
+    r.reset(row, 0, row.length);
+    return r;
+  }
+
+  /**
    * Gets the row ID as a <code>Text</code> object.
    *
    * @return Text containing the row ID
@@ -684,6 +698,20 @@ public class Key implements WritableComparable<Key>, Cloneable {
    */
   public ByteSequence getColumnFamilyData() {
     return new ArrayByteSequence(colFamily);
+  }
+
+  /**
+   * Writes the column family into the given <code>ArrayByteSequence</code>. This method gives users
+   * control over allocation of ArrayByteSequence objects by copying into the passed in
+   * ArrayByteSequence.
+   *
+   * @param cf <code>ArrayByteSequence</code> object to copy into
+   * @return the <code>ArrayByteSequence</code> that was passed in
+   * @since 3.1.0
+   */
+  public ArrayByteSequence getColumnFamilyData(ArrayByteSequence cf) {
+    cf.reset(colFamily, 0, colFamily.length);
+    return cf;
   }
 
   /**
@@ -727,6 +755,20 @@ public class Key implements WritableComparable<Key>, Cloneable {
    */
   public ByteSequence getColumnQualifierData() {
     return new ArrayByteSequence(colQualifier);
+  }
+
+  /**
+   * Writes the column qualifier into the given <code>ArrayByteSequence</code>. This method gives
+   * users control over allocation of ArrayByteSequence objects by copying into the passed in
+   * ArrayByteSequence.
+   *
+   * @param cq <code>ArrayByteSequence</code> object to copy into
+   * @return the <code>ArrayByteSequence</code> that was passed in
+   * @since 3.1.0
+   */
+  public ArrayByteSequence getColumnQualifierData(ArrayByteSequence cq) {
+    cq.reset(colQualifier, 0, colQualifier.length);
+    return cq;
   }
 
   /**


### PR DESCRIPTION
This PR is meant to add overloaded methods to `Key` class which populate existing `ArrayByteSequence` objects with respective fields row, column family, and column qualifier. The methods are modeled after `getColumnVisibilityData` which was added in #4735. 

The following files have been modified:

- `core/src/main/java/org/apache/accumulo/core/data/Key.java`: Added overloaded `getRowData`, `getColumnFamilyData`, and `getColumnQualifierData` methods.

Fixes #4749 "Add methods to Key that populate existing ArrayByteSequence"