### PR TITLE
deprecates table.compaction.minor.idle property

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -907,11 +907,7 @@ public enum Property {
       "A tablet is split when the combined size of RFiles exceeds this amount.", "1.3.5"),
   TABLE_MAX_END_ROW_SIZE("table.split.endrow.size.max", "10k", PropertyType.BYTES,
       "Maximum size of end row.", "1.7.0"),
-  TABLE_MINC_COMPACT_IDLETIME("table.compaction.minor.idle", "5m", PropertyType.TIMEDURATION,
-      "When the age of the youngest key value in a tablets in memory map exceeds this configuration, then"
-          + " a minor compaction may be initiated. There is no guarantee an idle tablet will be compacted.",
-      "1.3.5"),
-  TABLE_MINC_COMPACT_MAXAGE("table.compaction.minor.age", "365000d", PropertyType.TIMEDURATION,
+  TABLE_MINC_COMPACT_MAXAGE("table.compaction.minor.age", "10m", PropertyType.TIMEDURATION,
       "Key values written to a tablet are temporarily stored in a per tablet in memory map.  When "
           + "the age of the oldest key value in a tablets in memory map exceeds this configuration, then  "
           + "a minor compaction may be initiated. This determines the maximum amount of time new data can "
@@ -921,6 +917,14 @@ public enum Property {
           + "server to see a write to a tablet server. The default value of this property is set to such a "
           + "high value that is should never cause a minor compaction.",
       "3.1.0"),
+  @Deprecated(since = "3.1.0")
+  @ReplacedBy(property = TABLE_MINC_COMPACT_MAXAGE)
+  TABLE_MINC_COMPACT_IDLETIME("table.compaction.minor.idle", "5m", PropertyType.TIMEDURATION,
+      "When the age of the youngest key value in a tablets in memory map exceeds this configuration, then"
+          + " a minor compaction may be initiated. There is no guarantee an idle tablet will be compacted."
+          + "This property was deprecated because the new property table.compaction.minor.age can offer the "
+          + " same functionality although it may cause more minor compactions than this property would have.",
+      "1.3.5"),
   TABLE_COMPACTION_DISPATCHER("table.compaction.dispatcher",
       SimpleCompactionDispatcher.class.getName(), PropertyType.CLASSNAME,
       "A configurable dispatcher that decides what compaction service a table should use.",

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManager.java
@@ -142,6 +142,7 @@ public class LargestFirstMemoryManager {
     maxObserved = 0;
   }
 
+  @SuppressWarnings("deprecation")
   protected long getMinCIdleThreshold(KeyExtent extent) {
     TableId tableId = extent.tableId();
     if (!mincIdleThresholds.containsKey(tableId)) {

--- a/test/src/main/java/org/apache/accumulo/test/ScanServerMaxLatencyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ScanServerMaxLatencyIT.java
@@ -57,6 +57,9 @@ public class ScanServerMaxLatencyIT extends ConfigurableMacBase {
     cfg.setProperty(Property.SSERV_CACHED_TABLET_METADATA_EXPIRATION, "2s");
   }
 
+  @SuppressWarnings("deprecation")
+  private static Property IDLE_MINC_PROP = Property.TABLE_MINC_COMPACT_IDLETIME;
+
   @Test
   public void testMaxLatency() throws Exception {
     final String[] tables = this.getUniqueNames(4);
@@ -78,7 +81,7 @@ public class ScanServerMaxLatencyIT extends ConfigurableMacBase {
       client.tableOperations().create(table1, ntc);
       client.tableOperations().create(table2);
       ntc = new NewTableConfiguration();
-      ntc.setProperties(Map.of(Property.TABLE_MINC_COMPACT_IDLETIME.getKey(), "2s"));
+      ntc.setProperties(Map.of(IDLE_MINC_PROP.getKey(), "2s"));
       client.tableOperations().create(table3, ntc);
       ntc = new NewTableConfiguration();
       ntc.setProperties(Map.of(Property.TABLE_MINC_COMPACT_MAXAGE.getKey(), "3s"));

--- a/test/src/main/java/org/apache/accumulo/test/functional/ManyWriteAheadLogsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ManyWriteAheadLogsIT.java
@@ -56,6 +56,9 @@ public class ManyWriteAheadLogsIT extends AccumuloClusterHarness {
 
   private String majcDelay, walSize;
 
+  @SuppressWarnings("deprecation")
+  private static Property IDLE_MINC_PROP = Property.TABLE_MINC_COMPACT_IDLETIME;
+
   @Override
   public void configureMiniCluster(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
     // configure a smaller wal size so the wals will roll frequently in the test
@@ -68,7 +71,7 @@ public class ManyWriteAheadLogsIT extends AccumuloClusterHarness {
     // idle compactions may addess the problem this test is creating, however they will not prevent
     // lots of closed WALs for all write patterns. This test ensures code that directly handles many
     // tablets referencing many different WALs is working.
-    cfg.setProperty(Property.TABLE_MINC_COMPACT_IDLETIME, "1h");
+    cfg.setProperty(IDLE_MINC_PROP, "1h");
     cfg.setNumTservers(1);
     hadoopCoreSite.set("fs.file.impl", RawLocalFileSystem.class.getName());
   }


### PR DESCRIPTION
Also changed the default value of replacement property to what it should be once the deprecated property is removed.

For details on why the property was deprecated see :

https://github.com/apache/accumulo/pull/4853#issuecomment-2330214458