### PR TITLE
Mark member variables that can be final in 3.1

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/AccumuloSecurityException.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/AccumuloSecurityException.java
@@ -68,7 +68,7 @@ public class AccumuloSecurityException extends Exception {
 
   private String user;
   private String tableInfo;
-  private SecurityErrorCode errorCode;
+  private final SecurityErrorCode errorCode;
 
   /**
    * @return this exception as a thrift exception

--- a/core/src/main/java/org/apache/accumulo/core/client/ClientSideIteratorScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/ClientSideIteratorScanner.java
@@ -89,8 +89,8 @@ public class ClientSideIteratorScanner extends ScannerOptions implements Scanner
 
   private class ClientSideIteratorEnvironment implements IteratorEnvironment {
 
-    private SamplerConfiguration samplerConfig;
-    private boolean sampleEnabled;
+    private final SamplerConfiguration samplerConfig;
+    private final boolean sampleEnabled;
 
     ClientSideIteratorEnvironment(boolean sampleEnabled, SamplerConfiguration samplerConfig) {
       this.sampleEnabled = sampleEnabled;

--- a/core/src/main/java/org/apache/accumulo/core/client/ConditionalWriter.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/ConditionalWriter.java
@@ -33,8 +33,8 @@ public interface ConditionalWriter extends AutoCloseable {
   class Result {
 
     private Status status;
-    private ConditionalMutation mutation;
-    private String server;
+    private final ConditionalMutation mutation;
+    private final String server;
     private Exception exception;
 
     public Result(Status s, ConditionalMutation m, String server) {

--- a/core/src/main/java/org/apache/accumulo/core/client/IsolatedScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/IsolatedScanner.java
@@ -45,17 +45,17 @@ public class IsolatedScanner extends ScannerOptions implements Scanner {
   private static class RowBufferingIterator implements Iterator<Entry<Key,Value>> {
 
     private Iterator<Entry<Key,Value>> source;
-    private RowBuffer buffer;
+    private final RowBuffer buffer;
     private Entry<Key,Value> nextRowStart;
     private Iterator<Entry<Key,Value>> rowIter;
     private ByteSequence lastRow = null;
-    private long timeout;
+    private final long timeout;
 
     private final Scanner scanner;
-    private ScannerOptions opts;
-    private Range range;
-    private int batchSize;
-    private long readaheadThreshold;
+    private final ScannerOptions opts;
+    private final Range range;
+    private final int batchSize;
+    private final long readaheadThreshold;
 
     private void readRow() {
 
@@ -195,7 +195,7 @@ public class IsolatedScanner extends ScannerOptions implements Scanner {
 
   public static class MemoryRowBuffer implements RowBuffer {
 
-    private ArrayList<Entry<Key,Value>> buffer = new ArrayList<>();
+    private final ArrayList<Entry<Key,Value>> buffer = new ArrayList<>();
 
     @Override
     public void add(Entry<Key,Value> entry) {
@@ -214,11 +214,11 @@ public class IsolatedScanner extends ScannerOptions implements Scanner {
 
   }
 
-  private Scanner scanner;
+  private final Scanner scanner;
   private Range range;
   private int batchSize;
   private long readaheadThreshold;
-  private RowBufferFactory bufferFactory;
+  private final RowBufferFactory bufferFactory;
 
   public IsolatedScanner(Scanner scanner) {
     this(scanner, new MemoryRowBufferFactory());

--- a/core/src/main/java/org/apache/accumulo/core/client/IteratorSetting.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/IteratorSetting.java
@@ -55,7 +55,7 @@ public class IteratorSetting implements Writable {
   private int priority;
   private String name;
   private String iteratorClass;
-  private Map<String,String> properties;
+  private final Map<String,String> properties;
 
   /**
    * Get layer at which this iterator applies. See {@link #setPriority(int)} for how the priority is

--- a/core/src/main/java/org/apache/accumulo/core/client/NamespaceNotEmptyException.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/NamespaceNotEmptyException.java
@@ -27,7 +27,7 @@ public class NamespaceNotEmptyException extends Exception {
 
   private static final long serialVersionUID = 1L;
 
-  private String namespace;
+  private final String namespace;
 
   /**
    * @param namespaceId the internal id of the namespace

--- a/core/src/main/java/org/apache/accumulo/core/client/NamespaceNotFoundException.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/NamespaceNotFoundException.java
@@ -29,7 +29,7 @@ public class NamespaceNotFoundException extends Exception {
    */
   private static final long serialVersionUID = 1L;
 
-  private String namespace;
+  private final String namespace;
 
   /**
    * @param namespaceId the internal id of the namespace that was sought

--- a/core/src/main/java/org/apache/accumulo/core/client/RowIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/RowIterator.java
@@ -40,7 +40,7 @@ public class RowIterator implements Iterator<Iterator<Entry<Key,Value>>> {
    * Iterate over entries in a single row.
    */
   private static class SingleRowIter implements Iterator<Entry<Key,Value>> {
-    private PeekingIterator<Entry<Key,Value>> source;
+    private final PeekingIterator<Entry<Key,Value>> source;
     private Text currentRow = null;
     private long count = 0;
     private boolean disabled = false;

--- a/core/src/main/java/org/apache/accumulo/core/client/TableDeletedException.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/TableDeletedException.java
@@ -27,7 +27,7 @@ package org.apache.accumulo.core.client;
 public class TableDeletedException extends RuntimeException {
 
   private static final long serialVersionUID = 1L;
-  private String tableId;
+  private final String tableId;
 
   public TableDeletedException(String tableId) {
     super("Table ID " + tableId + " was deleted");

--- a/core/src/main/java/org/apache/accumulo/core/client/TableNotFoundException.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/TableNotFoundException.java
@@ -30,7 +30,7 @@ public class TableNotFoundException extends Exception {
    */
   private static final long serialVersionUID = 1L;
 
-  private String tableName;
+  private final String tableName;
 
   /**
    * @param tableId the internal id of the table that was sought

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/DateLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/DateLexicoder.java
@@ -27,7 +27,7 @@ import java.util.Date;
  */
 public class DateLexicoder extends AbstractLexicoder<Date> {
 
-  private LongLexicoder longEncoder = new LongLexicoder();
+  private final LongLexicoder longEncoder = new LongLexicoder();
 
   @Override
   public byte[] encode(Date data) {

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/DoubleLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/DoubleLexicoder.java
@@ -25,7 +25,7 @@ package org.apache.accumulo.core.client.lexicoder;
  */
 public class DoubleLexicoder extends AbstractLexicoder<Double> {
 
-  private ULongLexicoder longEncoder = new ULongLexicoder();
+  private final ULongLexicoder longEncoder = new ULongLexicoder();
 
   @Override
   public byte[] encode(Double d) {

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/FloatLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/FloatLexicoder.java
@@ -25,7 +25,7 @@ package org.apache.accumulo.core.client.lexicoder;
  */
 public class FloatLexicoder extends AbstractLexicoder<Float> {
 
-  private UIntegerLexicoder intEncoder = new UIntegerLexicoder();
+  private final UIntegerLexicoder intEncoder = new UIntegerLexicoder();
 
   @Override
   public byte[] encode(Float f) {

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/IntegerLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/IntegerLexicoder.java
@@ -26,7 +26,7 @@ package org.apache.accumulo.core.client.lexicoder;
  */
 public class IntegerLexicoder extends AbstractLexicoder<Integer> {
 
-  private UIntegerLexicoder uil = new UIntegerLexicoder();
+  private final UIntegerLexicoder uil = new UIntegerLexicoder();
 
   @Override
   public byte[] encode(Integer i) {

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/ListLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/ListLexicoder.java
@@ -37,7 +37,7 @@ import java.util.List;
  */
 public class ListLexicoder<LT> extends AbstractLexicoder<List<LT>> {
 
-  private Lexicoder<LT> lexicoder;
+  private final Lexicoder<LT> lexicoder;
 
   public ListLexicoder(Lexicoder<LT> lexicoder) {
     this.lexicoder = lexicoder;

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/PairLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/PairLexicoder.java
@@ -54,8 +54,8 @@ import org.apache.accumulo.core.util.ComparablePair;
 public class PairLexicoder<A extends Comparable<A>,B extends Comparable<B>>
     extends AbstractLexicoder<ComparablePair<A,B>> {
 
-  private Lexicoder<A> firstLexicoder;
-  private Lexicoder<B> secondLexicoder;
+  private final Lexicoder<A> firstLexicoder;
+  private final Lexicoder<B> secondLexicoder;
 
   public PairLexicoder(Lexicoder<A> firstLexicoder, Lexicoder<B> secondLexicoder) {
     this.firstLexicoder = firstLexicoder;

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/ReverseLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/ReverseLexicoder.java
@@ -31,7 +31,7 @@ import static org.apache.accumulo.core.clientImpl.lexicoder.ByteUtils.unescape;
  */
 public class ReverseLexicoder<T> extends AbstractLexicoder<T> {
 
-  private Lexicoder<T> lexicoder;
+  private final Lexicoder<T> lexicoder;
 
   /**
    * @param lexicoder The lexicoder who's sort order will be flipped.

--- a/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileScanner.java
@@ -84,11 +84,11 @@ class RFileScanner extends ScannerOptions implements Scanner {
   private BlockCacheManager blockCacheManager = null;
   private BlockCache dataCache = null;
   private BlockCache indexCache = null;
-  private Opts opts;
+  private final Opts opts;
   private int batchSize = 1000;
   private long readaheadThreshold = 3;
-  private AccumuloConfiguration tableConf;
-  private CryptoService cryptoService;
+  private final AccumuloConfiguration tableConf;
+  private final CryptoService cryptoService;
 
   static class Opts {
     InputArgs in;

--- a/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileScannerBuilder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileScannerBuilder.java
@@ -77,7 +77,7 @@ class RFileScannerBuilder implements RFile.InputArguments, RFile.ScannerFSOption
     }
   }
 
-  private RFileScanner.Opts opts = new RFileScanner.Opts();
+  private final RFileScanner.Opts opts = new RFileScanner.Opts();
 
   @Override
   public ScannerOptions withoutSystemIterators() {

--- a/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileWriter.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileWriter.java
@@ -90,7 +90,7 @@ import com.google.common.base.Preconditions;
  */
 public class RFileWriter implements AutoCloseable {
 
-  private FileSKVWriter writer;
+  private final FileSKVWriter writer;
   private final LRUMap<ByteSequence,Boolean> validVisibilities;
   private boolean startedLG;
   private boolean startedDefaultLG;

--- a/core/src/main/java/org/apache/accumulo/core/client/sample/SamplerConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/sample/SamplerConfiguration.java
@@ -33,7 +33,7 @@ import java.util.Map.Entry;
  */
 public class SamplerConfiguration {
 
-  private String className;
+  private final String className;
   private Map<String,String> options = new HashMap<>();
 
   public SamplerConfiguration(Class<? extends Sampler> samplerClass) {

--- a/core/src/main/java/org/apache/accumulo/core/client/security/tokens/AuthenticationToken.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/security/tokens/AuthenticationToken.java
@@ -124,7 +124,7 @@ public interface AuthenticationToken extends Writable, Destroyable, Cloneable {
   class Properties implements Destroyable, Map<String,char[]> {
 
     private boolean destroyed = false;
-    private HashMap<String,char[]> map = new HashMap<>();
+    private final HashMap<String,char[]> map = new HashMap<>();
 
     private void checkDestroyed() {
       if (destroyed) {
@@ -241,8 +241,9 @@ public interface AuthenticationToken extends Writable, Destroyable, Cloneable {
   }
 
   class TokenProperty implements Comparable<TokenProperty> {
-    private String key, description;
-    private boolean masked;
+    private final String key;
+    private final String description;
+    private final boolean masked;
 
     public TokenProperty(String name, String description, boolean mask) {
       this.key = name;

--- a/core/src/main/java/org/apache/accumulo/core/client/summary/CountingSummarizer.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/summary/CountingSummarizer.java
@@ -218,15 +218,15 @@ public abstract class CountingSummarizer<K> implements Summarizer {
       // efficient than converting String for each Key. The
       // conversion to String is deferred until the summary is requested.
 
-      private Map<K,MutableLong> counters = new HashMap<>();
+      private final Map<K,MutableLong> counters = new HashMap<>();
       private long tooMany = 0;
       private long tooLong = 0;
       private long seen = 0;
       private long emitted = 0;
       private long deleted = 0;
-      private Converter<K> converter = converter();
-      private Function<K,String> encoder = encoder();
-      private UnaryOperator<K> copier = copier();
+      private final Converter<K> converter = converter();
+      private final Function<K,String> encoder = encoder();
+      private final UnaryOperator<K> copier = copier();
 
       private void incrementCounter(K counter) {
         emitted++;

--- a/core/src/main/java/org/apache/accumulo/core/client/summary/summarizers/AuthorizationSummarizer.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/summary/summarizers/AuthorizationSummarizer.java
@@ -63,7 +63,7 @@ public class AuthorizationSummarizer extends CountingSummarizer<ByteSequence> {
   private static class AuthsConverter implements Converter<ByteSequence> {
 
     final int MAX_ENTRIES = 1000;
-    private Map<ByteSequence,Set<ByteSequence>> cache =
+    private final Map<ByteSequence,Set<ByteSequence>> cache =
         new LinkedHashMap<>(MAX_ENTRIES + 1, .75F, true) {
           private static final long serialVersionUID = 1L;
 

--- a/core/src/main/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizer.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizer.java
@@ -45,7 +45,7 @@ public class EntryLengthSummarizer implements Summarizer {
     private long min = Long.MAX_VALUE;
     private long max = Long.MIN_VALUE;
     private long sum = 0;
-    private long[] counts = new long[32];
+    private final long[] counts = new long[32];
 
     private void accept(int length) {
       int idx;
@@ -106,12 +106,12 @@ public class EntryLengthSummarizer implements Summarizer {
   public Collector collector(SummarizerConfiguration sc) {
     return new Collector() {
 
-      private LengthStats keyStats = new LengthStats();
-      private LengthStats rowStats = new LengthStats();
-      private LengthStats familyStats = new LengthStats();
-      private LengthStats qualifierStats = new LengthStats();
-      private LengthStats visibilityStats = new LengthStats();
-      private LengthStats valueStats = new LengthStats();
+      private final LengthStats keyStats = new LengthStats();
+      private final LengthStats rowStats = new LengthStats();
+      private final LengthStats familyStats = new LengthStats();
+      private final LengthStats qualifierStats = new LengthStats();
+      private final LengthStats visibilityStats = new LengthStats();
+      private final LengthStats valueStats = new LengthStats();
       private long total = 0;
 
       @Override

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ActiveCompactionImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ActiveCompactionImpl.java
@@ -38,10 +38,10 @@ import com.google.common.net.HostAndPort;
  */
 public class ActiveCompactionImpl extends ActiveCompaction {
 
-  private org.apache.accumulo.core.tabletserver.thrift.ActiveCompaction tac;
-  private ClientContext context;
-  private HostAndPort hostport;
-  private Type type;
+  private final org.apache.accumulo.core.tabletserver.thrift.ActiveCompaction tac;
+  private final ClientContext context;
+  private final HostAndPort hostport;
+  private final Type type;
 
   ActiveCompactionImpl(ClientContext context,
       org.apache.accumulo.core.tabletserver.thrift.ActiveCompaction tac, HostAndPort hostport,

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ActiveScanImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ActiveScanImpl.java
@@ -42,19 +42,19 @@ import org.apache.accumulo.core.security.Authorizations;
  */
 public class ActiveScanImpl extends ActiveScan {
 
-  private long scanId;
-  private String client;
-  private String tableName;
-  private long age;
-  private long idle;
-  private ScanType type;
-  private ScanState state;
-  private KeyExtent extent;
-  private List<Column> columns;
-  private List<String> ssiList;
-  private Map<String,Map<String,String>> ssio;
-  private String user;
-  private Authorizations authorizations;
+  private final long scanId;
+  private final String client;
+  private final String tableName;
+  private final long age;
+  private final long idle;
+  private final ScanType type;
+  private final ScanState state;
+  private final KeyExtent extent;
+  private final List<Column> columns;
+  private final List<String> ssiList;
+  private final Map<String,Map<String,String>> ssio;
+  private final String user;
+  private final Authorizations authorizations;
 
   ActiveScanImpl(ClientContext context,
       org.apache.accumulo.core.tabletscan.thrift.ActiveScan activeScan)

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/CompressedIterators.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/CompressedIterators.java
@@ -31,7 +31,7 @@ import org.apache.accumulo.core.util.UnsynchronizedBuffer;
 
 public class CompressedIterators {
   private Map<String,Integer> symbolMap;
-  private List<String> symbolTable;
+  private final List<String> symbolTable;
 
   public static class IterConfig {
     public List<IterInfo> ssiList = new ArrayList<>();

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
@@ -114,14 +114,14 @@ public class ConditionalWriterImpl implements ConditionalWriter {
     boolean taskQueued = false;
   }
 
-  private Map<String,ServerQueue> serverQueues;
-  private DelayQueue<QCMutation> failedMutations = new DelayQueue<>();
-  private ScheduledThreadPoolExecutor threadPool;
+  private final Map<String,ServerQueue> serverQueues;
+  private final DelayQueue<QCMutation> failedMutations = new DelayQueue<>();
+  private final ScheduledThreadPoolExecutor threadPool;
   private final ScheduledFuture<?> failureTaskFuture;
 
   private class RQIterator implements Iterator<Result> {
 
-    private BlockingQueue<Result> rq;
+    private final BlockingQueue<Result> rq;
     private int count;
 
     public RQIterator(BlockingQueue<Result> resultQueue, int count) {
@@ -165,10 +165,10 @@ public class ConditionalWriterImpl implements ConditionalWriter {
   }
 
   private static class QCMutation extends ConditionalMutation implements Delayed {
-    private BlockingQueue<Result> resultQueue;
+    private final BlockingQueue<Result> resultQueue;
     private long resetTime;
     private long delay = 50;
-    private long entryTime;
+    private final long entryTime;
 
     QCMutation(ConditionalMutation cm, BlockingQueue<Result> resultQueue, long entryTime) {
       super(cm);
@@ -224,7 +224,7 @@ public class ConditionalWriterImpl implements ConditionalWriter {
   }
 
   private class CleanupTask implements Runnable {
-    private List<SessionID> sessions;
+    private final List<SessionID> sessions;
 
     CleanupTask(List<SessionID> activeSessions) {
       this.sessions = activeSessions;
@@ -483,7 +483,7 @@ public class ConditionalWriterImpl implements ConditionalWriter {
     }
   }
 
-  private HashMap<HostAndPort,SessionID> cachedSessionIDs = new HashMap<>();
+  private final HashMap<HostAndPort,SessionID> cachedSessionIDs = new HashMap<>();
 
   private SessionID reserveSessionID(HostAndPort location, TabletIngestClientService.Iface client,
       TInfo tinfo) throws ThriftSecurityException, TException {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/Credentials.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/Credentials.java
@@ -43,8 +43,8 @@ import org.apache.accumulo.core.securityImpl.thrift.TCredentials;
  */
 public class Credentials {
 
-  private String principal;
-  private AuthenticationToken token;
+  private final String principal;
+  private final AuthenticationToken token;
 
   /**
    * Creates a new credentials object.

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/NamespaceOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/NamespaceOperationsImpl.java
@@ -68,7 +68,7 @@ import org.slf4j.LoggerFactory;
 
 public class NamespaceOperationsImpl extends NamespaceOperationsHelper {
   private final ClientContext context;
-  private TableOperationsImpl tableOps;
+  private final TableOperationsImpl tableOps;
 
   private static final Logger log = LoggerFactory.getLogger(TableOperations.class);
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/OfflineScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/OfflineScanner.java
@@ -37,9 +37,9 @@ public class OfflineScanner extends ScannerOptions implements Scanner {
   private int batchSize;
   private Range range;
 
-  private ClientContext context;
-  private Authorizations authorizations;
-  private Text tableId;
+  private final ClientContext context;
+  private final Authorizations authorizations;
+  private final Text tableId;
 
   public OfflineScanner(ClientContext context, TableId tableId, Authorizations authorizations) {
     checkArgument(context != null, "context is null");

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerImpl.java
@@ -51,8 +51,8 @@ public class ScannerImpl extends ScannerOptions implements Scanner {
   // and just query for the next highest row from the tablet server
 
   private final ClientContext context;
-  private Authorizations authorizations;
-  private TableId tableId;
+  private final Authorizations authorizations;
+  private final TableId tableId;
 
   private int size;
 
@@ -71,7 +71,7 @@ public class ScannerImpl extends ScannerOptions implements Scanner {
   // and does not read all of the data. For this case do not want iterator tracking to consume too
   // much memory. Also it would be best to avoid an RPC storm of close methods for thousands
   // sessions that may have timed out.
-  private Map<ScannerIterator,Long> iters = new LinkedHashMap<>(MAX_ENTRIES + 1, .75F, true) {
+  private final Map<ScannerIterator,Long> iters = new LinkedHashMap<>(MAX_ENTRIES + 1, .75F, true) {
     private static final long serialVersionUID = 1L;
 
     // This method is called just after a new entry has been added

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerIterator.java
@@ -49,26 +49,26 @@ import com.google.common.base.Preconditions;
 public class ScannerIterator implements Iterator<Entry<Key,Value>> {
 
   // scanner options
-  private long timeOut;
+  private final long timeOut;
 
   // scanner state
   private Iterator<KeyValue> iter;
   private final ScanState scanState;
 
-  private ScannerOptions options;
+  private final ScannerOptions options;
 
   private Future<List<KeyValue>> readAheadOperation;
 
   private boolean finished = false;
 
   private long batchCount = 0;
-  private long readaheadThreshold;
+  private final long readaheadThreshold;
 
-  private ScannerImpl.Reporter reporter;
+  private final ScannerImpl.Reporter reporter;
 
   private final ClientContext context;
 
-  private AtomicBoolean closed = new AtomicBoolean(false);
+  private final AtomicBoolean closed = new AtomicBoolean(false);
 
   ScannerIterator(ClientContext context, TableId tableId, Authorizations authorizations,
       Range range, int size, long timeOut, ScannerOptions options, boolean isolated,

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -440,8 +440,8 @@ public class TableOperationsImpl extends TableOperationsHelper {
 
   private class SplitTask implements Runnable {
 
-    private List<Text> splits;
-    private SplitEnv env;
+    private final List<Text> splits;
+    private final SplitEnv env;
 
     SplitTask(SplitEnv env, List<Text> splits) {
       this.env = env;
@@ -1811,7 +1811,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
 
     private Map<Range,List<TabletId>> groupedByRanges;
     private Map<TabletId,List<Range>> groupedByTablets;
-    private Map<TabletId,String> tabletLocations;
+    private final Map<TabletId,String> tabletLocations;
 
     public LocationsImpl(Map<String,Map<KeyExtent,List<Range>>> binnedRanges) {
       groupedByTablets = new HashMap<>();

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletLocator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletLocator.java
@@ -246,8 +246,8 @@ public abstract class TabletLocator {
   }
 
   public static class TabletServerMutations<T extends Mutation> {
-    private Map<KeyExtent,List<T>> mutations;
-    private String tserverSession;
+    private final Map<KeyExtent,List<T>> mutations;
+    private final String tserverSession;
 
     public TabletServerMutations(String tserverSession) {
       this.tserverSession = tserverSession;

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchDeleter.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchDeleter.java
@@ -37,8 +37,8 @@ import org.apache.accumulo.core.security.ColumnVisibility;
 public class TabletServerBatchDeleter extends TabletServerBatchReader implements BatchDeleter {
 
   private final ClientContext context;
-  private TableId tableId;
-  private BatchWriterConfig bwConfig;
+  private final TableId tableId;
+  private final BatchWriterConfig bwConfig;
 
   public TabletServerBatchDeleter(ClientContext context, TableId tableId, String tableName,
       Authorizations authorizations, int numQueryThreads, BatchWriterConfig bwConfig) {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java
@@ -100,7 +100,7 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
   private final ExecutorService queryThreadPool;
   private final ScannerOptions options;
 
-  private ArrayBlockingQueue<List<Entry<Key,Value>>> resultsQueue;
+  private final ArrayBlockingQueue<List<Entry<Key,Value>>> resultsQueue;
   private Iterator<Entry<Key,Value>> batchIterator;
   private List<Entry<Key,Value>> batch;
   private static final List<Entry<Key,Value>> LAST_BATCH = new ArrayList<>();
@@ -110,13 +110,13 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
 
   private volatile Throwable fatalException = null;
 
-  private Map<String,TimeoutTracker> timeoutTrackers;
-  private Set<String> timedoutServers;
+  private final Map<String,TimeoutTracker> timeoutTrackers;
+  private final Set<String> timedoutServers;
   private final long retryTimeout;
 
-  private TabletLocator locator;
+  private final TabletLocator locator;
 
-  private ScanServerAttemptsImpl scanAttempts = new ScanServerAttemptsImpl();
+  private final ScanServerAttemptsImpl scanAttempts = new ScanServerAttemptsImpl();
 
   public interface ResultReceiver {
     void receive(List<Entry<Key,Value>> entries);
@@ -356,12 +356,12 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
 
   private class QueryTask implements Runnable {
 
-    private String tsLocation;
-    private Map<KeyExtent,List<Range>> tabletsRanges;
-    private ResultReceiver receiver;
+    private final String tsLocation;
+    private final Map<KeyExtent,List<Range>> tabletsRanges;
+    private final ResultReceiver receiver;
     private Semaphore semaphore = null;
     private final Map<KeyExtent,List<Range>> failures;
-    private List<Column> columns;
+    private final List<Column> columns;
     private int semaphoreSize;
     private final long busyTimeout;
     private final ScanServerAttemptReporter reporter;

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchWriter.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchWriter.java
@@ -154,13 +154,13 @@ public class TabletServerBatchWriter implements AutoCloseable {
   private long initialCompileTimes;
   private double initialSystemLoad;
 
-  private AtomicInteger tabletServersBatchSum = new AtomicInteger(0);
-  private AtomicInteger tabletBatchSum = new AtomicInteger(0);
-  private AtomicInteger numBatches = new AtomicInteger(0);
-  private AtomicInteger maxTabletBatch = new AtomicInteger(Integer.MIN_VALUE);
-  private AtomicInteger minTabletBatch = new AtomicInteger(Integer.MAX_VALUE);
-  private AtomicInteger minTabletServersBatch = new AtomicInteger(Integer.MAX_VALUE);
-  private AtomicInteger maxTabletServersBatch = new AtomicInteger(Integer.MIN_VALUE);
+  private final AtomicInteger tabletServersBatchSum = new AtomicInteger(0);
+  private final AtomicInteger tabletBatchSum = new AtomicInteger(0);
+  private final AtomicInteger numBatches = new AtomicInteger(0);
+  private final AtomicInteger maxTabletBatch = new AtomicInteger(Integer.MIN_VALUE);
+  private final AtomicInteger minTabletBatch = new AtomicInteger(Integer.MAX_VALUE);
+  private final AtomicInteger minTabletServersBatch = new AtomicInteger(Integer.MAX_VALUE);
+  private final AtomicInteger maxTabletServersBatch = new AtomicInteger(Integer.MIN_VALUE);
 
   // error handling
   private final Violations violations = new Violations();

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TimeoutTabletLocator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TimeoutTabletLocator.java
@@ -39,7 +39,7 @@ import org.apache.hadoop.io.Text;
  */
 public class TimeoutTabletLocator extends SyncingTabletLocator {
 
-  private long timeout;
+  private final long timeout;
   private Long firstFailTime = null;
 
   private void failed() {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/Bulk.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/Bulk.java
@@ -38,8 +38,8 @@ public class Bulk {
    * WARNING : do not change this class, its used for serialization to Json
    */
   public static class Mapping {
-    private Tablet tablet;
-    private Collection<FileInfo> files;
+    private final Tablet tablet;
+    private final Collection<FileInfo> files;
 
     public Mapping(KeyExtent tablet, Files files) {
       this.tablet = toTablet(tablet);
@@ -64,8 +64,8 @@ public class Bulk {
    */
   public static class Tablet {
 
-    private byte[] endRow;
-    private byte[] prevEndRow;
+    private final byte[] endRow;
+    private final byte[] prevEndRow;
 
     public Tablet(Text endRow, Text prevEndRow) {
       this.endRow = endRow == null ? null : TextUtil.getBytes(endRow);

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/ConcurrentKeyExtentCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/ConcurrentKeyExtentCache.java
@@ -45,19 +45,20 @@ import com.google.common.annotations.VisibleForTesting;
 
 class ConcurrentKeyExtentCache implements KeyExtentCache {
 
-  private static Logger log = LoggerFactory.getLogger(ConcurrentKeyExtentCache.class);
+  private static final Logger log = LoggerFactory.getLogger(ConcurrentKeyExtentCache.class);
 
   private static final Text MAX = new Text();
 
-  private Set<Text> rowsToLookup = Collections.synchronizedSet(new HashSet<>());
+  private final Set<Text> rowsToLookup = Collections.synchronizedSet(new HashSet<>());
 
   List<Text> lookupRows = new ArrayList<>();
 
-  private ConcurrentSkipListMap<Text,KeyExtent> extents = new ConcurrentSkipListMap<>((t1, t2) -> {
-    return (t1 == t2) ? 0 : (t1 == MAX ? 1 : (t2 == MAX ? -1 : t1.compareTo(t2)));
-  });
-  private TableId tableId;
-  private ClientContext ctx;
+  private final ConcurrentSkipListMap<Text,KeyExtent> extents =
+      new ConcurrentSkipListMap<>((t1, t2) -> {
+        return (t1 == t2) ? 0 : (t1 == MAX ? 1 : (t2 == MAX ? -1 : t1.compareTo(t2)));
+      });
+  private final TableId tableId;
+  private final ClientContext ctx;
 
   ConcurrentKeyExtentCache(TableId tableId, ClientContext ctx) {
     this.tableId = tableId;

--- a/core/src/main/java/org/apache/accumulo/core/compaction/CompactionSettings.java
+++ b/core/src/main/java/org/apache/accumulo/core/compaction/CompactionSettings.java
@@ -36,8 +36,8 @@ public enum CompactionSettings {
   OUTPUT_INDEX_BLOCK_SIZE_OPT(new SizeType(), false),
   OUTPUT_REPLICATION_OPT(new UIntType(), false);
 
-  private Type type;
-  private boolean selectorOpt;
+  private final Type type;
+  private final boolean selectorOpt;
 
   private CompactionSettings(Type type, boolean selectorOpt) {
     this.type = type;

--- a/core/src/main/java/org/apache/accumulo/core/conf/ConfigurationDocGen.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ConfigurationDocGen.java
@@ -29,7 +29,7 @@ import java.util.TreeMap;
  * presentable form.
  */
 public class ConfigurationDocGen {
-  private PrintStream doc;
+  private final PrintStream doc;
   private final TreeMap<String,Property> sortedProps = new TreeMap<>();
 
   void generate() {

--- a/core/src/main/java/org/apache/accumulo/core/conf/ConfigurationTypeHelper.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ConfigurationTypeHelper.java
@@ -154,7 +154,7 @@ public class ConfigurationTypeHelper {
   }
 
   // This is not a cache for loaded classes, just a way to avoid spamming the debug log
-  private static Map<String,Class<?>> loaded = Collections.synchronizedMap(new HashMap<>());
+  private static final Map<String,Class<?>> loaded = Collections.synchronizedMap(new HashMap<>());
 
   /**
    * Loads a class in the given classloader context, suppressing any exceptions, and optionally

--- a/core/src/main/java/org/apache/accumulo/core/constraints/Violations.java
+++ b/core/src/main/java/org/apache/accumulo/core/constraints/Violations.java
@@ -62,7 +62,7 @@ public class Violations {
 
   public static final Violations EMPTY = new Violations(Collections.emptyMap());
 
-  private Map<CVSKey,ConstraintViolationSummary> cvsmap;
+  private final Map<CVSKey,ConstraintViolationSummary> cvsmap;
 
   /**
    * Creates a new empty object.

--- a/core/src/main/java/org/apache/accumulo/core/data/ColumnUpdate.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/ColumnUpdate.java
@@ -25,13 +25,13 @@ import java.util.Arrays;
  */
 public class ColumnUpdate {
 
-  private byte[] columnFamily;
-  private byte[] columnQualifier;
-  private byte[] columnVisibility;
-  private long timestamp;
-  private boolean hasTimestamp;
-  private byte[] val;
-  private boolean deleted;
+  private final byte[] columnFamily;
+  private final byte[] columnQualifier;
+  private final byte[] columnVisibility;
+  private final long timestamp;
+  private final boolean hasTimestamp;
+  private final byte[] val;
+  private final boolean deleted;
 
   /**
    * Creates a new column update.

--- a/core/src/main/java/org/apache/accumulo/core/data/Condition.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Condition.java
@@ -36,8 +36,8 @@ import org.apache.hadoop.io.Text;
  */
 public class Condition {
 
-  private ByteSequence cf;
-  private ByteSequence cq;
+  private final ByteSequence cf;
+  private final ByteSequence cq;
   private ByteSequence cv;
   private ByteSequence val;
   private Long ts;

--- a/core/src/main/java/org/apache/accumulo/core/data/Value.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Value.java
@@ -245,7 +245,7 @@ public class Value implements WritableComparable<Object> {
    * A Comparator optimized for Value.
    */
   public static class Comparator extends WritableComparator {
-    private BytesWritable.Comparator comparator = new BytesWritable.Comparator();
+    private final BytesWritable.Comparator comparator = new BytesWritable.Comparator();
 
     /** constructor */
     public Comparator() {

--- a/core/src/main/java/org/apache/accumulo/core/fate/AgeOffStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/AgeOffStore.java
@@ -45,10 +45,10 @@ public class AgeOffStore<T> implements TStore<T> {
   private static final Logger log = LoggerFactory.getLogger(AgeOffStore.class);
 
   private final ZooStore<T> store;
-  private Map<Long,Long> candidates;
-  private long ageOffTime;
+  private final Map<Long,Long> candidates;
+  private final long ageOffTime;
   private long minTime;
-  private TimeSource timeSource;
+  private final TimeSource timeSource;
 
   private synchronized void updateMinTime() {
     minTime = Long.MAX_VALUE;

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/DistributedReadWriteLock.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/DistributedReadWriteLock.java
@@ -89,8 +89,8 @@ public class DistributedReadWriteLock implements java.util.concurrent.locks.Read
       return result;
     }
 
-    private LockType type;
-    private byte[] userData;
+    private final LockType type;
+    private final byte[] userData;
   }
 
   // This kind of lock can be easily implemented by ZooKeeper
@@ -241,8 +241,8 @@ public class DistributedReadWriteLock implements java.util.concurrent.locks.Read
     }
   }
 
-  private QueueLock qlock;
-  private byte[] data;
+  private final QueueLock qlock;
+  private final byte[] data;
 
   public DistributedReadWriteLock(QueueLock qlock, byte[] data) {
     this.qlock = qlock;

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooCacheFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooCacheFactory.java
@@ -36,7 +36,7 @@ import org.apache.accumulo.core.singletons.SingletonService;
  */
 public class ZooCacheFactory {
 
-  private static Map<String,ZooCache> instances = new HashMap<>();
+  private static final Map<String,ZooCache> instances = new HashMap<>();
   private static boolean enabled = true;
 
   public ZooCacheFactory() {}

--- a/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
@@ -93,7 +93,7 @@ public class BloomFilterLayer {
     private int numKeys;
     private int vectorSize;
 
-    private FileSKVWriter writer;
+    private final FileSKVWriter writer;
     private KeyFunctor transformer = null;
     private boolean closed = false;
     private long length = -1;
@@ -205,7 +205,7 @@ public class BloomFilterLayer {
     private volatile DynamicBloomFilter bloomFilter;
     private int loadRequest = 0;
     private int loadThreshold = 1;
-    private int maxLoadThreads;
+    private final int maxLoadThreads;
     private Runnable loadTask;
     private volatile KeyFunctor transformer = null;
     private volatile boolean closed = false;
@@ -349,8 +349,8 @@ public class BloomFilterLayer {
 
   public static class Reader implements FileSKVIterator {
 
-    private BloomFilterLoader bfl;
-    private FileSKVIterator reader;
+    private final BloomFilterLoader bfl;
+    private final FileSKVIterator reader;
 
     public Reader(FileSKVIterator reader, AccumuloConfiguration acuconf) {
       this.reader = reader;

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/lru/LruBlockCacheConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/lru/LruBlockCacheConfiguration.java
@@ -157,8 +157,8 @@ public final class LruBlockCacheConfiguration {
   }
 
   public static class Builder {
-    private Map<String,String> props = new HashMap<>();
-    private String prefix;
+    private final Map<String,String> props = new HashMap<>();
+    private final String prefix;
 
     private Builder(String prefix) {
       this.prefix = prefix;

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/CachableBlockFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/CachableBlockFile.java
@@ -252,9 +252,9 @@ public class CachableBlockFile {
     }
 
     private class RawBlockLoader extends BaseBlockLoader {
-      private long offset;
-      private long compressedSize;
-      private long rawSize;
+      private final long offset;
+      private final long compressedSize;
+      private final long rawSize;
 
       private RawBlockLoader(long offset, long compressedSize, long rawSize, boolean loadingMeta) {
         super(loadingMeta);
@@ -278,7 +278,7 @@ public class CachableBlockFile {
     }
 
     private class OffsetBlockLoader extends BaseBlockLoader {
-      private int blockIndex;
+      private final int blockIndex;
 
       private OffsetBlockLoader(int blockIndex, boolean loadingMeta) {
         super(loadingMeta);
@@ -327,7 +327,7 @@ public class CachableBlockFile {
 
       abstract String getBlockId();
 
-      private boolean loadingMetaBlock;
+      private final boolean loadingMetaBlock;
 
       public BaseBlockLoader(boolean loadingMetaBlock) {
         this.loadingMetaBlock = loadingMetaBlock;
@@ -501,7 +501,7 @@ public class CachableBlockFile {
   }
 
   public static class CachedBlockRead extends DataInputStream {
-    private SeekableByteArrayInputStream seekableInput;
+    private final SeekableByteArrayInputStream seekableInput;
     private final CacheEntry cb;
     boolean indexable;
 

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/OpportunisticBlockCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/OpportunisticBlockCache.java
@@ -23,7 +23,7 @@ import org.apache.accumulo.core.spi.cache.CacheEntry;
 
 public class OpportunisticBlockCache implements BlockCache {
 
-  private BlockCache cache;
+  private final BlockCache cache;
 
   public OpportunisticBlockCache(BlockCache cache) {
     this.cache = cache;

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/BlockIndex.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/BlockIndex.java
@@ -62,12 +62,12 @@ public class BlockIndex implements Weighable {
     return ((x > 0) && (x & (x - 1)) == 0);
   }
 
-  private AtomicInteger accessCount = new AtomicInteger(0);
+  private final AtomicInteger accessCount = new AtomicInteger(0);
   private volatile BlockIndexEntry[] blockIndex = null;
 
   public static class BlockIndexEntry implements Comparable<BlockIndexEntry> {
 
-    private Key prevKey;
+    private final Key prevKey;
     private int entriesLeft;
     private int pos;
 

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/IndexIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/IndexIterator.java
@@ -34,7 +34,7 @@ import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 class IndexIterator implements SortedKeyValueIterator<Key,Value> {
 
   private Key key;
-  private Iterator<IndexEntry> indexIter;
+  private final Iterator<IndexEntry> indexIter;
 
   IndexIterator(Iterator<IndexEntry> indexIter) {
     this.indexIter = indexIter;

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/MultiIndexIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/MultiIndexIterator.java
@@ -42,7 +42,7 @@ import org.apache.hadoop.io.Text;
 
 class MultiIndexIterator extends HeapIterator implements FileSKVIterator {
 
-  private RFile.Reader source;
+  private final RFile.Reader source;
 
   MultiIndexIterator(RFile.Reader source, List<Iterator<IndexEntry>> indexes) {
     super(indexes.size());

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/MultiLevelIndex.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/MultiLevelIndex.java
@@ -53,7 +53,7 @@ public class MultiLevelIndex {
     private long offset;
     private long compressedSize;
     private long rawSize;
-    private boolean newFormat;
+    private final boolean newFormat;
 
     IndexEntry(Key k, int e, long offset, long compressedSize, long rawSize) {
       this.key = k;
@@ -209,7 +209,7 @@ public class MultiLevelIndex {
   // a list that deserializes index entries on demand
   private static class SerializedIndex extends SerializedIndexBase<IndexEntry> {
 
-    private boolean newFormat;
+    private final boolean newFormat;
 
     SerializedIndex(int[] offsets, byte[] data, boolean newFormat) {
       super(offsets, data);
@@ -452,7 +452,7 @@ public class MultiLevelIndex {
    */
   public static class BufferedWriter {
 
-    private Writer writer;
+    private final Writer writer;
     private DataOutputStream buffer;
     private int buffered;
     private ByteArrayOutputStream baos;
@@ -504,15 +504,15 @@ public class MultiLevelIndex {
   }
 
   public static class Writer {
-    private int threshold;
+    private final int threshold;
 
-    private ArrayList<IndexBlock> levels;
+    private final ArrayList<IndexBlock> levels;
 
     private int totalAdded;
 
     private boolean addedLast = false;
 
-    private BCFile.Writer blockFileWriter;
+    private final BCFile.Writer blockFileWriter;
 
     Writer(BCFile.Writer blockFileWriter, int maxBlockSize) {
       this.blockFileWriter = blockFileWriter;
@@ -593,14 +593,14 @@ public class MultiLevelIndex {
 
   public static class Reader {
     private IndexBlock rootBlock;
-    private CachableBlockFile.Reader blockStore;
-    private int version;
+    private final CachableBlockFile.Reader blockStore;
+    private final int version;
     private int size;
 
     public class Node {
 
-      private Node parent;
-      private IndexBlock indexBlock;
+      private final Node parent;
+      private final IndexBlock indexBlock;
       private int currentPos;
 
       Node(Node parent, IndexBlock iBlock) {

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/RFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/RFile.java
@@ -387,12 +387,12 @@ public class RFile {
 
   private static class SampleLocalityGroupWriter {
 
-    private Sampler sampler;
+    private final Sampler sampler;
 
-    private List<SampleEntry> entries = new ArrayList<>();
+    private final List<SampleEntry> entries = new ArrayList<>();
     private long dataSize = 0;
 
-    private LocalityGroupWriter lgw;
+    private final LocalityGroupWriter lgw;
 
     public SampleLocalityGroupWriter(LocalityGroupWriter lgw, Sampler sampler) {
       this.lgw = lgw;
@@ -436,7 +436,7 @@ public class RFile {
 
   private static class LocalityGroupWriter {
 
-    private BCFile.Writer fileWriter;
+    private final BCFile.Writer fileWriter;
     private BlockAppender blockWriter;
 
     private final long blockSize;
@@ -449,10 +449,10 @@ public class RFile {
 
     private Key prevKey = new Key();
 
-    private SampleLocalityGroupWriter sample;
+    private final SampleLocalityGroupWriter sample;
 
     // Use windowed stats to fix ACCUMULO-4669
-    private RollingStats keyLenStats = new RollingStats(2017);
+    private final RollingStats keyLenStats = new RollingStats(2017);
     private double averageKeySize = 0;
 
     LocalityGroupWriter(BCFile.Writer fileWriter, long blockSize, long maxBlockSize,
@@ -568,14 +568,14 @@ public class RFile {
     public static final int MAX_CF_IN_DLG = 1000;
     private static final double MAX_BLOCK_MULTIPLIER = 1.1;
 
-    private BCFile.Writer fileWriter;
+    private final BCFile.Writer fileWriter;
 
     private final long blockSize;
     private final long maxBlockSize;
     private final int indexBlockSize;
 
-    private ArrayList<LocalityGroupMetadata> localityGroups = new ArrayList<>();
-    private ArrayList<LocalityGroupMetadata> sampleGroups = new ArrayList<>();
+    private final ArrayList<LocalityGroupMetadata> localityGroups = new ArrayList<>();
+    private final ArrayList<LocalityGroupMetadata> sampleGroups = new ArrayList<>();
     private LocalityGroupMetadata currentLocalityGroup = null;
     private LocalityGroupMetadata sampleLocalityGroup = null;
 
@@ -583,13 +583,13 @@ public class RFile {
     private boolean closed = false;
     private boolean startedDefaultLocalityGroup = false;
 
-    private HashSet<ByteSequence> previousColumnFamilies;
+    private final HashSet<ByteSequence> previousColumnFamilies;
     private long length = -1;
 
     private LocalityGroupWriter lgWriter;
 
-    private SamplerConfigurationImpl samplerConfig;
-    private Sampler sampler;
+    private final SamplerConfigurationImpl samplerConfig;
+    private final Sampler sampler;
 
     public Writer(BCFile.Writer bfw, int blockSize) throws IOException {
       this(bfw, blockSize, (int) DefaultConfiguration.getInstance()
@@ -762,13 +762,13 @@ public class RFile {
 
   private static class LocalityGroupReader extends LocalityGroup implements FileSKVIterator {
 
-    private CachableBlockFile.Reader reader;
-    private MultiLevelIndex.Reader index;
-    private int blockCount;
-    private Key firstKey;
-    private int startBlock;
+    private final CachableBlockFile.Reader reader;
+    private final MultiLevelIndex.Reader index;
+    private final int blockCount;
+    private final Key firstKey;
+    private final int startBlock;
     private boolean closed = false;
-    private int version;
+    private final int version;
     private boolean checkRange = true;
 
     private LocalityGroupReader(CachableBlockFile.Reader reader, LocalityGroupMetadata lgm,
@@ -1185,14 +1185,14 @@ public class RFile {
     private final LocalityGroupContext lgContext;
     private LocalityGroupSeekCache lgCache;
 
-    private List<Reader> deepCopies;
+    private final List<Reader> deepCopies;
     private boolean deepCopy = false;
 
     private AtomicBoolean interruptFlag;
 
     private SamplerConfigurationImpl samplerConfig = null;
 
-    private int rfileVersion;
+    private final int rfileVersion;
 
     public Reader(CachableBlockFile.Reader rdr) throws IOException {
       this.reader = rdr;

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/RollingStats.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/RollingStats.java
@@ -34,7 +34,7 @@ import org.apache.commons.math3.util.FastMath;
  */
 class RollingStats {
   private int position;
-  private double[] window;
+  private final double[] window;
 
   private double average;
   private double variance;

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/VisMetricsGatherer.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/VisMetricsGatherer.java
@@ -52,7 +52,7 @@ public class VisMetricsGatherer
   protected Map<String,AtomicLongMap<String>> blocks;
   protected ArrayList<Long> numEntries;
   protected ArrayList<Integer> numBlocks;
-  private ArrayList<String> inBlock;
+  private final ArrayList<String> inBlock;
   protected ArrayList<String> localityGroups;
   private int numLG;
   private Map<String,ArrayList<ByteSequence>> localityGroupCF;

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/VisibilityMetric.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/VisibilityMetric.java
@@ -26,9 +26,11 @@ package org.apache.accumulo.core.file.rfile;
  */
 public class VisibilityMetric {
 
-  private long visLG, visBlock;
-  private double visLGPer, visBlockPer;
-  private String visibility;
+  private final long visLG;
+  private final long visBlock;
+  private final double visLGPer;
+  private final double visBlockPer;
+  private final String visibility;
 
   public VisibilityMetric(String visibility, long visLG, double visLGPer, long visBlock,
       double visBlockPer) {

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/bcfile/BCFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/bcfile/BCFile.java
@@ -106,8 +106,8 @@ public final class BCFile {
   public static class Writer implements Closeable {
     private final RateLimitedOutputStream out;
     private final Configuration conf;
-    private FileEncrypter encrypter;
-    private CryptoEnvironmentImpl cryptoEnvironment;
+    private final FileEncrypter encrypter;
+    private final CryptoEnvironmentImpl cryptoEnvironment;
     // the single meta block containing index of compressed data blocks
     final DataIndex dataIndex;
     // index for meta blocks
@@ -117,7 +117,7 @@ public final class BCFile {
     private boolean closed = false;
     long errorCount = 0;
     // reusable buffers.
-    private BytesWritable fsOutputBuffer;
+    private final BytesWritable fsOutputBuffer;
     private long length = 0;
 
     public long getLength() {
@@ -458,8 +458,8 @@ public final class BCFile {
     // Index for meta blocks
     final MetaIndex metaIndex;
     final Version version;
-    private byte[] decryptionParams;
-    private FileDecrypter decrypter;
+    private final byte[] decryptionParams;
+    private final FileDecrypter decrypter;
 
     /**
      * Intermediate class that maintain the state of a Readable Compression Block.

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/bcfile/CompressionAlgorithm.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/bcfile/CompressionAlgorithm.java
@@ -110,8 +110,8 @@ public class CompressionAlgorithm extends Configured {
   /**
    * Guava cache to have a limited factory pattern defined in the Algorithm enum.
    */
-  private static LoadingCache<Entry<CompressionAlgorithm,Integer>,CompressionCodec> codecCache =
-      Caffeine.newBuilder().maximumSize(25)
+  private static final LoadingCache<Entry<CompressionAlgorithm,Integer>,
+      CompressionCodec> codecCache = Caffeine.newBuilder().maximumSize(25)
           .build(key -> key.getKey().createNewCodec(key.getValue()));
 
   // Data input buffer size to absorb small reads from application.

--- a/core/src/main/java/org/apache/accumulo/core/iterators/Combiner.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/Combiner.java
@@ -182,7 +182,7 @@ public abstract class Combiner extends WrappingIterator implements OptionDescrib
     findTop();
   }
 
-  private Key workKey = new Key();
+  private final Key workKey = new Key();
 
   @VisibleForTesting
   static final Cache<String,Boolean> loggedMsgCache =

--- a/core/src/main/java/org/apache/accumulo/core/iterators/OrIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/OrIterator.java
@@ -85,7 +85,7 @@ public class OrIterator implements SortedKeyValueIterator<Key,Value>, OptionDesc
 
   private TermSource currentTerm;
   private List<TermSource> sources;
-  private PriorityQueue<TermSource> sorted = new PriorityQueue<>(5);
+  private final PriorityQueue<TermSource> sorted = new PriorityQueue<>(5);
 
   protected static class TermSource implements Comparable<TermSource> {
     private final SortedKeyValueIterator<Key,Value> iter;

--- a/core/src/main/java/org/apache/accumulo/core/iterators/TypedValueCombiner.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/TypedValueCombiner.java
@@ -53,9 +53,9 @@ public abstract class TypedValueCombiner<V> extends Combiner {
    * decode method of an Encoder.
    */
   private static class VIterator<V> implements Iterator<V> {
-    private Iterator<Value> source;
-    private Encoder<V> encoder;
-    private boolean lossy;
+    private final Iterator<Value> source;
+    private final Encoder<V> encoder;
+    private final boolean lossy;
 
     /**
      * Constructs an {@code Iterator<V>} from an {@code Iterator<Value>}

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/GrepIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/GrepIterator.java
@@ -58,7 +58,7 @@ public class GrepIterator extends Filter {
   private static final String MATCH_VALUE_OPT = "matchValue";
 
   private byte[] term;
-  private int[] right = new int[256];
+  private final int[] right = new int[256];
 
   private boolean matchRow = true;
   private boolean matchColFam = true;

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/LargeRowFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/LargeRowFilter.java
@@ -58,8 +58,8 @@ public class LargeRowFilter implements SortedKeyValueIterator<Key,Value>, Option
   private SortedKeyValueIterator<Key,Value> source;
 
   // a cache of keys
-  private ArrayList<Key> keys = new ArrayList<>();
-  private ArrayList<Value> values = new ArrayList<>();
+  private final ArrayList<Key> keys = new ArrayList<>();
+  private final ArrayList<Value> values = new ArrayList<>();
 
   private int currentPosition;
 

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/TransformingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/TransformingIterator.java
@@ -93,7 +93,7 @@ public abstract class TransformingIterator extends WrappingIterator implements O
   public static final String MAX_BUFFER_SIZE_OPT = "maxBufferSize";
   private static final long DEFAULT_MAX_BUFFER_SIZE = 10000000;
 
-  private Logger log = LoggerFactory.getLogger(getClass());
+  private final Logger log = LoggerFactory.getLogger(getClass());
 
   protected ArrayList<Pair<Key,Value>> keys = new ArrayList<>();
   protected int keyPos = -1;
@@ -107,7 +107,8 @@ public abstract class TransformingIterator extends WrappingIterator implements O
   private LRUMap<ByteSequence,Boolean> parsedVisibilitiesCache = null;
   private long maxBufferSize;
 
-  private static Comparator<Pair<Key,Value>> keyComparator = Comparator.comparing(Pair::getFirst);
+  private static final Comparator<Pair<Key,Value>> keyComparator =
+      Comparator.comparing(Pair::getFirst);
 
   @Override
   public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options,
@@ -265,9 +266,9 @@ public abstract class TransformingIterator extends WrappingIterator implements O
 
   private static class RangeIterator implements SortedKeyValueIterator<Key,Value> {
 
-    private SortedKeyValueIterator<Key,Value> source;
-    private Key prefixKey;
-    private PartialKey keyPrefix;
+    private final SortedKeyValueIterator<Key,Value> source;
+    private final Key prefixKey;
+    private final PartialKey keyPrefix;
     private boolean hasTop = false;
 
     RangeIterator(SortedKeyValueIterator<Key,Value> source, Key prefixKey, PartialKey keyPrefix) {

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/VersioningIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/VersioningIterator.java
@@ -38,7 +38,7 @@ import org.apache.accumulo.core.iterators.WrappingIterator;
 public class VersioningIterator extends WrappingIterator implements OptionDescriber {
   private final int maxCount = 10;
 
-  private Key currentKey = new Key();
+  private final Key currentKey = new Key();
   private int numVersions;
   protected int maxVersions;
 

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/VisibilityFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/VisibilityFilter.java
@@ -47,7 +47,7 @@ public class VisibilityFilter extends Filter implements OptionDescriber {
 
   private AccessEvaluator accessEvaluator;
   protected Map<ByteSequence,Boolean> cache;
-  private ArrayByteSequence testVis = new ArrayByteSequence(new byte[0]);
+  private final ArrayByteSequence testVis = new ArrayByteSequence(new byte[0]);
 
   private static final Logger log = LoggerFactory.getLogger(VisibilityFilter.class);
 

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/conf/ColumnSet.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/conf/ColumnSet.java
@@ -31,11 +31,11 @@ import org.apache.accumulo.core.util.Pair;
 import org.apache.hadoop.io.Text;
 
 public class ColumnSet {
-  private Set<ColFamHashKey> objectsCF;
-  private Set<ColHashKey> objectsCol;
+  private final Set<ColFamHashKey> objectsCF;
+  private final Set<ColHashKey> objectsCol;
 
-  private ColHashKey lookupCol = new ColHashKey();
-  private ColFamHashKey lookupCF = new ColFamHashKey();
+  private final ColHashKey lookupCol = new ColHashKey();
+  private final ColFamHashKey lookupCF = new ColFamHashKey();
 
   public ColumnSet() {
     objectsCF = new HashSet<>();

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/conf/ColumnToClassMapping.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/conf/ColumnToClassMapping.java
@@ -32,11 +32,11 @@ import org.apache.hadoop.io.Text;
 
 public class ColumnToClassMapping<K> {
 
-  private HashMap<ColFamHashKey,K> objectsCF;
-  private HashMap<ColHashKey,K> objectsCol;
+  private final HashMap<ColFamHashKey,K> objectsCF;
+  private final HashMap<ColHashKey,K> objectsCol;
 
-  private ColHashKey lookupCol = new ColHashKey();
-  private ColFamHashKey lookupCF = new ColFamHashKey();
+  private final ColHashKey lookupCol = new ColHashKey();
+  private final ColFamHashKey lookupCF = new ColFamHashKey();
 
   public ColumnToClassMapping() {
     objectsCF = new HashMap<>();

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/ColumnQualifierFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/ColumnQualifierFilter.java
@@ -32,8 +32,8 @@ import org.apache.accumulo.core.iterators.ServerFilter;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 
 public class ColumnQualifierFilter extends ServerFilter {
-  private HashSet<ByteSequence> columnFamilies;
-  private HashMap<ByteSequence,HashSet<ByteSequence>> columnsQualifiers;
+  private final HashSet<ByteSequence> columnFamilies;
+  private final HashMap<ByteSequence,HashSet<ByteSequence>> columnsQualifiers;
 
   private ColumnQualifierFilter(SortedKeyValueIterator<Key,Value> iterator, Set<Column> columns) {
     super(iterator);

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/DeletingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/DeletingIterator.java
@@ -35,8 +35,8 @@ import org.apache.accumulo.core.iterators.ServerWrappingIterator;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 
 public class DeletingIterator extends ServerWrappingIterator {
-  private boolean propagateDeletes;
-  private Key workKey = new Key();
+  private final boolean propagateDeletes;
+  private final Key workKey = new Key();
 
   public enum Behavior {
     PROCESS, FAIL

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/MultiIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/MultiIterator.java
@@ -37,8 +37,8 @@ import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
  */
 public class MultiIterator extends HeapIterator {
 
-  private List<SortedKeyValueIterator<Key,Value>> iters;
-  private Range fence;
+  private final List<SortedKeyValueIterator<Key,Value>> iters;
+  private final Range fence;
 
   // deep copy with no seek/scan state
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/SequenceFileIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/SequenceFileIterator.java
@@ -40,10 +40,10 @@ import org.apache.hadoop.io.Text;
 
 public class SequenceFileIterator implements FileSKVIterator {
 
-  private Reader reader;
+  private final Reader reader;
   private Value top_value;
   private Key top_key;
-  private boolean readValue;
+  private final boolean readValue;
 
   @Override
   public SequenceFileIterator deepCopy(IteratorEnvironment env) {

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/SortedMapIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/SortedMapIterator.java
@@ -48,7 +48,7 @@ public class SortedMapIterator implements InterruptibleIterator {
   private Iterator<Entry<Key,Value>> iter;
   private Entry<Key,Value> entry;
 
-  private SortedMap<Key,Value> map;
+  private final SortedMap<Key,Value> map;
   private Range range;
 
   private AtomicBoolean interruptFlag;

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/SourceSwitchingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/SourceSwitchingIterator.java
@@ -70,7 +70,7 @@ public class SourceSwitchingIterator implements InterruptibleIterator {
   private boolean inclusive;
   private Collection<ByteSequence> columnFamilies;
 
-  private boolean onlySwitchAfterRow;
+  private final boolean onlySwitchAfterRow;
 
   // Synchronization on copies synchronizes operations across all deep copies of this instance.
   //

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/StatsIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/StatsIterator.java
@@ -34,9 +34,9 @@ import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 public class StatsIterator extends ServerWrappingIterator {
 
   private int numRead = 0;
-  private AtomicLong seekCounter;
-  private AtomicLong scanCounter;
-  private LongAdder serverScanCounter;
+  private final AtomicLong seekCounter;
+  private final AtomicLong scanCounter;
+  private final LongAdder serverScanCounter;
 
   public StatsIterator(SortedKeyValueIterator<Key,Value> source, AtomicLong seekCounter,
       AtomicLong tabletScanCounter, LongAdder serverScanCounter) {

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/TimeSettingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/TimeSettingIterator.java
@@ -33,8 +33,8 @@ import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 
 public class TimeSettingIterator implements InterruptibleIterator {
 
-  private SortedKeyValueIterator<Key,Value> source;
-  private long time;
+  private final SortedKeyValueIterator<Key,Value> source;
+  private final long time;
   private Range range;
 
   public TimeSettingIterator(SortedKeyValueIterator<Key,Value> source, long time) {

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/VisibilityFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/VisibilityFilter.java
@@ -46,7 +46,7 @@ public class VisibilityFilter extends SynchronizedServerFilter {
   protected final LRUMap<ByteSequence,Boolean> cache;
   protected final Authorizations authorizations;
 
-  private ArrayByteSequence testVis = new ArrayByteSequence(new byte[0]);
+  private final ArrayByteSequence testVis = new ArrayByteSequence(new byte[0]);
 
   private static final Logger log = LoggerFactory.getLogger(VisibilityFilter.class);
 

--- a/core/src/main/java/org/apache/accumulo/core/lock/ServiceLockData.java
+++ b/core/src/main/java/org/apache/accumulo/core/lock/ServiceLockData.java
@@ -146,7 +146,7 @@ public class ServiceLockData implements Comparable<ServiceLockData> {
     }
   }
 
-  private EnumMap<ThriftService,ServiceDescriptor> services;
+  private final EnumMap<ThriftService,ServiceDescriptor> services;
 
   public ServiceLockData(ServiceDescriptors sds) {
     this.services = new EnumMap<>(ThriftService.class);

--- a/core/src/main/java/org/apache/accumulo/core/metadata/MetadataLocationObtainer.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/MetadataLocationObtainer.java
@@ -68,8 +68,8 @@ import org.slf4j.LoggerFactory;
 public class MetadataLocationObtainer implements TabletLocationObtainer {
   private static final Logger log = LoggerFactory.getLogger(MetadataLocationObtainer.class);
 
-  private SortedSet<Column> locCols;
-  private ArrayList<Column> columns;
+  private final SortedSet<Column> locCols;
+  private final ArrayList<Column> columns;
 
   public MetadataLocationObtainer() {
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/TableMetadataServicer.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/TableMetadataServicer.java
@@ -43,8 +43,8 @@ import org.apache.hadoop.io.Text;
 abstract class TableMetadataServicer extends MetadataServicer {
 
   private final ClientContext context;
-  private TableId tableIdBeingServiced;
-  private String serviceTableName;
+  private final TableId tableIdBeingServiced;
+  private final String serviceTableName;
 
   public TableMetadataServicer(ClientContext context, String serviceTableName,
       TableId tableIdBeingServiced) {

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/DataFileValue.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/DataFileValue.java
@@ -25,8 +25,8 @@ import org.apache.accumulo.core.iteratorsImpl.system.InterruptibleIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.TimeSettingIterator;
 
 public class DataFileValue {
-  private long size;
-  private long numEntries;
+  private final long size;
+  private final long numEntries;
   private long time = -1;
 
   public DataFileValue(long size, long numEntries, long time) {

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/LinkingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/LinkingIterator.java
@@ -51,8 +51,8 @@ public class LinkingIterator implements Iterator<TabletMetadata> {
 
   private static final Logger log = LoggerFactory.getLogger(LinkingIterator.class);
 
-  private Range range;
-  private Function<Range,Iterator<TabletMetadata>> iteratorFactory;
+  private final Range range;
+  private final Function<Range,Iterator<TabletMetadata>> iteratorFactory;
   private Iterator<TabletMetadata> source;
   private TabletMetadata prevTablet = null;
 

--- a/core/src/main/java/org/apache/accumulo/core/rpc/clients/FateThriftClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/clients/FateThriftClient.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 
 public class FateThriftClient extends ThriftClientTypes<Client> implements ManagerClient<Client> {
 
-  private static Logger LOG = LoggerFactory.getLogger(FateThriftClient.class);
+  private static final Logger LOG = LoggerFactory.getLogger(FateThriftClient.class);
 
   FateThriftClient(String serviceName) {
     super(serviceName, new Client.Factory());

--- a/core/src/main/java/org/apache/accumulo/core/sample/impl/DataoutputHasher.java
+++ b/core/src/main/java/org/apache/accumulo/core/sample/impl/DataoutputHasher.java
@@ -26,7 +26,7 @@ import com.google.common.hash.Hasher;
 
 public class DataoutputHasher implements DataOutput {
 
-  private Hasher hasher;
+  private final Hasher hasher;
 
   public DataoutputHasher(Hasher hasher) {
     this.hasher = hasher;

--- a/core/src/main/java/org/apache/accumulo/core/schema/Section.java
+++ b/core/src/main/java/org/apache/accumulo/core/schema/Section.java
@@ -21,8 +21,8 @@ package org.apache.accumulo.core.schema;
 import org.apache.accumulo.core.data.Range;
 
 public class Section {
-  private String rowPrefix;
-  private Range range;
+  private final String rowPrefix;
+  private final Range range;
 
   public Section(String startRow, boolean startInclusive, String endRow, boolean endInclusive) {
     rowPrefix = startRow;

--- a/core/src/main/java/org/apache/accumulo/core/security/SystemPermission.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/SystemPermission.java
@@ -43,9 +43,9 @@ public enum SystemPermission {
   ALTER_NAMESPACE((byte) 10),
   OBTAIN_DELEGATION_TOKEN((byte) 11);
 
-  private byte permID;
+  private final byte permID;
 
-  private static HashMap<Byte,SystemPermission> mapping;
+  private static final HashMap<Byte,SystemPermission> mapping;
   static {
     mapping = new HashMap<>(SystemPermission.values().length);
     for (SystemPermission perm : SystemPermission.values()) {

--- a/core/src/main/java/org/apache/accumulo/core/security/VisibilityParseException.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/VisibilityParseException.java
@@ -29,7 +29,7 @@ import org.apache.accumulo.access.InvalidAccessExpressionException;
  */
 public class VisibilityParseException extends ParseException {
   private static final long serialVersionUID = 1L;
-  private String visibility;
+  private final String visibility;
 
   /**
    * Creates a new exception.

--- a/core/src/main/java/org/apache/accumulo/core/spi/fs/SpaceAwareVolumeChooser.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/fs/SpaceAwareVolumeChooser.java
@@ -49,12 +49,12 @@ public class SpaceAwareVolumeChooser extends PreferredVolumeChooser {
   public static final String RECOMPUTE_INTERVAL = "spaceaware.volume.chooser.recompute.interval";
 
   // Default time to wait in ms. Defaults to 5 min
-  private long defaultComputationCacheDuration = 300000;
+  private final long defaultComputationCacheDuration = 300000;
   private LoadingCache<Set<String>,WeightedRandomCollection> choiceCache = null;
 
   private static final Logger log = LoggerFactory.getLogger(SpaceAwareVolumeChooser.class);
 
-  private Configuration conf = new Configuration();
+  private final Configuration conf = new Configuration();
 
   protected double getFreeSpace(String uri) throws IOException {
     FileSystem pathFs = new Path(uri).getFileSystem(conf);

--- a/core/src/main/java/org/apache/accumulo/core/spi/scan/SimpleScanDispatcher.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/scan/SimpleScanDispatcher.java
@@ -65,7 +65,8 @@ public class SimpleScanDispatcher implements ScanDispatcher {
   private ScanDispatch multiDispatch;
   private Map<String,Map<ScanInfo.Type,ScanDispatch>> hintDispatch;
 
-  private static Pattern CACHE_PATTERN = Pattern.compile("cacheUsage[.](\\w+)([.](index|data))?");
+  private static final Pattern CACHE_PATTERN =
+      Pattern.compile("cacheUsage[.](\\w+)([.](index|data))?");
 
   public static final String DEFAULT_SCAN_EXECUTOR_NAME = "default";
 

--- a/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
@@ -107,20 +107,20 @@ public class Gatherer {
 
   private static final Logger log = LoggerFactory.getLogger(Gatherer.class);
 
-  private ClientContext ctx;
-  private TableId tableId;
-  private SummarizerFactory factory;
+  private final ClientContext ctx;
+  private final TableId tableId;
+  private final SummarizerFactory factory;
   private Text startRow = null;
   private Text endRow = null;
-  private Range clipRange;
+  private final Range clipRange;
   private Predicate<SummarizerConfiguration> summarySelector;
-  private CryptoService cryptoService;
+  private final CryptoService cryptoService;
 
-  private TSummaryRequest request;
+  private final TSummaryRequest request;
 
-  private String summarizerPattern;
+  private final String summarizerPattern;
 
-  private Set<SummarizerConfiguration> summaries;
+  private final Set<SummarizerConfiguration> summaries;
 
   public Gatherer(ClientContext context, TSummaryRequest request, AccumuloConfiguration tableConfig,
       CryptoService cryptoService) {
@@ -286,8 +286,8 @@ public class Gatherer {
 
     HostAndPort location;
     Map<StoredTabletFile,List<TRowRange>> allFiles;
-    private TInfo tinfo;
-    private AtomicBoolean cancelFlag;
+    private final TInfo tinfo;
+    private final AtomicBoolean cancelFlag;
 
     public FilesProcessor(TInfo tinfo, HostAndPort location,
         Map<StoredTabletFile,List<TRowRange>> allFiles, AtomicBoolean cancelFlag) {
@@ -455,10 +455,10 @@ public class Gatherer {
 
   private class GatherRequest implements Supplier<SummaryCollection> {
 
-    private int remainder;
-    private int modulus;
-    private TInfo tinfo;
-    private AtomicBoolean cancelFlag;
+    private final int remainder;
+    private final int modulus;
+    private final TInfo tinfo;
+    private final AtomicBoolean cancelFlag;
 
     GatherRequest(TInfo tinfo, int remainder, int modulus, AtomicBoolean cancelFlag) {
       this.remainder = remainder;
@@ -542,8 +542,8 @@ public class Gatherer {
   }
 
   public static class RowRange {
-    private Text startRow;
-    private Text endRow;
+    private final Text startRow;
+    private final Text endRow;
 
     public RowRange(KeyExtent ke) {
       this.startRow = ke.prevEndRow();

--- a/core/src/main/java/org/apache/accumulo/core/summary/SummaryCollection.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/SummaryCollection.java
@@ -82,7 +82,7 @@ public class SummaryCollection {
 
   }
 
-  private Map<SummarizerConfiguration,MergedSummary> mergedSummaries;
+  private final Map<SummarizerConfiguration,MergedSummary> mergedSummaries;
   private long totalFiles;
   private long deletedFiles;
 
@@ -120,10 +120,10 @@ public class SummaryCollection {
 
   static class FileSummary {
 
-    private SummarizerConfiguration conf;
-    private Map<String,Long> summary;
-    private boolean exceededBoundry;
-    private boolean exceededMaxSize;
+    private final SummarizerConfiguration conf;
+    private final Map<String,Long> summary;
+    private final boolean exceededBoundry;
+    private final boolean exceededMaxSize;
 
     FileSummary(SummarizerConfiguration conf, Map<String,Long> summary, boolean exceededBoundry) {
       this.conf = conf;

--- a/core/src/main/java/org/apache/accumulo/core/summary/SummaryReader.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/SummaryReader.java
@@ -56,8 +56,8 @@ public class SummaryReader {
 
   private static class CompositeCache implements BlockCache {
 
-    private BlockCache summaryCache;
-    private BlockCache indexCache;
+    private final BlockCache summaryCache;
+    private final BlockCache indexCache;
 
     CompositeCache(BlockCache summaryCache, BlockCache indexCache) {
       this.summaryCache = summaryCache;

--- a/core/src/main/java/org/apache/accumulo/core/summary/SummarySerializer.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/SummarySerializer.java
@@ -56,8 +56,8 @@ import com.google.common.collect.ImmutableMap;
  */
 class SummarySerializer {
 
-  private SummarizerConfiguration sconf;
-  private LgSummaries[] allSummaries;
+  private final SummarizerConfiguration sconf;
+  private final LgSummaries[] allSummaries;
 
   private SummarySerializer(SummarizerConfiguration sconf, LgSummaries[] allSummaries) {
     this.sconf = sconf;
@@ -126,11 +126,11 @@ class SummarySerializer {
   }
 
   private static class LgBuilder {
-    private Summarizer summarizer;
-    private SummarizerConfiguration conf;
+    private final Summarizer summarizer;
+    private final SummarizerConfiguration conf;
     private Collector collector;
 
-    private int maxSummaries = 10;
+    private final int maxSummaries = 10;
 
     private int cutoff = 1000;
     private int count = 0;
@@ -139,9 +139,9 @@ class SummarySerializer {
 
     private Key lastKey;
 
-    private SummaryStoreImpl sci = new SummaryStoreImpl();
+    private final SummaryStoreImpl sci = new SummaryStoreImpl();
 
-    private String name;
+    private final String name;
 
     private boolean sawFirst = false;
     private Text firstRow;
@@ -270,14 +270,14 @@ class SummarySerializer {
   }
 
   public static class Builder {
-    private Summarizer kvs;
+    private final Summarizer kvs;
 
-    private SummarizerConfiguration conf;
+    private final SummarizerConfiguration conf;
 
-    private List<LgBuilder> locGroups;
+    private final List<LgBuilder> locGroups;
     private LgBuilder lgb;
 
-    private long maxSize;
+    private final long maxSize;
 
     public Builder(SummarizerConfiguration conf, Summarizer kvs, long maxSize) {
       this.conf = conf;
@@ -421,9 +421,9 @@ class SummarySerializer {
 
   private static class LgSummaries {
 
-    private Text firstRow;
-    private SummaryInfo[] summaries;
-    private String lgroupName;
+    private final Text firstRow;
+    private final SummaryInfo[] summaries;
+    private final String lgroupName;
 
     LgSummaries(Text firstRow, SummaryInfo[] summaries, String lgroupName) {
       this.firstRow = firstRow;

--- a/core/src/main/java/org/apache/accumulo/core/summary/SummaryWriter.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/SummaryWriter.java
@@ -42,8 +42,8 @@ public class SummaryWriter implements FileSKVWriter {
   static long MAGIC = 0x15ea283ec03e4c49L;
   static byte VER = 1;
 
-  private FileSKVWriter writer;
-  private SummarySerializer.Builder[] summaryStores;
+  private final FileSKVWriter writer;
+  private final SummarySerializer.Builder[] summaryStores;
 
   private SummaryWriter(FileSKVWriter writer, SummarizerFactory factory,
       List<SummarizerConfiguration> configs, long maxSize) {

--- a/core/src/main/java/org/apache/accumulo/core/util/CancelFlagFuture.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/CancelFlagFuture.java
@@ -30,8 +30,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class CancelFlagFuture<T> implements Future<T> {
 
-  private Future<T> wrappedFuture;
-  private AtomicBoolean cancelFlag;
+  private final Future<T> wrappedFuture;
+  private final AtomicBoolean cancelFlag;
 
   public CancelFlagFuture(Future<T> wrappedFuture, AtomicBoolean cancelFlag) {
     this.wrappedFuture = wrappedFuture;

--- a/core/src/main/java/org/apache/accumulo/core/util/ColumnFQ.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/ColumnFQ.java
@@ -27,8 +27,8 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.hadoop.io.Text;
 
 public class ColumnFQ implements Comparable<ColumnFQ> {
-  private Text colf;
-  private Text colq;
+  private final Text colf;
+  private final Text colq;
 
   public ColumnFQ(Text colf, Text colq) {
     if (colf == null || colq == null) {

--- a/core/src/main/java/org/apache/accumulo/core/util/LocalityGroupUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/LocalityGroupUtil.java
@@ -246,8 +246,8 @@ public class LocalityGroupUtil {
   }
 
   public static class PartitionedMutation extends Mutation {
-    private byte[] row;
-    private List<ColumnUpdate> updates;
+    private final byte[] row;
+    private final List<ColumnUpdate> updates;
 
     public PartitionedMutation(byte[] row, List<ColumnUpdate> updates) {
       this.row = row;
@@ -289,8 +289,8 @@ public class LocalityGroupUtil {
 
   public static class Partitioner {
 
-    private Map<ByteSequence,Integer> colfamToLgidMap;
-    private PreAllocatedArray<Map<ByteSequence,MutableLong>> groups;
+    private final Map<ByteSequence,Integer> colfamToLgidMap;
+    private final PreAllocatedArray<Map<ByteSequence,MutableLong>> groups;
 
     public Partitioner(PreAllocatedArray<Map<ByteSequence,MutableLong>> groups) {
       this.groups = groups;

--- a/core/src/main/java/org/apache/accumulo/core/util/NumUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/NumUtil.java
@@ -25,8 +25,8 @@ public class NumUtil {
   private static final String[] QUANTITY_SUFFIX = {"", "K", "M", "B", "T", "e15", "e18", "e21"};
   private static final String[] SIZE_SUFFIX = {"", "K", "M", "G", "T", "P", "E", "Z"};
 
-  private static DecimalFormat df = new DecimalFormat("#,###,##0");
-  private static DecimalFormat df_mantissa = new DecimalFormat("#,###,##0.00");
+  private static final DecimalFormat df = new DecimalFormat("#,###,##0");
+  private static final DecimalFormat df_mantissa = new DecimalFormat("#,###,##0.00");
 
   public static String bigNumberForSize(long big) {
     return bigNumber(big, SIZE_SUFFIX, 1024);

--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionPlanImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionPlanImpl.java
@@ -55,7 +55,7 @@ public class CompactionPlanImpl implements CompactionPlan {
   public static class BuilderImpl implements CompactionPlan.Builder {
 
     private final CompactionKind kind;
-    private ArrayList<CompactionJob> jobs = new ArrayList<>();
+    private final ArrayList<CompactionJob> jobs = new ArrayList<>();
     private final Set<CompactableFile> allFiles;
     private final Set<CompactableFile> seenFiles = new HashSet<>();
     private final Set<CompactableFile> candidates;

--- a/core/src/main/java/org/apache/accumulo/core/util/format/DefaultFormatter.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/format/DefaultFormatter.java
@@ -86,7 +86,7 @@ public class DefaultFormatter implements Formatter {
   }
 
   /* so a new date object doesn't get created for every record in the scan result */
-  private static ThreadLocal<Date> tmpDate = ThreadLocal.withInitial(Date::new);
+  private static final ThreadLocal<Date> tmpDate = ThreadLocal.withInitial(Date::new);
 
   /** Does not show timestamps if timestampFormat is null */
   public static String formatEntry(Entry<Key,Value> entry, DateFormat timestampFormat) {

--- a/core/src/main/java/org/apache/accumulo/core/util/format/ShardedTableDistributionFormatter.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/format/ShardedTableDistributionFormatter.java
@@ -36,7 +36,7 @@ import org.apache.accumulo.core.data.Value;
  */
 public class ShardedTableDistributionFormatter extends AggregatingFormatter {
 
-  private Map<String,HashSet<String>> countsByDay = new HashMap<>();
+  private final Map<String,HashSet<String>> countsByDay = new HashMap<>();
 
   @Override
   protected void aggregateStats(Entry<Key,Value> entry) {

--- a/core/src/main/java/org/apache/accumulo/core/util/ratelimit/SharedRateLimiterFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/ratelimit/SharedRateLimiterFactory.java
@@ -143,8 +143,8 @@ public class SharedRateLimiterFactory {
   }
 
   protected class SharedRateLimiter extends GuavaRateLimiter {
-    private AtomicLong permitsAcquired = new AtomicLong();
-    private AtomicLong lastUpdate = new AtomicLong();
+    private final AtomicLong permitsAcquired = new AtomicLong();
+    private final AtomicLong lastUpdate = new AtomicLong();
 
     private final RateProvider rateProvider;
     private final String name;

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
@@ -103,7 +103,7 @@ public class ThreadPools {
   private static final ConcurrentLinkedQueue<ScheduledFuture<?>> NON_CRITICAL_RUNNING_TASKS =
       new ConcurrentLinkedQueue<>();
 
-  private static Runnable TASK_CHECKER = () -> {
+  private static final Runnable TASK_CHECKER = () -> {
     final List<ConcurrentLinkedQueue<ScheduledFuture<?>>> queues =
         List.of(CRITICAL_RUNNING_TASKS, NON_CRITICAL_RUNNING_TASKS);
     while (true) {

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoop/mapreduce/partition/KeyRangePartitioner.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoop/mapreduce/partition/KeyRangePartitioner.java
@@ -31,7 +31,7 @@ import org.apache.hadoop.mapreduce.Partitioner;
  * @since 2.0.0
  */
 public class KeyRangePartitioner extends Partitioner<Key,Writable> implements Configurable {
-  private RangePartitioner rp = new RangePartitioner();
+  private final RangePartitioner rp = new RangePartitioner();
 
   @Override
   public int getPartition(Key key, Writable value, int numPartitions) {

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapred/AccumuloRecordWriter.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapred/AccumuloRecordWriter.java
@@ -52,11 +52,11 @@ public class AccumuloRecordWriter implements RecordWriter<Text,Mutation> {
   private static final Class<AccumuloOutputFormat> CLASS = AccumuloOutputFormat.class;
   private static final Logger log = LoggerFactory.getLogger(AccumuloRecordWriter.class);
   private MultiTableBatchWriter mtbw = null;
-  private HashMap<Text,BatchWriter> bws;
-  private Text defaultTableName;
+  private final HashMap<Text,BatchWriter> bws;
+  private final Text defaultTableName;
 
-  private boolean simulate;
-  private boolean createTables;
+  private final boolean simulate;
+  private final boolean createTables;
 
   private long mutCount = 0;
   private long valCount = 0;

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/AccumuloRecordWriter.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/AccumuloRecordWriter.java
@@ -53,10 +53,10 @@ public class AccumuloRecordWriter extends RecordWriter<Text,Mutation> {
   private static final Logger log = LoggerFactory.getLogger(AccumuloRecordWriter.class);
   private MultiTableBatchWriter mtbw = null;
   private final HashMap<Text,BatchWriter> bws;
-  private Text defaultTableName;
+  private final Text defaultTableName;
 
-  private boolean simulate;
-  private boolean createTables;
+  private final boolean simulate;
+  private final boolean createTables;
 
   private long mutCount = 0;
   private long valCount = 0;

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/InputFormatBuilderImpl.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/InputFormatBuilderImpl.java
@@ -46,7 +46,7 @@ public class InputFormatBuilderImpl<T>
     implements InputFormatBuilder, InputFormatBuilder.ClientParams<T>,
     InputFormatBuilder.TableParams<T>, InputFormatBuilder.InputFormatOptions<T> {
 
-  private Class<?> callingClass;
+  private final Class<?> callingClass;
   private Properties clientProps;
   private String clientPropsPath;
   private String currentTable;

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/OutputFormatBuilderImpl.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/OutputFormatBuilderImpl.java
@@ -37,7 +37,7 @@ public class OutputFormatBuilderImpl<T>
   // optional values
   private Optional<String> defaultTableName = Optional.empty();
   private boolean createTables = false;
-  private boolean simulationMode = false;
+  private final boolean simulationMode = false;
 
   public OutputFormatBuilderImpl(Class<?> callingClass) {
     this.callingClass = callingClass;

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/FileManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/FileManager.java
@@ -65,7 +65,7 @@ public class FileManager {
 
   private static final Logger log = LoggerFactory.getLogger(FileManager.class);
 
-  private int maxOpen;
+  private final int maxOpen;
 
   private static class OpenReader implements Comparable<OpenReader> {
     long releaseTime;
@@ -97,15 +97,15 @@ public class FileManager {
     }
   }
 
-  private Map<StoredTabletFile,List<OpenReader>> openFiles;
-  private HashMap<FileSKVIterator,StoredTabletFile> reservedReaders;
+  private final Map<StoredTabletFile,List<OpenReader>> openFiles;
+  private final HashMap<FileSKVIterator,StoredTabletFile> reservedReaders;
 
-  private Semaphore filePermits;
+  private final Semaphore filePermits;
 
-  private Cache<String,Long> fileLenCache;
+  private final Cache<String,Long> fileLenCache;
 
-  private long maxIdleTime;
-  private long slowFilePermitMillis;
+  private final long maxIdleTime;
+  private final long slowFilePermitMillis;
 
   private final ServerContext context;
 
@@ -383,7 +383,7 @@ public class FileManager {
   static class FileDataSource implements DataSource {
 
     private SortedKeyValueIterator<Key,Value> iter;
-    private ArrayList<FileDataSource> deepCopies;
+    private final ArrayList<FileDataSource> deepCopies;
     private boolean current = true;
     private IteratorEnvironment env;
     private StoredTabletFile file;
@@ -456,11 +456,11 @@ public class FileManager {
 
   public class ScanFileManager {
 
-    private ArrayList<FileDataSource> dataSources;
-    private ArrayList<FileSKVIterator> tabletReservedReaders;
-    private KeyExtent tablet;
+    private final ArrayList<FileDataSource> dataSources;
+    private final ArrayList<FileSKVIterator> tabletReservedReaders;
+    private final KeyExtent tablet;
     private boolean continueOnFailure;
-    private CacheProvider cacheProvider;
+    private final CacheProvider cacheProvider;
 
     ScanFileManager(KeyExtent tablet, CacheProvider cacheProvider) {
       tabletReservedReaders = new ArrayList<>();

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManager.java
@@ -52,7 +52,7 @@ public interface VolumeManager extends AutoCloseable {
   enum FileType {
     TABLE(Constants.TABLE_DIR), WAL(Constants.WAL_DIR), RECOVERY(Constants.RECOVERY_DIR);
 
-    private String dir;
+    private final String dir;
 
     FileType(String dir) {
       this.dir = dir;

--- a/server/base/src/main/java/org/apache/accumulo/server/log/SortedLogState.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/log/SortedLogState.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.fs.Path;
 public enum SortedLogState {
   FINISHED("finished"), FAILED("failed");
 
-  private String marker;
+  private final String marker;
 
   private SortedLogState(String marker) {
     this.marker = marker;

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/LiveTServerSet.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/LiveTServerSet.java
@@ -229,12 +229,12 @@ public class LiveTServerSet implements Watcher {
   }
 
   // The set of active tservers with locks, indexed by their name in zookeeper
-  private Map<String,TServerInfo> current = new HashMap<>();
+  private final Map<String,TServerInfo> current = new HashMap<>();
   // as above, indexed by TServerInstance
-  private Map<TServerInstance,TServerInfo> currentInstances = new HashMap<>();
+  private final Map<TServerInstance,TServerInfo> currentInstances = new HashMap<>();
 
   // The set of entries in zookeeper without locks, and the first time each was noticed
-  private Map<String,Long> locklessServers = new HashMap<>();
+  private final Map<String,Long> locklessServers = new HashMap<>();
 
   public LiveTServerSet(ServerContext context, Listener cback) {
     this.cback = cback;

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/LoggingTabletStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/LoggingTabletStateStore.java
@@ -36,7 +36,7 @@ import com.google.common.net.HostAndPort;
  */
 class LoggingTabletStateStore implements TabletStateStore {
 
-  private TabletStateStore wrapped;
+  private final TabletStateStore wrapped;
 
   LoggingTabletStateStore(TabletStateStore tss) {
     this.wrapped = tss;

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletServerState.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletServerState.java
@@ -41,10 +41,10 @@ public enum TabletServerState {
   BAD_VERSION_AND_INSTANCE_AND_CONFIG((byte) 107),
   BAD_INSTANCE_AND_CONFIG((byte) 108);
 
-  private byte id;
+  private final byte id;
 
-  private static HashMap<Byte,TabletServerState> mapping;
-  private static HashSet<TabletServerState> badStates;
+  private static final HashMap<Byte,TabletServerState> mapping;
+  private static final HashSet<TabletServerState> badStates;
 
   static {
     mapping = new HashMap<>(TabletServerState.values().length);

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ScanServerRefStoreImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ScanServerRefStoreImpl.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
 
 public class ScanServerRefStoreImpl implements ScanServerRefStore {
 
-  private static Logger log = LoggerFactory.getLogger(ScanServerRefStoreImpl.class);
+  private static final Logger log = LoggerFactory.getLogger(ScanServerRefStoreImpl.class);
 
   private final ClientContext context;
   private final String tableName;

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
@@ -68,9 +68,9 @@ import com.google.common.base.Preconditions;
 
 public class ServerAmpleImpl extends AmpleImpl implements Ample {
 
-  private static Logger log = LoggerFactory.getLogger(ServerAmpleImpl.class);
+  private static final Logger log = LoggerFactory.getLogger(ServerAmpleImpl.class);
 
-  private ServerContext context;
+  private final ServerContext context;
   private final ScanServerRefStore scanServerRefStore;
 
   public ServerAmpleImpl(ServerContext context) {

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorImpl.java
@@ -25,7 +25,7 @@ import org.apache.accumulo.server.ServerContext;
 
 class TabletMutatorImpl extends TabletMutatorBase implements Ample.TabletMutator {
 
-  private BatchWriter writer;
+  private final BatchWriter writer;
 
   TabletMutatorImpl(ServerContext context, KeyExtent extent, BatchWriter batchWriter) {
     super(context, extent);

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletsMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletsMutatorImpl.java
@@ -32,7 +32,7 @@ import com.google.common.base.Preconditions;
 
 public class TabletsMutatorImpl implements TabletsMutator {
 
-  private ServerContext context;
+  private final ServerContext context;
 
   private BatchWriter rootWriter;
   private BatchWriter metaWriter;

--- a/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReport.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReport.java
@@ -44,9 +44,9 @@ import org.apache.accumulo.server.ServerContext;
 import org.apache.zookeeper.KeeperException;
 
 public class ProblemReport {
-  private TableId tableId;
-  private ProblemType problemType;
-  private String resource;
+  private final TableId tableId;
+  private final ProblemType problemType;
+  private final String resource;
   private String exception;
   private String server;
   private long creationTime;

--- a/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReportingIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReportingIterator.java
@@ -37,8 +37,8 @@ public class ProblemReportingIterator implements InterruptibleIterator {
   private final SortedKeyValueIterator<Key,Value> source;
   private boolean sawError = false;
   private final boolean continueOnError;
-  private String resource;
-  private TableId tableId;
+  private final String resource;
+  private final TableId tableId;
   private final ServerContext context;
 
   public ProblemReportingIterator(ServerContext context, TableId tableId, String resource,

--- a/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReports.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReports.java
@@ -192,7 +192,7 @@ public class ProblemReports implements Iterable<ProblemReport> {
   public Iterator<ProblemReport> iterator(final TableId table) {
     return new Iterator<>() {
 
-      ZooReaderWriter zoo = context.getZooReaderWriter();
+      final ZooReaderWriter zoo = context.getZooReaderWriter();
       private int iter1Count = 0;
       private Iterator<String> iter1;
 

--- a/server/base/src/main/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenKeyManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenKeyManager.java
@@ -36,8 +36,8 @@ public class AuthenticationTokenKeyManager implements Runnable {
   private final ZooAuthenticationKeyDistributor keyDistributor;
 
   private long lastKeyUpdate = 0;
-  private long keyUpdateInterval;
-  private long tokenMaxLifetime;
+  private final long keyUpdateInterval;
+  private final long tokenMaxLifetime;
   private int idSeq = 0;
   private volatile boolean keepRunning = true, initialized = false;
 

--- a/server/base/src/main/java/org/apache/accumulo/server/security/delegation/ZooAuthenticationKeyDistributor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/delegation/ZooAuthenticationKeyDistributor.java
@@ -49,7 +49,7 @@ public class ZooAuthenticationKeyDistributor {
 
   private final ZooReaderWriter zk;
   private final String baseNode;
-  private AtomicBoolean initialized = new AtomicBoolean(false);
+  private final AtomicBoolean initialized = new AtomicBoolean(false);
 
   public ZooAuthenticationKeyDistributor(ZooReaderWriter zk, String baseNode) {
     requireNonNull(zk);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/RandomWriter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/RandomWriter.java
@@ -42,12 +42,12 @@ import io.opentelemetry.context.Scope;
 
 public class RandomWriter {
 
-  private static int num_columns_per_row = 1;
-  private static int num_payload_bytes = 1024;
+  private static final int num_columns_per_row = 1;
+  private static final int num_payload_bytes = 1024;
   private static final Logger log = LoggerFactory.getLogger(RandomWriter.class);
 
   public static class RandomMutationGenerator implements Iterable<Mutation>, Iterator<Mutation> {
-    private long max_mutations;
+    private final long max_mutations;
     private int mutations_so_far = 0;
     private static final Logger log = LoggerFactory.getLogger(RandomMutationGenerator.class);
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/TableDiskUsage.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/TableDiskUsage.java
@@ -79,10 +79,10 @@ public class TableDiskUsage {
 
   private static final Logger log = LoggerFactory.getLogger(TableDiskUsage.class);
   private int nextInternalId = 0;
-  private Map<TableId,Integer> internalIds = new HashMap<>();
-  private Map<Integer,TableId> externalIds = new HashMap<>();
-  private Map<String,Integer[]> tableFiles = new HashMap<>();
-  private Map<String,Long> fileSizes = new HashMap<>();
+  private final Map<TableId,Integer> internalIds = new HashMap<>();
+  private final Map<Integer,TableId> externalIds = new HashMap<>();
+  private final Map<String,Integer[]> tableFiles = new HashMap<>();
+  private final Map<String,Long> fileSizes = new HashMap<>();
 
   void addTable(TableId tableId) {
     if (internalIds.containsKey(tableId)) {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/time/RelativeTime.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/time/RelativeTime.java
@@ -29,7 +29,7 @@ public class RelativeTime extends BaseRelativeTime {
     super(new SystemTime());
   }
 
-  private static BaseRelativeTime instance = new RelativeTime();
+  private static final BaseRelativeTime instance = new RelativeTime();
 
   public static BaseRelativeTime getInstance() {
     return instance;

--- a/server/base/src/main/java/org/apache/accumulo/server/zookeeper/DistributedWorkQueue.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/zookeeper/DistributedWorkQueue.java
@@ -58,12 +58,13 @@ public class DistributedWorkQueue {
   private static final Logger log = LoggerFactory.getLogger(DistributedWorkQueue.class);
 
   private ThreadPoolExecutor threadPool;
-  private ZooReaderWriter zoo;
-  private String path;
-  private ServerContext context;
-  private long timerInitialDelay, timerPeriod;
+  private final ZooReaderWriter zoo;
+  private final String path;
+  private final ServerContext context;
+  private final long timerInitialDelay;
+  private final long timerPeriod;
 
-  private AtomicInteger numTask = new AtomicInteger(0);
+  private final AtomicInteger numTask = new AtomicInteger(0);
 
   private void lookForWork(final Processor processor, List<String> children) {
     if (children.isEmpty()) {

--- a/server/base/src/main/java/org/apache/accumulo/server/zookeeper/TransactionWatcher.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/zookeeper/TransactionWatcher.java
@@ -57,8 +57,8 @@ public class TransactionWatcher {
 
   public static class ZooArbitrator implements Arbitrator {
 
-    private ServerContext context;
-    private ZooReader rdr;
+    private final ServerContext context;
+    private final ZooReader rdr;
 
     public ZooArbitrator(ServerContext context) {
       this.context = context;

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/QueueAndPriority.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/QueueAndPriority.java
@@ -24,7 +24,7 @@ import org.apache.accumulo.core.util.Pair;
 
 public class QueueAndPriority implements Comparable<QueueAndPriority> {
 
-  private static WeakHashMap<Pair<String,Short>,QueueAndPriority> CACHE = new WeakHashMap<>();
+  private static final WeakHashMap<Pair<String,Short>,QueueAndPriority> CACHE = new WeakHashMap<>();
 
   public static QueueAndPriority get(String queue, short priority) {
     return CACHE.computeIfAbsent(new Pair<>(queue, priority),

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/ExtCEnv.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/ExtCEnv.java
@@ -39,12 +39,12 @@ import com.google.common.annotations.VisibleForTesting;
 public class ExtCEnv implements CompactionEnv {
 
   private final CompactionJobHolder jobHolder;
-  private TExternalCompactionJob job;
-  private String queueName;
+  private final TExternalCompactionJob job;
+  private final String queueName;
 
   public static class CompactorIterEnv extends TabletIteratorEnvironment {
 
-    private String queueName;
+    private final String queueName;
 
     public CompactorIterEnv(ServerContext context, IteratorScope scope, boolean fullMajC,
         AccumuloConfiguration tableConfig, TableId tableId, CompactionKind kind, String queueName) {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/recovery/RecoveryManager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/recovery/RecoveryManager.java
@@ -59,13 +59,13 @@ public class RecoveryManager {
 
   private static final Logger log = LoggerFactory.getLogger(RecoveryManager.class);
 
-  private Map<String,Long> recoveryDelay = new HashMap<>();
-  private Set<String> closeTasksQueued = new HashSet<>();
-  private Set<String> sortsQueued = new HashSet<>();
-  private Cache<Path,Boolean> existenceCache;
-  private ScheduledExecutorService executor;
-  private Manager manager;
-  private ZooCache zooCache;
+  private final Map<String,Long> recoveryDelay = new HashMap<>();
+  private final Set<String> closeTasksQueued = new HashSet<>();
+  private final Set<String> sortsQueued = new HashSet<>();
+  private final Cache<Path,Boolean> existenceCache;
+  private final ScheduledExecutorService executor;
+  private final Manager manager;
+  private final ZooCache zooCache;
 
   public RecoveryManager(Manager manager, long timeToCacheExistsInMillis) {
     this.manager = manager;
@@ -87,10 +87,10 @@ public class RecoveryManager {
   }
 
   private class LogSortTask implements Runnable {
-    private String source;
-    private String destination;
-    private String sortId;
-    private LogCloser closer;
+    private final String source;
+    private final String destination;
+    private final String sortId;
+    private final LogCloser closer;
 
     public LogSortTask(LogCloser closer, String source, String destination, String sortId) {
       this.closer = closer;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/ChangeTableState.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/ChangeTableState.java
@@ -32,9 +32,9 @@ import org.slf4j.LoggerFactory;
 public class ChangeTableState extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;
-  private TableId tableId;
-  private NamespaceId namespaceId;
-  private TableOperation top;
+  private final TableId tableId;
+  private final NamespaceId namespaceId;
+  private final TableOperation top;
   private final EnumSet<TableState> expectedCurrStates;
 
   public ChangeTableState(NamespaceId namespaceId, TableId tableId, TableOperation top,

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/CleanUpBulkImport.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/CleanUpBulkImport.java
@@ -43,7 +43,7 @@ public class CleanUpBulkImport extends ManagerRepo {
 
   private static final Logger log = LoggerFactory.getLogger(CleanUpBulkImport.class);
 
-  private BulkInfo info;
+  private final BulkInfo info;
 
   public CleanUpBulkImport(BulkInfo info) {
     this.info = info;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/CompleteBulkImport.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/CompleteBulkImport.java
@@ -28,7 +28,7 @@ public class CompleteBulkImport extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;
 
-  private BulkInfo info;
+  private final BulkInfo info;
 
   public CompleteBulkImport(BulkInfo info) {
     this.info = info;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneMetadata.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneMetadata.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 class CloneMetadata extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;
-  private CloneInfo cloneInfo;
+  private final CloneInfo cloneInfo;
 
   public CloneMetadata(CloneInfo cloneInfo) {
     this.cloneInfo = cloneInfo;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/ClonePermissions.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/ClonePermissions.java
@@ -33,7 +33,7 @@ class ClonePermissions extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;
 
-  private CloneInfo cloneInfo;
+  private final CloneInfo cloneInfo;
 
   public ClonePermissions(CloneInfo cloneInfo) {
     this.cloneInfo = cloneInfo;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneTable.java
@@ -33,7 +33,7 @@ import org.apache.accumulo.manager.tableOps.Utils;
 public class CloneTable extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;
-  private CloneInfo cloneInfo;
+  private final CloneInfo cloneInfo;
 
   public CloneTable(String user, NamespaceId namespaceId, TableId srcTableId, String tableName,
       Map<String,String> propertiesToSet, Set<String> propertiesToExclude, boolean keepOffline) {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneZookeeper.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneZookeeper.java
@@ -33,7 +33,7 @@ class CloneZookeeper extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;
 
-  private CloneInfo cloneInfo;
+  private final CloneInfo cloneInfo;
 
   public CloneZookeeper(CloneInfo cloneInfo, ClientContext context)
       throws NamespaceNotFoundException {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/FinishCloneTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/FinishCloneTable.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 class FinishCloneTable extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;
-  private CloneInfo cloneInfo;
+  private final CloneInfo cloneInfo;
 
   public FinishCloneTable(CloneInfo cloneInfo) {
     this.cloneInfo = cloneInfo;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactRange.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactRange.java
@@ -51,8 +51,8 @@ public class CompactRange extends ManagerRepo {
   private static final long serialVersionUID = 1L;
   private final TableId tableId;
   private final NamespaceId namespaceId;
-  private byte[] startRow;
-  private byte[] endRow;
+  private final byte[] startRow;
+  private final byte[] endRow;
   private byte[] config;
 
   public CompactRange(NamespaceId namespaceId, TableId tableId, CompactionConfig compactionConfig)

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriver.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriver.java
@@ -60,11 +60,11 @@ class CompactionDriver extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;
 
-  private long compactId;
+  private final long compactId;
   private final TableId tableId;
   private final NamespaceId namespaceId;
-  private byte[] startRow;
-  private byte[] endRow;
+  private final byte[] startRow;
+  private final byte[] endRow;
 
   private static final Logger log = LoggerFactory.getLogger(CompactionDriver.class);
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/cancel/CancelCompactions.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/cancel/CancelCompactions.java
@@ -37,8 +37,8 @@ import org.slf4j.LoggerFactory;
 public class CancelCompactions extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;
-  private TableId tableId;
-  private NamespaceId namespaceId;
+  private final TableId tableId;
+  private final NamespaceId namespaceId;
 
   private static final Logger log = LoggerFactory.getLogger(CancelCompactions.class);
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/cancel/FinishCancelCompaction.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/cancel/FinishCancelCompaction.java
@@ -28,8 +28,8 @@ import org.apache.accumulo.manager.tableOps.Utils;
 
 class FinishCancelCompaction extends ManagerRepo {
   private static final long serialVersionUID = 1L;
-  private TableId tableId;
-  private NamespaceId namespaceId;
+  private final TableId tableId;
+  private final NamespaceId namespaceId;
 
   public FinishCancelCompaction(NamespaceId namespaceId, TableId tableId) {
     this.tableId = tableId;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/CreateTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/CreateTable.java
@@ -41,7 +41,7 @@ public class CreateTable extends ManagerRepo {
   private static final long serialVersionUID = 1L;
   private static final Logger log = LoggerFactory.getLogger(CreateTable.class);
 
-  private TableInfo tableInfo;
+  private final TableInfo tableInfo;
 
   public CreateTable(String user, String tableName, TimeType timeType, Map<String,String> props,
       Path splitPath, int splitCount, Path splitDirsPath, InitialTableState initialTableState,

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/SetupPermissions.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/SetupPermissions.java
@@ -31,7 +31,7 @@ class SetupPermissions extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;
 
-  private TableInfo tableInfo;
+  private final TableInfo tableInfo;
 
   SetupPermissions(TableInfo ti) {
     this.tableInfo = ti;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/CleanUp.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/CleanUp.java
@@ -60,8 +60,8 @@ class CleanUp extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;
 
-  private TableId tableId;
-  private NamespaceId namespaceId;
+  private final TableId tableId;
+  private final NamespaceId namespaceId;
 
   private long creationTime;
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/DeleteTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/DeleteTable.java
@@ -34,8 +34,8 @@ public class DeleteTable extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;
 
-  private TableId tableId;
-  private NamespaceId namespaceId;
+  private final TableId tableId;
+  private final NamespaceId namespaceId;
 
   public DeleteTable(NamespaceId namespaceId, TableId tableId) {
     this.namespaceId = namespaceId;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/PreDeleteTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/PreDeleteTable.java
@@ -42,8 +42,8 @@ public class PreDeleteTable extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;
 
-  private TableId tableId;
-  private NamespaceId namespaceId;
+  private final TableId tableId;
+  private final NamespaceId namespaceId;
 
   public PreDeleteTable(NamespaceId namespaceId, TableId tableId) {
     this.tableId = tableId;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/TableRangeOp.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/TableRangeOp.java
@@ -45,9 +45,9 @@ public class TableRangeOp extends ManagerRepo {
 
   private final TableId tableId;
   private final NamespaceId namespaceId;
-  private byte[] startRow;
-  private byte[] endRow;
-  private Operation op;
+  private final byte[] startRow;
+  private final byte[] endRow;
+  private final Operation op;
 
   @Override
   public long isReady(long tid, Manager env) throws Exception {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/TableRangeOpWait.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/TableRangeOpWait.java
@@ -51,8 +51,8 @@ class TableRangeOpWait extends ManagerRepo {
   private static final Logger log = LoggerFactory.getLogger(TableRangeOpWait.class);
 
   private static final long serialVersionUID = 1L;
-  private TableId tableId;
-  private NamespaceId namespaceId;
+  private final TableId tableId;
+  private final NamespaceId namespaceId;
 
   public TableRangeOpWait(NamespaceId namespaceId, TableId tableId) {
     this.tableId = tableId;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/CreateNamespace.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/CreateNamespace.java
@@ -29,7 +29,7 @@ import org.apache.accumulo.manager.tableOps.Utils;
 public class CreateNamespace extends ManagerRepo {
   private static final long serialVersionUID = 1L;
 
-  private NamespaceInfo namespaceInfo;
+  private final NamespaceInfo namespaceInfo;
 
   public CreateNamespace(String user, String namespaceName, Map<String,String> props) {
     namespaceInfo = new NamespaceInfo();

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/FinishCreateNamespace.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/FinishCreateNamespace.java
@@ -29,7 +29,7 @@ class FinishCreateNamespace extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;
 
-  private NamespaceInfo namespaceInfo;
+  private final NamespaceInfo namespaceInfo;
 
   public FinishCreateNamespace(NamespaceInfo ti) {
     this.namespaceInfo = ti;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/SetupNamespacePermissions.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/SetupNamespacePermissions.java
@@ -30,7 +30,7 @@ class SetupNamespacePermissions extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;
 
-  private NamespaceInfo namespaceInfo;
+  private final NamespaceInfo namespaceInfo;
 
   public SetupNamespacePermissions(NamespaceInfo ti) {
     this.namespaceInfo = ti;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/delete/DeleteNamespace.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/delete/DeleteNamespace.java
@@ -30,7 +30,7 @@ public class DeleteNamespace extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;
 
-  private NamespaceId namespaceId;
+  private final NamespaceId namespaceId;
 
   public DeleteNamespace(NamespaceId namespaceId) {
     this.namespaceId = namespaceId;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/delete/NamespaceCleanUp.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/delete/NamespaceCleanUp.java
@@ -34,7 +34,7 @@ class NamespaceCleanUp extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;
 
-  private NamespaceId namespaceId;
+  private final NamespaceId namespaceId;
 
   public NamespaceCleanUp(NamespaceId namespaceId) {
     this.namespaceId = namespaceId;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/rename/RenameNamespace.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/rename/RenameNamespace.java
@@ -36,9 +36,9 @@ import org.slf4j.LoggerFactory;
 public class RenameNamespace extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;
-  private NamespaceId namespaceId;
-  private String oldName;
-  private String newName;
+  private final NamespaceId namespaceId;
+  private final String oldName;
+  private final String newName;
 
   @Override
   public long isReady(long id, Manager environment) throws Exception {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/rename/RenameTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/rename/RenameTable.java
@@ -41,10 +41,10 @@ import org.slf4j.LoggerFactory;
 public class RenameTable extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;
-  private TableId tableId;
-  private NamespaceId namespaceId;
-  private String oldTableName;
-  private String newTableName;
+  private final TableId tableId;
+  private final NamespaceId namespaceId;
+  private final String oldTableName;
+  private final String newTableName;
 
   @Override
   public long isReady(long tid, Manager env) throws Exception {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/CreateImportDir.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/CreateImportDir.java
@@ -34,7 +34,7 @@ class CreateImportDir extends ManagerRepo {
   private static final Logger log = LoggerFactory.getLogger(CreateImportDir.class);
   private static final long serialVersionUID = 1L;
 
-  private ImportedTableInfo tableInfo;
+  private final ImportedTableInfo tableInfo;
 
   CreateImportDir(ImportedTableInfo ti) {
     this.tableInfo = ti;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/FinishImportTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/FinishImportTable.java
@@ -35,7 +35,7 @@ class FinishImportTable extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;
 
-  private ImportedTableInfo tableInfo;
+  private final ImportedTableInfo tableInfo;
 
   public FinishImportTable(ImportedTableInfo ti) {
     this.tableInfo = ti;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportPopulateZookeeper.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportPopulateZookeeper.java
@@ -43,7 +43,7 @@ class ImportPopulateZookeeper extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;
 
-  private ImportedTableInfo tableInfo;
+  private final ImportedTableInfo tableInfo;
 
   ImportPopulateZookeeper(ImportedTableInfo ti) {
     this.tableInfo = ti;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportSetupPermissions.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportSetupPermissions.java
@@ -30,7 +30,7 @@ class ImportSetupPermissions extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;
 
-  private ImportedTableInfo tableInfo;
+  private final ImportedTableInfo tableInfo;
 
   public ImportSetupPermissions(ImportedTableInfo ti) {
     this.tableInfo = ti;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/MapImportFileNames.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/MapImportFileNames.java
@@ -44,7 +44,7 @@ class MapImportFileNames extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;
 
-  private ImportedTableInfo tableInfo;
+  private final ImportedTableInfo tableInfo;
 
   MapImportFileNames(ImportedTableInfo ti) {
     this.tableInfo = ti;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/MoveExportedFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/MoveExportedFiles.java
@@ -51,7 +51,7 @@ class MoveExportedFiles extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;
 
-  private ImportedTableInfo tableInfo;
+  private final ImportedTableInfo tableInfo;
 
   MoveExportedFiles(ImportedTableInfo ti) {
     this.tableInfo = ti;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ConditionCheckerContext.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ConditionCheckerContext.java
@@ -51,12 +51,12 @@ import org.apache.accumulo.tserver.data.ServerConditionalMutation;
 import org.apache.hadoop.io.Text;
 
 public class ConditionCheckerContext {
-  private CompressedIterators compressedIters;
+  private final CompressedIterators compressedIters;
 
-  private List<IterInfo> tableIters;
-  private Map<String,Map<String,String>> tableIterOpts;
-  private TabletIteratorEnvironment tie;
-  private String context;
+  private final List<IterInfo> tableIters;
+  private final Map<String,Map<String,String>> tableIterOpts;
+  private final TabletIteratorEnvironment tie;
+  private final String context;
 
   private static class MergedIterConfig {
     List<IterInfo> mergedIters;
@@ -68,7 +68,7 @@ public class ConditionCheckerContext {
     }
   }
 
-  private Map<ByteSequence,MergedIterConfig> mergedIterCache = new HashMap<>();
+  private final Map<ByteSequence,MergedIterConfig> mergedIterCache = new HashMap<>();
 
   ConditionCheckerContext(ServerContext context, CompressedIterators compressedIters,
       TableConfiguration tableConf) {
@@ -144,9 +144,9 @@ public class ConditionCheckerContext {
 
   public class ConditionChecker {
 
-    private List<ServerConditionalMutation> conditionsToCheck;
-    private List<ServerConditionalMutation> okMutations;
-    private List<TCMResult> results;
+    private final List<ServerConditionalMutation> conditionsToCheck;
+    private final List<ServerConditionalMutation> okMutations;
+    private final List<TCMResult> results;
     private boolean checked = false;
 
     public ConditionChecker(List<ServerConditionalMutation> conditionsToCheck,

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
@@ -90,7 +90,7 @@ public class InMemoryMap {
   private final String mapType;
   private final TableId tableId;
 
-  private Map<String,Set<ByteSequence>> lggroups;
+  private final Map<String,Set<ByteSequence>> lggroups;
 
   private static Pair<SamplerConfigurationImpl,Sampler> getSampler(AccumuloConfiguration config) {
     try {
@@ -110,10 +110,10 @@ public class InMemoryMap {
   public static final String TYPE_LOCALITY_GROUP_MAP = "LocalityGroupMap";
   public static final String TYPE_LOCALITY_GROUP_MAP_NATIVE = "LocalityGroupMap with native";
 
-  private AtomicReference<Pair<SamplerConfigurationImpl,Sampler>> samplerRef =
+  private final AtomicReference<Pair<SamplerConfigurationImpl,Sampler>> samplerRef =
       new AtomicReference<>(null);
 
-  private AccumuloConfiguration config;
+  private final AccumuloConfiguration config;
 
   // defer creating sampler until first write. This was done because an empty sample map configured
   // with no sampler will not flush after a user changes sample
@@ -198,8 +198,8 @@ public class InMemoryMap {
 
   private class SampleMap implements SimpleMap {
 
-    private SimpleMap map;
-    private SimpleMap sample;
+    private final SimpleMap map;
+    private final SimpleMap sample;
 
     public SampleMap(SimpleMap map, SimpleMap sampleMap) {
       this.map = map;
@@ -280,12 +280,12 @@ public class InMemoryMap {
 
   private static class LocalityGroupMap implements SimpleMap {
 
-    private PreAllocatedArray<Map<ByteSequence,MutableLong>> groupFams;
+    private final PreAllocatedArray<Map<ByteSequence,MutableLong>> groupFams;
 
     // the last map in the array is the default locality group
-    private SimpleMap[] maps;
-    private Partitioner partitioner;
-    private PreAllocatedArray<List<Mutation>> partitioned;
+    private final SimpleMap[] maps;
+    private final Partitioner partitioner;
+    private final PreAllocatedArray<List<Mutation>> partitioned;
 
     LocalityGroupMap(Map<String,Set<ByteSequence>> groups, boolean useNativeMap) {
       this.groupFams = new PreAllocatedArray<>(groups.size());
@@ -385,8 +385,8 @@ public class InMemoryMap {
   private static class DefaultMap implements SimpleMap {
     private ConcurrentSkipListMap<Key,Value> map =
         new ConcurrentSkipListMap<>(new MemKeyComparator());
-    private AtomicLong bytesInMemory = new AtomicLong();
-    private AtomicInteger size = new AtomicInteger();
+    private final AtomicLong bytesInMemory = new AtomicLong();
+    private final AtomicInteger size = new AtomicInteger();
 
     public void put(Key key, Value value) {
       // Always a MemKey, so account for the kvCount int
@@ -448,7 +448,7 @@ public class InMemoryMap {
   }
 
   private static class NativeMapWrapper implements SimpleMap {
-    private NativeMap nativeMap;
+    private final NativeMap nativeMap;
 
     NativeMapWrapper() {
       nativeMap = new NativeMap();
@@ -483,10 +483,10 @@ public class InMemoryMap {
     }
   }
 
-  private AtomicInteger nextKVCount = new AtomicInteger(1);
-  private AtomicInteger kvCount = new AtomicInteger(0);
+  private final AtomicInteger nextKVCount = new AtomicInteger(1);
+  private final AtomicInteger kvCount = new AtomicInteger(0);
 
-  private Object writeSerializer = new Object();
+  private final Object writeSerializer = new Object();
 
   /**
    * Applies changes to a row in the InMemoryMap
@@ -537,10 +537,10 @@ public class InMemoryMap {
     private boolean switched = false;
     private InterruptibleIterator iter;
     private FileSKVIterator reader;
-    private MemoryDataSource parent;
-    private IteratorEnvironment env;
+    private final MemoryDataSource parent;
+    private final IteratorEnvironment env;
     private AtomicBoolean iflag;
-    private SamplerConfigurationImpl iteratorSamplerConfig;
+    private final SamplerConfigurationImpl iteratorSamplerConfig;
 
     private SamplerConfigurationImpl getSamplerConfig() {
       if (env != null) {
@@ -659,7 +659,7 @@ public class InMemoryMap {
 
   public class MemoryIterator extends WrappingIterator implements InterruptibleIterator {
 
-    private AtomicBoolean closed;
+    private final AtomicBoolean closed;
     private SourceSwitchingIterator ssi;
     private MemoryDataSource mds;
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/NativeMap.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/NativeMap.java
@@ -284,8 +284,8 @@ public class NativeMap implements Iterable<Map.Entry<Key,Value>> {
 
     private final AtomicLong nmiPtr = new AtomicLong(0);
     private boolean hasNext;
-    private int expectedModCount;
-    private int[] fieldsLens = new int[7];
+    private final int expectedModCount;
+    private final int[] fieldsLens = new int[7];
     private byte[] lastRow;
     private final Cleanable cleanableNMI;
 
@@ -537,7 +537,7 @@ public class NativeMap implements Iterable<Map.Entry<Key,Value>> {
     private ConcurrentIterator iter;
     private Entry<Key,Value> entry;
 
-    private NativeMap map;
+    private final NativeMap map;
     private Range range;
     private AtomicBoolean interruptFlag;
     private int interruptCheckCount = 0;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/PartialMutationSkippingIterator.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/PartialMutationSkippingIterator.java
@@ -30,7 +30,7 @@ import org.apache.accumulo.core.iteratorsImpl.system.InterruptibleIterator;
 
 class PartialMutationSkippingIterator extends SkippingIterator implements InterruptibleIterator {
 
-  private int kvCount;
+  private final int kvCount;
 
   public PartialMutationSkippingIterator(SortedKeyValueIterator<Key,Value> source, int maxKVCount) {
     setSource(source);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -206,7 +206,7 @@ public class ScanServer extends AbstractServer
   private ScanServerMetrics scanServerMetrics;
   private BlockCacheMetrics blockCacheMetrics;
 
-  private ZooCache managerLockCache;
+  private final ZooCache managerLockCache;
 
   private final String groupName;
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletMutations.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletMutations.java
@@ -25,7 +25,7 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.tserver.tablet.CommitSession;
 
 public class TabletMutations {
-  private CommitSession commitSession;
+  private final CommitSession commitSession;
   private final List<Mutation> mutations;
   private final Durability durability;
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -265,9 +265,9 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
     if (numBusyTabletsToLog > 0) {
       ScheduledFuture<?> future = context.getScheduledExecutor()
           .scheduleWithFixedDelay(Threads.createNamedRunnable("BusyTabletLogger", new Runnable() {
-            private BusiestTracker ingestTracker =
+            private final BusiestTracker ingestTracker =
                 BusiestTracker.newBusiestIngestTracker(numBusyTabletsToLog);
-            private BusiestTracker queryTracker =
+            private final BusiestTracker queryTracker =
                 BusiestTracker.newBusiestQueryTracker(numBusyTabletsToLog);
 
             @Override

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
@@ -134,7 +134,7 @@ public class TabletServerResourceManager {
   private final BlockCache _sCache;
   private final ServerContext context;
 
-  private Cache<String,Long> fileLenCache;
+  private final Cache<String,Long> fileLenCache;
 
   /**
    * This method creates a task that changes the number of core and maximum threads on the thread
@@ -467,7 +467,7 @@ public class TabletServerResourceManager {
     private final Map<KeyExtent,TabletMemoryReport> tabletReports;
     private final LinkedBlockingQueue<TabletMemoryReport> memUsageReports;
     private long lastMemCheckTime = System.currentTimeMillis();
-    private long maxMem;
+    private final long maxMem;
     private long lastMemTotal = 0;
     private final Thread memoryGuardThread;
     private final Thread minorCompactionInitiatorThread;
@@ -652,7 +652,7 @@ public class TabletServerResourceManager {
 
   public class TabletResourceManager {
 
-    private volatile boolean openFilesReserved = false;
+    private final boolean openFilesReserved = false;
 
     private volatile boolean closed = false;
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletStatsKeeper.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletStatsKeeper.java
@@ -33,7 +33,7 @@ public class TabletStatsKeeper {
     MAJOR, SPLIT, MINOR
   }
 
-  private ActionStats[] map = {major, split, minor};
+  private final ActionStats[] map = {major, split, minor};
 
   public void updateTime(Operation operation, long queued, long start, long count, boolean failed) {
     try {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionManager.java
@@ -64,24 +64,24 @@ public class CompactionManager {
 
   private static final Logger log = LoggerFactory.getLogger(CompactionManager.class);
 
-  private Iterable<Compactable> compactables;
+  private final Iterable<Compactable> compactables;
   private volatile Map<CompactionServiceId,CompactionService> services;
 
-  private LinkedBlockingQueue<Compactable> compactablesToCheck = new LinkedBlockingQueue<>();
+  private final LinkedBlockingQueue<Compactable> compactablesToCheck = new LinkedBlockingQueue<>();
 
-  private long maxTimeBetweenChecks;
+  private final long maxTimeBetweenChecks;
 
-  private ServerContext context;
+  private final ServerContext context;
 
   private CompactionServicesConfig currentCfg;
 
   private long lastConfigCheckTime = System.nanoTime();
 
-  private CompactionExecutorsMetrics ceMetrics;
+  private final CompactionExecutorsMetrics ceMetrics;
 
-  private Map<CompactionExecutorId,ExternalCompactionExecutor> externalExecutors;
+  private final Map<CompactionExecutorId,ExternalCompactionExecutor> externalExecutors;
 
-  private Map<ExternalCompactionId,ExtCompInfo> runningExternalCompactions;
+  private final Map<ExternalCompactionId,ExtCompInfo> runningExternalCompactions;
 
   // use to limit logging of unknown compaction services
   private final Cache<Pair<TableId,CompactionServiceId>,Long> unknownCompactionServiceErrorCache;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionService.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionService.java
@@ -77,18 +77,18 @@ public class CompactionService {
   private CompactionPlanner planner;
   private Map<CompactionExecutorId,CompactionExecutor> executors;
   private final CompactionServiceId myId;
-  private Map<KeyExtent,Collection<SubmittedJob>> submittedJobs = new ConcurrentHashMap<>();
-  private ServerContext context;
+  private final Map<KeyExtent,Collection<SubmittedJob>> submittedJobs = new ConcurrentHashMap<>();
+  private final ServerContext context;
   private String plannerClassName;
   private Map<String,String> plannerOpts;
-  private CompactionExecutorsMetrics ceMetrics;
-  private ExecutorService planningExecutor;
-  private Map<CompactionKind,ConcurrentMap<KeyExtent,Compactable>> queuedForPlanning;
+  private final CompactionExecutorsMetrics ceMetrics;
+  private final ExecutorService planningExecutor;
+  private final Map<CompactionKind,ConcurrentMap<KeyExtent,Compactable>> queuedForPlanning;
 
-  private RateLimiter readLimiter;
-  private RateLimiter writeLimiter;
-  private AtomicLong rateLimit = new AtomicLong(0);
-  private Function<CompactionExecutorId,ExternalCompactionExecutor> externExecutorSupplier;
+  private final RateLimiter readLimiter;
+  private final RateLimiter writeLimiter;
+  private final AtomicLong rateLimit = new AtomicLong(0);
+  private final Function<CompactionExecutorId,ExternalCompactionExecutor> externExecutorSupplier;
 
   // use to limit logging of max scan files exceeded
   private final Cache<TableId,Long> maxScanFilesExceededErrorCache;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/InternalCompactionExecutor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/InternalCompactionExecutor.java
@@ -59,10 +59,10 @@ public class InternalCompactionExecutor implements CompactionExecutor {
 
   private static final Logger log = LoggerFactory.getLogger(InternalCompactionExecutor.class);
 
-  private PriorityBlockingQueue<Runnable> queue;
+  private final PriorityBlockingQueue<Runnable> queue;
   private final CompactionExecutorId ceid;
-  private AtomicLong cancelCount = new AtomicLong();
-  private ThreadPoolExecutor threadPool;
+  private final AtomicLong cancelCount = new AtomicLong();
+  private final ThreadPoolExecutor threadPool;
 
   // This set provides an accurate count of queued compactions for metrics. The PriorityQueue is
   // not used because its size may be off due to it containing cancelled compactions. The collection

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/ProvisionalCompactionPlanner.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/ProvisionalCompactionPlanner.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 public class ProvisionalCompactionPlanner implements CompactionPlanner {
 
   private final CompactionServiceId serviceId;
-  private AtomicLong lastWarnNanoTime = new AtomicLong(System.nanoTime());
+  private final AtomicLong lastWarnNanoTime = new AtomicLong(System.nanoTime());
 
   public ProvisionalCompactionPlanner(CompactionServiceId serviceId) {
     this.serviceId = serviceId;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/constraints/ConstraintChecker.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/constraints/ConstraintChecker.java
@@ -41,7 +41,7 @@ import com.google.common.annotations.VisibleForTesting;
 
 public class ConstraintChecker {
 
-  private ArrayList<Constraint> constraints;
+  private final ArrayList<Constraint> constraints;
   private static final Logger log = LoggerFactory.getLogger(ConstraintChecker.class);
 
   public ConstraintChecker(AccumuloConfiguration conf) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/constraints/UnsatisfiableConstraint.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/constraints/UnsatisfiableConstraint.java
@@ -26,8 +26,8 @@ import org.apache.accumulo.core.data.constraints.Constraint;
 
 public class UnsatisfiableConstraint implements Constraint {
 
-  private List<Short> violations;
-  private String vDesc;
+  private final List<Short> violations;
+  private final String vDesc;
 
   public UnsatisfiableConstraint(short vcode, String violationDescription) {
     this.violations = Collections.unmodifiableList(Collections.singletonList(vcode));

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/data/ServerConditionalMutation.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/data/ServerConditionalMutation.java
@@ -26,8 +26,8 @@ import org.apache.accumulo.server.data.ServerMutation;
 
 public class ServerConditionalMutation extends ServerMutation {
 
-  private long cmid;
-  private List<TCondition> conditions;
+  private final long cmid;
+  private final List<TCondition> conditions;
 
   public ServerConditionalMutation(TConditionalMutation input) {
     super(input.mutation);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/SortedLogRecovery.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/SortedLogRecovery.java
@@ -171,7 +171,7 @@ public class SortedLogRecovery {
 
   static class DeduplicatingIterator implements Iterator<Entry<LogFileKey,LogFileValue>> {
 
-    private PeekingIterator<Entry<LogFileKey,LogFileValue>> source;
+    private final PeekingIterator<Entry<LogFileKey,LogFileValue>> source;
 
     public DeduplicatingIterator(Iterator<Entry<LogFileKey,LogFileValue>> source) {
       this.source = Iterators.peekingIterator(source);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/managermessage/SplitReportMessage.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/managermessage/SplitReportMessage.java
@@ -32,8 +32,8 @@ import org.apache.hadoop.io.Text;
 import org.apache.thrift.TException;
 
 public class SplitReportMessage implements ManagerMessage {
-  private Map<KeyExtent,Text> extents;
-  private KeyExtent old_extent;
+  private final Map<KeyExtent,Text> extents;
+  private final KeyExtent old_extent;
 
   public SplitReportMessage(KeyExtent old_extent, KeyExtent ne1, Text np1, KeyExtent ne2,
       Text np2) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/managermessage/TabletStatusMessage.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/managermessage/TabletStatusMessage.java
@@ -28,8 +28,8 @@ import org.apache.thrift.TException;
 
 public class TabletStatusMessage implements ManagerMessage {
 
-  private KeyExtent extent;
-  private TabletLoadState status;
+  private final KeyExtent extent;
+  private final TabletLoadState status;
 
   public TabletStatusMessage(TabletLoadState status, KeyExtent extent) {
     this.extent = extent;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SummarySession.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SummarySession.java
@@ -25,7 +25,7 @@ import org.apache.accumulo.core.summary.SummaryCollection;
 
 public class SummarySession extends Session {
 
-  private Future<SummaryCollection> future;
+  private final Future<SummaryCollection> future;
 
   public SummarySession(TCredentials credentials, Future<SummaryCollection> future) {
     super(credentials);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactionTask.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactionTask.java
@@ -35,11 +35,11 @@ class MinorCompactionTask implements Runnable {
   private static final Logger log = LoggerFactory.getLogger(MinorCompactionTask.class);
 
   private final Tablet tablet;
-  private long queued;
-  private CommitSession commitSession;
+  private final long queued;
+  private final CommitSession commitSession;
   private DataFileValue stats;
-  private long flushId;
-  private MinorCompactionReason mincReason;
+  private final long flushId;
+  private final MinorCompactionReason mincReason;
 
   MinorCompactionTask(Tablet tablet, CommitSession commitSession, long flushId,
       MinorCompactionReason mincReason) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
@@ -62,12 +62,12 @@ class ScanDataSource implements DataSource {
   // data source state
   private final TabletBase tablet;
   private ScanFileManager fileManager;
-  private static AtomicLong nextSourceId = new AtomicLong(0);
+  private static final AtomicLong nextSourceId = new AtomicLong(0);
   private SortedKeyValueIterator<Key,Value> iter;
   private long expectedDeletionCount;
   private List<MemoryIterator> memIters = null;
   private long fileReservationId;
-  private AtomicBoolean interruptFlag;
+  private final AtomicBoolean interruptFlag;
   private StatsIterator statsIterator;
 
   private final ScanParameters scanParams;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -157,7 +157,7 @@ public class Tablet extends TabletBase {
   private long persistedTime;
 
   private Location lastLocation = null;
-  private volatile Set<Path> checkedTabletDirs = new ConcurrentSkipListSet<>();
+  private final Set<Path> checkedTabletDirs = new ConcurrentSkipListSet<>();
 
   private final AtomicLong dataSourceDeletions = new AtomicLong(0);
 
@@ -175,8 +175,8 @@ public class Tablet extends TabletBase {
 
   private boolean updatingFlushID = false;
 
-  private AtomicLong lastFlushID = new AtomicLong(-1);
-  private AtomicLong lastCompactID = new AtomicLong(-1);
+  private final AtomicLong lastFlushID = new AtomicLong(-1);
+  private final AtomicLong lastCompactID = new AtomicLong(-1);
 
   public long getLastCompactId() {
     return lastCompactID.get();
@@ -195,7 +195,7 @@ public class Tablet extends TabletBase {
     WAITING_TO_START, IN_PROGRESS
   }
 
-  private CompactableImpl compactable;
+  private final CompactableImpl compactable;
 
   private volatile CompactionState minorCompactionState = null;
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletData.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletData.java
@@ -42,15 +42,15 @@ import org.apache.accumulo.core.tabletserver.log.LogEntry;
 public class TabletData {
   private MetadataTime time = null;
   private SortedMap<StoredTabletFile,DataFileValue> dataFiles = new TreeMap<>();
-  private List<LogEntry> logEntries = new ArrayList<>();
-  private HashSet<StoredTabletFile> scanFiles = new HashSet<>();
+  private final List<LogEntry> logEntries = new ArrayList<>();
+  private final HashSet<StoredTabletFile> scanFiles = new HashSet<>();
   private long flushID = -1;
   private long compactID = -1;
   private Location lastLocation = null;
   private Map<Long,List<ReferencedTabletFile>> bulkImported = new HashMap<>();
   private long splitTime = 0;
   private String directoryName = null;
-  private Map<ExternalCompactionId,ExternalCompactionMetadata> extCompactions;
+  private final Map<ExternalCompactionId,ExternalCompactionMetadata> extCompactions;
 
   // Read tablet data from metadata tables
   public TabletData(TabletMetadata meta) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletMemory.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletMemory.java
@@ -39,7 +39,7 @@ class TabletMemory implements Closeable {
   private InMemoryMap deletingMemTable;
   private long nextSeq = 1L;
   private CommitSession commitSession;
-  private ServerContext context;
+  private final ServerContext context;
 
   TabletMemory(Tablet tablet) {
     this.tablet = tablet;


### PR DESCRIPTION
This applies the same updates from #4831, #4832, #4833, #4834  to 3.1

Updates to mark member variables that can be final in the following modules:

core, server-base hadoop-mapreduce, gc, manager, tserver

Issue #4830

**Note:** This should be merged forward into elasticity by itself as an empty commit using `git merge -s ours` because elasticity already had these changes applied.