### PR TITLE
Disable more Gson JDK Unsafe usages

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/SelectedFiles.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/SelectedFiles.java
@@ -51,8 +51,10 @@ public class SelectedFiles {
 
   private String metadataValue;
 
-  private static final Gson GSON = new GsonBuilder()
-      .registerTypeAdapter(SelectedFiles.class, new SelectedFilesTypeAdapter()).create();
+  // This class does not need a default constructor because there is a custom TypeAdapter
+  private static final Gson GSON =
+      new GsonBuilder().registerTypeAdapter(SelectedFiles.class, new SelectedFilesTypeAdapter())
+          .disableJdkUnsafe().create();
 
   public SelectedFiles(Set<StoredTabletFile> files, boolean initiallySelectedAll, FateId fateId,
       SteadyTime selectedTime) {


### PR DESCRIPTION
Follow on to #4859 that disables Gson JDK Unsafe uses that were added in elasticity in 4.0 that did not exist in 3.1

This closes #4837