### PR TITLE
New `admin check` command structure implementation

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
@@ -29,17 +29,23 @@ import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.Formatter;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -76,6 +82,13 @@ import org.apache.accumulo.core.util.tables.TableMap;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.cli.ServerUtilOpts;
 import org.apache.accumulo.server.security.SecurityUtil;
+import org.apache.accumulo.server.util.checkCommand.CheckRunner;
+import org.apache.accumulo.server.util.checkCommand.MetadataTableCheckRunner;
+import org.apache.accumulo.server.util.checkCommand.RootMetadataCheckRunner;
+import org.apache.accumulo.server.util.checkCommand.RootTableCheckRunner;
+import org.apache.accumulo.server.util.checkCommand.SystemConfigCheckRunner;
+import org.apache.accumulo.server.util.checkCommand.SystemFilesCheckRunner;
+import org.apache.accumulo.server.util.checkCommand.UserFilesCheckRunner;
 import org.apache.accumulo.server.util.fateCommand.FateSummaryReport;
 import org.apache.accumulo.start.spi.KeywordExecutable;
 import org.apache.zookeeper.KeeperException;
@@ -86,6 +99,8 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.google.auto.service.AutoService;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Lists;
 import com.google.common.net.HostAndPort;
@@ -112,6 +127,82 @@ public class Admin implements KeywordExecutable {
   static class PingCommand {
     @Parameter(description = "{<host> ... }")
     List<String> args = new ArrayList<>();
+  }
+
+  @Parameters(commandNames = "check",
+      commandDescription = "Performs checks for problems in Accumulo.")
+  public static class CheckCommand {
+    @Parameter(names = "list",
+        description = "Lists the different checks that can be run, the description of each check, and the other check(s) each check depends on.")
+    boolean list;
+
+    @Parameter(names = "run",
+        description = "Runs the provided check(s) (explicit list or regex pattern specified following '-p'), beginning with their dependencies, or all checks if none are provided.")
+    boolean run;
+
+    @Parameter(names = {"--name_pattern", "-p"},
+        description = "Runs all checks that match the provided regex pattern.")
+    boolean useRegex;
+
+    @Parameter(description = "[<Check>...]")
+    List<String> checks;
+
+    public enum Check {
+      // Caution should be taken when changing or adding any new checks: order is important
+      SYSTEM_CONFIG, ROOT_METADATA, ROOT_TABLE, METADATA_TABLE, SYSTEM_FILES, USER_FILES;
+
+      private static final Map<Check,String> CHECK_DESCRIPTION = new EnumMap<>(Check.class);
+      private static final Map<Check,List<Check>> CHECK_DEPENDENCIES = new EnumMap<>(Check.class);
+      private static final Map<Check,Supplier<CheckRunner>> CHECK_RUNNERS =
+          new EnumMap<>(Check.class);
+
+      static {
+        CHECK_DESCRIPTION.put(SYSTEM_CONFIG, "Validate the system config stored in ZooKeeper");
+        CHECK_DESCRIPTION.put(ROOT_METADATA,
+            "Checks integrity of the root tablet metadata stored in ZooKeeper");
+        CHECK_DESCRIPTION.put(ROOT_TABLE,
+            "Scans all the tablet metadata stored in the root table and checks integrity");
+        CHECK_DESCRIPTION.put(METADATA_TABLE,
+            "Scans all the tablet metadata stored in the metadata table and checks integrity");
+        CHECK_DESCRIPTION.put(SYSTEM_FILES,
+            "Checks that files in system tablet metadata exist in DFS");
+        CHECK_DESCRIPTION.put(USER_FILES, "Checks that files in user tablet metadata exist in DFS");
+
+        CHECK_DEPENDENCIES.put(SYSTEM_CONFIG, Collections.emptyList());
+        CHECK_DEPENDENCIES.put(ROOT_METADATA, Collections.singletonList(SYSTEM_CONFIG));
+        CHECK_DEPENDENCIES.put(ROOT_TABLE, Collections.singletonList(ROOT_METADATA));
+        CHECK_DEPENDENCIES.put(METADATA_TABLE, Collections.singletonList(ROOT_TABLE));
+        CHECK_DEPENDENCIES.put(SYSTEM_FILES, Collections.singletonList(ROOT_TABLE));
+        CHECK_DEPENDENCIES.put(USER_FILES, Collections.singletonList(METADATA_TABLE));
+
+        CHECK_RUNNERS.put(SYSTEM_CONFIG, SystemConfigCheckRunner::new);
+        CHECK_RUNNERS.put(ROOT_METADATA, RootMetadataCheckRunner::new);
+        CHECK_RUNNERS.put(ROOT_TABLE, RootTableCheckRunner::new);
+        CHECK_RUNNERS.put(METADATA_TABLE, MetadataTableCheckRunner::new);
+        CHECK_RUNNERS.put(SYSTEM_FILES, SystemFilesCheckRunner::new);
+        CHECK_RUNNERS.put(USER_FILES, UserFilesCheckRunner::new);
+      }
+
+      /**
+       * @return the list of other checks the check depends on
+       */
+      private List<Check> getDependencies() {
+        return Optional.ofNullable(CHECK_DEPENDENCIES.get(this))
+            .orElseThrow(() -> new IllegalStateException("Invalid check " + this));
+      }
+
+      /**
+       * @return the interface for running a check
+       */
+      private CheckRunner getCheckRunner() {
+        return Optional.ofNullable(CHECK_RUNNERS.get(this).get())
+            .orElseThrow(() -> new IllegalStateException("Invalid check " + this));
+      }
+    }
+
+    public enum CheckStatus {
+      OK, FAILED, SKIPPED_DEPENDENCY_FAILED;
+    }
   }
 
   @Parameters(commandDescription = "print tablets that are offline in online tables")
@@ -274,6 +365,9 @@ public class Admin implements KeywordExecutable {
     ChangeSecretCommand changeSecretCommand = new ChangeSecretCommand();
     cl.addCommand("changeSecret", changeSecretCommand);
 
+    CheckCommand checkCommand = new CheckCommand();
+    cl.addCommand("check", checkCommand);
+
     CheckTabletsCommand checkTabletsCommand = new CheckTabletsCommand();
     cl.addCommand("checkTablets", checkTabletsCommand);
 
@@ -380,6 +474,8 @@ public class Admin implements KeywordExecutable {
         executeFateOpsCommand(context, fateOpsCommand);
       } else if (cl.getParsedCommand().equals("serviceStatus")) {
         printServiceStatus(context, serviceStatusCommandOpts);
+      } else if (cl.getParsedCommand().equals("check")) {
+        executeCheckCommand(context, checkCommand);
       } else {
         everything = cl.getParsedCommand().equals("stopAll");
 
@@ -906,5 +1002,130 @@ public class Admin implements KeywordExecutable {
       }
     }
     return statusFilter;
+  }
+
+  @VisibleForTesting
+  public static void executeCheckCommand(ServerContext context, CheckCommand cmd) {
+    List<CheckCommand.Check> checks;
+
+    validateAndTransformCheckCommand(cmd);
+
+    if (cmd.list) {
+      listChecks();
+    } else if (cmd.run) {
+      checks = cmd.checks.stream().map(CheckCommand.Check::valueOf).collect(Collectors.toList());
+      executeRunCheckCommand(checks);
+    }
+  }
+
+  private static void validateAndTransformCheckCommand(CheckCommand cmd) {
+    Preconditions.checkArgument(cmd.list != cmd.run, "Must use either 'list' or 'run'");
+    if (cmd.list) {
+      Preconditions.checkArgument(cmd.checks == null,
+          "'list' does not expect any further arguments");
+    } else if (cmd.useRegex) {
+      // run with regex provided
+      Preconditions.checkArgument(cmd.checks != null, "Expected a regex pattern to be provided");
+      Preconditions.checkArgument(cmd.checks.size() == 1,
+          "Expected one argument (the regex pattern)");
+      String regex = cmd.checks.get(0).toUpperCase();
+      List<String> matchingChecks = new ArrayList<>();
+      var pattern = Pattern.compile(regex);
+      for (CheckCommand.Check check : CheckCommand.Check.values()) {
+        if (pattern.matcher(check.name()).matches()) {
+          matchingChecks.add(check.name());
+        }
+      }
+      Preconditions.checkArgument(!matchingChecks.isEmpty(),
+          "No checks matched the given pattern: " + regex);
+      cmd.checks = matchingChecks;
+    } else {
+      // run without regex provided
+      if (cmd.checks == null) {
+        cmd.checks = EnumSet.allOf(CheckCommand.Check.class).stream().map(Enum::name)
+            .collect(Collectors.toList());
+      }
+    }
+  }
+
+  private static void listChecks() {
+    System.out.println();
+    System.out.printf("%-20s | %-80s | %-20s%n", "Check Name", "Description", "Depends on");
+    System.out.println("-".repeat(120));
+    for (CheckCommand.Check check : CheckCommand.Check.values()) {
+      System.out.printf("%-20s | %-80s | %-20s%n", check.name(),
+          CheckCommand.Check.CHECK_DESCRIPTION.get(check), check.getDependencies().stream()
+              .map(CheckCommand.Check::name).collect(Collectors.joining(", ")));
+    }
+    System.out.println("-".repeat(120));
+    System.out.println();
+  }
+
+  private static void executeRunCheckCommand(List<CheckCommand.Check> checks) {
+    final List<CheckCommand.Check> allChecksToRun = new ArrayList<>();
+    final TreeMap<CheckCommand.Check,CheckCommand.CheckStatus> checkStatus = new TreeMap<>();
+
+    // From the given list of checks to run, we need to compute all the checks that need to be
+    // run (the given checks and all the checks the given checks depend on)
+    computeAllChecksToRun(checks, allChecksToRun);
+    Preconditions.checkState(!allChecksToRun.isEmpty());
+
+    // Sort the checks in the order they are declared in the enum
+    Collections.sort(allChecksToRun);
+    CheckCommand.Check firstCheck = allChecksToRun.remove(0);
+    Preconditions.checkState(firstCheck.ordinal() == 0,
+        "Expected first check to be " + CheckCommand.Check.values()[0] + " but was " + firstCheck);
+    checkStatus.put(firstCheck, firstCheck.getCheckRunner().runCheck());
+    // Run each of the checks only if the dependencies of that check were successful
+    // Otherwise, skip the check
+    for (CheckCommand.Check check : allChecksToRun) {
+      boolean runCheck = true;
+      for (CheckCommand.Check dep : check.getDependencies()) {
+        Preconditions.checkState(checkStatus.get(dep) != null,
+            "Expected dependency " + dep + " to have a status set before attempting to run " + check
+                + ", but this was not the case.");
+        if (checkStatus.get(dep) == CheckCommand.CheckStatus.SKIPPED_DEPENDENCY_FAILED
+            || checkStatus.get(dep) == CheckCommand.CheckStatus.FAILED) {
+          runCheck = false;
+          break;
+        }
+      }
+      if (runCheck) {
+        checkStatus.put(check, check.getCheckRunner().runCheck());
+      } else {
+        checkStatus.put(check, CheckCommand.CheckStatus.SKIPPED_DEPENDENCY_FAILED);
+      }
+    }
+
+    printChecksResults(checkStatus);
+  }
+
+  private static void computeAllChecksToRun(final List<CheckCommand.Check> givenChecks,
+      final List<CheckCommand.Check> allChecksToRun) {
+    // Avoids unnecessary computation
+    if ((new HashSet<>(givenChecks)).equals(Set.of(CheckCommand.Check.values()))) {
+      allChecksToRun.clear();
+      allChecksToRun.addAll(givenChecks);
+      return;
+    }
+
+    for (CheckCommand.Check check : givenChecks) {
+      if (!allChecksToRun.contains(check)) {
+        allChecksToRun.add(check);
+        computeAllChecksToRun(check.getDependencies(), allChecksToRun);
+      }
+    }
+  }
+
+  private static void
+      printChecksResults(TreeMap<CheckCommand.Check,CheckCommand.CheckStatus> checkStatus) {
+    System.out.println();
+    System.out.printf("%-20s | %-20s%n", "Check Name", "Status");
+    System.out.println("-".repeat(50));
+    for (Map.Entry<CheckCommand.Check,CheckCommand.CheckStatus> entry : checkStatus.entrySet()) {
+      System.out.printf("%-20s | %-20s%n", entry.getKey().name(), entry.getValue().name());
+    }
+    System.out.println("-".repeat(50));
+    System.out.println();
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
@@ -140,7 +140,7 @@ public class Admin implements KeywordExecutable {
 
     @Parameter(names = {"--name_pattern", "-p"},
         description = "Runs all checks that match the provided regex pattern.")
-    boolean useRegex;
+    String pattern;
 
     @Parameter(description = "[<Check>...]")
     List<String> checks;
@@ -1029,22 +1029,19 @@ public class Admin implements KeywordExecutable {
   private static void validateAndTransformCheckCommand(CheckCommand cmd) {
     Preconditions.checkArgument(cmd.list != cmd.run, "Must use either 'list' or 'run'");
     if (cmd.list) {
-      Preconditions.checkArgument(cmd.checks == null,
+      Preconditions.checkArgument(cmd.checks == null && cmd.pattern == null,
           "'list' does not expect any further arguments");
-    } else if (cmd.useRegex) {
-      Preconditions.checkArgument(cmd.checks != null, "Expected a regex pattern to be provided");
-      Preconditions.checkArgument(cmd.checks.size() == 1,
-          "Expected one argument (the regex pattern)");
-      String regex = cmd.checks.get(0).toUpperCase();
+    } else if (cmd.pattern != null) {
+      Preconditions.checkArgument(cmd.checks == null, "Expected one argument (the regex pattern)");
       List<String> matchingChecks = new ArrayList<>();
-      var pattern = Pattern.compile(regex);
+      var pattern = Pattern.compile(cmd.pattern.toUpperCase());
       for (CheckCommand.Check check : CheckCommand.Check.values()) {
         if (pattern.matcher(check.name()).matches()) {
           matchingChecks.add(check.name());
         }
       }
       Preconditions.checkArgument(!matchingChecks.isEmpty(),
-          "No checks matched the given pattern: " + regex);
+          "No checks matched the given pattern: " + pattern.pattern());
       cmd.checks = matchingChecks;
     } else {
       if (cmd.checks == null) {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
@@ -28,7 +28,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Formatter;

--- a/server/base/src/main/java/org/apache/accumulo/server/util/checkCommand/CheckRunner.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/checkCommand/CheckRunner.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.util.checkCommand;
+
+import org.apache.accumulo.server.util.Admin;
+
+public interface CheckRunner {
+
+  /**
+   * Runs the check
+   *
+   * @return the {@link Admin.CheckCommand.CheckStatus} resulting from running the check
+   */
+  Admin.CheckCommand.CheckStatus runCheck();
+
+  /**
+   *
+   * @return the check that this check runner runs
+   */
+  Admin.CheckCommand.Check getCheck();
+
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/util/checkCommand/MetadataTableCheckRunner.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/checkCommand/MetadataTableCheckRunner.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.util.checkCommand;
+
+import org.apache.accumulo.server.util.Admin;
+
+public class MetadataTableCheckRunner implements CheckRunner {
+  private static final Admin.CheckCommand.Check check = Admin.CheckCommand.Check.METADATA_TABLE;
+
+  @Override
+  public Admin.CheckCommand.CheckStatus runCheck() {
+    Admin.CheckCommand.CheckStatus status = Admin.CheckCommand.CheckStatus.OK;
+
+    System.out.println("Running check " + check);
+    // work
+    System.out.println("Check " + check + " completed with status " + status);
+    return status;
+  }
+
+  @Override
+  public Admin.CheckCommand.Check getCheck() {
+    return check;
+  }
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/util/checkCommand/RootMetadataCheckRunner.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/checkCommand/RootMetadataCheckRunner.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.util.checkCommand;
+
+import org.apache.accumulo.server.util.Admin;
+
+public class RootMetadataCheckRunner implements CheckRunner {
+  private static final Admin.CheckCommand.Check check = Admin.CheckCommand.Check.ROOT_METADATA;
+
+  @Override
+  public Admin.CheckCommand.CheckStatus runCheck() {
+    Admin.CheckCommand.CheckStatus status = Admin.CheckCommand.CheckStatus.OK;
+
+    System.out.println("Running check " + check);
+    // work
+    System.out.println("Check " + check + " completed with status " + status);
+    return status;
+  }
+
+  @Override
+  public Admin.CheckCommand.Check getCheck() {
+    return check;
+  }
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/util/checkCommand/RootTableCheckRunner.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/checkCommand/RootTableCheckRunner.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.util.checkCommand;
+
+import org.apache.accumulo.server.util.Admin;
+
+public class RootTableCheckRunner implements CheckRunner {
+  private static final Admin.CheckCommand.Check check = Admin.CheckCommand.Check.ROOT_TABLE;
+
+  @Override
+  public Admin.CheckCommand.CheckStatus runCheck() {
+    Admin.CheckCommand.CheckStatus status = Admin.CheckCommand.CheckStatus.OK;
+
+    System.out.println("Running check " + check);
+    // work
+    System.out.println("Check " + check + " completed with status " + status);
+    return status;
+  }
+
+  @Override
+  public Admin.CheckCommand.Check getCheck() {
+    return check;
+  }
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/util/checkCommand/SystemConfigCheckRunner.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/checkCommand/SystemConfigCheckRunner.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.util.checkCommand;
+
+import org.apache.accumulo.server.util.Admin;
+
+public class SystemConfigCheckRunner implements CheckRunner {
+  private static final Admin.CheckCommand.Check check = Admin.CheckCommand.Check.SYSTEM_CONFIG;
+
+  @Override
+  public Admin.CheckCommand.CheckStatus runCheck() {
+    Admin.CheckCommand.CheckStatus status = Admin.CheckCommand.CheckStatus.OK;
+
+    System.out.println("Running check " + check);
+    // work
+    System.out.println("Check " + check + " completed with status " + status);
+    return status;
+  }
+
+  @Override
+  public Admin.CheckCommand.Check getCheck() {
+    return check;
+  }
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/util/checkCommand/SystemFilesCheckRunner.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/checkCommand/SystemFilesCheckRunner.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.util.checkCommand;
+
+import org.apache.accumulo.server.util.Admin;
+
+public class SystemFilesCheckRunner implements CheckRunner {
+  private static final Admin.CheckCommand.Check check = Admin.CheckCommand.Check.SYSTEM_FILES;
+
+  @Override
+  public Admin.CheckCommand.CheckStatus runCheck() {
+    Admin.CheckCommand.CheckStatus status = Admin.CheckCommand.CheckStatus.OK;
+
+    System.out.println("Running check " + check);
+    // work
+    System.out.println("Check " + check + " completed with status " + status);
+    return status;
+  }
+
+  @Override
+  public Admin.CheckCommand.Check getCheck() {
+    return check;
+  }
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/util/checkCommand/UserFilesCheckRunner.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/checkCommand/UserFilesCheckRunner.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.util.checkCommand;
+
+import static org.apache.accumulo.server.util.Admin.CheckCommand.Check;
+
+import org.apache.accumulo.server.util.Admin;
+
+public class UserFilesCheckRunner implements CheckRunner {
+  private static final Check check = Check.USER_FILES;
+
+  @Override
+  public Admin.CheckCommand.CheckStatus runCheck() {
+    Admin.CheckCommand.CheckStatus status = Admin.CheckCommand.CheckStatus.OK;
+
+    System.out.println("Running check " + check);
+    // work
+    System.out.println("Check " + check + " completed with status " + status);
+    return status;
+  }
+
+  @Override
+  public Admin.CheckCommand.Check getCheck() {
+    return check;
+  }
+}

--- a/test/src/main/java/org/apache/accumulo/test/AdminCheckIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/AdminCheckIT.java
@@ -1,0 +1,425 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.UncheckedIOException;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.apache.accumulo.server.cli.ServerUtilOpts;
+import org.apache.accumulo.server.util.Admin;
+import org.apache.accumulo.server.util.checkCommand.CheckRunner;
+import org.apache.accumulo.test.functional.ConfigurableMacBase;
+import org.easymock.EasyMock;
+import org.easymock.IAnswer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import com.beust.jcommander.JCommander;
+
+public class AdminCheckIT extends ConfigurableMacBase {
+
+  private static final Map<Admin.CheckCommand.Check,Supplier<CheckRunner>> DUMMY_CHECK_RUNNERS =
+      new EnumMap<>(Admin.CheckCommand.Check.class);
+  private static final Map<Admin.CheckCommand.Check,Supplier<CheckRunner>> ORIGINAL_CHECK_RUNNERS =
+      new EnumMap<>(getRealCheckRunners());
+  private static final PrintStream ORIGINAL_OUT = System.out;
+
+  @AfterEach
+  public void assertCorrectPostTestState() {
+    // ensure that changes to the real check runners are not kept after the test completes
+    assertEquals(ORIGINAL_CHECK_RUNNERS, getRealCheckRunners());
+    // ensure that the output after the test is System.out
+    assertEquals(ORIGINAL_OUT, System.out);
+  }
+
+  /*
+   * The following tests test the expected outputs and functionality of the admin check command
+   * (e.g., are the correct checks run, dependencies run before the actual check, run in the correct
+   * order, etc.) without actually testing the correct functionality of the checks
+   */
+
+  @Test
+  public void testAdminCheckList() throws Exception {
+    // verifies output of list command
+
+    var p = getCluster().exec(Admin.class, "check", "list");
+    assertEquals(0, p.getProcess().waitFor());
+    String out = p.readStdOut();
+
+    // Checks that the header is correct and that all checks are in the output
+    assertTrue(
+        out.contains("Check Name") && out.contains("Description") && out.contains("Depends on"));
+    List<Admin.CheckCommand.Check> checksSeen = new ArrayList<>();
+    Arrays.stream(out.split("\\s+")).forEach(word -> {
+      try {
+        checksSeen.add(Admin.CheckCommand.Check.valueOf(word));
+      } catch (IllegalArgumentException e) {
+        // skip
+      }
+    });
+    assertTrue(checksSeen.containsAll(List.of(Admin.CheckCommand.Check.values())));
+  }
+
+  @Test
+  public void testAdminCheckListAndRunTogether() throws Exception {
+    // Tries to execute list and run together; should not work
+
+    var p = getCluster().exec(Admin.class, "check", "list", "run");
+    assertNotEquals(0, p.getProcess().waitFor());
+    p = getCluster().exec(Admin.class, "check", "run", "list");
+    assertNotEquals(0, p.getProcess().waitFor());
+    p = getCluster().exec(Admin.class, "check", "run",
+        Admin.CheckCommand.Check.SYSTEM_CONFIG.name(), "list");
+    assertNotEquals(0, p.getProcess().waitFor());
+    p = getCluster().exec(Admin.class, "check", "list",
+        Admin.CheckCommand.Check.SYSTEM_CONFIG.name(), "run");
+    assertNotEquals(0, p.getProcess().waitFor());
+  }
+
+  @Test
+  public void testAdminCheckListAndRunInvalidArgs() throws Exception {
+    // tests providing invalid args to check
+
+    // extra args to list
+    var p = getCluster().exec(Admin.class, "check", "list", "abc");
+    assertNotEquals(0, p.getProcess().waitFor());
+    assertTrue(p.readStdOut().contains("'list' does not expect any further arguments"));
+    p = getCluster().exec(Admin.class, "check", "list",
+        Admin.CheckCommand.Check.SYSTEM_CONFIG.name());
+    assertNotEquals(0, p.getProcess().waitFor());
+    assertTrue(p.readStdOut().contains("'list' does not expect any further arguments"));
+    // invalid arg to run
+    p = getCluster().exec(Admin.class, "check", "run", "123");
+    assertNotEquals(0, p.getProcess().waitFor());
+    assertTrue(p.readStdOut().contains("IllegalArgumentException"));
+    // no provided pattern
+    p = getCluster().exec(Admin.class, "check", "run", "-p");
+    assertNotEquals(0, p.getProcess().waitFor());
+    assertTrue(p.readStdOut().contains("Expected a regex pattern to be provided"));
+    // no checks match pattern
+    p = getCluster().exec(Admin.class, "check", "run", "-p", "abc");
+    assertNotEquals(0, p.getProcess().waitFor());
+    assertTrue(p.readStdOut().contains("No checks matched the given pattern"));
+    // invalid pattern
+    p = getCluster().exec(Admin.class, "check", "run", "-p", "[abc");
+    assertNotEquals(0, p.getProcess().waitFor());
+    assertTrue(p.readStdOut().contains("PatternSyntaxException"));
+    // more than one arg provided to pattern
+    p = getCluster().exec(Admin.class, "check", "run", "-p", ".*files", ".*files");
+    assertNotEquals(0, p.getProcess().waitFor());
+    assertTrue(p.readStdOut().contains("Expected one argument (the regex pattern)"));
+    // no list or run provided
+    p = getCluster().exec(Admin.class, "check");
+    assertNotEquals(0, p.getProcess().waitFor());
+    assertTrue(p.readStdOut().contains("Must use either 'list' or 'run'"));
+  }
+
+  @Test
+  public void testAdminCheckRunAll() {
+    // tests running all the checks
+
+    boolean[] checksPass = new boolean[Admin.CheckCommand.Check.values().length];
+    Arrays.fill(checksPass, true);
+
+    // no checks specified: should run all
+    String out1 = executeCheckCommand(new String[] {"check", "run"}, checksPass);
+
+    // all checks specified: should run all
+    String[] allChecksArgs = new String[Admin.CheckCommand.Check.values().length + 2];
+    allChecksArgs[0] = "check";
+    allChecksArgs[1] = "run";
+    for (int i = 2; i < allChecksArgs.length; i++) {
+      allChecksArgs[i] = Admin.CheckCommand.Check.values()[i - 2].name();
+    }
+    String out2 = executeCheckCommand(allChecksArgs, checksPass);
+
+    // these two checks specified: should run all
+    String out3 = executeCheckCommand(new String[] {"check", "run",
+        Admin.CheckCommand.Check.SYSTEM_FILES.name(), Admin.CheckCommand.Check.USER_FILES.name()},
+        checksPass);
+
+    // the two checks ending in 'files': should run all
+    String out4 = executeCheckCommand(new String[] {"check", "run", "-p", ".*files"}, checksPass);
+
+    String expRunOrder =
+        "Running dummy check SYSTEM_CONFIG\nDummy check SYSTEM_CONFIG completed with status OK\n"
+            + "Running dummy check ROOT_METADATA\nDummy check ROOT_METADATA completed with status OK\n"
+            + "Running dummy check ROOT_TABLE\nDummy check ROOT_TABLE completed with status OK\n"
+            + "Running dummy check METADATA_TABLE\nDummy check METADATA_TABLE completed with status OK\n"
+            + "Running dummy check SYSTEM_FILES\nDummy check SYSTEM_FILES completed with status OK\n"
+            + "Running dummy check USER_FILES\nDummy check USER_FILES completed with status OK";
+    // The dashes at the beginning and end of the string marks the begging and end of the
+    // printed table allowing us to ensure the table only includes what is expected
+    String expStatusInfo = "-SYSTEM_CONFIG|OKROOT_METADATA|OKROOT_TABLE|OK"
+        + "METADATA_TABLE|OKSYSTEM_FILES|OKUSER_FILES|OK-";
+
+    assertTrue(out1.contains(expRunOrder));
+    assertTrue(out2.contains(expRunOrder));
+    assertTrue(out3.contains(expRunOrder));
+    assertTrue(out4.contains(expRunOrder));
+
+    out1 = out1.replaceAll("\\s+", "");
+    out2 = out2.replaceAll("\\s+", "");
+    out3 = out3.replaceAll("\\s+", "");
+    out4 = out4.replaceAll("\\s+", "");
+
+    assertTrue(out1.contains(expStatusInfo));
+    assertTrue(out2.contains(expStatusInfo));
+    assertTrue(out3.contains(expStatusInfo));
+    assertTrue(out4.contains(expStatusInfo));
+  }
+
+  @Test
+  public void testAdminCheckRunWithFailingChecks() {
+    // tests running checks with some failing
+
+    boolean[] rootTableFails = new boolean[] {true, true, false, true, true, true};
+    boolean[] systemConfigFails = new boolean[] {false, true, true, true, true, true};
+
+    // run all checks with ROOT_TABLE failing: only SYSTEM_CONFIG and ROOT_METADATA should pass
+    String out1 = executeCheckCommand(new String[] {"check", "run"}, rootTableFails);
+
+    // run all checks with SYSTEM_CONFIG failing: only SYSTEM_CONFIG should run and fail
+    String out2 = executeCheckCommand(new String[] {"check", "run"}, systemConfigFails);
+
+    // run SYSTEM_FILES with ROOT_TABLE failing: only SYSTEM_CONFIG and ROOT_METADATA should pass
+    String out3 = executeCheckCommand(
+        new String[] {"check", "run", Admin.CheckCommand.Check.SYSTEM_FILES.name()},
+        rootTableFails);
+
+    String expRunOrder1 =
+        "Running dummy check SYSTEM_CONFIG\nDummy check SYSTEM_CONFIG completed with status OK\n"
+            + "Running dummy check ROOT_METADATA\nDummy check ROOT_METADATA completed with status OK\n"
+            + "Running dummy check ROOT_TABLE\nDummy check ROOT_TABLE completed with status FAILED";
+    String expRunOrder2 =
+        "Running dummy check SYSTEM_CONFIG\nDummy check SYSTEM_CONFIG completed with status FAILED\n";
+    String expRunOrder3 = expRunOrder1;
+
+    assertTrue(out1.contains(expRunOrder1));
+    assertTrue(out2.contains(expRunOrder2));
+    assertTrue(out3.contains(expRunOrder3));
+
+    out1 = out1.replaceAll("\\s+", "");
+    out2 = out2.replaceAll("\\s+", "");
+    out3 = out3.replaceAll("\\s+", "");
+
+    String expStatusInfo1 = "-SYSTEM_CONFIG|OKROOT_METADATA|OKROOT_TABLE|FAILED"
+        + "METADATA_TABLE|SKIPPED_DEPENDENCY_FAILEDSYSTEM_FILES|SKIPPED_DEPENDENCY_FAILED"
+        + "USER_FILES|SKIPPED_DEPENDENCY_FAILED-";
+    String expStatusInfo2 = "-SYSTEM_CONFIG|FAILEDROOT_METADATA|SKIPPED_DEPENDENCY_FAILED"
+        + "ROOT_TABLE|SKIPPED_DEPENDENCY_FAILEDMETADATA_TABLE|SKIPPED_DEPENDENCY_FAILED"
+        + "SYSTEM_FILES|SKIPPED_DEPENDENCY_FAILEDUSER_FILES|SKIPPED_DEPENDENCY_FAILED-";
+    String expStatusInfo3 = "-SYSTEM_CONFIG|OKROOT_METADATA|OKROOT_TABLE|FAILED"
+        + "SYSTEM_FILES|SKIPPED_DEPENDENCY_FAILED-";
+
+    assertTrue(out1.contains(expStatusInfo1));
+    assertTrue(out2.contains(expStatusInfo2));
+    assertTrue(out3.contains(expStatusInfo3));
+  }
+
+  private String executeCheckCommand(String[] checkCmdArgs, boolean[] checksPass) {
+    String output;
+
+    try (ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+        PrintStream printStream = new PrintStream(outStream)) {
+      Admin admin = createMockAdmin();
+      setCheckRunnersAsDummies(checksPass);
+      System.setOut(printStream);
+      admin.execute(checkCmdArgs);
+      output = outStream.toString();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    } finally {
+      resetCheckRunners();
+      System.setOut(ORIGINAL_OUT);
+    }
+
+    return output;
+  }
+
+  private Admin createMockAdmin() {
+    // mocking admin.execute() to just execute the check command; avoids issues with some
+    // unneeded calls done in the real execute()
+    Admin admin = EasyMock.createMock(Admin.class);
+    admin.execute(EasyMock.anyObject(String[].class));
+    EasyMock.expectLastCall().andAnswer((IAnswer<Void>) () -> {
+      String[] args = EasyMock.getCurrentArgument(0);
+      ServerUtilOpts opts = new ServerUtilOpts();
+      JCommander cl = new JCommander(opts);
+      Admin.CheckCommand checkCommand = new Admin.CheckCommand();
+      cl.addCommand("check", checkCommand);
+      cl.parse(args);
+      Admin.executeCheckCommand(getServerContext(), checkCommand);
+      return null;
+    });
+    EasyMock.replay(admin);
+    return admin;
+  }
+
+  /**
+   *
+   * @return the real check runner map used in Admin
+   */
+  @SuppressWarnings("unchecked")
+  private static Map<Admin.CheckCommand.Check,Supplier<CheckRunner>> getRealCheckRunners() {
+    Class<?> clazz = Admin.CheckCommand.Check.class;
+    Field checkRunners;
+    Map<Admin.CheckCommand.Check,Supplier<CheckRunner>> realCheckRunners;
+    try {
+      checkRunners = clazz.getDeclaredField("CHECK_RUNNERS");
+      checkRunners.setAccessible(true);
+      realCheckRunners =
+          (Map<Admin.CheckCommand.Check,Supplier<CheckRunner>>) checkRunners.get(null);
+    } catch (IllegalAccessException | NoSuchFieldException e) {
+      throw new RuntimeException(e);
+    }
+    return realCheckRunners;
+  }
+
+  /**
+   * Sets the admin check runners to the dummy check runners for testing. Must always later call
+   * {@link AdminCheckIT#resetCheckRunners()}
+   */
+  private void setCheckRunnersAsDummies(boolean[] checksPass) {
+    assertEquals(Admin.CheckCommand.Check.values().length, checksPass.length);
+
+    DUMMY_CHECK_RUNNERS.put(Admin.CheckCommand.Check.SYSTEM_CONFIG,
+        () -> new DummySystemConfigCheckRunner(checksPass[0]));
+    DUMMY_CHECK_RUNNERS.put(Admin.CheckCommand.Check.ROOT_METADATA,
+        () -> new DummyRootMetadataCheckRunner(checksPass[1]));
+    DUMMY_CHECK_RUNNERS.put(Admin.CheckCommand.Check.ROOT_TABLE,
+        () -> new DummyRootTableCheckRunner(checksPass[2]));
+    DUMMY_CHECK_RUNNERS.put(Admin.CheckCommand.Check.METADATA_TABLE,
+        () -> new DummyMetadataTableCheckRunner(checksPass[3]));
+    DUMMY_CHECK_RUNNERS.put(Admin.CheckCommand.Check.SYSTEM_FILES,
+        () -> new DummySystemFilesCheckRunner(checksPass[4]));
+    DUMMY_CHECK_RUNNERS.put(Admin.CheckCommand.Check.USER_FILES,
+        () -> new DummyUserFilesCheckRunner(checksPass[5]));
+
+    getRealCheckRunners().clear();
+    getRealCheckRunners().putAll(DUMMY_CHECK_RUNNERS);
+  }
+
+  /**
+   * Resets the admin check runners to their original value. Must always call this after
+   * {@link AdminCheckIT#setCheckRunnersAsDummies(boolean[])}
+   */
+  private void resetCheckRunners() {
+    getRealCheckRunners().clear();
+    getRealCheckRunners().putAll(ORIGINAL_CHECK_RUNNERS);
+  }
+
+  static abstract class DummyCheckRunner implements CheckRunner {
+    private final boolean passes;
+
+    public DummyCheckRunner(boolean passes) {
+      this.passes = passes;
+    }
+
+    @Override
+    public Admin.CheckCommand.CheckStatus runCheck() {
+      Admin.CheckCommand.CheckStatus status =
+          passes ? Admin.CheckCommand.CheckStatus.OK : Admin.CheckCommand.CheckStatus.FAILED;
+
+      System.out.println("Running dummy check " + getCheck());
+      // no work to perform in the dummy check runner
+      System.out.println("Dummy check " + getCheck() + " completed with status " + status);
+      return status;
+    }
+  }
+
+  static class DummySystemConfigCheckRunner extends DummyCheckRunner {
+    public DummySystemConfigCheckRunner(boolean passes) {
+      super(passes);
+    }
+
+    @Override
+    public Admin.CheckCommand.Check getCheck() {
+      return Admin.CheckCommand.Check.SYSTEM_CONFIG;
+    }
+  }
+
+  static class DummyRootMetadataCheckRunner extends DummyCheckRunner {
+    public DummyRootMetadataCheckRunner(boolean passes) {
+      super(passes);
+    }
+
+    @Override
+    public Admin.CheckCommand.Check getCheck() {
+      return Admin.CheckCommand.Check.ROOT_METADATA;
+    }
+  }
+
+  static class DummyRootTableCheckRunner extends DummyCheckRunner {
+    public DummyRootTableCheckRunner(boolean passes) {
+      super(passes);
+    }
+
+    @Override
+    public Admin.CheckCommand.Check getCheck() {
+      return Admin.CheckCommand.Check.ROOT_TABLE;
+    }
+  }
+
+  static class DummyMetadataTableCheckRunner extends DummyCheckRunner {
+    public DummyMetadataTableCheckRunner(boolean passes) {
+      super(passes);
+    }
+
+    @Override
+    public Admin.CheckCommand.Check getCheck() {
+      return Admin.CheckCommand.Check.METADATA_TABLE;
+    }
+  }
+
+  static class DummySystemFilesCheckRunner extends DummyCheckRunner {
+    public DummySystemFilesCheckRunner(boolean passes) {
+      super(passes);
+    }
+
+    @Override
+    public Admin.CheckCommand.Check getCheck() {
+      return Admin.CheckCommand.Check.SYSTEM_FILES;
+    }
+  }
+
+  static class DummyUserFilesCheckRunner extends DummyCheckRunner {
+    public DummyUserFilesCheckRunner(boolean passes) {
+      super(passes);
+    }
+
+    @Override
+    public Admin.CheckCommand.Check getCheck() {
+      return Admin.CheckCommand.Check.USER_FILES;
+    }
+  }
+}


### PR DESCRIPTION
This is part of https://github.com/apache/accumulo/issues/4687
Changes:
- Added new `admin check` command
- `admin check list` prints the checks that can be run along with their descriptions and dependencies
- `admin check run` runs all the checks or a specified list of checks (explicitly provide each check, provide a regex of the checks to run, or just run all if no further args are provided). The dependencies are run first and if a checks dependency fails, the check is skipped
- Current impl of `admin check run` does not do any actual work besides printing that the check is running (to ensure correct run order) and returning an `OK` status
- New IT AdminCheckIT
	- This IT includes a verion of the Checks where no work is actually done (right now, this is equivalent to the actual implementation). This is done so correct run order, correct checks run, etc. can be
	verified without actually running the checks which may take a long time. More tests can be added later to test the actual check functionality when that is implemented.
- No existing functionality was changed

Questions:
1) Are new classes and packages in suitable locations?
2) Is the way I went about implementing the dummy checks in AdminCheckIT okay? Mostly concerned if changing the real static CHECK_RUNNERS field is okay (changes it during the test but asserts that it is reset after the test completes).