### PR TITLE
Stops waiting on scans during tablet close.

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ThriftScanClientHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ThriftScanClientHandler.java
@@ -214,6 +214,8 @@ public class ThriftScanClientHandler implements TabletScanClientService.Iface {
 
     long sid = server.getSessionManager().createSession(scanSession, true);
 
+    scanParams.setSessionDisabler(() -> server.getSessionManager().disableReservations(sid));
+
     ScanResult scanResult;
     try {
       scanResult = continueScan(tinfo, sid, scanSession, busyTimeout);
@@ -439,6 +441,8 @@ public class ThriftScanClientHandler implements TabletScanClientService.Iface {
     }
 
     long sid = server.getSessionManager().createSession(mss, true);
+
+    scanParams.setSessionDisabler(() -> server.getSessionManager().disableReservations(sid));
 
     MultiScanResult result;
     try {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ThriftScanClientHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ThriftScanClientHandler.java
@@ -214,7 +214,7 @@ public class ThriftScanClientHandler implements TabletScanClientService.Iface {
 
     long sid = server.getSessionManager().createSession(scanSession, true);
 
-    scanParams.setSessionDisabler(() -> server.getSessionManager().disableReservations(sid));
+    scanParams.setScanSessionId(sid);
 
     ScanResult scanResult;
     try {
@@ -442,7 +442,7 @@ public class ThriftScanClientHandler implements TabletScanClientService.Iface {
 
     long sid = server.getSessionManager().createSession(mss, true);
 
-    scanParams.setSessionDisabler(() -> server.getSessionManager().disableReservations(sid));
+    scanParams.setScanSessionId(sid);
 
     MultiScanResult result;
     try {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/scan/ScanParameters.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/scan/ScanParameters.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.tserver.scan;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BooleanSupplier;
 
 import org.apache.accumulo.core.client.sample.SamplerConfiguration;
 import org.apache.accumulo.core.data.Column;
@@ -43,6 +44,7 @@ public final class ScanParameters {
   private final SamplerConfiguration samplerConfig;
   private final long batchTimeOut;
   private final String classLoaderContext;
+  private volatile BooleanSupplier sessionDisabler = () -> false;
   private volatile ScanDispatch dispatch;
 
   public ScanParameters(int maxEntries, Authorizations authorizations, Set<Column> columnSet,
@@ -104,6 +106,14 @@ public final class ScanParameters {
 
   public ScanDispatch getScanDispatch() {
     return dispatch;
+  }
+
+  public void setSessionDisabler(BooleanSupplier sessionDisabler) {
+    this.sessionDisabler = sessionDisabler;
+  }
+
+  public BooleanSupplier getSessionDisabler() {
+    return sessionDisabler;
   }
 
   @Override

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/scan/ScanParameters.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/scan/ScanParameters.java
@@ -21,7 +21,6 @@ package org.apache.accumulo.tserver.scan;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.BooleanSupplier;
 
 import org.apache.accumulo.core.client.sample.SamplerConfiguration;
 import org.apache.accumulo.core.data.Column;
@@ -44,7 +43,7 @@ public final class ScanParameters {
   private final SamplerConfiguration samplerConfig;
   private final long batchTimeOut;
   private final String classLoaderContext;
-  private volatile BooleanSupplier sessionDisabler = () -> false;
+  private volatile Long scanSessionId = null;
   private volatile ScanDispatch dispatch;
 
   public ScanParameters(int maxEntries, Authorizations authorizations, Set<Column> columnSet,
@@ -108,12 +107,12 @@ public final class ScanParameters {
     return dispatch;
   }
 
-  public void setSessionDisabler(BooleanSupplier sessionDisabler) {
-    this.sessionDisabler = sessionDisabler;
+  public void setScanSessionId(long scanSessionId) {
+    this.scanSessionId = scanSessionId;
   }
 
-  public BooleanSupplier getSessionDisabler() {
-    return sessionDisabler;
+  public Long getScanSessionId() {
+    return scanSessionId;
   }
 
   @Override
@@ -128,6 +127,7 @@ public final class ScanParameters {
     buf.append(", maxEntries=").append(this.maxEntries);
     buf.append(", num=").append(this.maxEntries);
     buf.append(", samplerConfig=").append(this.samplerConfig);
+    buf.append(", scanSessionId=").append(this.scanSessionId);
     buf.append("]");
     return buf.toString();
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/Session.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/Session.java
@@ -31,6 +31,7 @@ public class Session {
   public long lastAccessTime;
   public long startTime;
   State state = State.NEW;
+  boolean allowReservation = true;
   private final TCredentials credentials;
 
   Session(TCredentials credentials) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SessionManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SessionManager.java
@@ -259,7 +259,7 @@ public class SessionManager {
    *
    * @return true if the sessions is currently not reserved, false otherwise
    */
-  public boolean disableReservations(long sessionId) {
+  public boolean disallowNewReservations(long sessionId) {
     var session = getSession(sessionId);
     if (session == null) {
       return true;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
@@ -321,4 +321,8 @@ class ScanDataSource implements DataSource {
         .append("expectedDeletionCount", expectedDeletionCount).append("scanParams", scanParams)
         .toString();
   }
+
+  public boolean disableClientSession() {
+    return scanParams.getSessionDisabler().getAsBoolean();
+  }
 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
@@ -322,7 +322,7 @@ class ScanDataSource implements DataSource {
         .toString();
   }
 
-  public boolean disableClientSession() {
-    return scanParams.getSessionDisabler().getAsBoolean();
+  public ScanParameters getScanParameters() {
+    return scanParams;
   }
 }

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/session/SessionManagerTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/session/SessionManagerTest.java
@@ -116,13 +116,13 @@ public class SessionManagerTest {
   }
 
   @Test
-  public void testDisableReservations() {
+  public void testDisallowNewReservation() {
     var sessionManager = createSessionManager();
 
     var sid = sessionManager.createSession(new TestSession(2), true);
 
     // this should prevent future reservation and return false because its currently reserved
-    assertFalse(sessionManager.disableReservations(sid));
+    assertFalse(sessionManager.disallowNewReservations(sid));
 
     // should not have a problem un-reserving
     sessionManager.unreserveSession(sid);
@@ -132,12 +132,12 @@ public class SessionManagerTest {
     assertNull(sessionManager.reserveSession(sid, false));
 
     // should return true now that its not reserved
-    assertTrue(sessionManager.disableReservations(sid));
+    assertTrue(sessionManager.disallowNewReservations(sid));
 
     sessionManager.removeSession(sid);
 
     // should return true for nonexistent session
-    assertTrue(sessionManager.disableReservations(sid));
+    assertTrue(sessionManager.disallowNewReservations(sid));
   }
 
   private SessionManager createSessionManager() {

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/session/SessionManagerTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/session/SessionManagerTest.java
@@ -18,12 +18,20 @@
  */
 package org.apache.accumulo.tserver.session;
 
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 
+import org.apache.accumulo.core.conf.DefaultConfiguration;
+import org.apache.accumulo.server.ServerContext;
 import org.junit.jupiter.api.Test;
 
 public class SessionManagerTest {
@@ -105,5 +113,39 @@ public class SessionManagerTest {
     assertEquals(2, deferredCleanupQeue.size());
     assertEquals(2,
         deferredCleanupQeue.stream().filter(s -> ((TestSession) s).cleanupCount == 2).count());
+  }
+
+  @Test
+  public void testDisableReservations() {
+    var sessionManager = createSessionManager();
+
+    var sid = sessionManager.createSession(new TestSession(2), true);
+
+    // this should prevent future reservation and return false because its currently reserved
+    assertFalse(sessionManager.disableReservations(sid));
+
+    // should not have a problem un-reserving
+    sessionManager.unreserveSession(sid);
+
+    // should not be able to reserve the session because reservations were disabled
+    assertNull(sessionManager.reserveSession(sid));
+    assertNull(sessionManager.reserveSession(sid, false));
+
+    // should return true now that its not reserved
+    assertTrue(sessionManager.disableReservations(sid));
+
+    sessionManager.removeSession(sid);
+
+    // should return true for nonexistent session
+    assertTrue(sessionManager.disableReservations(sid));
+  }
+
+  private SessionManager createSessionManager() {
+    ServerContext ctx = createMock(ServerContext.class);
+    expect(ctx.getConfiguration()).andReturn(DefaultConfiguration.getInstance()).anyTimes();
+    var executor = (ScheduledThreadPoolExecutor) Executors.newScheduledThreadPool(1);
+    expect(ctx.getScheduledExecutor()).andReturn(executor).anyTimes();
+    replay(ctx);
+    return new SessionManager(ctx);
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/ZombieScanIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ZombieScanIT.java
@@ -51,6 +51,7 @@ import org.junit.jupiter.api.Test;
 
 public class ZombieScanIT extends ConfigurableMacBase {
 
+  @Override
   protected void configure(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
     super.configure(cfg, hadoopCoreSite);
 

--- a/test/src/main/java/org/apache/accumulo/test/ZombieScanIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ZombieScanIT.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
+import java.util.stream.Collectors;
+
+import org.apache.accumulo.core.client.Accumulo;
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
+import org.apache.accumulo.core.clientImpl.ClientContext;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.iterators.WrappingIterator;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.minicluster.ServerType;
+import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
+import org.apache.accumulo.test.functional.ConfigurableMacBase;
+import org.apache.accumulo.test.util.Wait;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.Text;
+import org.junit.jupiter.api.Test;
+
+public class ZombieScanIT extends ConfigurableMacBase {
+
+  protected void configure(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
+    super.configure(cfg, hadoopCoreSite);
+
+    cfg.setNumTservers(1);
+  }
+
+  /**
+   * An iterator that should get stuck forever when used
+   */
+  public static class ZombieIterator extends WrappingIterator {
+    @Override
+    public boolean hasTop() {
+      // must call super.hasTop() before blocking as that will run accumulo code to setup iterator
+      boolean ht = super.hasTop();
+      Semaphore semaphore = new Semaphore(10);
+      semaphore.acquireUninterruptibly(5);
+      // this should block forever
+      semaphore.acquireUninterruptibly(6);
+      return ht;
+    }
+  }
+
+  /**
+   * This test ensure that scans threads that run forever do not prevent tablets from unloading.
+   */
+  @Test
+  public void testZombieScan() throws Exception {
+
+    String table = getUniqueNames(1)[0];
+
+    try (AccumuloClient c = Accumulo.newClient().from(getClientProperties()).build()) {
+
+      var splits = new TreeSet<Text>();
+      splits.add(new Text("3"));
+      splits.add(new Text("5"));
+      splits.add(new Text("7"));
+      var ntc = new NewTableConfiguration().withSplits(splits);
+      c.tableOperations().create(table, ntc);
+
+      try (var writer = c.createBatchWriter(table)) {
+        for (var row : List.of("2", "4", "6", "8")) {
+          Mutation m = new Mutation(row);
+          m.put("f", "q", "v");
+          writer.addMutation(m);
+        }
+      }
+
+      // Flush the data otherwise when the tablet attempts to close with an active scan reading from
+      // the in memory map it will wait for 15 seconds for the scan
+      c.tableOperations().flush(table, null, null, true);
+
+      var executor = Executors.newCachedThreadPool();
+
+      // start two zombie scans that should never return using a normal scanner
+      List<Future<String>> futures = new ArrayList<>();
+      for (var row : List.of("2", "4")) {
+        var future = executor.submit(() -> {
+          try (var scanner = c.createScanner(table)) {
+            IteratorSetting iter = new IteratorSetting(100, "Z", ZombieIterator.class);
+            scanner.addScanIterator(iter);
+            scanner.setRange(new Range(row));
+            return scanner.stream().findFirst().map(e -> e.getKey().getRowData().toString())
+                .orElse("none");
+          }
+        });
+        futures.add(future);
+      }
+
+      // start two zombie scans that should never return using a batch scanner
+      for (var row : List.of("6", "8")) {
+        var future = executor.submit(() -> {
+          try (var scanner = c.createBatchScanner(table)) {
+            IteratorSetting iter = new IteratorSetting(100, "Z", ZombieIterator.class);
+            scanner.addScanIterator(iter);
+            scanner.setRanges(List.of(new Range(row)));
+            return scanner.stream().findFirst().map(e -> e.getKey().getRowData().toString())
+                .orElse("none");
+          }
+        });
+        futures.add(future);
+      }
+
+      // should eventually see the four zombie scans running against four tablets
+      Wait.waitFor(() -> countDistinctTabletsScans(table, c) == 4);
+
+      assertEquals(1, c.instanceOperations().getTabletServers().size());
+
+      // Start 3 new tablet servers, this should cause the table to balance and the tablets with
+      // zombie scans to unload. The Zombie scans should not prevent the table from unloading. The
+      // scan threads will still be running on the old tablet servers.
+      getCluster().getConfig().setNumTservers(4);
+      getCluster().getClusterControl().startAllServers(ServerType.TABLET_SERVER);
+
+      // Wait for all tablets servers
+      Wait.waitFor(() -> c.instanceOperations().getTabletServers().size() == 4);
+
+      // The table should eventually balance across the 4 tablet servers
+      Wait.waitFor(() -> countLocations(table, c) == 4);
+
+      // The zombie scans should still be running
+      assertTrue(futures.stream().noneMatch(Future::isDone));
+
+      // Should be able to scan all the tablets at the new locations.
+      try (var scanner = c.createScanner(table)) {
+        var rows = scanner.stream().map(e -> e.getKey().getRowData().toString())
+            .collect(Collectors.toSet());
+        assertEquals(Set.of("2", "4", "6", "8"), rows);
+      }
+
+      try (var scanner = c.createBatchScanner(table)) {
+        scanner.setRanges(List.of(new Range()));
+        var rows = scanner.stream().map(e -> e.getKey().getRowData().toString())
+            .collect(Collectors.toSet());
+        assertEquals(Set.of("2", "4", "6", "8"), rows);
+      }
+
+      // The zombie scans should migrate with the tablets, taking up more scan threads in the
+      // system.
+      Set<String> tabletSeversWithZombieScans = new HashSet<>();
+      for (String tserver : c.instanceOperations().getTabletServers()) {
+        if (c.instanceOperations().getActiveScans(tserver).stream()
+            .flatMap(activeScan -> activeScan.getSsiList().stream())
+            .anyMatch(scanIters -> scanIters.contains(ZombieIterator.class.getName()))) {
+          tabletSeversWithZombieScans.add(tserver);
+        }
+      }
+      assertEquals(4, tabletSeversWithZombieScans.size());
+
+      executor.shutdownNow();
+    }
+
+  }
+
+  private static long countLocations(String table, AccumuloClient client) throws Exception {
+    var ctx = (ClientContext) client;
+    var tableId = ctx.getTableId(table);
+    return ctx.getAmple().readTablets().forTable(tableId).build().stream()
+        .map(TabletMetadata::getLocation).filter(Objects::nonNull).distinct().count();
+  }
+
+  private static long countDistinctTabletsScans(String table, AccumuloClient client)
+      throws Exception {
+    var tservers = client.instanceOperations().getTabletServers();
+    long count = 0;
+    for (String tserver : tservers) {
+      count += client.instanceOperations().getActiveScans(tserver).stream()
+          .filter(activeScan -> activeScan.getTable().equals(table))
+          .map(activeScan -> activeScan.getTablet()).distinct().count();
+    }
+    return count;
+  }
+
+}


### PR DESCRIPTION
Before this change when a tablet was closing it would prevent new scans from starting and wait for running scans to finish.  This could cause the tablet to become unavailable for long periods of time.  After this change tablets will no longer wait on running scans to complete.  They will set something to interrupt the thread and then disable the client scan session which prevents the client form ever seeing any data after the tablet is closed.  Once all scan sessions are disabled the tablet will proceed to close.  Disabling the scan session will cause the client side scanner to eventually switch to the new tablet server where the tablet is loaded.

Its possible that threads may be left running on the tablet server therefore it will be important to also implement #4756

fixes #4757