### PR TITLE
Ensure resources are closed in GarbageCollectWriteAheadLogs

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletStateStore.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.server.manager.state;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -35,15 +36,11 @@ import org.apache.accumulo.core.metadata.TabletLocationState;
 import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.hadoop.fs.Path;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Interface for storing information about tablet assignments. There are three implementations:
  */
 public interface TabletStateStore extends Iterable<TabletLocationState> {
-
-  private static final Logger log = LoggerFactory.getLogger(TabletStateStore.class);
 
   /**
    * Get the level for this state store

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletStateStore.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.server.manager.state;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -34,11 +35,15 @@ import org.apache.accumulo.core.metadata.TabletLocationState;
 import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Interface for storing information about tablet assignments. There are three implementations:
  */
 public interface TabletStateStore extends Iterable<TabletLocationState> {
+
+  Logger log = LoggerFactory.getLogger(TabletStateStore.class);
 
   /**
    * Get the level for this state store
@@ -66,8 +71,8 @@ public interface TabletStateStore extends Iterable<TabletLocationState> {
         .onClose(() -> {
           try {
             iterator.close();
-          } catch (Exception e) {
-            throw new RuntimeException("Failed to close iterator", e);
+          } catch (IOException e) {
+            log.warn("Error closing iterator", e);
           }
         });
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletStateStore.java
@@ -72,7 +72,7 @@ public interface TabletStateStore extends Iterable<TabletLocationState> {
           try {
             iterator.close();
           } catch (IOException e) {
-            log.warn("Error closing iterator", e);
+            throw new UncheckedIOException(e);
           }
         });
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletStateStore.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
  */
 public interface TabletStateStore extends Iterable<TabletLocationState> {
 
-  Logger log = LoggerFactory.getLogger(TabletStateStore.class);
+  private static final Logger log = LoggerFactory.getLogger(TabletStateStore.class);
 
   /**
    * Get the level for this state store

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
@@ -88,6 +88,17 @@ public class GarbageCollectWriteAheadLogs {
     this(context, fs, liveServers, useTrash, new WalStateManager(context), createStore(context));
   }
 
+  /**
+   * Creates a new GC WAL object. Meant for testing -- allows for mocked objects.
+   *
+   *
+   * @param context the collection server's context
+   * @param fs volume manager to use
+   * @param liveServers a started LiveTServerSet instance
+   * @param useTrash true to move files to trash rather than delete them
+   * @param walMarker a WalStateManager instance
+   * @param store a stream of TabletLocationState objects
+   */
   GarbageCollectWriteAheadLogs(final ServerContext context, final VolumeManager fs,
       final LiveTServerSet liveServers, boolean useTrash, final WalStateManager walMarker,
       final Stream<TabletLocationState> store) {

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
@@ -109,18 +109,12 @@ public class GarbageCollectWriteAheadLogs {
     return Streams.concat(rootStream, metadataStream, userStream).onClose(() -> {
       try {
         rootStream.close();
-      } catch (Exception e) {
-        log.error("Failed to close rootStream", e);
-      }
-      try {
-        metadataStream.close();
-      } catch (Exception e) {
-        log.error("Failed to close metadataStream", e);
-      }
-      try {
-        userStream.close();
-      } catch (Exception e) {
-        log.error("Failed to close userStream", e);
+      } finally {
+        try {
+          metadataStream.close();
+        } finally {
+          userStream.close();
+        }
       }
     });
   }

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
@@ -28,6 +28,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
 
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
@@ -58,7 +60,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Iterators;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Streams;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Scope;
@@ -71,7 +74,7 @@ public class GarbageCollectWriteAheadLogs {
   private final boolean useTrash;
   private final LiveTServerSet liveServers;
   private final WalStateManager walMarker;
-  private final Iterable<TabletLocationState> store;
+  private final AtomicBoolean hasCollected;
 
   /**
    * Creates a new GC WAL object.
@@ -86,34 +89,32 @@ public class GarbageCollectWriteAheadLogs {
     this.fs = fs;
     this.useTrash = useTrash;
     this.liveServers = liveServers;
-    this.walMarker = new WalStateManager(context);
-    this.store = () -> Iterators.concat(
-        TabletStateStore.getStoreForLevel(DataLevel.ROOT, context).iterator(),
-        TabletStateStore.getStoreForLevel(DataLevel.METADATA, context).iterator(),
-        TabletStateStore.getStoreForLevel(DataLevel.USER, context).iterator());
+    this.walMarker = createWalStateManager(context);
+    this.hasCollected = new AtomicBoolean(false);
   }
 
-  /**
-   * Creates a new GC WAL object. Meant for testing -- allows mocked objects.
-   *
-   * @param context the collection server's context
-   * @param fs volume manager to use
-   * @param useTrash true to move files to trash rather than delete them
-   * @param liveTServerSet a started LiveTServerSet instance
-   */
   @VisibleForTesting
-  GarbageCollectWriteAheadLogs(ServerContext context, VolumeManager fs, boolean useTrash,
-      LiveTServerSet liveTServerSet, WalStateManager walMarker,
-      Iterable<TabletLocationState> store) {
-    this.context = context;
-    this.fs = fs;
-    this.useTrash = useTrash;
-    this.liveServers = liveTServerSet;
-    this.walMarker = walMarker;
-    this.store = store;
+  WalStateManager createWalStateManager(ServerContext context) {
+    return new WalStateManager(context);
+  }
+
+  @VisibleForTesting
+  Stream<TabletLocationState> createStore() {
+    Stream<TabletLocationState> rootStream =
+        TabletStateStore.getStoreForLevel(DataLevel.ROOT, context).stream();
+    Stream<TabletLocationState> metadataStream =
+        TabletStateStore.getStoreForLevel(DataLevel.METADATA, context).stream();
+    Stream<TabletLocationState> userStream =
+        TabletStateStore.getStoreForLevel(DataLevel.USER, context).stream();
+    return Streams.concat(rootStream, metadataStream, userStream).onClose(() -> {
+      rootStream.close();
+      metadataStream.close();
+      userStream.close();
+    });
   }
 
   public void collect(GCStatus status) {
+    Preconditions.checkState(!hasCollected.get(), "Can only call collect once per object");
     try {
       long count;
       long fileScanStop;
@@ -216,7 +217,7 @@ public class GarbageCollectWriteAheadLogs {
       } finally {
         span5.end();
       }
-
+      hasCollected.set(true);
     } catch (Exception e) {
       log.error("exception occurred while garbage collecting write ahead logs", e);
     } finally {
@@ -302,30 +303,32 @@ public class GarbageCollectWriteAheadLogs {
     }
 
     // remove any entries if there's a log reference (recovery hasn't finished)
-    for (TabletLocationState state : store) {
-      // Tablet is still assigned to a dead server. Manager has moved markers and reassigned it
-      // Easiest to just ignore all the WALs for the dead server.
-      if (state.getState(liveServers) == TabletState.ASSIGNED_TO_DEAD_SERVER) {
-        Set<UUID> idsToIgnore = candidates.remove(state.current.getServerInstance());
-        if (idsToIgnore != null) {
-          result.keySet().removeAll(idsToIgnore);
-          recoveryLogs.keySet().removeAll(idsToIgnore);
-        }
-      }
-      // Tablet is being recovered and has WAL references, remove all the WALs for the dead server
-      // that made the WALs.
-      for (Collection<String> wals : state.walogs) {
-        for (String wal : wals) {
-          UUID walUUID = path2uuid(new Path(wal));
-          TServerInstance dead = result.get(walUUID);
-          // There's a reference to a log file, so skip that server's logs
-          Set<UUID> idsToIgnore = candidates.remove(dead);
+    try (Stream<TabletLocationState> store = createStore()) {
+      store.forEach(state -> {
+        // Tablet is still assigned to a dead server. Manager has moved markers and reassigned it
+        // Easiest to just ignore all the WALs for the dead server.
+        if (state.getState(liveServers) == TabletState.ASSIGNED_TO_DEAD_SERVER) {
+          Set<UUID> idsToIgnore = candidates.remove(state.current.getServerInstance());
           if (idsToIgnore != null) {
             result.keySet().removeAll(idsToIgnore);
             recoveryLogs.keySet().removeAll(idsToIgnore);
           }
         }
-      }
+        // Tablet is being recovered and has WAL references, remove all the WALs for the dead server
+        // that made the WALs.
+        for (Collection<String> wals : state.walogs) {
+          for (String wal : wals) {
+            UUID walUUID = path2uuid(new Path(wal));
+            TServerInstance dead = result.get(walUUID);
+            // There's a reference to a log file, so skip that server's logs
+            Set<UUID> idsToIgnore = candidates.remove(dead);
+            if (idsToIgnore != null) {
+              result.keySet().removeAll(idsToIgnore);
+              recoveryLogs.keySet().removeAll(idsToIgnore);
+            }
+          }
+        }
+      });
     }
 
     // Remove OPEN and CLOSED logs for live servers: they are still in use

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
@@ -107,9 +107,15 @@ public class GarbageCollectWriteAheadLogs {
     Stream<TabletLocationState> userStream =
         TabletStateStore.getStoreForLevel(DataLevel.USER, context).stream();
     return Streams.concat(rootStream, metadataStream, userStream).onClose(() -> {
-      rootStream.close();
-      metadataStream.close();
-      userStream.close();
+      try {
+        rootStream.close();
+      } finally {
+        try {
+          metadataStream.close();
+        } finally {
+          userStream.close();
+        }
+      }
     });
   }
 

--- a/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogsTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogsTest.java
@@ -111,27 +111,27 @@ public class GarbageCollectWriteAheadLogsTest {
     EasyMock.expectLastCall().once();
     EasyMock.replay(context, fs, marker, tserverSet);
     var gc = new GarbageCollectWriteAheadLogs(context, fs, tserverSet, false) {
-          @Override
-          @Deprecated
-          protected int removeReplicationEntries(Map<UUID,TServerInstance> candidates) {
-            return 0;
-          }
+      @Override
+      @Deprecated
+      protected int removeReplicationEntries(Map<UUID,TServerInstance> candidates) {
+        return 0;
+      }
 
-          @Override
-          protected Map<UUID,Path> getSortedWALogs() {
-            return Collections.emptyMap();
-          }
+      @Override
+      protected Map<UUID,Path> getSortedWALogs() {
+        return Collections.emptyMap();
+      }
 
-          @Override
-          WalStateManager createWalStateManager(ServerContext context) {
-            return marker;
-          }
+      @Override
+      WalStateManager createWalStateManager(ServerContext context) {
+        return marker;
+      }
 
-          @Override
-          Stream<TabletLocationState> createStore() {
-            return tabletOnServer1List;
-          }
-        };
+      @Override
+      Stream<TabletLocationState> createStore() {
+        return tabletOnServer1List;
+      }
+    };
     gc.collect(status);
     EasyMock.verify(context, fs, marker, tserverSet);
   }
@@ -341,7 +341,7 @@ public class GarbageCollectWriteAheadLogsTest {
 
           @Override
           Stream<TabletLocationState> createStore() {
-            return tabletOnServer2List;
+            return tabletOnServer1List;
           }
         };
     gc.collect(status);

--- a/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogsTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogsTest.java
@@ -152,29 +152,28 @@ public class GarbageCollectWriteAheadLogsTest {
     EasyMock.expect(marker.getAllMarkers()).andReturn(markers).once();
     EasyMock.expect(marker.state(server1, id)).andReturn(new Pair<>(WalState.CLOSED, path));
     EasyMock.replay(context, marker, tserverSet, fs);
-    GarbageCollectWriteAheadLogs gc =
-        new GarbageCollectWriteAheadLogs(context, fs, tserverSet, false) {
-          @Override
-          @Deprecated
-          protected int removeReplicationEntries(Map<UUID,TServerInstance> candidates) {
-            return 0;
-          }
+    var gc = new GarbageCollectWriteAheadLogs(context, fs, tserverSet, false) {
+      @Override
+      @Deprecated
+      protected int removeReplicationEntries(Map<UUID,TServerInstance> candidates) {
+        return 0;
+      }
 
-          @Override
-          protected Map<UUID,Path> getSortedWALogs() {
-            return Collections.emptyMap();
-          }
+      @Override
+      protected Map<UUID,Path> getSortedWALogs() {
+        return Collections.emptyMap();
+      }
 
-          @Override
-          WalStateManager createWalStateManager(ServerContext context) {
-            return marker;
-          }
+      @Override
+      WalStateManager createWalStateManager(ServerContext context) {
+        return marker;
+      }
 
-          @Override
-          Stream<TabletLocationState> createStore() {
-            return tabletOnServer1List;
-          }
-        };
+      @Override
+      Stream<TabletLocationState> createStore() {
+        return tabletOnServer1List;
+      }
+    };
     gc.collect(status);
     EasyMock.verify(context, marker, tserverSet, fs);
   }
@@ -216,23 +215,22 @@ public class GarbageCollectWriteAheadLogsTest {
     marker.forget(server2);
     EasyMock.expectLastCall().once();
     EasyMock.replay(context, fs, marker, tserverSet, rscanner, mscanner);
-    GarbageCollectWriteAheadLogs gc =
-        new GarbageCollectWriteAheadLogs(context, fs, tserverSet, false) {
-          @Override
-          protected Map<UUID,Path> getSortedWALogs() {
-            return Collections.emptyMap();
-          }
+    var gc = new GarbageCollectWriteAheadLogs(context, fs, tserverSet, false) {
+      @Override
+      protected Map<UUID,Path> getSortedWALogs() {
+        return Collections.emptyMap();
+      }
 
-          @Override
-          WalStateManager createWalStateManager(ServerContext context) {
-            return marker;
-          }
+      @Override
+      WalStateManager createWalStateManager(ServerContext context) {
+        return marker;
+      }
 
-          @Override
-          Stream<TabletLocationState> createStore() {
-            return tabletOnServer1List;
-          }
-        };
+      @Override
+      Stream<TabletLocationState> createStore() {
+        return tabletOnServer1List;
+      }
+    };
     gc.collect(status);
     EasyMock.verify(context, fs, marker, tserverSet, rscanner, mscanner);
   }
@@ -269,23 +267,22 @@ public class GarbageCollectWriteAheadLogsTest {
     EasyMock.expectLastCall().once();
     EasyMock.expect(mscanner.iterator()).andReturn(emptyKV);
     EasyMock.replay(context, fs, marker, tserverSet, rscanner, mscanner);
-    GarbageCollectWriteAheadLogs gc =
-        new GarbageCollectWriteAheadLogs(context, fs, tserverSet, false) {
-          @Override
-          protected Map<UUID,Path> getSortedWALogs() {
-            return Collections.emptyMap();
-          }
+    var gc = new GarbageCollectWriteAheadLogs(context, fs, tserverSet, false) {
+      @Override
+      protected Map<UUID,Path> getSortedWALogs() {
+        return Collections.emptyMap();
+      }
 
-          @Override
-          WalStateManager createWalStateManager(ServerContext context) {
-            return marker;
-          }
+      @Override
+      WalStateManager createWalStateManager(ServerContext context) {
+        return marker;
+      }
 
-          @Override
-          Stream<TabletLocationState> createStore() {
-            return tabletOnServer2List;
-          }
-        };
+      @Override
+      Stream<TabletLocationState> createStore() {
+        return tabletOnServer2List;
+      }
+    };
     gc.collect(status);
     EasyMock.verify(context, fs, marker, tserverSet, rscanner, mscanner);
   }
@@ -327,23 +324,22 @@ public class GarbageCollectWriteAheadLogsTest {
     EasyMock.expectLastCall().once();
     EasyMock.expect(mscanner.iterator()).andReturn(replicationWork.entrySet().iterator());
     EasyMock.replay(context, fs, marker, tserverSet, rscanner, mscanner);
-    GarbageCollectWriteAheadLogs gc =
-        new GarbageCollectWriteAheadLogs(context, fs, tserverSet, false) {
-          @Override
-          protected Map<UUID,Path> getSortedWALogs() {
-            return Collections.emptyMap();
-          }
+    var gc = new GarbageCollectWriteAheadLogs(context, fs, tserverSet, false) {
+      @Override
+      protected Map<UUID,Path> getSortedWALogs() {
+        return Collections.emptyMap();
+      }
 
-          @Override
-          WalStateManager createWalStateManager(ServerContext context) {
-            return marker;
-          }
+      @Override
+      WalStateManager createWalStateManager(ServerContext context) {
+        return marker;
+      }
 
-          @Override
-          Stream<TabletLocationState> createStore() {
-            return tabletOnServer1List;
-          }
-        };
+      @Override
+      Stream<TabletLocationState> createStore() {
+        return tabletOnServer1List;
+      }
+    };
     gc.collect(status);
     EasyMock.verify(context, fs, marker, tserverSet, rscanner, mscanner);
   }

--- a/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogsTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogsTest.java
@@ -88,8 +88,7 @@ public class GarbageCollectWriteAheadLogsTest {
       Stream.of(tabletAssignedToServer1);
   private final Stream<TabletLocationState> tabletOnServer2List =
       Stream.of(tabletAssignedToServer2);
-  private final List<Entry<Key,Value>> emptyList = Collections.emptyList();
-  private final Iterator<Entry<Key,Value>> emptyKV = emptyList.iterator();
+  private final Iterator<Entry<Key,Value>> emptyKV = Collections.emptyIterator();
 
   @Test
   public void testRemoveUnusedLog() throws Exception {
@@ -110,7 +109,8 @@ public class GarbageCollectWriteAheadLogsTest {
     marker.removeWalMarker(server1, id);
     EasyMock.expectLastCall().once();
     EasyMock.replay(context, fs, marker, tserverSet);
-    var gc = new GarbageCollectWriteAheadLogs(context, fs, tserverSet, false) {
+    var gc = new GarbageCollectWriteAheadLogs(context, fs, tserverSet, false, marker,
+        tabletOnServer1List) {
       @Override
       @Deprecated
       protected int removeReplicationEntries(Map<UUID,TServerInstance> candidates) {
@@ -120,16 +120,6 @@ public class GarbageCollectWriteAheadLogsTest {
       @Override
       protected Map<UUID,Path> getSortedWALogs() {
         return Collections.emptyMap();
-      }
-
-      @Override
-      WalStateManager createWalStateManager(ServerContext context) {
-        return marker;
-      }
-
-      @Override
-      Stream<TabletLocationState> createStore() {
-        return tabletOnServer1List;
       }
     };
     gc.collect(status);
@@ -152,7 +142,8 @@ public class GarbageCollectWriteAheadLogsTest {
     EasyMock.expect(marker.getAllMarkers()).andReturn(markers).once();
     EasyMock.expect(marker.state(server1, id)).andReturn(new Pair<>(WalState.CLOSED, path));
     EasyMock.replay(context, marker, tserverSet, fs);
-    var gc = new GarbageCollectWriteAheadLogs(context, fs, tserverSet, false) {
+    var gc = new GarbageCollectWriteAheadLogs(context, fs, tserverSet, false, marker,
+        tabletOnServer1List) {
       @Override
       @Deprecated
       protected int removeReplicationEntries(Map<UUID,TServerInstance> candidates) {
@@ -163,23 +154,13 @@ public class GarbageCollectWriteAheadLogsTest {
       protected Map<UUID,Path> getSortedWALogs() {
         return Collections.emptyMap();
       }
-
-      @Override
-      WalStateManager createWalStateManager(ServerContext context) {
-        return marker;
-      }
-
-      @Override
-      Stream<TabletLocationState> createStore() {
-        return tabletOnServer1List;
-      }
     };
     gc.collect(status);
     EasyMock.verify(context, marker, tserverSet, fs);
   }
 
   @Test
-  public void deleteUnreferenceLogOnDeadServer() throws Exception {
+  public void deleteUnreferencedLogOnDeadServer() throws Exception {
     ServerContext context = EasyMock.createMock(ServerContext.class);
     VolumeManager fs = EasyMock.createMock(VolumeManager.class);
     WalStateManager marker = EasyMock.createMock(WalStateManager.class);
@@ -215,20 +196,11 @@ public class GarbageCollectWriteAheadLogsTest {
     marker.forget(server2);
     EasyMock.expectLastCall().once();
     EasyMock.replay(context, fs, marker, tserverSet, rscanner, mscanner);
-    var gc = new GarbageCollectWriteAheadLogs(context, fs, tserverSet, false) {
+    var gc = new GarbageCollectWriteAheadLogs(context, fs, tserverSet, false, marker,
+        tabletOnServer1List) {
       @Override
       protected Map<UUID,Path> getSortedWALogs() {
         return Collections.emptyMap();
-      }
-
-      @Override
-      WalStateManager createWalStateManager(ServerContext context) {
-        return marker;
-      }
-
-      @Override
-      Stream<TabletLocationState> createStore() {
-        return tabletOnServer1List;
       }
     };
     gc.collect(status);
@@ -267,20 +239,11 @@ public class GarbageCollectWriteAheadLogsTest {
     EasyMock.expectLastCall().once();
     EasyMock.expect(mscanner.iterator()).andReturn(emptyKV);
     EasyMock.replay(context, fs, marker, tserverSet, rscanner, mscanner);
-    var gc = new GarbageCollectWriteAheadLogs(context, fs, tserverSet, false) {
+    var gc = new GarbageCollectWriteAheadLogs(context, fs, tserverSet, false, marker,
+        tabletOnServer2List) {
       @Override
       protected Map<UUID,Path> getSortedWALogs() {
         return Collections.emptyMap();
-      }
-
-      @Override
-      WalStateManager createWalStateManager(ServerContext context) {
-        return marker;
-      }
-
-      @Override
-      Stream<TabletLocationState> createStore() {
-        return tabletOnServer2List;
       }
     };
     gc.collect(status);
@@ -324,20 +287,11 @@ public class GarbageCollectWriteAheadLogsTest {
     EasyMock.expectLastCall().once();
     EasyMock.expect(mscanner.iterator()).andReturn(replicationWork.entrySet().iterator());
     EasyMock.replay(context, fs, marker, tserverSet, rscanner, mscanner);
-    var gc = new GarbageCollectWriteAheadLogs(context, fs, tserverSet, false) {
+    var gc = new GarbageCollectWriteAheadLogs(context, fs, tserverSet, false, marker,
+        tabletOnServer1List) {
       @Override
       protected Map<UUID,Path> getSortedWALogs() {
         return Collections.emptyMap();
-      }
-
-      @Override
-      WalStateManager createWalStateManager(ServerContext context) {
-        return marker;
-      }
-
-      @Override
-      Stream<TabletLocationState> createStore() {
-        return tabletOnServer1List;
       }
     };
     gc.collect(status);

--- a/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogsTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogsTest.java
@@ -110,8 +110,7 @@ public class GarbageCollectWriteAheadLogsTest {
     marker.removeWalMarker(server1, id);
     EasyMock.expectLastCall().once();
     EasyMock.replay(context, fs, marker, tserverSet);
-    GarbageCollectWriteAheadLogs gc =
-        new GarbageCollectWriteAheadLogs(context, fs, tserverSet, false) {
+    var gc = new GarbageCollectWriteAheadLogs(context, fs, tserverSet, false) {
           @Override
           @Deprecated
           protected int removeReplicationEntries(Map<UUID,TServerInstance> candidates) {


### PR DESCRIPTION
Fixes #4753

The changes in this PR were closely modeled after the changes in #4207

This PR:
#### moves some of the logic out of the GarbageCollectWriteAheadLogs constructor and into separate methods
These new methods are `createWalStateManager()` and `createStore()`. Moving this logic into separate methods allows us to override these methods for testing. It also makes it easier to construct the collection of `TabletLocationState` that is used in the `collect()` method.
#### Creates TabletStateStore.stream()
This new method returns a `Stream<TabletLocationState>` that is created off of the `ClosableIterator<TabletLocationState> iterator()`. The goal of this PR is to make sure that these `ClosableIterator<TabletLocationState>` objects are closed so the stream adds an `onClose()` for this.

This stream method lets us more easily concatonate and then close multple streams of `TabletLocationState` that are returned in `GarbageCollectWriteAheadLogs.createStore()`.
#### Adds a `AtomicBoolean hasCollected` to ensure that `GarbageCollectWriteAheadLogs.collect()` is only ever called once.

This is important because the resources will be closed after they are read.

