### PR TITLE
adds startedAfter method to Timer

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientTabletCacheImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientTabletCacheImpl.java
@@ -19,7 +19,6 @@
 package org.apache.accumulo.core.clientImpl;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -889,10 +888,10 @@ public class ClientTabletCacheImpl extends ClientTabletCache {
     }
 
     if (tl == null || (locationNeed == LocationNeed.REQUIRED && tl.getTserverLocation().isEmpty()
-        && tl.getCreationTimer().elapsed(NANOSECONDS) > cacheCutoffTimer.elapsed(NANOSECONDS))) {
+        && cacheCutoffTimer.startedAfter(tl.getCreationTimer()))) {
 
-      // not in cache OR the cached entry was created before the cut off time, so obtain info from
-      // metadata table
+      // not in cache OR the cutoff timer was started after when the cached entry timer was started,
+      // so obtain info from metadata table
       if (lock) {
         wLock.lock();
         try {

--- a/core/src/main/java/org/apache/accumulo/core/util/Timer.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/Timer.java
@@ -88,4 +88,12 @@ public final class Timer {
     return unit.convert(getElapsedNanos(), TimeUnit.NANOSECONDS);
   }
 
+  /**
+   * @return true if this timer was started/reset after the other timer was started/reset, false
+   *         otherwise
+   */
+  public boolean startedAfter(Timer otherTimer) {
+    return (startNanos - otherTimer.startNanos) > 0;
+  }
+
 }

--- a/core/src/test/java/org/apache/accumulo/core/util/TimerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/TimerTest.java
@@ -93,7 +93,27 @@ public class TimerTest {
       assertEquals(0, elapsedSeconds,
           "Elapsed time in seconds should be 0 for 50 milliseconds of sleep.");
     }
-
   }
 
+  @Test
+  public void testStartedAfter() throws Exception {
+    var timer1 = Timer.startNew();
+    Thread.sleep(3);
+    var timer2 = Timer.startNew();
+
+    assertTrue(timer2.startedAfter(timer1));
+    assertFalse(timer1.startedAfter(timer2));
+
+    Thread.sleep(3);
+    timer1.restart();
+
+    assertTrue(timer1.startedAfter(timer2));
+    assertFalse(timer2.startedAfter(timer1));
+
+    Thread.sleep(3);
+    timer2.restart();
+
+    assertTrue(timer2.startedAfter(timer1));
+    assertFalse(timer1.startedAfter(timer2));
+  }
 }


### PR DESCRIPTION
This [comment][1] identified a flaky unit test. The test was likely flakey because it compared elapsed times on two timers.  Each call to elapsed time would call System.nanoTime. Depending on how much nano time drifted between the two calls different results could be obtained making the code non-deteministic. Added a method to check if one timer started after another and used it for this check making the code deterministic.  Its also much easier to understand the intent of the code with this change.

[1]:https://github.com/apache/accumulo/pull/4821#issuecomment-2307244079