### PR TITLE
Remove Timer.startNewWithOffset() methods

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/util/Timer.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/Timer.java
@@ -46,27 +46,6 @@ public final class Timer {
   }
 
   /**
-   * Creates a new Timer with an offset applied.
-   *
-   * @param offset the duration of the offset to apply.
-   * @return a new Timer instance with the specified offset.
-   */
-  public static Timer startNewWithOffset(Duration offset) {
-    return new Timer(offset.toNanos());
-  }
-
-  /**
-   * Creates a new Timer with an offset applied.
-   *
-   * @param offset the duration of the offset to apply.
-   * @param unit the TimeUnit of the offset.
-   * @return a new Timer instance with the specified offset.
-   */
-  public static Timer startNewWithOffset(long offset, TimeUnit unit) {
-    return new Timer(unit.toNanos(offset));
-  }
-
-  /**
    * Resets the start point for this timer.
    */
   public void restart() {

--- a/core/src/main/java/org/apache/accumulo/core/util/Timer.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/Timer.java
@@ -32,10 +32,6 @@ public final class Timer {
     this.startNanos = System.nanoTime();
   }
 
-  private Timer(long offsetNanos) {
-    this.startNanos = System.nanoTime() + offsetNanos;
-  }
-
   /**
    * Creates and starts a new Timer instance.
    *

--- a/core/src/test/java/org/apache/accumulo/core/util/TimerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/TimerTest.java
@@ -96,38 +96,4 @@ public class TimerTest {
 
   }
 
-  @Test
-  public void testStartNewWithOffsetDuration() throws InterruptedException {
-    Timer timer = Timer.startNewWithOffset(Duration.ofMillis(100));
-
-    assertFalse(timer.hasElapsed(Duration.ZERO));
-
-    Thread.sleep(50);
-
-    assertFalse(timer.hasElapsed(Duration.ZERO),
-        "The timer should not indicate time has elapsed before the offset has passed.");
-
-    Thread.sleep(60);
-
-    assertTrue(timer.hasElapsed(Duration.ZERO),
-        "The timer should indicate time has elapsed after the offset has passed.");
-  }
-
-  @Test
-  public void testStartNewWithOffsetTimeUnit() throws InterruptedException {
-    Timer timer = Timer.startNewWithOffset(100, MILLISECONDS);
-
-    assertFalse(timer.hasElapsed(0, MILLISECONDS));
-
-    Thread.sleep(50);
-
-    assertFalse(timer.hasElapsed(0, MILLISECONDS),
-        "The timer should not indicate time has elapsed before the offset has passed.");
-
-    Thread.sleep(60);
-
-    assertTrue(timer.hasElapsed(0, MILLISECONDS),
-        "The timer should indicate time has elapsed after the offset has passed.");
-  }
-
 }


### PR DESCRIPTION
#4796 added CountDownTimer which replaces the functionality of these methods in a way that makes more sense. These methods are not used in 2.1 and their usages have already been replaced in main.