### PR TITLE
encapsulates Session.state field

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/Session.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/Session.java
@@ -30,7 +30,7 @@ public class Session {
   public final String client;
   public long lastAccessTime;
   public long startTime;
-  State state = State.NEW;
+  private State state = State.NEW;
   private final TCredentials credentials;
 
   Session(TCredentials credentials) {
@@ -48,6 +48,14 @@ public class Session {
 
   public boolean cleanup() {
     return true;
+  }
+
+  public void setState(State state) {
+    this.state = state;
+  }
+
+  public State getState() {
+    return state;
   }
 
   @Override

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SessionManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SessionManager.java
@@ -90,8 +90,8 @@ public class SessionManager {
     long sid = random.nextLong();
 
     synchronized (session) {
-      Preconditions.checkArgument(session.state == State.NEW);
-      session.state = reserve ? State.RESERVED : State.UNRESERVED;
+      Preconditions.checkArgument(session.getState() == State.NEW);
+      session.setState(reserve ? State.RESERVED : State.UNRESERVED);
       session.startTime = session.lastAccessTime = System.currentTimeMillis();
     }
 
@@ -114,14 +114,14 @@ public class SessionManager {
     Session session = sessions.get(sessionId);
     if (session != null) {
       synchronized (session) {
-        if (session.state == State.RESERVED) {
+        if (session.getState() == State.RESERVED) {
           throw new IllegalStateException(
               "Attempted to reserved session that is already reserved " + sessionId);
         }
-        if (session.state == State.REMOVED) {
+        if (session.getState() == State.REMOVED) {
           return null;
         }
-        session.state = State.RESERVED;
+        session.setState(State.RESERVED);
       }
     }
 
@@ -134,11 +134,11 @@ public class SessionManager {
     if (session != null) {
       synchronized (session) {
 
-        if (session.state == State.REMOVED) {
+        if (session.getState() == State.REMOVED) {
           return null;
         }
 
-        while (wait && session.state == State.RESERVED) {
+        while (wait && session.getState() == State.RESERVED) {
           try {
             session.wait(1000);
           } catch (InterruptedException e) {
@@ -146,14 +146,14 @@ public class SessionManager {
           }
         }
 
-        if (session.state == State.RESERVED) {
+        if (session.getState() == State.RESERVED) {
           throw new IllegalStateException(
               "Attempted to reserved session that is already reserved " + sessionId);
         }
-        if (session.state == State.REMOVED) {
+        if (session.getState() == State.REMOVED) {
           return null;
         }
-        session.state = State.RESERVED;
+        session.setState(State.RESERVED);
       }
     }
 
@@ -163,14 +163,14 @@ public class SessionManager {
 
   public void unreserveSession(Session session) {
     synchronized (session) {
-      if (session.state == State.REMOVED) {
+      if (session.getState() == State.REMOVED) {
         return;
       }
-      if (session.state != State.RESERVED) {
-        throw new IllegalStateException("Cannon unreserve, state: " + session.state);
+      if (session.getState() != State.RESERVED) {
+        throw new IllegalStateException("Cannon unreserve, state: " + session.getState());
       }
       session.notifyAll();
-      session.state = State.UNRESERVED;
+      session.setState(State.UNRESERVED);
       session.lastAccessTime = System.currentTimeMillis();
     }
   }
@@ -187,7 +187,7 @@ public class SessionManager {
 
     if (session != null) {
       synchronized (session) {
-        if (session.state == State.REMOVED) {
+        if (session.getState() == State.REMOVED) {
           return null;
         }
         session.lastAccessTime = System.currentTimeMillis();
@@ -207,12 +207,12 @@ public class SessionManager {
     if (session != null) {
       boolean doCleanup = false;
       synchronized (session) {
-        if (session.state != State.REMOVED) {
+        if (session.getState() != State.REMOVED) {
           if (unreserve) {
             unreserveSession(session);
           }
           doCleanup = true;
-          session.state = State.REMOVED;
+          session.setState(State.REMOVED);
         }
       }
 
@@ -234,11 +234,11 @@ public class SessionManager {
     boolean removed = false;
 
     synchronized (session) {
-      if (session.state == State.RESERVED) {
+      if (session.getState() == State.RESERVED) {
         return false;
       }
 
-      session.state = State.REMOVED;
+      session.setState(State.REMOVED);
       removed = true;
     }
 
@@ -283,7 +283,7 @@ public class SessionManager {
     while (iter.hasNext()) {
       Session session = iter.next();
       synchronized (session) {
-        if (session.state == State.UNRESERVED) {
+        if (session.getState() == State.UNRESERVED) {
           long configuredIdle = maxIdle;
           if (session instanceof UpdateSession) {
             configuredIdle = maxUpdateIdle;
@@ -294,7 +294,7 @@ public class SessionManager {
                 session.client, idleTime);
             iter.remove();
             sessionsToCleanup.add(session);
-            session.state = State.REMOVED;
+            session.setState(State.REMOVED);
           }
         }
       }
@@ -325,8 +325,9 @@ public class SessionManager {
           if (session2 != null) {
             boolean shouldRemove = false;
             synchronized (session2) {
-              if (session2.lastAccessTime == removeTime && session2.state == State.UNRESERVED) {
-                session2.state = State.REMOVED;
+              if (session2.lastAccessTime == removeTime
+                  && session2.getState() == State.UNRESERVED) {
+                session2.setState(State.REMOVED);
                 shouldRemove = true;
               }
             }


### PR DESCRIPTION
Using an IDE automatically encapsulated Session.state.  This change is needed in support of changes being made for #4756.  In #4756 need the ability to react to the state of a session changing.  Did this refactoring in its own PR to exclude automated changes from the eventual #4756 PR.