### PR TITLE
Add Flaky external compaction tests for failed compactions

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction2BaseIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction2BaseIT.java
@@ -59,32 +59,28 @@ import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.harness.MiniClusterConfigurationCallback;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
-import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.util.FindCompactionTmpFiles;
 import org.apache.accumulo.test.util.Wait;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
-public class ExternalCompaction_2_IT extends SharedMiniClusterBase {
+public class ExternalCompaction2BaseIT extends SharedMiniClusterBase {
 
-  public static class ExternalCompaction2Config implements MiniClusterConfigurationCallback {
+  static class ExternalCompaction2Config implements MiniClusterConfigurationCallback {
     @Override
     public void configureMiniCluster(MiniAccumuloConfigImpl cfg, Configuration coreSite) {
       ExternalCompactionTestUtils.configureMiniCluster(cfg, coreSite);
     }
   }
 
-  @BeforeAll
-  public static void beforeTests() throws Exception {
-    startMiniClusterWithConfig(new ExternalCompaction2Config());
-    getCluster().getClusterControl().stop(ServerType.COMPACTOR);
-    getCluster().getClusterControl().start(ServerType.COMPACTOR, null, 1,
-        ExternalDoNothingCompactor.class);
+  @AfterAll
+  public static void teardown() {
+    SharedMiniClusterBase.stopMiniCluster();
   }
 
   @Test

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction2_IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction2_IT.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test.compaction;
+
+import org.apache.accumulo.minicluster.ServerType;
+import org.junit.jupiter.api.BeforeAll;
+
+public class ExternalCompaction2_IT extends ExternalCompaction2BaseIT {
+
+  @BeforeAll
+  public static void beforeTests() throws Exception {
+    startMiniClusterWithConfig(new ExternalCompaction2Config());
+    getCluster().getClusterControl().stop(ServerType.COMPACTOR);
+    getCluster().getClusterControl().start(ServerType.COMPACTOR, null, 1,
+        ExternalDoNothingCompactor.class);
+  }
+}

--- a/test/src/main/java/org/apache/accumulo/test/compaction/FlakyExternalCompaction2IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/FlakyExternalCompaction2IT.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test.compaction;
+
+import org.apache.accumulo.harness.SharedMiniClusterBase;
+import org.apache.accumulo.minicluster.ServerType;
+import org.apache.accumulo.test.ample.FlakyAmpleManager;
+import org.apache.accumulo.test.ample.FlakyAmpleServerContext;
+import org.apache.accumulo.test.ample.FlakyAmpleTserver;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+/**
+ * Run all of ExternalCompaction2 ITs using a flaky Ample impl that will cause random UNKNOWN status
+ * to be returned when submitting conditional mutations so that rejection handlers can be tested.
+ * See {@link FlakyAmpleServerContext} for more info.
+ *
+ * The tests in this IT primarily test cancelling compactions and the flaky Ample impl will test
+ * that rejection handlers such as the handler used for
+ * CompactionCoordinator.compactionFailedForLevel work.
+ */
+public class FlakyExternalCompaction2IT extends ExternalCompaction2BaseIT {
+
+  @BeforeAll
+  public static void setup() throws Exception {
+    SharedMiniClusterBase.startMiniClusterWithConfig((cfg, coreSite) -> {
+      ExternalCompactionTestUtils.configureMiniCluster(cfg, coreSite);
+      cfg.setServerClass(ServerType.MANAGER, FlakyAmpleManager.class);
+      cfg.setServerClass(ServerType.TABLET_SERVER, FlakyAmpleTserver.class);
+    });
+    getCluster().getClusterControl().stop(ServerType.COMPACTOR);
+    getCluster().getClusterControl().start(ServerType.COMPACTOR, null, 1,
+        ExternalDoNothingCompactor.class);
+  }
+
+  @AfterAll
+  public static void teardown() {
+    SharedMiniClusterBase.stopMiniCluster();
+  }
+}


### PR DESCRIPTION
This refactors `ExternalCompaction_2_IT` so that the same tests can be run using a Flaky Ample implementation which will randomly return an UNKNOWN status when submitting conditional mutations. The tests being run are related to cancelling compaction jobs so this test makes sure the rejection handlers related to job cancellation in CompactionCoordinator work correctly, such as the rejection handler used inside of `CompactionCoordinator.compactionFailedForLevel`

This implements one of the methods detected as missing code coverage that is listed in #4710

I first looked at using TestAmple directly but there would have a been a ton of changes to isolate and test as there would have been a lot of refactoring to be able to ceate a CompactionCoordinator in an IT and inject a test Ample instance. It was much simpler to use FlakyAmple for the testing and extend the existing tests. I verified that when running the new test, if the rejection handler is not used and commented out, the tests will fail (at least on some runs as UNKNOWN status is randomly returned)

**Note:** that I renamed ExternalCompaction_2_IT to ExternalCompaction2BaseIt and created a new ExternalCompaction2IT class so that git would pick up the rename and not have a huge diff. We could rename it back after this is merged.