### PR TITLE
always uses conditional writer interceptor in test ample

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ConditionalTabletsMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ConditionalTabletsMutatorImpl.java
@@ -163,6 +163,12 @@ public class ConditionalTabletsMutatorImpl implements Ample.ConditionalTabletsMu
     }
   }
 
+  protected Retry createUnknownRetry() {
+    return Retry.builder().infiniteRetries().retryAfter(Duration.ofMillis(100))
+        .incrementBy(Duration.ofMillis(100)).maxWait(Duration.ofSeconds(2)).backOffFactor(1.5)
+        .logInterval(Duration.ofMinutes(3)).createRetry();
+  }
+
   private Iterator<ConditionalWriter.Result> writeMutations(ConditionalWriter conditionalWriter) {
     var results = conditionalWriter.write(mutations.iterator());
 
@@ -175,9 +181,7 @@ public class ConditionalTabletsMutatorImpl implements Ample.ConditionalTabletsMu
     while (!unknownResults.isEmpty()) {
       try {
         if (retry == null) {
-          retry = Retry.builder().infiniteRetries().retryAfter(Duration.ofMillis(100))
-              .incrementBy(Duration.ofMillis(100)).maxWait(Duration.ofSeconds(2)).backOffFactor(1.5)
-              .logInterval(Duration.ofMinutes(3)).createRetry();
+          retry = createUnknownRetry();
         }
         retry.waitForNextAttempt(log, "handle conditional mutations with unknown status");
       } catch (InterruptedException e) {

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
@@ -99,7 +99,8 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
   @Override
   public AsyncConditionalTabletsMutator
       conditionallyMutateTablets(Consumer<ConditionalResult> resultsConsumer) {
-    return new AsyncConditionalTabletsMutatorImpl(context, getTableMapper(), resultsConsumer);
+    return new AsyncConditionalTabletsMutatorImpl(resultsConsumer,
+        () -> new ConditionalTabletsMutatorImpl(context, getTableMapper()));
   }
 
   private void mutateRootGcCandidates(Consumer<RootGcCandidates> mutator) {


### PR DESCRIPTION
Ample has two ways to write conditional mutations.  TestAmple was only intercepting conditional mutations for one of these methods. This commit updates TestAmple to incercept both.

Also made TestAmple set more aggressive retry times for failed conditional muations.  This speeds up all of the FlakyAmple ITs. This change is important because more conditional mutations are failing with these changes and the those tests were running slower.