### PR TITLE
Fix javadoc format error with metrics

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metrics/MetricsProducer.java
+++ b/core/src/main/java/org/apache/accumulo/core/metrics/MetricsProducer.java
@@ -362,25 +362,25 @@ import io.micrometer.core.instrument.MeterRegistry;
  * </tr>
  * <!-- scan server -->
  * <tr>
- * <th>N/A</th>
- * <th>N/A</th>
- * <th>{@value #METRICS_SCAN_RESERVATION_TOTAL_TIMER}</th>
- * <th>Timer</th>
- * <th>Time to reserve a tablets files for scan</th>
+ * <td>N/A</td>
+ * <td>N/A</td>
+ * <td>{@value #METRICS_SCAN_RESERVATION_TOTAL_TIMER}</td>
+ * <td>Timer</td>
+ * <td>Time to reserve a tablets files for scan</td>
  * </tr>
  * <tr>
- * <th>N/A</th>
- * <th>N/A</th>
- * <th>{@value #METRICS_SCAN_BUSY_TIMEOUT_COUNTER}</th>
- * <th>Counter</th>
- * <th>Count of the scans where a busy timeout happened</th>
+ * <td>N/A</td>
+ * <td>N/A</td>
+ * <td>{@value #METRICS_SCAN_BUSY_TIMEOUT_COUNTER}</td>
+ * <td>Counter</td>
+ * <td>Count of the scans where a busy timeout happened</td>
  * </tr>
  * <tr>
- * <th>N/A</th>
- * <th>N/A</th>
- * <th>{@value #METRICS_SCAN_TABLET_METADATA_CACHE}</th>
- * <th>Cache</th>
- * <th>scan server tablet cache metrics</th>
+ * <td>N/A</td>
+ * <td>N/A</td>
+ * <td>{@value #METRICS_SCAN_TABLET_METADATA_CACHE}</td>
+ * <td>Cache</td>
+ * <td>scan server tablet cache metrics</td>
  * </tr>
  * <!-- scans -->
  * <tr>


### PR DESCRIPTION
Switches from `<th>` to `<td>` for metric entry documentation