### PR TITLE
Fix String-to-bytes and bytes-to-String for UTF-8 Pt. 2

### DIFF
--- a/core/src/test/java/org/apache/accumulo/core/client/lexicoder/BytesLexicoderTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/lexicoder/BytesLexicoderTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.core.client.lexicoder;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoderTest;
 import org.junit.jupiter.api.Test;
 
@@ -27,6 +29,6 @@ public class BytesLexicoderTest extends AbstractLexicoderTest {
   public void testDecodes() {
     BytesLexicoder lexicoder = new BytesLexicoder();
     assertDecodesB(lexicoder, new byte[0]);
-    assertDecodesB(lexicoder, "accumulo".getBytes());
+    assertDecodesB(lexicoder, "accumulo".getBytes(UTF_8));
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/client/lexicoder/LexicoderTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/lexicoder/LexicoderTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.client.lexicoder;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
@@ -65,8 +66,8 @@ public abstract class LexicoderTest {
     assertSortOrder(lexicoder, null, data);
   }
 
-  public static final byte[] START_PAD = "start".getBytes();
-  public static final byte[] END_PAD = "end".getBytes();
+  public static final byte[] START_PAD = "start".getBytes(UTF_8);
+  public static final byte[] END_PAD = "end".getBytes(UTF_8);
 
   /** Asserts a value can be encoded and decoded back to original value */
   public static <T> void assertDecodes(Lexicoder<T> lexicoder, T expected) {

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/TabletLocatorImplTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/TabletLocatorImplTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.clientImpl;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.easymock.EasyMock.replay;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -271,7 +272,7 @@ public class TabletLocatorImplTest {
     ArrayList<String> efs = new ArrayList<>(List.of(efailures));
 
     for (Mutation mutation : afailures) {
-      afs.add(new String(mutation.getRow()));
+      afs.add(new String(mutation.getRow(), UTF_8));
     }
 
     Collections.sort(afs);
@@ -296,7 +297,7 @@ public class TabletLocatorImplTest {
         ArrayList<String> aRows = new ArrayList<>();
 
         for (Mutation m : atb.getMutations().get(ke)) {
-          aRows.add(new String(m.getRow()));
+          aRows.add(new String(m.getRow(), UTF_8));
         }
 
         Collections.sort(eRows);

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/lexicoder/ByteUtilsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/lexicoder/ByteUtilsTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.clientImpl.lexicoder;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -27,8 +28,8 @@ import org.junit.jupiter.api.Test;
 public class ByteUtilsTest {
 
   private final byte[] empty = new byte[0];
-  private final byte[] noSplits = "nosplits".getBytes();
-  private final byte[] splitAt5 = ("1234" + (char) 0x00 + "56789").getBytes();
+  private final byte[] noSplits = "nosplits".getBytes(UTF_8);
+  private final byte[] splitAt5 = ("1234" + (char) 0x00 + "56789").getBytes(UTF_8);
 
   @Test
   public void testSplit() {
@@ -45,8 +46,8 @@ public class ByteUtilsTest {
 
     result = ByteUtils.split(splitAt5);
     assertEquals(2, result.length);
-    assertArrayEquals("1234".getBytes(), result[0]);
-    assertArrayEquals("56789".getBytes(), result[1]);
+    assertArrayEquals("1234".getBytes(UTF_8), result[0]);
+    assertArrayEquals("56789".getBytes(UTF_8), result[1]);
   }
 
   @Test
@@ -59,20 +60,20 @@ public class ByteUtilsTest {
     result = ByteUtils.split(splitAt5, offset, splitAt5.length - offset);
     assertEquals(2, result.length);
     assertArrayEquals(empty, result[0]);
-    assertArrayEquals("56789".getBytes(), result[1]);
+    assertArrayEquals("56789".getBytes(UTF_8), result[1]);
 
     // should only see 1 split at this offset
     offset = 5;
     result = ByteUtils.split(splitAt5, offset, splitAt5.length - offset);
     assertEquals(1, result.length);
-    assertArrayEquals("56789".getBytes(), result[0]);
+    assertArrayEquals("56789".getBytes(UTF_8), result[0]);
 
     // still one split, but smaller ending
     offset = 5;
     int len = splitAt5.length - offset - 1;
     result = ByteUtils.split(splitAt5, offset, len);
     assertEquals(1, result.length);
-    assertArrayEquals("5678".getBytes(), result[0]);
+    assertArrayEquals("5678".getBytes(UTF_8), result[0]);
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/conf/ClientPropertyTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/ClientPropertyTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.conf;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -38,19 +39,19 @@ public class ClientPropertyTest {
     assertEquals("testpass1", ClientProperty.AUTH_TOKEN.getValue(props));
     AuthenticationToken token = ClientProperty.getAuthenticationToken(props);
     assertTrue(token instanceof PasswordToken);
-    assertEquals("testpass1", new String(((PasswordToken) token).getPassword()));
+    assertEquals("testpass1", new String(((PasswordToken) token).getPassword(), UTF_8));
 
     ClientProperty.setAuthenticationToken(props, new PasswordToken("testpass2"));
     assertEquals("/////gAAAAl0ZXN0cGFzczI=", ClientProperty.AUTH_TOKEN.getValue(props));
     token = ClientProperty.getAuthenticationToken(props);
     assertTrue(token instanceof PasswordToken);
-    assertEquals("testpass2", new String(((PasswordToken) token).getPassword()));
+    assertEquals("testpass2", new String(((PasswordToken) token).getPassword(), UTF_8));
 
     ClientProperty.setAuthenticationToken(props, new PasswordToken("testpass3"));
     assertEquals("/////gAAAAl0ZXN0cGFzczM=", ClientProperty.AUTH_TOKEN.getValue(props));
     token = ClientProperty.getAuthenticationToken(props);
     assertTrue(token instanceof PasswordToken);
-    assertEquals("testpass3", new String(((PasswordToken) token).getPassword()));
+    assertEquals("testpass3", new String(((PasswordToken) token).getPassword(), UTF_8));
 
     ClientProperty.setKerberosKeytab(props, "/path/to/keytab");
     assertEquals("/path/to/keytab", ClientProperty.AUTH_TOKEN.getValue(props));

--- a/core/src/test/java/org/apache/accumulo/core/crypto/CryptoTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/crypto/CryptoTest.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.core.crypto;
 
 import static com.google.common.collect.MoreCollectors.onlyElement;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.core.conf.Property.INSTANCE_CRYPTO_FACTORY;
 import static org.apache.accumulo.core.crypto.CryptoUtils.getFileDecrypter;
 import static org.apache.accumulo.core.spi.crypto.CryptoEnvironment.Scope.TABLE;
@@ -290,7 +291,7 @@ public class CryptoTest {
 
     String stringifiedBytes = Arrays.toString(encryptedBytes);
     String stringifiedMarkerBytes =
-        getStringifiedBytes("U+1F47B".getBytes(), MARKER_STRING, MARKER_INT);
+        getStringifiedBytes("U+1F47B".getBytes(UTF_8), MARKER_STRING, MARKER_INT);
 
     assertEquals(stringifiedBytes, stringifiedMarkerBytes);
 
@@ -304,7 +305,7 @@ public class CryptoTest {
 
     String stringifiedBytes = Arrays.toString(encryptedBytes);
     String stringifiedMarkerBytes =
-        getStringifiedBytes("U+1F47B".getBytes(), MARKER_STRING, MARKER_INT);
+        getStringifiedBytes("U+1F47B".getBytes(UTF_8), MARKER_STRING, MARKER_INT);
 
     assertEquals(stringifiedBytes, stringifiedMarkerBytes);
 

--- a/core/src/test/java/org/apache/accumulo/core/data/ColumnTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/ColumnTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.data;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -39,11 +40,11 @@ public class ColumnTest {
   @BeforeAll
   public static void setup() {
     col = new Column[5];
-    col[0] = new Column("colfam".getBytes(), "colq".getBytes(), "colv".getBytes());
-    col[1] = new Column("colfam".getBytes(), "colq".getBytes(), "colv".getBytes());
+    col[0] = new Column("colfam".getBytes(UTF_8), "colq".getBytes(UTF_8), "colv".getBytes(UTF_8));
+    col[1] = new Column("colfam".getBytes(UTF_8), "colq".getBytes(UTF_8), "colv".getBytes(UTF_8));
     col[2] = new Column(new byte[0], new byte[0], new byte[0]);
     col[3] = new Column(null, null, null);
-    col[4] = new Column("colfam".getBytes(), "cq".getBytes(), "cv".getBytes());
+    col[4] = new Column("colfam".getBytes(UTF_8), "cq".getBytes(UTF_8), "cv".getBytes(UTF_8));
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/data/KeyTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/KeyTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.data;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
@@ -39,10 +40,14 @@ public class KeyTest {
 
   @Test
   public void testDeletedCompare() {
-    Key k1 = new Key("r1".getBytes(), "cf".getBytes(), "cq".getBytes(), new byte[0], 0, false);
-    Key k2 = new Key("r1".getBytes(), "cf".getBytes(), "cq".getBytes(), new byte[0], 0, false);
-    Key k3 = new Key("r1".getBytes(), "cf".getBytes(), "cq".getBytes(), new byte[0], 0, true);
-    Key k4 = new Key("r1".getBytes(), "cf".getBytes(), "cq".getBytes(), new byte[0], 0, true);
+    Key k1 = new Key("r1".getBytes(UTF_8), "cf".getBytes(UTF_8), "cq".getBytes(UTF_8), new byte[0],
+        0, false);
+    Key k2 = new Key("r1".getBytes(UTF_8), "cf".getBytes(UTF_8), "cq".getBytes(UTF_8), new byte[0],
+        0, false);
+    Key k3 = new Key("r1".getBytes(UTF_8), "cf".getBytes(UTF_8), "cq".getBytes(UTF_8), new byte[0],
+        0, true);
+    Key k4 = new Key("r1".getBytes(UTF_8), "cf".getBytes(UTF_8), "cq".getBytes(UTF_8), new byte[0],
+        0, true);
 
     assertEquals(k1, k2);
     assertEquals(k3, k4);
@@ -52,10 +57,10 @@ public class KeyTest {
 
   @Test
   public void testCopyData() {
-    byte[] row = "r".getBytes();
-    byte[] cf = "cf".getBytes();
-    byte[] cq = "cq".getBytes();
-    byte[] cv = "cv".getBytes();
+    byte[] row = "r".getBytes(UTF_8);
+    byte[] cf = "cf".getBytes(UTF_8);
+    byte[] cq = "cq".getBytes(UTF_8);
+    byte[] cv = "cv".getBytes(UTF_8);
 
     Key k1 = new Key(row, cf, cq, cv, 5L, false, false);
     Key k2 = new Key(row, cf, cq, cv, 5L, false, true);
@@ -86,11 +91,11 @@ public class KeyTest {
 
   @Test
   public void testCopyDataWithByteArrayConstructors() {
-    byte[] row = "r".getBytes();
-    byte[] cf = "cf".getBytes();
-    byte[] cq = "cq".getBytes();
-    byte[] cv = "cv".getBytes();
-    byte[] empty = "".getBytes();
+    byte[] row = "r".getBytes(UTF_8);
+    byte[] cf = "cf".getBytes(UTF_8);
+    byte[] cq = "cq".getBytes(UTF_8);
+    byte[] cv = "cv".getBytes(UTF_8);
+    byte[] empty = "".getBytes(UTF_8);
 
     Key kRow = new Key(row);
     Key kRowcolFam = new Key(row, cf);
@@ -171,10 +176,10 @@ public class KeyTest {
   }
 
   private void assertTextValueConversionToByteArray(Key key) {
-    byte[] row = "r".getBytes();
-    byte[] cf = "cf".getBytes();
-    byte[] cq = "cq".getBytes();
-    byte[] cv = "cv".getBytes();
+    byte[] row = "r".getBytes(UTF_8);
+    byte[] cf = "cf".getBytes(UTF_8);
+    byte[] cq = "cq".getBytes(UTF_8);
+    byte[] cv = "cv".getBytes(UTF_8);
     // show Text values submitted in constructor
     // are converted to byte array containing
     // the same value

--- a/core/src/test/java/org/apache/accumulo/core/data/KeyTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/KeyTest.java
@@ -40,14 +40,13 @@ public class KeyTest {
 
   @Test
   public void testDeletedCompare() {
-    Key k1 = new Key("r1".getBytes(UTF_8), "cf".getBytes(UTF_8), "cq".getBytes(UTF_8), new byte[0],
-        0, false);
-    Key k2 = new Key("r1".getBytes(UTF_8), "cf".getBytes(UTF_8), "cq".getBytes(UTF_8), new byte[0],
-        0, false);
-    Key k3 = new Key("r1".getBytes(UTF_8), "cf".getBytes(UTF_8), "cq".getBytes(UTF_8), new byte[0],
-        0, true);
-    Key k4 = new Key("r1".getBytes(UTF_8), "cf".getBytes(UTF_8), "cq".getBytes(UTF_8), new byte[0],
-        0, true);
+    final byte[] row = "r1".getBytes(UTF_8);
+    final byte[] cf = "cf".getBytes(UTF_8);
+    final byte[] cq = "cq".getBytes(UTF_8);
+    Key k1 = new Key(row, cf, cq, new byte[0], 0, false);
+    Key k2 = new Key(row, cf, cq, new byte[0], 0, false);
+    Key k3 = new Key(row, cf, cq, new byte[0], 0, true);
+    Key k4 = new Key(row, cf, cq, new byte[0], 0, true);
 
     assertEquals(k1, k2);
     assertEquals(k3, k4);

--- a/core/src/test/java/org/apache/accumulo/core/data/MutationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/MutationTest.java
@@ -77,9 +77,9 @@ public class MutationTest {
 
     ColumnUpdate cu = updates.get(0);
 
-    assertEquals("cf1", new String(cu.getColumnFamily()));
-    assertEquals("cq1", new String(cu.getColumnQualifier()));
-    assertEquals("", new String(cu.getColumnVisibility()));
+    assertEquals("cf1", new String(cu.getColumnFamily(), UTF_8));
+    assertEquals("cq1", new String(cu.getColumnQualifier(), UTF_8));
+    assertEquals("", new String(cu.getColumnVisibility(), UTF_8));
     assertFalse(cu.hasTimestamp());
 
   }
@@ -94,41 +94,41 @@ public class MutationTest {
 
     assertEquals(2, updates.size());
 
-    assertEquals("r1", new String(m.getRow()));
+    assertEquals("r1", new String(m.getRow(), UTF_8));
     ColumnUpdate cu = updates.get(0);
 
-    assertEquals("cf1", new String(cu.getColumnFamily()));
-    assertEquals("cq1", new String(cu.getColumnQualifier()));
-    assertEquals("", new String(cu.getColumnVisibility()));
+    assertEquals("cf1", new String(cu.getColumnFamily(), UTF_8));
+    assertEquals("cq1", new String(cu.getColumnQualifier(), UTF_8));
+    assertEquals("", new String(cu.getColumnVisibility(), UTF_8));
     assertFalse(cu.hasTimestamp());
 
     cu = updates.get(1);
 
-    assertEquals("cf2", new String(cu.getColumnFamily()));
-    assertEquals("cq2", new String(cu.getColumnQualifier()));
-    assertEquals("", new String(cu.getColumnVisibility()));
+    assertEquals("cf2", new String(cu.getColumnFamily(), UTF_8));
+    assertEquals("cq2", new String(cu.getColumnQualifier(), UTF_8));
+    assertEquals("", new String(cu.getColumnVisibility(), UTF_8));
     assertTrue(cu.hasTimestamp());
     assertEquals(56, cu.getTimestamp());
 
     m = cloneMutation(m);
 
-    assertEquals("r1", new String(m.getRow()));
+    assertEquals("r1", new String(m.getRow(), UTF_8));
     updates = m.getUpdates();
 
     assertEquals(2, updates.size());
 
     cu = updates.get(0);
 
-    assertEquals("cf1", new String(cu.getColumnFamily()));
-    assertEquals("cq1", new String(cu.getColumnQualifier()));
-    assertEquals("", new String(cu.getColumnVisibility()));
+    assertEquals("cf1", new String(cu.getColumnFamily(), UTF_8));
+    assertEquals("cq1", new String(cu.getColumnQualifier(), UTF_8));
+    assertEquals("", new String(cu.getColumnVisibility(), UTF_8));
     assertFalse(cu.hasTimestamp());
 
     cu = updates.get(1);
 
-    assertEquals("cf2", new String(cu.getColumnFamily()));
-    assertEquals("cq2", new String(cu.getColumnQualifier()));
-    assertEquals("", new String(cu.getColumnVisibility()));
+    assertEquals("cf2", new String(cu.getColumnFamily(), UTF_8));
+    assertEquals("cq2", new String(cu.getColumnQualifier(), UTF_8));
+    assertEquals("", new String(cu.getColumnVisibility(), UTF_8));
     assertTrue(cu.hasTimestamp());
     assertEquals(56, cu.getTimestamp());
 
@@ -163,14 +163,14 @@ public class MutationTest {
     }
 
     for (int r = 0; r < 3; r++) {
-      assertEquals("r1", new String(m.getRow()));
+      assertEquals("r1", new String(m.getRow(), UTF_8));
       List<ColumnUpdate> updates = m.getUpdates();
       assertEquals(5, updates.size());
       for (int i = 0; i < 5; i++) {
         ColumnUpdate cu = updates.get(i);
-        assertEquals("cf" + i, new String(cu.getColumnFamily()));
-        assertEquals("cq" + i, new String(cu.getColumnQualifier()));
-        assertEquals("", new String(cu.getColumnVisibility()));
+        assertEquals("cf" + i, new String(cu.getColumnFamily(), UTF_8));
+        assertEquals("cq" + i, new String(cu.getColumnQualifier(), UTF_8));
+        assertEquals("", new String(cu.getColumnVisibility(), UTF_8));
         assertFalse(cu.hasTimestamp());
 
         byte[] val = cu.getValue();
@@ -296,7 +296,8 @@ public class MutationTest {
 
     // vis: CharSequence (String implementation)
     actual = new Mutation("row5");
-    actual.at().family(fam).qualifier(qual).visibility(new String(vis.getExpression())).put(val);
+    actual.at().family(fam).qualifier(qual).visibility(new String(vis.getExpression(), UTF_8))
+        .put(val);
     assertEquals(expected, actual);
 
     // vis: ColumnVisibility
@@ -488,7 +489,7 @@ public class MutationTest {
     m.putDelete("cf8", "cq8", new ColumnVisibility("cv8"), 8L);
 
     assertEquals(8, m.size());
-    assertEquals("r1", new String(m.getRow()));
+    assertEquals("r1", new String(m.getRow(), UTF_8));
 
     List<ColumnUpdate> updates = m.getUpdates();
 
@@ -555,14 +556,14 @@ public class MutationTest {
     m1.put("cf1.2", "cq1.2", new ColumnVisibility("C|D"), "val1.2");
     byte[] val1_3 = new byte[Mutation.VALUE_SIZE_COPY_CUTOFF + 3];
     Arrays.fill(val1_3, (byte) 3);
-    m1.put("cf1.3", "cq1.3", new ColumnVisibility("E|F"), new String(val1_3));
+    m1.put("cf1.3", "cq1.3", new ColumnVisibility("E|F"), new String(val1_3, UTF_8));
     int size1 = m1.size();
     long nb1 = m1.numBytes();
 
     Mutation m2 = new Mutation("row2");
     byte[] val2 = new byte[Mutation.VALUE_SIZE_COPY_CUTOFF + 2];
     Arrays.fill(val2, (byte) 2);
-    m2.put("cf2", "cq2", new ColumnVisibility("G|H"), 1234, new String(val2));
+    m2.put("cf2", "cq2", new ColumnVisibility("G|H"), 1234, new String(val2, UTF_8));
     int size2 = m2.size();
     long nb2 = m2.numBytes();
 
@@ -580,39 +581,39 @@ public class MutationTest {
     Mutation m = new Mutation();
     m.readFields(dis);
 
-    assertEquals("row1", new String(m.getRow()));
+    assertEquals("row1", new String(m.getRow(), UTF_8));
     assertEquals(size1, m.size());
     assertEquals(nb1, m.numBytes());
     assertEquals(3, m.getUpdates().size());
     verifyColumnUpdate(m.getUpdates().get(0), "cf1.1", "cq1.1", "A|B", 0L, false, false, "val1.1");
     verifyColumnUpdate(m.getUpdates().get(1), "cf1.2", "cq1.2", "C|D", 0L, false, false, "val1.2");
     verifyColumnUpdate(m.getUpdates().get(2), "cf1.3", "cq1.3", "E|F", 0L, false, false,
-        new String(val1_3));
+        new String(val1_3, UTF_8));
 
     // Reuse the same mutation object (which is what happens in the hadoop framework
     // when objects are read by an input format)
     m.readFields(dis);
 
-    assertEquals("row2", new String(m.getRow()));
+    assertEquals("row2", new String(m.getRow(), UTF_8));
     assertEquals(size2, m.size());
     assertEquals(nb2, m.numBytes());
     assertEquals(1, m.getUpdates().size());
     verifyColumnUpdate(m.getUpdates().get(0), "cf2", "cq2", "G|H", 1234L, true, false,
-        new String(val2));
+        new String(val2, UTF_8));
   }
 
   private void verifyColumnUpdate(ColumnUpdate cu, String cf, String cq, String cv, long ts,
       boolean timeSet, boolean deleted, String val) {
 
-    assertEquals(cf, new String(cu.getColumnFamily()));
-    assertEquals(cq, new String(cu.getColumnQualifier()));
-    assertEquals(cv, new String(cu.getColumnVisibility()));
+    assertEquals(cf, new String(cu.getColumnFamily(), UTF_8));
+    assertEquals(cq, new String(cu.getColumnQualifier(), UTF_8));
+    assertEquals(cv, new String(cu.getColumnVisibility(), UTF_8));
     assertEquals(timeSet, cu.hasTimestamp());
     if (timeSet) {
       assertEquals(ts, cu.getTimestamp());
     }
     assertEquals(deleted, cu.isDeleted());
-    assertEquals(val, new String(cu.getValue()));
+    assertEquals(val, new String(cu.getValue(), UTF_8));
   }
 
   @Test
@@ -639,7 +640,7 @@ public class MutationTest {
     // after readFields
     m2.readFields(dis);
 
-    assertEquals("r1", new String(m2.getRow()));
+    assertEquals("r1", new String(m2.getRow(), UTF_8));
     assertEquals(2, m2.getUpdates().size());
     assertEquals(2, m2.size());
     verifyColumnUpdate(m2.getUpdates().get(0), "cf1", "cq1", "", 0L, false, false, "v1");
@@ -677,7 +678,7 @@ public class MutationTest {
     dis.close();
 
     // check it
-    assertEquals("r1", new String(m2.getRow()));
+    assertEquals("r1", new String(m2.getRow(), UTF_8));
     assertEquals(3, m2.getUpdates().size());
     assertEquals(3, m2.size());
     verifyColumnUpdate(m2.getUpdates().get(0), "cf1", "cq1", "", 0L, false, false, "v1");
@@ -686,7 +687,7 @@ public class MutationTest {
 
     Mutation m1 = convert(m2);
 
-    assertEquals("r1", new String(m1.getRow()));
+    assertEquals("r1", new String(m1.getRow(), UTF_8));
     assertEquals(3, m1.getUpdates().size());
     assertEquals(3, m1.size());
     verifyColumnUpdate(m1.getUpdates().get(0), "cf1", "cq1", "", 0L, false, false, "v1");
@@ -749,7 +750,7 @@ public class MutationTest {
     DataInputStream dis = new DataInputStream(bis);
     m2.readFields(dis);
 
-    assertEquals("r1", new String(m1.getRow()));
+    assertEquals("r1", new String(m1.getRow(), UTF_8));
     assertEquals(4, m2.getUpdates().size());
     assertEquals(4, m2.size());
     verifyColumnUpdate(m2.getUpdates().get(0), "cf1", "cq1", "", 0L, false, false, "v1");

--- a/core/src/test/java/org/apache/accumulo/core/data/MutationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/MutationTest.java
@@ -56,13 +56,13 @@ public class MutationTest {
    */
   @Test
   public void testByteConstructor() {
-    Mutation m = new Mutation("0123456789".getBytes());
+    Mutation m = new Mutation("0123456789".getBytes(UTF_8));
     assertEquals("30313233343536373839", toHexString(m.getRow()));
   }
 
   @Test
   public void testLimitedByteConstructor() {
-    Mutation m = new Mutation("0123456789".getBytes(), 2, 5);
+    Mutation m = new Mutation("0123456789".getBytes(UTF_8), 2, 5);
     assertEquals("3233343536", toHexString(m.getRow()));
   }
 
@@ -378,7 +378,7 @@ public class MutationTest {
     expected.put(fam, qual, val);
 
     Mutation actual = new Mutation("row5");
-    actual.at().family(fam).qualifier(qual).put(val.getBytes());
+    actual.at().family(fam).qualifier(qual).put(val.getBytes(UTF_8));
     assertEquals(expected, actual);
     assertEquals(34, actual.numBytes());
     assertThrows(IllegalStateException.class,
@@ -508,17 +508,19 @@ public class MutationTest {
 
   @Test
   public void testByteArrays() {
-    Mutation m = new Mutation("r1".getBytes());
+    Mutation m = new Mutation("r1".getBytes(UTF_8));
 
-    m.put("cf1".getBytes(), "cq1".getBytes(), "v1".getBytes());
-    m.put("cf2".getBytes(), "cq2".getBytes(), new ColumnVisibility("cv2"), "v2".getBytes());
-    m.put("cf3".getBytes(), "cq3".getBytes(), 3L, "v3".getBytes());
-    m.put("cf4".getBytes(), "cq4".getBytes(), new ColumnVisibility("cv4"), 4L, "v4".getBytes());
+    m.put("cf1".getBytes(UTF_8), "cq1".getBytes(UTF_8), "v1".getBytes(UTF_8));
+    m.put("cf2".getBytes(UTF_8), "cq2".getBytes(UTF_8), new ColumnVisibility("cv2"),
+        "v2".getBytes(UTF_8));
+    m.put("cf3".getBytes(UTF_8), "cq3".getBytes(UTF_8), 3L, "v3".getBytes(UTF_8));
+    m.put("cf4".getBytes(UTF_8), "cq4".getBytes(UTF_8), new ColumnVisibility("cv4"), 4L,
+        "v4".getBytes(UTF_8));
 
-    m.putDelete("cf5".getBytes(), "cq5".getBytes());
-    m.putDelete("cf6".getBytes(), "cq6".getBytes(), new ColumnVisibility("cv6"));
-    m.putDelete("cf7".getBytes(), "cq7".getBytes(), 7L);
-    m.putDelete("cf8".getBytes(), "cq8".getBytes(), new ColumnVisibility("cv8"), 8L);
+    m.putDelete("cf5".getBytes(UTF_8), "cq5".getBytes(UTF_8));
+    m.putDelete("cf6".getBytes(UTF_8), "cq6".getBytes(UTF_8), new ColumnVisibility("cv6"));
+    m.putDelete("cf7".getBytes(UTF_8), "cq7".getBytes(UTF_8), 7L);
+    m.putDelete("cf8".getBytes(UTF_8), "cq8".getBytes(UTF_8), new ColumnVisibility("cv8"), 8L);
 
     assertEquals(8, m.size());
 

--- a/core/src/test/java/org/apache/accumulo/core/data/RangeTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/RangeTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.data;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -617,11 +618,10 @@ public class RangeTest {
     runClipTest(fence, range);
 
     // scanner was not handling edge case properly...
-    Range scanRange =
-        new Range(
-            new Key("10;007cdc5b0".getBytes(), "~tab".getBytes(), "~pr".getBytes(), "".getBytes(),
-                130962, false),
-            false, new Key(new Text("10<")).followingKey(PartialKey.ROW), false);
+    Range scanRange = new Range(
+        new Key("10;007cdc5b0".getBytes(UTF_8), "~tab".getBytes(UTF_8), "~pr".getBytes(UTF_8),
+            "".getBytes(UTF_8), 130962, false),
+        false, new Key(new Text("10<")).followingKey(PartialKey.ROW), false);
     // below is the proper check the scanner now does instead of just comparing the row bytes
     scanRange.afterEndKey(new Key(new Text("10<")).followingKey(PartialKey.ROW));
   }
@@ -644,7 +644,7 @@ public class RangeTest {
   }
 
   private static Column newColumn(String cf, String cq) {
-    return new Column(cf.getBytes(), cq == null ? null : cq.getBytes(), null);
+    return new Column(cf.getBytes(UTF_8), cq == null ? null : cq.getBytes(UTF_8), null);
   }
 
   private static Column newColumn(String cf) {

--- a/core/src/test/java/org/apache/accumulo/core/fate/zookeeper/DistributedReadWriteLockTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/fate/zookeeper/DistributedReadWriteLockTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.fate.zookeeper;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.SortedMap;
@@ -90,7 +91,7 @@ public class DistributedReadWriteLockTest {
     data.read();
     QueueLock qlock = new MockQueueLock();
 
-    final ReadWriteLock locker = new DistributedReadWriteLock(qlock, "locker1".getBytes());
+    final ReadWriteLock locker = new DistributedReadWriteLock(qlock, "locker1".getBytes(UTF_8));
     final Lock readLock = locker.readLock();
     final Lock writeLock = locker.writeLock();
     readLock.lock();

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/CreateCompatTestFile.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/CreateCompatTestFile.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.core.file.rfile;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.util.HashSet;
 import java.util.Set;
 
@@ -46,7 +48,8 @@ public class CreateCompatTestFile {
   }
 
   private static Key newKey(String row, String cf, String cq, String cv, long ts) {
-    return new Key(row.getBytes(), cf.getBytes(), cq.getBytes(), cv.getBytes(), ts);
+    return new Key(row.getBytes(UTF_8), cf.getBytes(UTF_8), cq.getBytes(UTF_8), cv.getBytes(UTF_8),
+        ts);
   }
 
   private static Value newValue(String val) {

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/GenerateSplitsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/GenerateSplitsTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.file.rfile;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.core.file.rfile.GenerateSplits.getEvenlySpacedSplits;
 import static org.apache.accumulo.core.file.rfile.GenerateSplits.main;
 import static org.apache.accumulo.core.file.rfile.RFileTest.newColFamByteSequence;
@@ -124,7 +125,7 @@ public class GenerateSplitsTest {
 
   private String decode(boolean decode, String string) {
     if (decode) {
-      return new String(Base64.getDecoder().decode(string));
+      return new String(Base64.getDecoder().decode(string), UTF_8);
     }
     return string;
   }

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/KeyShortenerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/KeyShortenerTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.file.rfile;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -46,19 +47,19 @@ public class KeyShortenerTest {
    * append 0xff to end of string
    */
   private byte[] apendFF(String s) {
-    return Bytes.concat(s.getBytes(), FF);
+    return Bytes.concat(s.getBytes(UTF_8), FF);
   }
 
   /**
    * append 0x00 to end of string
    */
   private byte[] append00(String s) {
-    return Bytes.concat(s.getBytes(), new byte[] {(byte) 0x00});
+    return Bytes.concat(s.getBytes(UTF_8), new byte[] {(byte) 0x00});
   }
 
   private byte[] toBytes(Object o) {
     if (o instanceof String) {
-      return ((String) o).getBytes();
+      return ((String) o).getBytes(UTF_8);
     } else if (o instanceof byte[]) {
       return (byte[]) o;
     }
@@ -104,8 +105,8 @@ public class KeyShortenerTest {
 
   @Test
   public void testOneCharacterDifferenceAndFF() {
-    byte[] ff1 = Bytes.concat(apendFF("mop"), "b".getBytes());
-    byte[] ff2 = Bytes.concat(apendFF("mop"), FF, "b".getBytes());
+    byte[] ff1 = Bytes.concat(apendFF("mop"), "b".getBytes(UTF_8));
+    byte[] ff2 = Bytes.concat(apendFF("mop"), FF, "b".getBytes(UTF_8));
 
     String eff1 = "moq";
 

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.file.rfile;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -198,7 +199,8 @@ public class MultiThreadedRFileTest {
   }
 
   static Key newKey(String row, String cf, String cq, String cv, long ts) {
-    return new Key(row.getBytes(), cf.getBytes(), cq.getBytes(), cv.getBytes(), ts);
+    return new Key(row.getBytes(UTF_8), cf.getBytes(UTF_8), cq.getBytes(UTF_8), cv.getBytes(UTF_8),
+        ts);
   }
 
   static Value newValue(String val) {

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.file.rfile;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -347,7 +348,8 @@ public class RFileTest {
   }
 
   static Key newKey(String row, String cf, String cq, String cv, long ts) {
-    return new Key(row.getBytes(), cf.getBytes(), cq.getBytes(), cv.getBytes(), ts);
+    return new Key(row.getBytes(UTF_8), cf.getBytes(UTF_8), cq.getBytes(UTF_8), cv.getBytes(UTF_8),
+        ts);
   }
 
   static Value newValue(String val) {
@@ -2282,7 +2284,7 @@ public class RFileTest {
     // If we get here, we have encrypted bytes
     for (Property prop : Property.values()) {
       if (prop.isSensitive()) {
-        byte[] toCheck = prop.getKey().getBytes();
+        byte[] toCheck = prop.getKey().getBytes(UTF_8);
         assertEquals(-1, Bytes.indexOf(rfBytes, toCheck));
       }
     }

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/ColumnFilterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/ColumnFilterTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.iterators.system;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -44,11 +45,11 @@ public class ColumnFilterTest {
   }
 
   Column newColumn(String cf) {
-    return new Column(cf.getBytes(), null, null);
+    return new Column(cf.getBytes(UTF_8), null, null);
   }
 
   Column newColumn(String cf, String cq) {
-    return new Column(cf.getBytes(), cq.getBytes(), null);
+    return new Column(cf.getBytes(UTF_8), cq.getBytes(UTF_8), null);
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/VisibilityFilterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/VisibilityFilterTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.iterators.system;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -42,8 +43,8 @@ public class VisibilityFilterTest {
     TreeMap<Key,Value> tm = new TreeMap<>();
 
     tm.put(new Key("r1", "cf1", "cq1", "A&"), new Value());
-    SortedKeyValueIterator<Key,Value> filter =
-        VisibilityFilter.wrap(new SortedMapIterator(tm), new Authorizations("A"), "".getBytes());
+    SortedKeyValueIterator<Key,Value> filter = VisibilityFilter.wrap(new SortedMapIterator(tm),
+        new Authorizations("A"), "".getBytes(UTF_8));
 
     filter.seek(new Range(), new HashSet<>(), false);
     assertFalse(filter.hasTop());
@@ -58,7 +59,7 @@ public class VisibilityFilterTest {
     tm.put(new Key("r1", "cf1", "cq2", "C"), new Value());
     tm.put(new Key("r1", "cf1", "cq3", ""), new Value());
     SortedKeyValueIterator<Key,Value> filter =
-        VisibilityFilter.wrap(new SortedMapIterator(tm), Authorizations.EMPTY, "".getBytes());
+        VisibilityFilter.wrap(new SortedMapIterator(tm), Authorizations.EMPTY, "".getBytes(UTF_8));
 
     filter.seek(new Range(), new HashSet<>(), false);
     assertTrue(filter.hasTop());

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/FilterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/FilterTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.iterators.user;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -335,7 +336,7 @@ public class FilterTest {
     Value dv = new Value();
     TreeMap<Key,Value> tm = new TreeMap<>();
     HashSet<Column> hsc = new HashSet<>();
-    hsc.add(new Column("c".getBytes(), null, null));
+    hsc.add(new Column("c".getBytes(UTF_8), null, null));
 
     Text colf1 = new Text("a");
     Text colq1 = new Text("b");
@@ -363,7 +364,7 @@ public class FilterTest {
     assertEquals(1000, size(a));
 
     hsc = new HashSet<>();
-    hsc.add(new Column("a".getBytes(), "b".getBytes(), null));
+    hsc.add(new Column("a".getBytes(UTF_8), "b".getBytes(UTF_8), null));
     a = ColumnQualifierFilter.wrap(new SortedMapIterator(tm), hsc);
     a.seek(new Range(), EMPTY_COL_FAMS, false);
     int size = size(a);
@@ -427,25 +428,25 @@ public class FilterTest {
 
     assertEquals(5, tm.size());
 
-    int size = size(ncqf(tm, new Column("c".getBytes(), null, null)));
+    int size = size(ncqf(tm, new Column("c".getBytes(UTF_8), null, null)));
     assertEquals(5, size);
 
-    size = size(ncqf(tm, new Column("a".getBytes(), null, null)));
+    size = size(ncqf(tm, new Column("a".getBytes(UTF_8), null, null)));
     assertEquals(5, size);
 
-    size = size(ncqf(tm, new Column("a".getBytes(), "x".getBytes(), null)));
+    size = size(ncqf(tm, new Column("a".getBytes(UTF_8), "x".getBytes(UTF_8), null)));
     assertEquals(1, size);
 
-    size = size(ncqf(tm, new Column("a".getBytes(), "x".getBytes(), null),
-        new Column("b".getBytes(), "x".getBytes(), null)));
+    size = size(ncqf(tm, new Column("a".getBytes(UTF_8), "x".getBytes(UTF_8), null),
+        new Column("b".getBytes(UTF_8), "x".getBytes(UTF_8), null)));
     assertEquals(2, size);
 
-    size = size(ncqf(tm, new Column("a".getBytes(), "x".getBytes(), null),
-        new Column("b".getBytes(), "y".getBytes(), null)));
+    size = size(ncqf(tm, new Column("a".getBytes(UTF_8), "x".getBytes(UTF_8), null),
+        new Column("b".getBytes(UTF_8), "y".getBytes(UTF_8), null)));
     assertEquals(2, size);
 
-    size = size(ncqf(tm, new Column("a".getBytes(), "x".getBytes(), null),
-        new Column("b".getBytes(), null, null)));
+    size = size(ncqf(tm, new Column("a".getBytes(UTF_8), "x".getBytes(UTF_8), null),
+        new Column("b".getBytes(UTF_8), null, null)));
     assertEquals(3, size);
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/IndexedDocIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/IndexedDocIteratorTest.java
@@ -214,7 +214,7 @@ public class IndexedDocIteratorTest {
 
       Text d = IndexedDocIterator.parseDocID(k);
       assertTrue(docs.contains(d));
-      assertTrue(new String(v.get()).endsWith(" docID=" + d));
+      assertTrue(new String(v.get(), UTF_8).endsWith(" docID=" + d));
 
       iter.next();
     }
@@ -251,7 +251,7 @@ public class IndexedDocIteratorTest {
       Value v = iter.getTopValue();
       Text d = IndexedDocIterator.parseDocID(k);
       assertTrue(docs.contains(d));
-      assertTrue(new String(v.get()).endsWith(" docID=" + d));
+      assertTrue(new String(v.get(), UTF_8).endsWith(" docID=" + d));
       iter.next();
     }
     assertEquals(hitCount, docs.size());
@@ -296,7 +296,7 @@ public class IndexedDocIteratorTest {
       Value v = iter.getTopValue();
       Text d = IndexedDocIterator.parseDocID(k);
       assertTrue(docs.contains(d));
-      assertTrue(new String(v.get()).endsWith(" docID=" + d));
+      assertTrue(new String(v.get(), UTF_8).endsWith(" docID=" + d));
       iter.next();
     }
     assertEquals(hitCount, docs.size());
@@ -339,7 +339,7 @@ public class IndexedDocIteratorTest {
       Value v = iter.getTopValue();
       Text d = IndexedDocIterator.parseDocID(k);
       assertTrue(docs.contains(d));
-      assertTrue(new String(v.get()).endsWith(" docID=" + d));
+      assertTrue(new String(v.get(), UTF_8).endsWith(" docID=" + d));
       iter.next();
     }
     assertEquals(hitCount, docs.size());

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/IndexedDocIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/IndexedDocIteratorTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.iterators.user;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -62,7 +63,7 @@ public class IndexedDocIteratorTest {
 
   static {
     docColf.append(nullByte, 0, 1);
-    docColf.append("type".getBytes(), 0, "type".getBytes().length);
+    docColf.append("type".getBytes(UTF_8), 0, "type".getBytes(UTF_8).length);
   }
 
   private TreeMap<Key,Value> createSortedMap(float hitRatio, int numRows, int numDocsPerRow,
@@ -91,14 +92,14 @@ public class IndexedDocIteratorTest {
         boolean docHits = true;
         Text doc = new Text("type");
         doc.append(nullByte, 0, 1);
-        doc.append(String.format("%010d", docid).getBytes(), 0, 10);
+        doc.append(String.format("%010d", docid).getBytes(UTF_8), 0, 10);
         for (int j = 0; j < columnFamilies.length; j++) {
           if (random.nextFloat() < hitRatio) {
             Text colq = new Text(columnFamilies[j]);
             colq.append(nullByte, 0, 1);
             colq.append(doc.getBytes(), 0, doc.getLength());
             colq.append(nullByte, 0, 1);
-            colq.append("stuff".getBytes(), 0, "stuff".length());
+            colq.append("stuff".getBytes(UTF_8), 0, "stuff".length());
             Key k = new Key(row, indexColf, colq);
             map.put(k, v);
             sb.append(" ");
@@ -121,7 +122,7 @@ public class IndexedDocIteratorTest {
             colq.append(nullByte, 0, 1);
             colq.append(doc.getBytes(), 0, doc.getLength());
             colq.append(nullByte, 0, 1);
-            colq.append("stuff".getBytes(), 0, "stuff".length());
+            colq.append("stuff".getBytes(UTF_8), 0, "stuff".length());
             Key k = new Key(row, indexColf, colq);
             map.put(k, v);
             sb.append(" ");

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/RegExFilterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/RegExFilterTest.java
@@ -226,7 +226,8 @@ public class RegExFilterTest {
     String multiByteText = new String("\u6d67\u6F68\u7067");
     String multiByteRegex = new String(".*\u6F68.*");
 
-    Key k4 = new Key("boo4".getBytes(), "hoo".getBytes(), "20080203".getBytes(), "".getBytes(), 1L);
+    Key k4 = new Key("boo4".getBytes(UTF_8), "hoo".getBytes(UTF_8), "20080203".getBytes(UTF_8),
+        "".getBytes(UTF_8), 1L);
     Value inVal = new Value(multiByteText);
     tm.put(k4, inVal);
 
@@ -248,7 +249,7 @@ public class RegExFilterTest {
     TreeMap<Key,Value> tm = new TreeMap<>();
 
     String s1 = "first", s2 = "second";
-    byte[] b1 = s1.getBytes(), b2 = s2.getBytes(), ball;
+    byte[] b1 = s1.getBytes(UTF_8), b2 = s2.getBytes(UTF_8), ball;
     ball = new byte[b1.length + b2.length + 1];
     System.arraycopy(b1, 0, ball, 0, b1.length);
     ball[b1.length] = (byte) 0;

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/RowDeletingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/RowDeletingIteratorTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.iterators.user;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -177,13 +178,13 @@ public class RowDeletingIteratorTest {
         new TestIE(IteratorScope.scan, false));
 
     HashSet<ByteSequence> cols = new HashSet<>();
-    cols.add(new ArrayByteSequence("cf1".getBytes()));
+    cols.add(new ArrayByteSequence("cf1".getBytes(UTF_8)));
 
     rdi.seek(new Range(), cols, true);
     testAssertions(rdi, "r2", "cf1", "cq1", 5, "v1");
 
     cols.clear();
-    cols.add(new ArrayByteSequence("".getBytes()));
+    cols.add(new ArrayByteSequence("".getBytes(UTF_8)));
     rdi.seek(new Range(), cols, false);
     testAssertions(rdi, "r2", "cf1", "cq1", 5, "v1");
 

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/VersioningIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/VersioningIteratorTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.iterators.user;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -308,7 +309,7 @@ public class VersioningIteratorTest {
     it.seek(testRange, EMPTY_COL_FAMS, false);
 
     assertTrue(it.hasTop());
-    assertTrue(it.getTopValue().contentEquals("00".getBytes()));
+    assertTrue(it.getTopValue().contentEquals("00".getBytes(UTF_8)));
     it.next();
     assertFalse(it.hasTop());
   }

--- a/core/src/test/java/org/apache/accumulo/core/security/AuthorizationsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/security/AuthorizationsTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.security;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -32,7 +33,7 @@ public class AuthorizationsTest {
 
   @Test
   public void testSetOfByteArrays() {
-    assertTrue(ByteArraySet.fromStrings("a", "b", "c").contains("a".getBytes()));
+    assertTrue(ByteArraySet.fromStrings("a", "b", "c").contains("a".getBytes(UTF_8)));
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/security/ColumnVisibilityTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/security/ColumnVisibilityTest.java
@@ -37,7 +37,7 @@ public class ColumnVisibilityTest {
 
   private void shouldThrow(String... strings) {
     for (String s : strings) {
-      final byte[] sBytes = s.getBytes();
+      final byte[] sBytes = s.getBytes(UTF_8);
       assertThrows(IllegalArgumentException.class, () -> new ColumnVisibility(sBytes),
           "Should throw: " + s);
     }
@@ -45,7 +45,7 @@ public class ColumnVisibilityTest {
 
   private void shouldNotThrow(String... strings) {
     for (String s : strings) {
-      new ColumnVisibility(s.getBytes());
+      new ColumnVisibility(s.getBytes(UTF_8));
     }
   }
 
@@ -89,8 +89,8 @@ public class ColumnVisibilityTest {
 
   public void normalized(String... values) {
     for (int i = 0; i < values.length; i += 2) {
-      ColumnVisibility cv = new ColumnVisibility(values[i].getBytes());
-      assertArrayEquals(cv.flatten(), values[i + 1].getBytes());
+      ColumnVisibility cv = new ColumnVisibility(values[i].getBytes(UTF_8));
+      assertArrayEquals(cv.flatten(), values[i + 1].getBytes(UTF_8));
     }
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancerTest.java
@@ -505,8 +505,8 @@ public class HostRegexTableLoadBalancerTest extends BaseHostRegexTableLoadBalanc
       // Report that we have a bar tablet on this server
       TKeyExtent tke = new TKeyExtent();
       tke.setTable(BAR.getId().canonical().getBytes(UTF_8));
-      tke.setEndRow("11".getBytes());
-      tke.setPrevEndRow("10".getBytes());
+      tke.setEndRow("11".getBytes(UTF_8));
+      tke.setPrevEndRow("10".getBytes(UTF_8));
       TabletStats tstats = new TabletStats();
       tstats.setExtent(tke);
       TabletStatistics ts = new TabletStatisticsImpl(tstats);
@@ -515,8 +515,8 @@ public class HostRegexTableLoadBalancerTest extends BaseHostRegexTableLoadBalanc
       // Report that we have a foo tablet on this server
       TKeyExtent tke = new TKeyExtent();
       tke.setTable(FOO.getId().canonical().getBytes(UTF_8));
-      tke.setEndRow("1".getBytes());
-      tke.setPrevEndRow("0".getBytes());
+      tke.setEndRow("1".getBytes(UTF_8));
+      tke.setPrevEndRow("0".getBytes(UTF_8));
       TabletStats tstats = new TabletStats();
       tstats.setExtent(tke);
       TabletStatistics ts = new TabletStatisticsImpl(tstats);

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/AccumuloInputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/AccumuloInputFormatIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.hadoop.its.mapred;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -77,10 +78,10 @@ public class AccumuloInputFormatIT extends AccumuloClusterHarness {
       public void map(Key k, Value v, OutputCollector<Key,Value> output, Reporter reporter) {
         try {
           if (key != null) {
-            assertEquals(key.getRow().toString(), new String(v.get()));
+            assertEquals(key.getRow().toString(), new String(v.get(), UTF_8));
           }
           assertEquals(k.getRow(), new Text(String.format("%09x", count + 1)));
-          assertEquals(new String(v.get()), String.format("%09x", count));
+          assertEquals(new String(v.get(), UTF_8), String.format("%09x", count));
         } catch (AssertionError e) {
           e1 = e;
           e1Count++;

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/AccumuloOutputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/AccumuloOutputFormatIT.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.hadoop.its.mapred;
 
 import static com.google.common.collect.MoreCollectors.onlyElement;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -124,10 +125,10 @@ public class AccumuloOutputFormatIT extends ConfigurableMacBase {
         finalOutput = output;
         try {
           if (key != null) {
-            assertEquals(key.getRow().toString(), new String(v.get()));
+            assertEquals(key.getRow().toString(), new String(v.get(), UTF_8));
           }
           assertEquals(k.getRow(), new Text(String.format("%09x", count + 1)));
-          assertEquals(new String(v.get()), String.format("%09x", count));
+          assertEquals(new String(v.get(), UTF_8), String.format("%09x", count));
         } catch (AssertionError e) {
           e1 = e;
         }

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/AccumuloOutputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/AccumuloOutputFormatIT.java
@@ -218,8 +218,8 @@ public class AccumuloOutputFormatIT extends ConfigurableMacBase {
       assertNull(e1);
 
       try (Scanner scanner = c.createScanner(table2, new Authorizations())) {
-        int i = scanner.stream().map(Map.Entry::getValue).map(Value::get).map(String::new)
-            .map(Integer::parseInt).collect(onlyElement());
+        int i = scanner.stream().map(Map.Entry::getValue).map(Value::get)
+            .map(e -> new String(e, UTF_8)).map(Integer::parseInt).collect(onlyElement());
         assertEquals(100, i);
       }
     }

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/AccumuloRowInputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/AccumuloRowInputFormatIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.hadoop.its.mapred;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -75,13 +76,13 @@ public class AccumuloRowInputFormatIT extends AccumuloClusterHarness {
   @BeforeAll
   public static void prepareRows() {
     row1 = new ArrayList<>();
-    row1.add(new KeyValue(new Key(ROW1, COLF1, "colq1"), "v1".getBytes()));
-    row1.add(new KeyValue(new Key(ROW1, COLF1, "colq2"), "v2".getBytes()));
-    row1.add(new KeyValue(new Key(ROW1, "colf2", "colq3"), "v3".getBytes()));
+    row1.add(new KeyValue(new Key(ROW1, COLF1, "colq1"), "v1".getBytes(UTF_8)));
+    row1.add(new KeyValue(new Key(ROW1, COLF1, "colq2"), "v2".getBytes(UTF_8)));
+    row1.add(new KeyValue(new Key(ROW1, "colf2", "colq3"), "v3".getBytes(UTF_8)));
     row2 = new ArrayList<>();
-    row2.add(new KeyValue(new Key(ROW2, COLF1, "colq4"), "v4".getBytes()));
+    row2.add(new KeyValue(new Key(ROW2, COLF1, "colq4"), "v4".getBytes(UTF_8)));
     row3 = new ArrayList<>();
-    row3.add(new KeyValue(new Key(ROW3, COLF1, "colq5"), "v5".getBytes()));
+    row3.add(new KeyValue(new Key(ROW3, COLF1, "colq5"), "v5".getBytes(UTF_8)));
   }
 
   private static void checkLists(final List<Entry<Key,Value>> first,

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/MultiTableInputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/MultiTableInputFormatIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.hadoop.its.mapred;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -62,10 +63,10 @@ public class MultiTableInputFormatIT extends AccumuloClusterHarness {
         try {
           String tableName = ((RangeInputSplit) reporter.getInputSplit()).getTableName();
           if (key != null) {
-            assertEquals(key.getRow().toString(), new String(v.get()));
+            assertEquals(key.getRow().toString(), new String(v.get(), UTF_8));
           }
           assertEquals(new Text(String.format("%s_%09x", tableName, count + 1)), k.getRow());
-          assertEquals(String.format("%s_%09x", tableName, count), new String(v.get()));
+          assertEquals(String.format("%s_%09x", tableName, count), new String(v.get(), UTF_8));
         } catch (AssertionError e) {
           e1 = e;
         }

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/TokenFileIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/TokenFileIT.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.hadoop.its.mapred;
 
 import static com.google.common.collect.MoreCollectors.onlyElement;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -71,10 +72,10 @@ public class TokenFileIT extends AccumuloClusterHarness {
         finalOutput = output;
         try {
           if (key != null) {
-            assertEquals(key.getRow().toString(), new String(v.get()));
+            assertEquals(key.getRow().toString(), new String(v.get(), UTF_8));
           }
           assertEquals(k.getRow(), new Text(String.format("%09x", count + 1)));
-          assertEquals(new String(v.get()), String.format("%09x", count));
+          assertEquals(new String(v.get(), UTF_8), String.format("%09x", count));
         } catch (AssertionError e) {
           e1 = e;
         }

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/TokenFileIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/TokenFileIT.java
@@ -171,8 +171,8 @@ public class TokenFileIT extends AccumuloClusterHarness {
       assertNull(e1);
 
       try (Scanner scanner = c.createScanner(table2, new Authorizations())) {
-        int i = scanner.stream().map(Map.Entry::getValue).map(Value::get).map(String::new)
-            .map(Integer::parseInt).collect(onlyElement());
+        int i = scanner.stream().map(Map.Entry::getValue).map(Value::get)
+            .map(e -> new String(e, UTF_8)).map(Integer::parseInt).collect(onlyElement());
         assertEquals(100, i);
       }
     }

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/AccumuloInputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/AccumuloInputFormatIT.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.hadoop.its.mapreduce;
 
 import static java.lang.System.currentTimeMillis;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.core.util.UtilWaitThread.sleepUninterruptibly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -243,10 +244,10 @@ public class AccumuloInputFormatIT extends AccumuloClusterHarness {
         assertNotNull(table);
         try {
           if (key != null) {
-            assertEquals(key.getRow().toString(), new String(v.get()));
+            assertEquals(key.getRow().toString(), new String(v.get(), UTF_8));
           }
           assertEquals(k.getRow(), new Text(String.format("%09x", count + 1)));
-          assertEquals(new String(v.get()), String.format("%09x", count));
+          assertEquals(new String(v.get(), UTF_8), String.format("%09x", count));
         } catch (AssertionError e) {
           assertionErrors.put(table + "_map", e);
         }

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/AccumuloOutputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/AccumuloOutputFormatIT.java
@@ -144,8 +144,8 @@ public class AccumuloOutputFormatIT extends AccumuloClusterHarness {
       assertNull(e1);
 
       try (Scanner scanner = c.createScanner(table2, new Authorizations())) {
-        int i = scanner.stream().map(Map.Entry::getValue).map(Value::get).map(String::new)
-            .map(Integer::parseInt).collect(onlyElement());
+        int i = scanner.stream().map(Map.Entry::getValue).map(Value::get)
+            .map(e -> new String(e, UTF_8)).map(Integer::parseInt).collect(onlyElement());
         assertEquals(100, i);
       }
     }

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/AccumuloOutputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/AccumuloOutputFormatIT.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.hadoop.its.mapreduce;
 
 import static com.google.common.collect.MoreCollectors.onlyElement;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -58,10 +59,10 @@ public class AccumuloOutputFormatIT extends AccumuloClusterHarness {
       protected void map(Key k, Value v, Context context) {
         try {
           if (key != null) {
-            assertEquals(key.getRow().toString(), new String(v.get()));
+            assertEquals(key.getRow().toString(), new String(v.get(), UTF_8));
           }
           assertEquals(k.getRow(), new Text(String.format("%09x", count + 1)));
-          assertEquals(new String(v.get()), String.format("%09x", count));
+          assertEquals(new String(v.get(), UTF_8), String.format("%09x", count));
         } catch (AssertionError e) {
           e1 = e;
         }

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/AccumuloRowInputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/AccumuloRowInputFormatIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.hadoop.its.mapreduce;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -72,13 +73,13 @@ public class AccumuloRowInputFormatIT extends AccumuloClusterHarness {
   @BeforeAll
   public static void prepareRows() {
     row1 = new ArrayList<>();
-    row1.add(new KeyValue(new Key(ROW1, COLF1, "colq1"), "v1".getBytes()));
-    row1.add(new KeyValue(new Key(ROW1, COLF1, "colq2"), "v2".getBytes()));
-    row1.add(new KeyValue(new Key(ROW1, "colf2", "colq3"), "v3".getBytes()));
+    row1.add(new KeyValue(new Key(ROW1, COLF1, "colq1"), "v1".getBytes(UTF_8)));
+    row1.add(new KeyValue(new Key(ROW1, COLF1, "colq2"), "v2".getBytes(UTF_8)));
+    row1.add(new KeyValue(new Key(ROW1, "colf2", "colq3"), "v3".getBytes(UTF_8)));
     row2 = new ArrayList<>();
-    row2.add(new KeyValue(new Key(ROW2, COLF1, "colq4"), "v4".getBytes()));
+    row2.add(new KeyValue(new Key(ROW2, COLF1, "colq4"), "v4".getBytes(UTF_8)));
     row3 = new ArrayList<>();
-    row3.add(new KeyValue(new Key(ROW3, COLF1, "colq5"), "v5".getBytes()));
+    row3.add(new KeyValue(new Key(ROW3, COLF1, "colq5"), "v5".getBytes(UTF_8)));
   }
 
   private static void checkLists(final List<Entry<Key,Value>> first,

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/MultiTableInputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/MultiTableInputFormatIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.hadoop.its.mapreduce;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -59,10 +60,10 @@ public class MultiTableInputFormatIT extends AccumuloClusterHarness {
         try {
           String tableName = ((RangeInputSplit) context.getInputSplit()).getTableName();
           if (key != null) {
-            assertEquals(key.getRow().toString(), new String(v.get()));
+            assertEquals(key.getRow().toString(), new String(v.get(), UTF_8));
           }
           assertEquals(new Text(String.format("%s_%09x", tableName, count + 1)), k.getRow());
-          assertEquals(String.format("%s_%09x", tableName, count), new String(v.get()));
+          assertEquals(String.format("%s_%09x", tableName, count), new String(v.get(), UTF_8));
         } catch (AssertionError e) {
           e1 = e;
         }

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/RowHashIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/RowHashIT.java
@@ -114,7 +114,7 @@ public class RowHashIT extends ConfigurableMacBase {
       for (Entry<Key,Value> entry : s) {
         MessageDigest md = MessageDigest.getInstance("MD5");
         byte[] check = Base64.getEncoder().encode(md.digest(("row" + i).getBytes(UTF_8)));
-        assertEquals(entry.getValue().toString(), new String(check));
+        assertEquals(entry.getValue().toString(), new String(check, UTF_8));
         i++;
       }
     }

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/RowHashIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/RowHashIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.hadoop.its.mapreduce;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
@@ -112,7 +113,7 @@ public class RowHashIT extends ConfigurableMacBase {
       int i = 0;
       for (Entry<Key,Value> entry : s) {
         MessageDigest md = MessageDigest.getInstance("MD5");
-        byte[] check = Base64.getEncoder().encode(md.digest(("row" + i).getBytes()));
+        byte[] check = Base64.getEncoder().encode(md.digest(("row" + i).getBytes(UTF_8)));
         assertEquals(entry.getValue().toString(), new String(check));
         i++;
       }

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/TokenFileIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/TokenFileIT.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.hadoop.its.mapreduce;
 
 import static com.google.common.collect.MoreCollectors.onlyElement;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -66,10 +67,10 @@ public class TokenFileIT extends AccumuloClusterHarness {
       protected void map(Key k, Value v, Context context) {
         try {
           if (key != null) {
-            assertEquals(key.getRow().toString(), new String(v.get()));
+            assertEquals(key.getRow().toString(), new String(v.get(), UTF_8));
           }
           assertEquals(k.getRow(), new Text(String.format("%09x", count + 1)));
-          assertEquals(new String(v.get()), String.format("%09x", count));
+          assertEquals(new String(v.get(), UTF_8), String.format("%09x", count));
         } catch (AssertionError e) {
           e1 = e;
         }

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/TokenFileIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/TokenFileIT.java
@@ -165,8 +165,8 @@ public class TokenFileIT extends AccumuloClusterHarness {
       assertNull(e1);
 
       try (Scanner scanner = c.createScanner(table2, new Authorizations())) {
-        int i = scanner.stream().map(Map.Entry::getValue).map(Value::get).map(String::new)
-            .map(Integer::parseInt).collect(onlyElement());
+        int i = scanner.stream().map(Map.Entry::getValue).map(Value::get)
+            .map(e -> new String(e, UTF_8)).map(Integer::parseInt).collect(onlyElement());
         assertEquals(100, i);
       }
     }

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
@@ -553,7 +553,7 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
               s.getOutputStream().flush();
               byte[] buffer = new byte[100];
               int n = s.getInputStream().read(buffer);
-              if (n >= 4 && new String(buffer, 0, 4).equals("imok")) {
+              if (n >= 4 && new String(buffer, 0, 4, UTF_8).equals("imok")) {
                 break;
               }
             } catch (IOException | RuntimeException e) {

--- a/server/base/src/test/java/org/apache/accumulo/server/data/ServerMutationTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/data/ServerMutationTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.server.data;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -44,12 +45,12 @@ public class ServerMutationTest {
 
     assertEquals(2, updates.size());
 
-    assertEquals("r1", new String(m.getRow()));
+    assertEquals("r1", new String(m.getRow(), UTF_8));
     ColumnUpdate cu = updates.get(0);
 
-    assertEquals("cf1", new String(cu.getColumnFamily()));
-    assertEquals("cq1", new String(cu.getColumnQualifier()));
-    assertEquals("", new String(cu.getColumnVisibility()));
+    assertEquals("cf1", new String(cu.getColumnFamily(), UTF_8));
+    assertEquals("cq1", new String(cu.getColumnQualifier(), UTF_8));
+    assertEquals("", new String(cu.getColumnVisibility(), UTF_8));
     assertFalse(cu.hasTimestamp());
     assertEquals(42L, cu.getTimestamp());
 
@@ -59,19 +60,19 @@ public class ServerMutationTest {
     updates = m2.getUpdates();
 
     assertEquals(2, updates.size());
-    assertEquals("r1", new String(m2.getRow()));
+    assertEquals("r1", new String(m2.getRow(), UTF_8));
 
     cu = updates.get(0);
-    assertEquals("cf1", new String(cu.getColumnFamily()));
-    assertEquals("cq1", new String(cu.getColumnQualifier()));
+    assertEquals("cf1", new String(cu.getColumnFamily(), UTF_8));
+    assertEquals("cq1", new String(cu.getColumnQualifier(), UTF_8));
     assertFalse(cu.hasTimestamp());
     assertEquals(42L, cu.getTimestamp());
 
     cu = updates.get(1);
 
-    assertEquals("r1", new String(m2.getRow()));
-    assertEquals("cf2", new String(cu.getColumnFamily()));
-    assertEquals("cq2", new String(cu.getColumnQualifier()));
+    assertEquals("r1", new String(m2.getRow(), UTF_8));
+    assertEquals("cf2", new String(cu.getColumnFamily(), UTF_8));
+    assertEquals("cq2", new String(cu.getColumnQualifier(), UTF_8));
     assertTrue(cu.hasTimestamp());
     assertEquals(56, cu.getTimestamp());
 

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancerTest.java
@@ -459,8 +459,8 @@ public class HostRegexTableLoadBalancerTest extends BaseHostRegexTableLoadBalanc
       // Report that we have a bar tablet on this server
       TKeyExtent tke = new TKeyExtent();
       tke.setTable(BAR.getId().canonical().getBytes(UTF_8));
-      tke.setEndRow("11".getBytes());
-      tke.setPrevEndRow("10".getBytes());
+      tke.setEndRow("11".getBytes(UTF_8));
+      tke.setPrevEndRow("10".getBytes(UTF_8));
       TabletStats ts = new TabletStats();
       ts.setExtent(tke);
       tablets.add(ts);
@@ -468,8 +468,8 @@ public class HostRegexTableLoadBalancerTest extends BaseHostRegexTableLoadBalanc
       // Report that we have a foo tablet on this server
       TKeyExtent tke = new TKeyExtent();
       tke.setTable(FOO.getId().canonical().getBytes(UTF_8));
-      tke.setEndRow("1".getBytes());
-      tke.setPrevEndRow("0".getBytes());
+      tke.setEndRow("1".getBytes(UTF_8));
+      tke.setPrevEndRow("0".getBytes(UTF_8));
       TabletStats ts = new TabletStats();
       ts.setExtent(tke);
       tablets.add(ts);

--- a/server/base/src/test/java/org/apache/accumulo/server/security/handler/ZKAuthenticatorTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/security/handler/ZKAuthenticatorTest.java
@@ -66,7 +66,7 @@ public class ZKAuthenticatorTest {
   public void testAuthorizationConversion() {
     ByteArraySet auths = new ByteArraySet();
     for (int i = 0; i < 300; i += 3) {
-      auths.add(Integer.toString(i).getBytes());
+      auths.add(Integer.toString(i).getBytes(UTF_8));
     }
 
     Authorizations converted = new Authorizations(auths);
@@ -116,7 +116,7 @@ public class ZKAuthenticatorTest {
   @Deprecated
   @Test
   public void testOutdatedEncryption() throws AccumuloException {
-    byte[] rawPass = "myPassword".getBytes();
+    byte[] rawPass = "myPassword".getBytes(UTF_8);
     byte[] storedBytes;
 
     storedBytes = ZKSecurityTool.createOutdatedPass(rawPass);
@@ -125,7 +125,7 @@ public class ZKAuthenticatorTest {
 
   @Test
   public void testEncryptionDifference() throws AccumuloException {
-    byte[] rawPass = "myPassword".getBytes();
+    byte[] rawPass = "myPassword".getBytes(UTF_8);
     @SuppressWarnings("deprecation")
     byte[] storedBytes = ZKSecurityTool.createOutdatedPass(rawPass);
     assertFalse(ZKSecurityTool.checkCryptPass(rawPass, storedBytes));

--- a/server/compaction-coordinator/src/test/java/org/apache/accumulo/coordinator/CompactionCoordinatorTest.java
+++ b/server/compaction-coordinator/src/test/java/org/apache/accumulo/coordinator/CompactionCoordinatorTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.coordinator;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.expect;
 import static org.junit.Assert.assertEquals;
@@ -453,7 +454,7 @@ public class CompactionCoordinatorTest {
     TExternalCompactionJob job = PowerMock.createNiceMock(TExternalCompactionJob.class);
     expect(job.getExternalCompactionId()).andReturn(eci.toString()).anyTimes();
     TKeyExtent extent = new TKeyExtent();
-    extent.setTable("1".getBytes());
+    extent.setTable("1".getBytes(UTF_8));
     runningCompactions.add(new RunningCompaction(job, tserverAddress.toString(), "queue"));
     expect(ExternalCompactionUtil.getCompactionsRunningOnCompactors(context))
         .andReturn(runningCompactions);

--- a/server/compactor/src/test/java/org/apache/accumulo/compactor/CompactorTest.java
+++ b/server/compactor/src/test/java/org/apache/accumulo/compactor/CompactorTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.compactor;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.easymock.EasyMock.expect;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -334,7 +335,7 @@ public class CompactorTest {
     expect(job.isSetExternalCompactionId()).andReturn(true).anyTimes();
     expect(job.getExternalCompactionId()).andReturn(eci.toString()).anyTimes();
     expect(job.getExtent()).andReturn(extent).anyTimes();
-    expect(extent.getTable()).andReturn("testTable".getBytes()).anyTimes();
+    expect(extent.getTable()).andReturn("testTable".getBytes(UTF_8)).anyTimes();
 
     var conf = new ConfigurationCopy(DefaultConfiguration.getInstance());
     conf.set(Property.INSTANCE_ZK_TIMEOUT, "1d");
@@ -437,7 +438,7 @@ public class CompactorTest {
     expect(job.isSetExternalCompactionId()).andReturn(true).anyTimes();
     expect(job.getExternalCompactionId()).andReturn(eci.toString()).anyTimes();
     expect(job.getExtent()).andReturn(extent).anyTimes();
-    expect(extent.getTable()).andReturn("testTable".getBytes()).anyTimes();
+    expect(extent.getTable()).andReturn("testTable".getBytes(UTF_8)).anyTimes();
 
     var conf = new ConfigurationCopy(DefaultConfiguration.getInstance());
     conf.set(Property.INSTANCE_ZK_TIMEOUT, "1d");

--- a/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriverTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriverTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.manager.tableOps.compact;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -58,7 +59,7 @@ public class CompactionDriverTest {
     EasyMock.expect(ctx.getZooReaderWriter()).andReturn(zrw);
 
     final String zCancelID = CompactionDriver.createCompactionCancellationPath(instance, tableId);
-    EasyMock.expect(zrw.getData(zCancelID)).andReturn(Long.toString(cancelId).getBytes());
+    EasyMock.expect(zrw.getData(zCancelID)).andReturn(Long.toString(cancelId).getBytes(UTF_8));
 
     EasyMock.replay(manager, ctx, zrw);
 
@@ -96,7 +97,7 @@ public class CompactionDriverTest {
     EasyMock.expect(ctx.getZooReaderWriter()).andReturn(zrw);
 
     final String zCancelID = CompactionDriver.createCompactionCancellationPath(instance, tableId);
-    EasyMock.expect(zrw.getData(zCancelID)).andReturn(Long.toString(cancelId).getBytes());
+    EasyMock.expect(zrw.getData(zCancelID)).andReturn(Long.toString(cancelId).getBytes(UTF_8));
 
     String deleteMarkerPath = PreDeleteTable.createDeleteMarkerPath(instance, tableId);
     EasyMock.expect(zrw.exists(deleteMarkerPath)).andReturn(true);

--- a/server/monitor/src/test/java/org/apache/accumulo/monitor/it/WebViewsIT.java
+++ b/server/monitor/src/test/java/org/apache/accumulo/monitor/it/WebViewsIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.monitor.it;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.monitor.it.TagNameConstants.MONITOR;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
@@ -158,7 +159,7 @@ public class WebViewsIT extends JerseyTest {
         Annotation[] annotations, MediaType mediaType, MultivaluedMap<String,Object> httpHeaders,
         OutputStream entityStream) throws IOException, WebApplicationException {
       String s = hashMap.toString();
-      entityStream.write(s.getBytes());
+      entityStream.write(s.getBytes(UTF_8));
     }
   }
 }

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/CheckTabletMetadataTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/CheckTabletMetadataTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.tserver;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.tserver.AssignmentHandler.checkTabletMetadata;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -94,8 +95,8 @@ public class CheckTabletMetadataTest {
 
     put(tabletMeta, "1<", TabletColumnFamily.PREV_ROW_COLUMN,
         TabletColumnFamily.encodePrevEndRow(null).get());
-    put(tabletMeta, "1<", ServerColumnFamily.DIRECTORY_COLUMN, "t1".getBytes());
-    put(tabletMeta, "1<", ServerColumnFamily.TIME_COLUMN, "M0".getBytes());
+    put(tabletMeta, "1<", ServerColumnFamily.DIRECTORY_COLUMN, "t1".getBytes(UTF_8));
+    put(tabletMeta, "1<", ServerColumnFamily.TIME_COLUMN, "M0".getBytes(UTF_8));
     put(tabletMeta, "1<", FutureLocationColumnFamily.NAME, "4", "127.0.0.1:9997");
 
     TServerInstance tsi = new TServerInstance("127.0.0.1:9997", 4);

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/TservConstraintEnvTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/TservConstraintEnvTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.tserver;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
@@ -42,7 +43,7 @@ public class TservConstraintEnvTest {
     TCredentials goodCred = createMock(TCredentials.class);
     TCredentials badCred = createMock(TCredentials.class);
 
-    ByteSequence bs = new ArrayByteSequence("foo".getBytes());
+    ByteSequence bs = new ArrayByteSequence("foo".getBytes(UTF_8));
     List<ByteBuffer> bbList =
         Collections.singletonList(ByteBuffer.wrap(bs.getBackingArray(), bs.offset(), bs.length()));
 

--- a/shell/src/test/java/org/apache/accumulo/shell/commands/HistoryCommandTest.java
+++ b/shell/src/test/java/org/apache/accumulo/shell/commands/HistoryCommandTest.java
@@ -70,8 +70,8 @@ public class HistoryCommandTest {
     baos = new ByteArrayOutputStream();
 
     String input = String.format("!1%n"); // Construct a platform dependent new-line
-    terminal = new ExternalTerminal("shell", "ansi", new ByteArrayInputStream(input.getBytes()),
-        baos, UTF_8);
+    terminal = new ExternalTerminal("shell", "ansi",
+        new ByteArrayInputStream(input.getBytes(UTF_8)), baos, UTF_8);
     reader = LineReaderBuilder.builder().history(history).terminal(terminal).build();
 
     shell = new Shell(reader);

--- a/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
@@ -607,7 +607,7 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
 
           while (results.hasNext()) {
             Result result = results.next();
-            String k = new String(result.getMutation().getRow());
+            String k = new String(result.getMutation().getRow(), UTF_8);
             assertFalse(actual.containsKey(k),
                 "Did not expect to see multiple results for the row: " + k);
             actual.put(k, result.getStatus());
@@ -743,7 +743,7 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
 
         while (results.hasNext()) {
           Result result = results.next();
-          String k = new String(result.getMutation().getRow());
+          String k = new String(result.getMutation().getRow(), UTF_8);
           assertFalse(actual.containsKey(k),
               "Did not expect to see multiple results for the row: " + k);
           actual.put(k, result.getStatus());
@@ -846,7 +846,7 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
         int rejected = 0;
         while (results.hasNext()) {
           Result result = results.next();
-          if (new String(result.getMutation().getRow()).equals("99006")) {
+          if (new String(result.getMutation().getRow(), UTF_8).equals("99006")) {
             assertEquals(Status.ACCEPTED, result.getStatus());
             accepted++;
           } else {
@@ -1017,7 +1017,7 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
         HashSet<String> rows = new HashSet<>();
         while (results.hasNext()) {
           Result result = results.next();
-          String row = new String(result.getMutation().getRow());
+          String row = new String(result.getMutation().getRow(), UTF_8);
           switch (row) {
             case "19059":
               assertEquals(Status.ACCEPTED, result.getStatus());

--- a/test/src/main/java/org/apache/accumulo/test/InMemoryMapIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/InMemoryMapIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.harness.AccumuloITBase.SUNNY_DAY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -375,7 +376,7 @@ public class InMemoryMapIT extends WithTestNames {
         if (value.length() > 0) {
           value.append(",");
         }
-        value.append(new String(bytes.toArray()));
+        value.append(new String(bytes.toArray(), UTF_8));
       }
       configuration.set("table.group." + entry.getKey(), value.toString());
       enabledLGs.append(entry.getKey());

--- a/test/src/main/java/org/apache/accumulo/test/MultiTableRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MultiTableRecoveryIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.core.util.UtilWaitThread.sleepUninterruptibly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -74,7 +75,7 @@ public class MultiTableRecoveryIT extends ConfigurableMacBase {
       System.out.println("Creating tables");
       for (String tableName : tables) {
         c.tableOperations().create(tableName);
-        values[i] = Integer.toString(i).getBytes();
+        values[i] = Integer.toString(i).getBytes(UTF_8);
         writers[i] = c.createBatchWriter(tableName);
         i++;
       }

--- a/test/src/main/java/org/apache/accumulo/test/VerifyIngest.java
+++ b/test/src/main/java/org/apache/accumulo/test/VerifyIngest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map.Entry;
@@ -227,8 +229,8 @@ public class VerifyIngest {
 
             if (entry.getValue().compareTo(value) != 0) {
               log.error("unexpected value, rowNum : {} colNum : {}", rowNum, colNum);
-              log.error(" saw = {} expected = {}", new String(entry.getValue().get()),
-                  new String(value));
+              log.error(" saw = {} expected = {}", new String(entry.getValue().get(), UTF_8),
+                  new String(value, UTF_8));
               errors++;
             }
 

--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ServiceLockIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ServiceLockIT.java
@@ -689,10 +689,10 @@ public class ServiceLockIT {
       TestALW lw = new TestALW();
 
       zl.lock(lw, "test1".getBytes(UTF_8));
-      assertEquals("test1", new String(zk.getData(zl.getLockPath(), null, null)));
+      assertEquals("test1", new String(zk.getData(zl.getLockPath(), null, null), UTF_8));
 
       zl.replaceLockData("test2".getBytes(UTF_8));
-      assertEquals("test2", new String(zk.getData(zl.getLockPath(), null, null)));
+      assertEquals("test2", new String(zk.getData(zl.getLockPath(), null, null), UTF_8));
     }
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/functional/AuthsIterator.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/AuthsIterator.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.test.functional;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.IOException;
 import java.util.Map;
 
@@ -31,7 +33,7 @@ import org.apache.hadoop.io.Text;
 
 public class AuthsIterator extends WrappingIterator {
 
-  public static final Authorizations AUTHS = new Authorizations("A,B".getBytes());
+  public static final Authorizations AUTHS = new Authorizations("A,B".getBytes(UTF_8));
   public static final String SUCCESS = "SUCCESS";
   public static final String FAIL = "FAIL";
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/CombinerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CombinerIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.test.functional;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Duration;
@@ -62,7 +63,7 @@ public class CombinerIT extends AccumuloClusterHarness {
       try (BatchWriter bw = c.createBatchWriter(tableName)) {
         for (int i = 0; i < 10; i++) {
           Mutation m = new Mutation("row1");
-          m.put("cf".getBytes(), "col1".getBytes(), ("" + i).getBytes());
+          m.put("cf".getBytes(UTF_8), "col1".getBytes(UTF_8), ("" + i).getBytes(UTF_8));
           bw.addMutation(m);
         }
       }

--- a/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.test.functional;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.core.util.UtilWaitThread.sleepUninterruptibly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -422,7 +423,7 @@ public class GarbageCollectorIT extends ConfigurableMacBase {
         if (locks != null && !locks.isEmpty()) {
           String lockPath = path + "/" + locks.get(0);
 
-          String gcLoc = new String(zk.getData(lockPath));
+          String gcLoc = new String(zk.getData(lockPath), UTF_8);
 
           assertTrue(gcLoc.startsWith(Service.GC_CLIENT.name()),
               "Found unexpected data in zookeeper for GC location: " + gcLoc);

--- a/test/src/main/java/org/apache/accumulo/test/functional/KerberosIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/KerberosIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.test.functional;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.apache.accumulo.harness.AccumuloITBase.MINI_CLUSTER_ONLY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -366,7 +367,7 @@ public class KerberosIT extends AccumuloITBase {
       final long ts = 1000L;
       try (BatchWriter bw = client.createBatchWriter(table)) {
         Mutation m = new Mutation("a");
-        m.put("b", "c", new ColumnVisibility(viz.getBytes()), ts, "d");
+        m.put("b", "c", new ColumnVisibility(viz.getBytes(UTF_8)), ts, "d");
         bw.addMutation(m);
       }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/WatchTheWatchCountIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/WatchTheWatchCountIT.java
@@ -73,7 +73,7 @@ public class WatchTheWatchCountIT extends ConfigurableMacBase {
           socket.getOutputStream().write("wchs\n".getBytes(UTF_8), 0, 5);
           byte[] buffer = new byte[1024];
           int n = socket.getInputStream().read(buffer);
-          String response = new String(buffer, 0, n);
+          String response = new String(buffer, 0, n, UTF_8);
           total = Long.parseLong(response.split(":")[1].trim());
           log.info("Total: {}", total);
           if (total > MIN && total < MAX) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/WatchTheWatchCountIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/WatchTheWatchCountIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.test.functional;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.Socket;
@@ -69,7 +70,7 @@ public class WatchTheWatchCountIT extends ConfigurableMacBase {
       final HostAndPort hostAndPort = HostAndPort.fromString(zooKeepers);
       for (int i = 0; i < 5; i++) {
         try (Socket socket = new Socket(hostAndPort.getHost(), hostAndPort.getPort())) {
-          socket.getOutputStream().write("wchs\n".getBytes(), 0, 5);
+          socket.getOutputStream().write("wchs\n".getBytes(UTF_8), 0, 5);
           byte[] buffer = new byte[1024];
           int n = socket.getInputStream().read(buffer);
           String response = new String(buffer, 0, n);

--- a/test/src/main/java/org/apache/accumulo/test/mapred/AccumuloOutputFormatIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapred/AccumuloOutputFormatIT.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.test.mapred;
 
 import static com.google.common.collect.MoreCollectors.onlyElement;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -233,8 +234,8 @@ public class AccumuloOutputFormatIT extends ConfigurableMacBase {
       assertNull(e1);
 
       try (Scanner scanner = c.createScanner(table2, new Authorizations())) {
-        int actual = scanner.stream().map(Entry::getValue).map(Value::get).map(String::new)
-            .map(Integer::parseInt).collect(onlyElement());
+        int actual = scanner.stream().map(Entry::getValue).map(Value::get)
+            .map(e -> new String(e, UTF_8)).map(Integer::parseInt).collect(onlyElement());
         assertEquals(100, actual);
       }
     }

--- a/test/src/main/java/org/apache/accumulo/test/metrics/TestStatsDSink.java
+++ b/test/src/main/java/org/apache/accumulo/test/metrics/TestStatsDSink.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.test.metrics;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.DatagramPacket;
@@ -102,7 +104,7 @@ public class TestStatsDSink implements Closeable {
         DatagramPacket packet = new DatagramPacket(buf, len);
         try {
           sock.receive(packet);
-          received.add(new String(packet.getData(), 0, packet.getLength()));
+          received.add(new String(packet.getData(), 0, packet.getLength(), UTF_8));
         } catch (IOException e) {
           if (!sock.isClosed()) {
             LOG.error("Error receiving packet", e);


### PR DESCRIPTION
This PR attempts to address all String-to-bytes and bytes-to-String conversions so they all consistently use UTF-8 (see more commentary in #3815). Being a follow-on to #3815, this PR mostly makes changes to test code that had not previously been covered.

The following fixes have been made:
- String-to-bytes: `String.getBytes()` -> `String.getBytes(UTF_8)`
- Bytes-to-String: `new String(byte[])` -> `new String(byte[], UTF_8)`

Fixes #4765 "Fix String-to-bytes and bytes-toString for UTF-8 for all remaining code"