### PR TITLE
Does all session clean up for normal scans

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SingleScanSession.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SingleScanSession.java
@@ -69,6 +69,6 @@ public class SingleScanSession extends ScanSession {
         ret = true;
       }
     }
-    return ret;
+    return ret && super.cleanup();
   }
 }


### PR DESCRIPTION
Normals scans were not running all session cleanup code like batch scans were.  AFAICT this change does not impact tablet severs and only scan severs.  The code that was not being called only seems to do some clean up on scan severs.  Following the code this change should cause SnapshotTablet.close() to be called now when a normal scan session is cleaned up on a scan server.