### PR TITLE
Add static creation method that applies offset to Timer object

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/util/Timer.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/Timer.java
@@ -32,6 +32,10 @@ public final class Timer {
     this.startNanos = System.nanoTime();
   }
 
+  private Timer(long offsetNanos) {
+    this.startNanos = System.nanoTime() + offsetNanos;
+  }
+
   /**
    * Creates and starts a new Timer instance.
    *
@@ -39,6 +43,27 @@ public final class Timer {
    */
   public static Timer startNew() {
     return new Timer();
+  }
+
+  /**
+   * Creates a new Timer with an offset applied.
+   *
+   * @param offset the duration of the offset to apply.
+   * @return a new Timer instance with the specified offset.
+   */
+  public static Timer startNewWithOffset(Duration offset) {
+    return new Timer(offset.toNanos());
+  }
+
+  /**
+   * Creates a new Timer with an offset applied.
+   *
+   * @param offset the duration of the offset to apply.
+   * @param unit the TimeUnit of the offset.
+   * @return a new Timer instance with the specified offset.
+   */
+  public static Timer startNewWithOffset(long offset, TimeUnit unit) {
+    return new Timer(unit.toNanos(offset));
   }
 
   /**

--- a/core/src/test/java/org/apache/accumulo/core/util/TimerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/TimerTest.java
@@ -96,4 +96,38 @@ public class TimerTest {
 
   }
 
+  @Test
+  public void testStartNewWithOffsetDuration() throws InterruptedException {
+    Timer timer = Timer.startNewWithOffset(Duration.ofMillis(100));
+
+    assertFalse(timer.hasElapsed(Duration.ZERO));
+
+    Thread.sleep(50);
+
+    assertFalse(timer.hasElapsed(Duration.ZERO),
+        "The timer should not indicate time has elapsed before the offset has passed.");
+
+    Thread.sleep(60);
+
+    assertTrue(timer.hasElapsed(Duration.ZERO),
+        "The timer should indicate time has elapsed after the offset has passed.");
+  }
+
+  @Test
+  public void testStartNewWithOffsetTimeUnit() throws InterruptedException {
+    Timer timer = Timer.startNewWithOffset(100, MILLISECONDS);
+
+    assertFalse(timer.hasElapsed(0, MILLISECONDS));
+
+    Thread.sleep(50);
+
+    assertFalse(timer.hasElapsed(0, MILLISECONDS),
+        "The timer should not indicate time has elapsed before the offset has passed.");
+
+    Thread.sleep(60);
+
+    assertTrue(timer.hasElapsed(0, MILLISECONDS),
+        "The timer should indicate time has elapsed after the offset has passed.");
+  }
+
 }


### PR DESCRIPTION
This PR adds two new `startNewWithOffset()` methods to the Timer class that add the supplied value to the internal start time of the object. This change was suggested [here](https://github.com/apache/accumulo/pull/4785#discussion_r1706098227).

These new methods allow for us to use the Timer object to pick a point in time in the future and check the object to see if that point has elapsed yet.