### PR TITLE
Disable Gson JDK sun.misc.Unsafe usage

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/Bulk.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/Bulk.java
@@ -38,8 +38,11 @@ public class Bulk {
    * WARNING : do not change this class, its used for serialization to Json
    */
   public static class Mapping {
-    private final Tablet tablet;
-    private final Collection<FileInfo> files;
+    private Tablet tablet;
+    private Collection<FileInfo> files;
+
+    // Gson requires a default constructor when JDK Unsafe usage is disabled
+    private Mapping() {}
 
     public Mapping(KeyExtent tablet, Files files) {
       this.tablet = toTablet(tablet);
@@ -64,8 +67,11 @@ public class Bulk {
    */
   public static class Tablet {
 
-    private final byte[] endRow;
-    private final byte[] prevEndRow;
+    private byte[] endRow;
+    private byte[] prevEndRow;
+
+    // Gson requires a default constructor when JDK Unsafe usage is disabled
+    private Tablet() {}
 
     public Tablet(Text endRow, Text prevEndRow) {
       this.endRow = endRow == null ? null : TextUtil.getBytes(endRow);
@@ -100,9 +106,12 @@ public class Bulk {
    * WARNING : do not change this class, its used for serialization to Json
    */
   public static class FileInfo {
-    final String name;
-    final long estSize;
-    final long estEntries;
+    String name;
+    long estSize;
+    long estEntries;
+
+    // Gson requires a default constructor when JDK Unsafe usage is disabled
+    private FileInfo() {}
 
     public FileInfo(String fileName, long estFileSize, long estNumEntries) {
       this.name = fileName;

--- a/core/src/main/java/org/apache/accumulo/core/lock/ServiceLockData.java
+++ b/core/src/main/java/org/apache/accumulo/core/lock/ServiceLockData.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.util.AddressUtil;
 
@@ -118,7 +119,11 @@ public class ServiceLockData implements Comparable<ServiceLockData> {
 
     @Override
     public String toString() {
-      return GSON.get().toJson(this);
+      return serialize();
+    }
+
+    private String serialize() {
+      return GSON.get().toJson(new ServiceDescriptorGson(uuid, service, address, group));
     }
 
   }
@@ -133,7 +138,7 @@ public class ServiceLockData implements Comparable<ServiceLockData> {
       descriptors = new HashSet<>();
     }
 
-    public ServiceDescriptors(HashSet<ServiceDescriptor> descriptors) {
+    public ServiceDescriptors(Set<ServiceDescriptor> descriptors) {
       this.descriptors = descriptors;
     }
 
@@ -184,9 +189,11 @@ public class ServiceLockData implements Comparable<ServiceLockData> {
   }
 
   public byte[] serialize() {
-    ServiceDescriptors sd = new ServiceDescriptors();
-    services.values().forEach(s -> sd.addService(s));
-    return GSON.get().toJson(sd).getBytes(UTF_8);
+    ServiceDescriptorsGson json = new ServiceDescriptorsGson();
+    json.descriptors = services.values().stream()
+        .map(s -> new ServiceDescriptorGson(s.uuid, s.service, s.address, s.group))
+        .collect(Collectors.toSet());
+    return GSON.get().toJson(json).getBytes(UTF_8);
   }
 
   @Override
@@ -215,7 +222,37 @@ public class ServiceLockData implements Comparable<ServiceLockData> {
     }
     String data = new String(lockData, UTF_8);
     return data.isBlank() ? Optional.empty()
-        : Optional.of(new ServiceLockData(GSON.get().fromJson(data, ServiceDescriptors.class)));
+        : Optional.of(new ServiceLockData(parseServiceDescriptors(data)));
   }
 
+  public static ServiceDescriptors parseServiceDescriptors(String data) {
+    return deserialize(GSON.get().fromJson(data, ServiceDescriptorsGson.class));
+  }
+
+  private static ServiceDescriptors deserialize(ServiceDescriptorsGson json) {
+    return new ServiceDescriptors(json.descriptors.stream()
+        .map(s -> new ServiceDescriptor(s.uuid, s.service, s.address, s.group))
+        .collect(Collectors.toSet()));
+  }
+
+  private static class ServiceDescriptorGson {
+    private UUID uuid;
+    private ThriftService service;
+    private String address;
+    private String group;
+
+    // default constructor required for Gson
+    public ServiceDescriptorGson() {}
+
+    public ServiceDescriptorGson(UUID uuid, ThriftService service, String address, String group) {
+      this.uuid = uuid;
+      this.service = service;
+      this.address = address;
+      this.group = group;
+    }
+  }
+
+  private static class ServiceDescriptorsGson {
+    private Set<ServiceDescriptorGson> descriptors;
+  }
 }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/ExternalCompactionFinalState.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/ExternalCompactionFinalState.java
@@ -76,9 +76,12 @@ public class ExternalCompactionFinalState {
   // class must consider persisted data.
   private static class Extent {
 
-    final String tableId;
-    final String er;
-    final String per;
+    String tableId;
+    String er;
+    String per;
+
+    // Gson requires a default constructor
+    private Extent() {}
 
     Extent(KeyExtent extent) {
       this.tableId = extent.tableId().canonical();

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/RootTabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/RootTabletMetadata.java
@@ -60,14 +60,17 @@ public class RootTabletMetadata {
   // This class is used to serialize and deserialize root tablet metadata using GSon. Any changes to
   // this class must consider persisted data.
   private static class Data {
-    private final int version;
+    private int version;
 
     /*
      * The data is mapped using Strings as follows:
      *
      * TreeMap<column_family, TreeMap<column_qualifier, value>>
      */
-    private final TreeMap<String,TreeMap<String,String>> columnValues;
+    private TreeMap<String,TreeMap<String,String>> columnValues;
+
+    // Gson requires a default constructor when JDK Unsafe usage is disabled
+    private Data() {}
 
     private Data(int version, TreeMap<String,TreeMap<String,String>> columnValues) {
       this.version = version;

--- a/core/src/main/java/org/apache/accumulo/core/util/LazySingletons.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/LazySingletons.java
@@ -23,6 +23,7 @@ import java.util.function.Supplier;
 
 import com.google.common.base.Suppliers;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 /**
  * This class provides easy access to global, immutable, lazily-instantiated, and thread-safe
@@ -36,7 +37,8 @@ public class LazySingletons {
   /**
    * A Gson instance constructed with defaults. Construct your own if you need custom settings.
    */
-  public static final Supplier<Gson> GSON = Suppliers.memoize(Gson::new);
+  public static final Supplier<Gson> GSON =
+      Suppliers.memoize(() -> new GsonBuilder().disableJdkUnsafe().create());
 
   /**
    * A SecureRandom instance created with the default constructor.

--- a/core/src/main/java/org/apache/accumulo/core/util/json/ByteArrayToBase64TypeAdapter.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/json/ByteArrayToBase64TypeAdapter.java
@@ -61,7 +61,7 @@ public class ByteArrayToBase64TypeAdapter
    * @return Gson instance
    */
   public static Gson createBase64Gson() {
-    return registerBase64TypeAdapter(new GsonBuilder()).create();
+    return registerBase64TypeAdapter(new GsonBuilder().disableJdkUnsafe()).create();
   }
 
   /**

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/RootGcCandidates.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/RootGcCandidates.java
@@ -41,7 +41,7 @@ public class RootGcCandidates {
   // This class is used to serialize and deserialize root tablet metadata using GSon. Any changes to
   // this class must consider persisted data.
   private static class Data {
-    private final int version;
+    private int version;
 
     /*
      * The root tablet will only have a single dir on each volume. Therefore, root file paths will
@@ -50,7 +50,10 @@ public class RootGcCandidates {
      *
      * SortedMap<dir path, SortedSet<file name>>
      */
-    private final SortedMap<String,SortedSet<String>> candidates;
+    private SortedMap<String,SortedSet<String>> candidates;
+
+    // Gson requires a default constructor when JDK Unsafe usage is disabled
+    private Data() {}
 
     public Data(int version, SortedMap<String,SortedSet<String>> candidates) {
       this.version = version;

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ServiceStatusCmd.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ServiceStatusCmd.java
@@ -21,7 +21,6 @@ package org.apache.accumulo.server.util;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.core.lock.ServiceLockData.ThriftService.TABLET_SCAN;
 import static org.apache.accumulo.core.lock.ServiceLockData.ThriftService.TSERV;
-import static org.apache.accumulo.core.util.LazySingletons.GSON;
 
 import java.util.Collection;
 import java.util.Map;
@@ -152,7 +151,7 @@ public class ServiceStatusCmd {
         } else {
 
           ServiceLockData.ServiceDescriptors sld =
-              GSON.get().fromJson(nodeData.getData(), ServiceLockData.ServiceDescriptors.class);
+              ServiceLockData.parseServiceDescriptors(nodeData.getData());
 
           sld.getServices().forEach(sd -> {
             if (serviceType == sd.getService()) {
@@ -210,8 +209,7 @@ public class ServiceStatusCmd {
     var result = readAllNodesData(zooReader, lockPath);
     Map<String,Set<String>> byGroup = new TreeMap<>();
     result.getData().forEach(data -> {
-      ServiceLockData.ServiceDescriptors sld =
-          GSON.get().fromJson(data, ServiceLockData.ServiceDescriptors.class);
+      ServiceLockData.ServiceDescriptors sld = ServiceLockData.parseServiceDescriptors(data);
       var services = sld.getServices();
       services.forEach(sd -> {
         byGroup.computeIfAbsent(sd.getGroup(), set -> new TreeSet<>()).add(sd.getAddress());

--- a/server/base/src/main/java/org/apache/accumulo/server/util/fateCommand/FateSummaryReport.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/fateCommand/FateSummaryReport.java
@@ -40,19 +40,23 @@ import com.google.gson.GsonBuilder;
 
 public class FateSummaryReport {
 
-  private final Map<String,Integer> statusCounts = new TreeMap<>();
-  private final Map<String,Integer> cmdCounts = new TreeMap<>();
-  private final Map<String,Integer> stepCounts = new TreeMap<>();
-  private final Set<FateTxnDetails> fateDetails = new TreeSet<>();
+  private Map<String,Integer> statusCounts = new TreeMap<>();
+  private Map<String,Integer> cmdCounts = new TreeMap<>();
+  private Map<String,Integer> stepCounts = new TreeMap<>();
+  private Set<FateTxnDetails> fateDetails = new TreeSet<>();
   // epoch millis to avoid needing gson type adapter.
-  private final long reportTime = Instant.now().toEpochMilli();
+  private long reportTime = Instant.now().toEpochMilli();
 
-  private final Set<String> statusFilterNames = new TreeSet<>();
+  private Set<String> statusFilterNames = new TreeSet<>();
 
-  private final static Gson gson = new GsonBuilder().setPrettyPrinting().create();
+  private final static Gson gson =
+      new GsonBuilder().setPrettyPrinting().disableJdkUnsafe().create();
 
   // exclude from json output
-  private final transient Map<String,String> idsToNameMap;
+  private transient Map<String,String> idsToNameMap;
+
+  // Gson requires a default constructor when JDK Unsafe usage is disabled
+  private FateSummaryReport() {}
 
   public FateSummaryReport(Map<String,String> idsToNameMap,
       EnumSet<ReadOnlyTStore.TStatus> statusFilter) {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/fateCommand/FateTxnDetails.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/fateCommand/FateTxnDetails.java
@@ -38,6 +38,9 @@ public class FateTxnDetails implements Comparable<FateTxnDetails> {
   private List<String> locksHeld = List.of();
   private List<String> locksWaiting = List.of();
 
+  // Default constructor for Gson
+  private FateTxnDetails() {}
+
   /**
    * Create a detailed FaTE transaction that can be formatted for status reports.
    * <p>

--- a/server/base/src/main/java/org/apache/accumulo/server/util/serviceStatus/ServiceStatusReport.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/serviceStatus/ServiceStatusReport.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.server.util.serviceStatus;
 
 import static org.apache.accumulo.core.lock.ServiceLockData.ServiceDescriptor.DEFAULT_GROUP_NAME;
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -38,7 +39,7 @@ public class ServiceStatusReport {
 
   private static final Logger LOG = LoggerFactory.getLogger(ServiceStatusReport.class);
 
-  private static final Gson gson = new Gson();
+  private static final Gson gson = GSON.get();
 
   private static final DateTimeFormatter rptTimeFmt =
       DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
@@ -46,10 +47,13 @@ public class ServiceStatusReport {
   private static final String I4 = "    ";
   private static final String I6 = "      ";
 
-  private final String reportTime;
-  private final int zkReadErrors;
-  private final boolean noHosts;
-  private final Map<ReportKey,StatusSummary> summaries;
+  private String reportTime;
+  private int zkReadErrors;
+  private boolean noHosts;
+  private Map<ReportKey,StatusSummary> summaries;
+
+  // Gson requires a default constructor when JDK Unsafe usage is disabled
+  private ServiceStatusReport() {}
 
   public ServiceStatusReport(final Map<ReportKey,StatusSummary> summaries, final boolean noHosts) {
     reportTime = rptTimeFmt.format(ZonedDateTime.now(ZoneId.of("UTC")));

--- a/server/base/src/main/java/org/apache/accumulo/server/util/serviceStatus/StatusSummary.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/serviceStatus/StatusSummary.java
@@ -24,11 +24,14 @@ import java.util.Set;
 
 public class StatusSummary {
 
-  private final ServiceStatusReport.ReportKey serviceType;
-  private final Set<String> resourceGroups;
-  private final Map<String,Set<String>> serviceByGroups;
-  private final int serviceCount;
-  private final int errorCount;
+  private ServiceStatusReport.ReportKey serviceType;
+  private Set<String> resourceGroups;
+  private Map<String,Set<String>> serviceByGroups;
+  private int serviceCount;
+  private int errorCount;
+
+  // Default constructor required for Gson
+  private StatusSummary() {}
 
   public StatusSummary(ServiceStatusReport.ReportKey serviceType, final Set<String> resourceGroups,
       final Map<String,Set<String>> serviceByGroups, final int errorCount) {


### PR DESCRIPTION
Configure Gson to no longer use JDK sun.misc.Unsafe as that can cause some strange behavior and Unsafe could change in future JDKs. This required making sure any serialized class has a default constructor and removing the final keyword from any member variables.

Issue #4837