### PR TITLE
Configure test server classes before starting MAC

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction2BaseIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction2BaseIT.java
@@ -59,6 +59,7 @@ import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.harness.MiniClusterConfigurationCallback;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
+import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.util.FindCompactionTmpFiles;
@@ -75,6 +76,7 @@ public class ExternalCompaction2BaseIT extends SharedMiniClusterBase {
     @Override
     public void configureMiniCluster(MiniAccumuloConfigImpl cfg, Configuration coreSite) {
       ExternalCompactionTestUtils.configureMiniCluster(cfg, coreSite);
+      cfg.setServerClass(ServerType.COMPACTOR, ExternalDoNothingCompactor.class);
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_2_IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_2_IT.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.test.compaction;
 
-import org.apache.accumulo.minicluster.ServerType;
 import org.junit.jupiter.api.BeforeAll;
 
 public class ExternalCompaction_2_IT extends ExternalCompaction2BaseIT {
@@ -26,8 +25,5 @@ public class ExternalCompaction_2_IT extends ExternalCompaction2BaseIT {
   @BeforeAll
   public static void beforeTests() throws Exception {
     startMiniClusterWithConfig(new ExternalCompaction2Config());
-    getCluster().getClusterControl().stop(ServerType.COMPACTOR);
-    getCluster().getClusterControl().start(ServerType.COMPACTOR, null, 1,
-        ExternalDoNothingCompactor.class);
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/compaction/FlakyExternalCompaction2IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/FlakyExternalCompaction2IT.java
@@ -20,9 +20,11 @@ package org.apache.accumulo.test.compaction;
 
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.minicluster.ServerType;
+import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.test.ample.FlakyAmpleManager;
 import org.apache.accumulo.test.ample.FlakyAmpleServerContext;
 import org.apache.accumulo.test.ample.FlakyAmpleTserver;
+import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 
@@ -37,16 +39,18 @@ import org.junit.jupiter.api.BeforeAll;
  */
 public class FlakyExternalCompaction2IT extends ExternalCompaction2BaseIT {
 
-  @BeforeAll
-  public static void setup() throws Exception {
-    SharedMiniClusterBase.startMiniClusterWithConfig((cfg, coreSite) -> {
-      ExternalCompactionTestUtils.configureMiniCluster(cfg, coreSite);
+  static class FlakyExternalCompaction2Config extends ExternalCompaction2Config {
+    @Override
+    public void configureMiniCluster(MiniAccumuloConfigImpl cfg, Configuration coreSite) {
+      super.configureMiniCluster(cfg, coreSite);
       cfg.setServerClass(ServerType.MANAGER, FlakyAmpleManager.class);
       cfg.setServerClass(ServerType.TABLET_SERVER, FlakyAmpleTserver.class);
-    });
-    getCluster().getClusterControl().stop(ServerType.COMPACTOR);
-    getCluster().getClusterControl().start(ServerType.COMPACTOR, null, 1,
-        ExternalDoNothingCompactor.class);
+    }
+  }
+
+  @BeforeAll
+  public static void setup() throws Exception {
+    startMiniClusterWithConfig(new FlakyExternalCompaction2Config());
   }
 
   @AfterAll


### PR DESCRIPTION
Update a few ITs that were stopping a normal server instance and starting up a test impl by taking advantage of changes in #4643 to set the server instance type before start up. This simplifies the tests and also prevents weird behavior by having servers start up and be shut down quickly.

I took a look around the tests and I didn't see too many tests that could be updated to use the new method as some required keeping the original servers around but these were the ones I found.

This closes #4644

**Note:** Another nice side effect of this is that the changes here actually fix the hanging `ExternalCompacttion_2_IT` test I was having issues with and mentioned in the gRPC prototype in this [comment](https://github.com/apache/accumulo/pull/4715#issuecomment-2241699447). 

The issue for the hanging wasn't related specifically to gRPC but was directly related to starting up and immediately stopping the first compactor procesess and how the new async future and long polling works from the compaction queue. Before the changes here, the test would kill the original compactors and start up new ones of the type `ExternalDoNothingCompactor`. Because of the long polling change, there is a race condition where the job is assigned to a future when the original compactor requests a job. Then when the compactor dies, the new one that starts up won't get a job assigned as the previous future never times out from the dead compactor even though the job was cleaned up by the dead compaction detector. Making sure the future will timeout is something that still needs to be fixed as well, but the test change here fixes the root cause by only starting up the `DoNothingCompactor` in the first place.