### PR TITLE
cleanup scan session when batch scanner closed

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java
@@ -817,6 +817,9 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
         client = ThriftUtil.getClient(ThriftClientTypes.TABLET_SCAN, parsedServer, context);
       }
 
+      // Tracks unclosed scan session id for the case when the following try block exits with an
+      // exception.
+      Long scanIdToClose = null;
       try {
 
         Timer timer = null;
@@ -850,6 +853,7 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
             ByteBufferUtil.toByteBuffers(authorizations.getAuthorizations()), waitForWrites,
             SamplerConfigurationImpl.toThrift(options.getSamplerConfiguration()),
             options.batchTimeout, options.classLoaderContext, execHints, busyTimeout);
+        scanIdToClose = imsr.scanID;
         if (waitForWrites) {
           ThriftScanner.serversWaitedForWrites.get(ttype).add(server.toString());
         }
@@ -916,9 +920,23 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
         }
 
         client.closeMultiScan(TraceUtil.traceInfo(), imsr.scanID);
+        scanIdToClose = null;
 
       } finally {
-        ThriftUtil.returnClient(client, context);
+        try {
+          if (scanIdToClose != null) {
+            // If this code is running it is likely that an exception happened and the scan session
+            // was never closed. Make a best effort attempt to close the scan session which will
+            // clean up server side resources. When the batch scanner is closed it will interrupt
+            // the threads in its thread pool which could cause an interrupted exception in this
+            // code.
+            client.closeMultiScan(TraceUtil.traceInfo(), scanIdToClose);
+          }
+        } catch (Exception e) {
+          log.trace("Failed to close scan session in finally {} {}", server, scanIdToClose, e);
+        } finally {
+          ThriftUtil.returnClient(client, context);
+        }
       }
     } catch (TTransportException e) {
       log.debug("Server : {} msg : {}", server, e.getMessage());

--- a/test/src/main/java/org/apache/accumulo/test/functional/ScannerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ScannerIT.java
@@ -18,10 +18,12 @@
  */
 package org.apache.accumulo.test.functional;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map.Entry;
 
 import org.apache.accumulo.core.client.Accumulo;
@@ -29,6 +31,7 @@ import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
@@ -36,6 +39,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
+import org.apache.accumulo.test.util.Wait;
 import org.junit.jupiter.api.Test;
 
 public class ScannerIT extends AccumuloClusterHarness {
@@ -112,5 +116,83 @@ public class ScannerIT extends AccumuloClusterHarness {
                 + ") than without immediate readahead (" + nanosWithWait + ")");
       }
     }
+  }
+
+  @Test
+  public void testSessionCleanup() throws Exception {
+    String tableName = getUniqueNames(1)[0];
+    final String table = getUniqueNames(1)[0];
+    try (AccumuloClient accumuloClient = Accumulo.newClient().from(getClientProps()).build()) {
+
+      accumuloClient.tableOperations().create(tableName);
+
+      try (var writer = accumuloClient.createBatchWriter(tableName)) {
+        for (int i = 0; i < 100000; i++) {
+          var m = new Mutation(String.format("%09d", i));
+          m.put("1", "1", "" + i);
+          writer.addMutation(m);
+        }
+      }
+
+      // The test assumes the session timeout is configured to 1 minute, validate this. Later in the
+      // test 10s is given for session to disappear and we want this 10s to be much smaller than the
+      // configured session timeout.
+      assertEquals("1m", accumuloClient.instanceOperations().getSystemConfiguration()
+          .get(Property.TSERV_SESSION_MAXIDLE.getKey()));
+
+      // The following test that when not all data is read from scanner that when the scanner is
+      // closed that any open sessions will be closed.
+      for (int i = 0; i < 3; i++) {
+        try (var scanner = accumuloClient.createScanner(tableName)) {
+          assertEquals(10, scanner.stream().limit(10).count());
+          assertEquals(10000, scanner.stream().limit(10000).count());
+          // since not all data in the range was read from the scanner it should leave an active
+          // scan session per scanner iterator created
+          assertEquals(2, countActiveScans(accumuloClient, tableName));
+        }
+        // When close is called on on the scanner it should close the scan session. The session
+        // cleanup is async on the server because task may still be running server side, but it
+        // should happen in less than the session timeout. Also the server should start working on
+        // it immediately.
+        Wait.waitFor(() -> countActiveScans(accumuloClient, tableName) == 0, 10000);
+
+        try (var scanner = accumuloClient.createBatchScanner(tableName)) {
+          scanner.setRanges(List.of(new Range()));
+          assertEquals(10, scanner.stream().limit(10).count());
+          assertEquals(10000, scanner.stream().limit(10000).count());
+          assertEquals(2, countActiveScans(accumuloClient, tableName));
+        }
+        Wait.waitFor(() -> countActiveScans(accumuloClient, tableName) == 0, 10000);
+      }
+
+      // Test the case where all data is read from a scanner. In this case the scanner should close
+      // the scan session at the end of the range even before the scanner itself is closed.
+      for (int i = 0; i < 3; i++) {
+        try (var scanner = accumuloClient.createScanner(tableName)) {
+          assertEquals(100000, scanner.stream().count());
+          assertEquals(100000, scanner.stream().count());
+          // The server side cleanup of the session should be able to happen immediately in this
+          // case because nothing should be running on the server side to fetch data because all
+          // data in the range was fetched.
+          assertEquals(0, countActiveScans(accumuloClient, tableName));
+        }
+
+        try (var scanner = accumuloClient.createBatchScanner(tableName)) {
+          scanner.setRanges(List.of(new Range()));
+          assertEquals(100000, scanner.stream().count());
+          assertEquals(100000, scanner.stream().count());
+          assertEquals(0, countActiveScans(accumuloClient, tableName));
+        }
+      }
+    }
+  }
+
+  public static long countActiveScans(AccumuloClient c, String tableName) throws Exception {
+    long count = 0;
+    for (String tserver : c.instanceOperations().getTabletServers()) {
+      count += c.instanceOperations().getActiveScans(tserver).stream()
+          .filter(activeScan -> activeScan.getTable().equals(tableName)).count();
+    }
+    return count;
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/functional/ScannerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ScannerIT.java
@@ -120,8 +120,7 @@ public class ScannerIT extends AccumuloClusterHarness {
 
   @Test
   public void testSessionCleanup() throws Exception {
-    String tableName = getUniqueNames(1)[0];
-    final String table = getUniqueNames(1)[0];
+    final String tableName = getUniqueNames(1)[0];
     try (AccumuloClient accumuloClient = Accumulo.newClient().from(getClientProps()).build()) {
 
       accumuloClient.tableOperations().create(tableName);


### PR DESCRIPTION
When not all data is read from a scanner it can leave server side scan sessions open.  When the scanner object is closed on the client side it should close these server side scan sessions.  The batch scanner was not doing this.  Updated the batch scanner to close sever side sessions. Added test for the scanner and batch scanner to ensure sessions are cleaned up.  Improved an existing test related to session timeout.