### PR TITLE
refactors how scan sessions track scan task

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -793,7 +793,7 @@ public class ScanServer extends AbstractServer
     return new ScanReservation(scanSessionFiles, myReservationId);
   }
 
-  private static Set<StoredTabletFile> getScanSessionFiles(ScanSession session) {
+  private static Set<StoredTabletFile> getScanSessionFiles(ScanSession<?> session) {
     if (session instanceof SingleScanSession) {
       var sss = (SingleScanSession) session;
       return Set.copyOf(session.getTabletResolver().getTablet(sss.extent).getDatafiles().keySet());

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
@@ -785,7 +785,7 @@ public class TabletServerResourceManager {
 
   }
 
-  public void executeReadAhead(KeyExtent tablet, ScanDispatcher dispatcher, ScanSession scanInfo,
+  public void executeReadAhead(KeyExtent tablet, ScanDispatcher dispatcher, ScanSession<?> scanInfo,
       Runnable task) {
 
     task = ScanSession.wrap(scanInfo, task);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/ScanSession.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/ScanSession.java
@@ -49,8 +49,8 @@ public abstract class ScanSession<T> extends Session implements ScanInfo {
 
   public static class ScanMeasurer implements Runnable {
 
-    private ScanSession<?> session;
-    private Runnable task;
+    private final ScanSession<?> session;
+    private final Runnable task;
 
     ScanMeasurer(ScanSession<?> session, Runnable task) {
       this.session = session;
@@ -75,11 +75,11 @@ public abstract class ScanSession<T> extends Session implements ScanInfo {
   }
 
   private OptionalLong lastRunTime = OptionalLong.empty();
-  private Stat idleStats = new Stat();
-  public Stat runStats = new Stat();
+  private final Stat idleStats = new Stat();
+  public final Stat runStats = new Stat();
 
   public final ScanParameters scanParams;
-  private Map<String,String> executionHints;
+  private final Map<String,String> executionHints;
   private final TabletResolver tabletResolver;
 
   private volatile ScanTask<T> scanTask;
@@ -132,7 +132,7 @@ public abstract class ScanSession<T> extends Session implements ScanInfo {
 
   private class IterConfImpl implements IteratorConfiguration {
 
-    private IterInfo ii;
+    private final IterInfo ii;
 
     IterConfImpl(IterInfo ii) {
       this.ii = ii;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/ScanSession.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/ScanSession.java
@@ -194,7 +194,11 @@ public abstract class ScanSession<T> extends Session implements ScanInfo {
   @Override
   public boolean cleanup() {
     tabletResolver.close();
-
+  @Override
+  public boolean cleanup() {
+    tabletResolver.close();
+    return super.cleanup();
+  }
     if (!super.cleanup()) {
       return false;
     }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/ScanSession.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/ScanSession.java
@@ -194,15 +194,7 @@ public abstract class ScanSession<T> extends Session implements ScanInfo {
   @Override
   public boolean cleanup() {
     tabletResolver.close();
-  @Override
-  public boolean cleanup() {
-    tabletResolver.close();
     return super.cleanup();
-  }
-    if (!super.cleanup()) {
-      return false;
-    }
-    return true;
   }
 
   @Override

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SessionManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SessionManager.java
@@ -368,11 +368,11 @@ public class SessionManager {
 
       if (session instanceof SingleScanSession) {
         SingleScanSession ss = (SingleScanSession) session;
-        nbt = ss.nextBatchTask;
+        nbt = ss.getScanTask();
         tableID = ss.extent.tableId();
       } else if (session instanceof MultiScanSession) {
         MultiScanSession mss = (MultiScanSession) session;
-        nbt = mss.lookupTask;
+        nbt = mss.getScanTask();
         tableID = mss.threadPoolExtent.tableId();
       }
 
@@ -407,7 +407,7 @@ public class SessionManager {
 
         ScanState state = ScanState.RUNNING;
 
-        ScanTask<ScanBatch> nbt = ss.nextBatchTask;
+        ScanTask<ScanBatch> nbt = ss.getScanTask();
         if (nbt == null) {
           state = ScanState.IDLE;
         } else {
@@ -443,7 +443,7 @@ public class SessionManager {
 
         ScanState state = ScanState.RUNNING;
 
-        ScanTask<MultiScanResult> nbt = mss.lookupTask;
+        ScanTask<MultiScanResult> nbt = mss.getScanTask();
         if (nbt == null) {
           state = ScanState.IDLE;
         } else {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SingleScanSession.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SingleScanSession.java
@@ -25,16 +25,15 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.securityImpl.thrift.TCredentials;
 import org.apache.accumulo.tserver.scan.ScanParameters;
-import org.apache.accumulo.tserver.scan.ScanTask;
 import org.apache.accumulo.tserver.tablet.ScanBatch;
 import org.apache.accumulo.tserver.tablet.Scanner;
 
-public class SingleScanSession extends ScanSession {
+public class SingleScanSession extends ScanSession<ScanBatch> {
   public final KeyExtent extent;
   public final AtomicBoolean interruptFlag = new AtomicBoolean();
   public long entriesReturned = 0;
   public long batchCount = 0;
-  public volatile ScanTask<ScanBatch> nextBatchTask;
+
   public Scanner scanner;
   public final long readaheadThreshold;
 
@@ -59,8 +58,10 @@ public class SingleScanSession extends ScanSession {
   public boolean cleanup() {
     final boolean ret;
     try {
-      if (nextBatchTask != null) {
-        nextBatchTask.cancel(true);
+      // read volatile once to avoid race conditions
+      var localScanTask = getScanTask();
+      if (localScanTask != null) {
+        localScanTask.cancel(true);
       }
     } finally {
       if (scanner != null) {


### PR DESCRIPTION
This is manual refactor of how scan sessions track scan task. MultiScanSession and SinceScanSession both extend ScanSession.  Each was tracking  scan task separately.  Moved this tracking into the parent class ScanSession.  This refactoring is needed for #4756 but want to do it on its own to simplify review for bug fix release changes.