### PR TITLE
Fix String-to-bytes and bytes-to-String for UTF-8 Pt. 3: main

### DIFF
--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/AbstractRFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/AbstractRFileTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.file.rfile;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
@@ -237,7 +238,8 @@ public abstract class AbstractRFileTest {
   }
 
   static Key newKey(String row, String cf, String cq, String cv, long ts) {
-    return new Key(row.getBytes(), cf.getBytes(), cq.getBytes(), cv.getBytes(), ts);
+    return new Key(row.getBytes(UTF_8), cf.getBytes(UTF_8), cq.getBytes(UTF_8), cv.getBytes(UTF_8),
+        ts);
   }
 
   static Value newValue(String val) {

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/IndexedDocIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/IndexedDocIteratorTest.java
@@ -129,7 +129,7 @@ public class IndexedDocIteratorTest {
           }
         }
         sb.append(" docID=").append(doc);
-        Key k = new Key(row, docColf, new Text(String.format("%010d", docid).getBytes()));
+        Key k = new Key(row, docColf, new Text(String.format("%010d", docid).getBytes(UTF_8)));
         map.put(k, new Value(sb.toString()));
       }
     }

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/MapReduceIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/MapReduceIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.hadoop.its.mapreduce;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
@@ -95,8 +96,8 @@ public class MapReduceIT extends ConfigurableMacBase {
       int i = 0;
       for (Entry<Key,Value> entry : s) {
         MessageDigest md = MessageDigest.getInstance("MD5");
-        byte[] check = Base64.getEncoder().encode(md.digest(("row" + i).getBytes()));
-        assertEquals(entry.getValue().toString(), new String(check));
+        byte[] check = Base64.getEncoder().encode(md.digest(("row" + i).getBytes(UTF_8)));
+        assertEquals(entry.getValue().toString(), new String(check, UTF_8));
         i++;
       }
     }

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterExistingZooKeepersTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterExistingZooKeepersTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.minicluster;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -79,7 +80,7 @@ public class MiniAccumuloClusterExistingZooKeepersTest extends WithTestNames {
             CuratorFrameworkFactory.newClient(zooKeeper.getConnectString(), new RetryOneTime(1))) {
           curatorClient.start();
           assertNotNull(curatorClient.checkExists().forPath(zkTablePath));
-          assertEquals(tableName, new String(curatorClient.getData().forPath(zkTablePath)));
+          assertEquals(tableName, new String(curatorClient.getData().forPath(zkTablePath), UTF_8));
         }
       }
     }


### PR DESCRIPTION
This PR attempts to address all String-to-bytes and bytes-to-String conversions so they all consistently use UTF-8 (see more commentary in https://github.com/apache/accumulo/pull/3815). This is a follow-on to #4791 and **covers fixes to code in the main branch that was not present in 2.1.**

The following fixes have been made:

- String-to-bytes: `String.getBytes()` -> `String.getBytes(UTF_8)`
- Bytes-to-String: `new String(byte[])` -> `new String(byte[], UTF_8)`
- No instances of `String::new` or `String::getBytes` were found that were missing UTF-8 specification

Fixes https://github.com/apache/accumulo/issues/4765 "Fix String-to-bytes and bytes-toString for UTF-8 for all remaining code"