### PR TITLE
Fix failing ITs due to recent features

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metrics/MetricsProducer.java
+++ b/core/src/main/java/org/apache/accumulo/core/metrics/MetricsProducer.java
@@ -634,6 +634,13 @@ import io.micrometer.core.instrument.MeterRegistry;
  * <tr>
  * <td>N/A</td>
  * <td>N/A</td>
+ * <td>{@link #METRICS_MANAGER_COMPACTION_SVC_ERRORS}</td>
+ * <td>Gauge</td>
+ * <td></td>
+ * </tr>
+ * <tr>
+ * <td>N/A</td>
+ * <td>N/A</td>
  * <td>{@link #METRICS_MANAGER_USER_TGW_ERRORS}</td>
  * <td>Gauge</td>
  * <td></td>
@@ -700,6 +707,8 @@ public interface MetricsProducer {
   String METRICS_MANAGER_ROOT_TGW_ERRORS = METRICS_MANAGER_PREFIX + "tabletmgmt.root.errors";
   String METRICS_MANAGER_META_TGW_ERRORS = METRICS_MANAGER_PREFIX + "tabletmgmt.meta.errors";
   String METRICS_MANAGER_USER_TGW_ERRORS = METRICS_MANAGER_PREFIX + "tabletmgmt.user.errors";
+  String METRICS_MANAGER_COMPACTION_SVC_ERRORS =
+      METRICS_MANAGER_PREFIX + "compaction.svc.misconfigured";
 
   String METRICS_MAJC_PREFIX = "accumulo.compactions.majc.";
   String METRICS_MAJC_QUEUED = METRICS_MAJC_PREFIX + "queued";

--- a/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
@@ -443,11 +443,12 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
 
     try {
       CheckCompactionConfig.validate(manager.getConfiguration());
-    } catch (SecurityException | IllegalArgumentException | IllegalStateException
-        | ReflectiveOperationException e) {
+      this.metrics.clearCompactionServiceConfigurationError();
+    } catch (RuntimeException | ReflectiveOperationException e) {
+      this.metrics.setCompactionServiceConfigurationError();
       LOG.error(
-          "Error validating compaction configuration, all compactions are paused until the configuration is fixed.",
-          e);
+          "Error validating compaction configuration, all {} compactions are paused until the configuration is fixed.",
+          store.getLevel(), e);
       compactionGenerator = null;
     }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/metrics/ManagerMetrics.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/metrics/ManagerMetrics.java
@@ -22,6 +22,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
@@ -42,6 +43,7 @@ public class ManagerMetrics implements MetricsProducer {
   private final AtomicLong rootTGWErrorsGauge = new AtomicLong(0);
   private final AtomicLong metadataTGWErrorsGauge = new AtomicLong(0);
   private final AtomicLong userTGWErrorsGauge = new AtomicLong(0);
+  private final AtomicInteger compactionConfigurationError = new AtomicInteger(0);
 
   public ManagerMetrics(final AccumuloConfiguration conf, final Manager manager) {
     requireNonNull(conf, "AccumuloConfiguration must not be null");
@@ -69,12 +71,22 @@ public class ManagerMetrics implements MetricsProducer {
     }
   }
 
+  public void setCompactionServiceConfigurationError() {
+    this.compactionConfigurationError.set(1);
+  }
+
+  public void clearCompactionServiceConfigurationError() {
+    this.compactionConfigurationError.set(0);
+  }
+
   @Override
   public void registerMetrics(MeterRegistry registry) {
     fateMetrics.forEach(fm -> fm.registerMetrics(registry));
     registry.gauge(METRICS_MANAGER_ROOT_TGW_ERRORS, rootTGWErrorsGauge);
     registry.gauge(METRICS_MANAGER_META_TGW_ERRORS, metadataTGWErrorsGauge);
     registry.gauge(METRICS_MANAGER_USER_TGW_ERRORS, userTGWErrorsGauge);
+    registry.gauge(METRICS_MANAGER_COMPACTION_SVC_ERRORS, compactionConfigurationError,
+        AtomicInteger::get);
   }
 
   public List<MetricsProducer> getProducers(AccumuloConfiguration conf, Manager manager) {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeCoordinator.java
@@ -263,7 +263,7 @@ public class UpgradeCoordinator {
     }
     try {
       CheckCompactionConfig.validate(context.getConfiguration());
-    } catch (SecurityException | IllegalArgumentException | ReflectiveOperationException e) {
+    } catch (RuntimeException | ReflectiveOperationException e) {
       throw new IllegalStateException("Error validating compaction configuration", e);
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/compaction/CompactionExecutorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/CompactionExecutorIT.java
@@ -80,6 +80,7 @@ import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -87,6 +88,7 @@ import org.slf4j.LoggerFactory;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 
+@Disabled
 public class CompactionExecutorIT extends SharedMiniClusterBase {
   public static final List<String> compactionGroups = new LinkedList<>();
   public static final Logger log = LoggerFactory.getLogger(CompactionExecutorIT.class);

--- a/test/src/main/java/org/apache/accumulo/test/compaction/CompactionExecutorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/CompactionExecutorIT.java
@@ -80,7 +80,6 @@ import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -88,7 +87,6 @@ import org.slf4j.LoggerFactory;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 
-@Disabled
 public class CompactionExecutorIT extends SharedMiniClusterBase {
   public static final List<String> compactionGroups = new LinkedList<>();
   public static final Logger log = LoggerFactory.getLogger(CompactionExecutorIT.class);
@@ -194,16 +192,6 @@ public class CompactionExecutorIT extends SharedMiniClusterBase {
       cfg.setProperty(csp + "cs4.planner.opts.filesPerCompaction", "11");
       cfg.setProperty(csp + "cs4.planner.opts.process", "USER");
 
-      // Setup three planner that fail to initialize or plan, these planners should not impede
-      // tablet assignment.
-      cfg.setProperty(csp + "cse1.planner", ErroringPlanner.class.getName());
-      cfg.setProperty(csp + "cse1.planner.opts.failInInit", "true");
-
-      cfg.setProperty(csp + "cse2.planner", ErroringPlanner.class.getName());
-      cfg.setProperty(csp + "cse2.planner.opts.failInInit", "false");
-
-      cfg.setProperty(csp + "cse3.planner", "NonExistentPlanner20240522");
-
       // this is meant to be dynamically reconfigured
       cfg.setProperty(csp + "recfg.planner", TestPlanner.class.getName());
       cfg.setProperty(csp + "recfg.planner.opts.groups", "[{'group':'i1'},{'group':'i2'}]");
@@ -262,6 +250,18 @@ public class CompactionExecutorIT extends SharedMiniClusterBase {
     // This test ensures that a table w/ failing compaction planner can still be read and written.
 
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
+
+      // Setup three planner that fail to initialize or plan, these planners should not impede
+      // tablet assignment.
+      var csp = Property.COMPACTION_SERVICE_PREFIX.getKey();
+      client.instanceOperations().setProperty(csp + "cse1.planner",
+          ErroringPlanner.class.getName());
+      client.instanceOperations().setProperty(csp + "cse1.planner.opts.failInInit", "true");
+      client.instanceOperations().setProperty(csp + "cse2.planner",
+          ErroringPlanner.class.getName());
+      client.instanceOperations().setProperty(csp + "cse2.planner.opts.failInInit", "false");
+      client.instanceOperations().setProperty(csp + "cse3.planner", "NonExistentPlanner20240522");
+
       createTable(client, "fail1", "cse1");
       createTable(client, "fail2", "cse2");
       createTable(client, "fail3", "cse3");
@@ -283,6 +283,14 @@ public class CompactionExecutorIT extends SharedMiniClusterBase {
       assertEquals(30, getFiles(client, "fail1").size());
       assertEquals(30, getFiles(client, "fail2").size());
       assertEquals(30, getFiles(client, "fail3").size());
+
+      // Remove the properties for the invalid planners
+      client.instanceOperations().removeProperty(csp + "cse1.planner");
+      client.instanceOperations().removeProperty(csp + "cse1.planner.opts.failInInit");
+      client.instanceOperations().removeProperty(csp + "cse2.planner");
+      client.instanceOperations().removeProperty(csp + "cse2.planner.opts.failInInit");
+      client.instanceOperations().removeProperty(csp + "cse3.planner");
+
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction2BaseIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction2BaseIT.java
@@ -70,7 +70,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
-public class ExternalCompaction2BaseIT extends SharedMiniClusterBase {
+public abstract class ExternalCompaction2BaseIT extends SharedMiniClusterBase {
 
   static class ExternalCompaction2Config implements MiniClusterConfigurationCallback {
     @Override

--- a/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
@@ -865,7 +865,7 @@ public class CompactionIT extends CompactionBaseIT {
           RatioBasedCompactionPlanner.class.getName());
       c.instanceOperations().setProperty(
           Property.COMPACTION_SERVICE_PREFIX.getKey() + "newcs.planner.opts.groups",
-          ("[{'group':'" + COMPACTOR_GROUP_2 + "'}]").replaceAll("'", "\""));
+          ("[{'group':'" + COMPACTOR_GROUP_1 + "'}]").replaceAll("'", "\""));
 
       // set table 1 to a compaction service newcs
       c.tableOperations().setProperty(table1,


### PR DESCRIPTION
Changes introduced in #4800 to validate compaction configurations caused several ITs to start failing. In these cases the ITs were using invalid configurations. The changes here fix the ITs by either isolating the invalid configurations to only the associated tests (vs having the invalid configuration persist for all the tests in the class), or I made modifications to the test so that they would continue to work.