### PR TITLE
remove mysterious pass in MetadataConstraints class

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
@@ -162,9 +162,6 @@ public class MetadataConstraints implements Constraint {
     if (row.length > 0 && row[0] == '~') {
       return null;
     }
-    if (row.length > 2 && row[0] == '!' && row[1] == '!' && row[2] == '~') {
-      return null;
-    }
 
     for (byte b : row) {
       if (b == ';') {


### PR DESCRIPTION
The Metadata constraint was allowing rows that started with `!!~` a free pass. AFAIK no code in Accumulo should produce a row with this prefix, so removed the code.  I suspect this may be somehow related to previous versions of accumulo where the root table was instead a root tablet which was  special tablet in the metadata table, but not really sure.