### PR TITLE
Update ThriftScanner to use nanotime

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerImpl.java
@@ -19,8 +19,8 @@
 package org.apache.accumulo.core.clientImpl;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
+import java.time.Duration;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -163,7 +163,7 @@ public class ScannerImpl extends ScannerOptions implements Scanner {
   public synchronized Iterator<Entry<Key,Value>> iterator() {
     ensureOpen();
     ScannerIterator iter = new ScannerIterator(context, tableId, authorizations, range, size,
-        getTimeout(SECONDS), this, isolated, readaheadThreshold, new Reporter());
+        Duration.ofMillis(retryTimeout), this, isolated, readaheadThreshold, new Reporter());
 
     iters.put(iter, iterCount++);
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerImpl.java
@@ -25,6 +25,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.Scanner;
@@ -163,7 +164,8 @@ public class ScannerImpl extends ScannerOptions implements Scanner {
   public synchronized Iterator<Entry<Key,Value>> iterator() {
     ensureOpen();
     ScannerIterator iter = new ScannerIterator(context, tableId, authorizations, range, size,
-        Duration.ofMillis(retryTimeout), this, isolated, readaheadThreshold, new Reporter());
+        Duration.ofMillis(getTimeout(TimeUnit.MILLISECONDS)), this, isolated, readaheadThreshold,
+        new Reporter());
 
     iters.put(iter, iterCount++);
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerImpl.java
@@ -19,13 +19,13 @@
 package org.apache.accumulo.core.clientImpl;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import java.time.Duration;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.Scanner;
@@ -164,7 +164,7 @@ public class ScannerImpl extends ScannerOptions implements Scanner {
   public synchronized Iterator<Entry<Key,Value>> iterator() {
     ensureOpen();
     ScannerIterator iter = new ScannerIterator(context, tableId, authorizations, range, size,
-        Duration.ofMillis(getTimeout(TimeUnit.MILLISECONDS)), this, isolated, readaheadThreshold,
+        Duration.ofMillis(getTimeout(MILLISECONDS)), this, isolated, readaheadThreshold,
         new Reporter());
 
     iters.put(iter, iterCount++);

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerIterator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.clientImpl;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -45,7 +46,7 @@ import com.google.common.base.Preconditions;
 public class ScannerIterator implements Iterator<Entry<Key,Value>> {
 
   // scanner options
-  private final long timeOut;
+  private final Duration timeOut;
 
   // scanner state
   private Iterator<KeyValue> iter;
@@ -67,7 +68,7 @@ public class ScannerIterator implements Iterator<Entry<Key,Value>> {
   private final AtomicBoolean closed = new AtomicBoolean(false);
 
   ScannerIterator(ClientContext context, TableId tableId, Authorizations authorizations,
-      Range range, int size, long timeOut, ScannerOptions options, boolean isolated,
+      Range range, int size, Duration timeOut, ScannerOptions options, boolean isolated,
       long readaheadThreshold, ScannerImpl.Reporter reporter) {
     this.context = context;
     this.timeOut = timeOut;

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftScanner.java
@@ -275,12 +275,12 @@ public class ThriftScanner {
         .incrementBy(100, MILLISECONDS).maxWait(1, SECONDS).backOffFactor(1.5)
         .logInterval(3, TimeUnit.MINUTES).createRetry();
 
-    long startTime = System.nanoTime();
+    Timer startTime = Timer.startNew();
     Optional<T> optional = condition.get();
     while (optional.isEmpty()) {
       log.trace("For tableId {} scan server selector is waiting for '{}'", tableId, description);
 
-      var elapsedTime = Duration.ofNanos(System.nanoTime() - startTime);
+      var elapsedTime = startTime.elapsed();
 
       if (elapsedTime.compareTo(timeoutLeft) > 0) {
         throw new TimedOutException("While waiting for '" + description
@@ -323,11 +323,11 @@ public class ThriftScanner {
     return (long) (Math.min(millis * 2, maxSleep) * (.9 + random.nextDouble() / 5));
   }
 
-  public static List<KeyValue> scan(ClientContext context, ScanState scanState, long timeOut)
+  public static List<KeyValue> scan(ClientContext context, ScanState scanState, Duration timeOut)
       throws ScanTimedOutException, AccumuloException, AccumuloSecurityException,
       TableNotFoundException {
     TabletLocation loc = null;
-    long startTime = System.currentTimeMillis();
+    Timer startTime = Timer.startNew();
     String lastError = null;
     String error = null;
     int tooManyFilesCount = 0;
@@ -343,14 +343,12 @@ public class ThriftScanner {
         if (Thread.currentThread().isInterrupted()) {
           throw new AccumuloException("Thread interrupted");
         }
-
-        if ((System.currentTimeMillis() - startTime) / 1000.0 > timeOut) {
+        if (startTime.elapsed(MILLISECONDS) > timeOut.toMillis()) {
           throw new ScanTimedOutException();
         }
 
         while (loc == null) {
-          long currentTime = System.currentTimeMillis();
-          if ((currentTime - startTime) / 1000.0 > timeOut) {
+          if (startTime.elapsed(MILLISECONDS) > timeOut.toMillis()) {
             throw new ScanTimedOutException();
           }
 
@@ -555,8 +553,9 @@ public class ThriftScanner {
   }
 
   private static List<KeyValue> scan(TabletLocation loc, ScanState scanState, ClientContext context,
-      long timeOut, long startTime) throws AccumuloSecurityException, NotServingTabletException,
-      TException, NoSuchScanIDException, TooManyFilesException, TSampleNotPresentException {
+      Duration timeOut, Timer startTime)
+      throws AccumuloSecurityException, NotServingTabletException, TException,
+      NoSuchScanIDException, TooManyFilesException, TSampleNotPresentException {
     if (scanState.finished) {
       return null;
     }
@@ -580,8 +579,7 @@ public class ThriftScanner {
         // obtain a snapshot once and only expose this snapshot to the plugin for consistency
         var attempts = scanState.scanAttempts.snapshot();
 
-        Duration timeoutLeft = Duration.ofSeconds(timeOut)
-            .minus(Duration.ofMillis(System.currentTimeMillis() - startTime));
+        Duration timeoutLeft = timeOut.minus(startTime.elapsed());
 
         var params = new ScanServerSelector.SelectorParameters() {
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftScanner.java
@@ -275,19 +275,17 @@ public class ThriftScanner {
         .incrementBy(100, MILLISECONDS).maxWait(1, SECONDS).backOffFactor(1.5)
         .logInterval(3, TimeUnit.MINUTES).createRetry();
 
-    Timer startTime = Timer.startNew();
+    Timer waitTimer = Timer.startNew();
     Optional<T> optional = condition.get();
     while (optional.isEmpty()) {
       log.trace("For tableId {} scan server selector is waiting for '{}'", tableId, description);
 
-      var elapsedTime = startTime.elapsed();
-
-      if (elapsedTime.compareTo(timeoutLeft) > 0) {
+      if (waitTimer.hasElapsed(timeoutLeft)) {
         throw new TimedOutException("While waiting for '" + description
             + "' in order to select a scan server, the scan timed out. ");
       }
 
-      if (elapsedTime.compareTo(maxWaitTime) > 0) {
+      if (waitTimer.hasElapsed(maxWaitTime)) {
         return Optional.empty();
       }
 
@@ -327,7 +325,7 @@ public class ThriftScanner {
       throws ScanTimedOutException, AccumuloException, AccumuloSecurityException,
       TableNotFoundException {
     TabletLocation loc = null;
-    Timer startTime = Timer.startNew();
+    Timer scanTimer = Timer.startNew();
     String lastError = null;
     String error = null;
     int tooManyFilesCount = 0;
@@ -343,12 +341,12 @@ public class ThriftScanner {
         if (Thread.currentThread().isInterrupted()) {
           throw new AccumuloException("Thread interrupted");
         }
-        if (startTime.elapsed(MILLISECONDS) > timeOut.toMillis()) {
+        if (scanTimer.hasElapsed(timeOut)) {
           throw new ScanTimedOutException();
         }
 
         while (loc == null) {
-          if (startTime.elapsed(MILLISECONDS) > timeOut.toMillis()) {
+          if (scanTimer.hasElapsed(timeOut)) {
             throw new ScanTimedOutException();
           }
 
@@ -412,7 +410,7 @@ public class ThriftScanner {
         Span child2 = TraceUtil.startSpan(ThriftScanner.class, "scan::location",
             Map.of("tserver", loc.tablet_location));
         try (Scope scanLocation = child2.makeCurrent()) {
-          results = scan(loc, scanState, context, timeOut, startTime);
+          results = scan(loc, scanState, context, timeOut, scanTimer);
         } catch (AccumuloSecurityException e) {
           context.clearTableListCache();
           context.requireNotDeleted(scanState.tableId);

--- a/core/src/main/java/org/apache/accumulo/core/util/Timer.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/Timer.java
@@ -59,7 +59,7 @@ public final class Timer {
    * @return true if the specified duration has elapsed, false otherwise.
    */
   public boolean hasElapsed(Duration duration) {
-    return getElapsedNanos() >= duration.toNanos();
+    return getElapsedNanos() >= toNanos(duration);
   }
 
   /**
@@ -88,4 +88,13 @@ public final class Timer {
     return unit.convert(getElapsedNanos(), TimeUnit.NANOSECONDS);
   }
 
+  private static long toNanos(Duration duration) {
+    try {
+      // This can overflow when very large, such as when the
+      // duration is created using Long.MAX_VALUE millis
+      return duration.toNanos();
+    } catch (ArithmeticException e) {
+      return Long.MAX_VALUE;
+    }
+  }
 }


### PR DESCRIPTION
Update `ThriftScanner` to use nano time to be consistent with elapsed time tracking in other locations. Also, convert `timeOut` to be a Duration to prevent future errors. This value was being converted to seconds from millis which is error prone as there was not a good indication the unit was in seconds.

This is a follow on to #4864

As a side note, there are plenty of other timeout related properties that are part of the scanner code. I started to convert those as well to Duration but it cascaded and started touching a lot of classes which i didn't think was a good idea for 2.1. However, I was thinking as part of 3.1 and 4.0 we may want to update some more fields in classes from a long to a Duration (assuming no performance concerns). Here are some examples I found but I am sure there are more spots:

[TimeoutTabletLocator](https://github.com/apache/accumulo/blob/2a9aa76e97ac7b0359a7748f753313a992ebbb46/core/src/main/java/org/apache/accumulo/core/clientImpl/TimeoutTabletLocator.java#L42) (in 3.1 only)
[ScannerOptions](https://github.com/apache/accumulo/blob/2a9aa76e97ac7b0359a7748f753313a992ebbb46/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerOptions.java#L56-L58)
[TabletServerBatchReaderIterator](https://github.com/apache/accumulo/blob/c2e4874986157af720473af46d77030716e3009b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java#L117)
[ScanState](https://github.com/apache/accumulo/blob/c2e4874986157af720473af46d77030716e3009b/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftScanner.java#L225) in `ThriftScanner`