### PR TITLE
lowers memory burden of listing external compactions in monitor

### DIFF
--- a/server/monitor/pom.xml
+++ b/server/monitor/pom.xml
@@ -45,6 +45,10 @@
       <artifactId>gson</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
       <groupId>jakarta.inject</groupId>
       <artifactId>jakarta.inject-api</artifactId>
     </dependency>

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/compactions/external/ECResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/compactions/external/ECResource.java
@@ -60,7 +60,7 @@ public class ECResource {
   @Path("running")
   @GET
   public RunningCompactions getRunning() {
-    return new RunningCompactions(monitor.fetchRunningInfo());
+    return monitor.getRunnningCompactions();
   }
 
   @Path("details")
@@ -68,16 +68,11 @@ public class ECResource {
   public RunningCompactorDetails getDetails(@QueryParam("ecid") @NotNull String ecid) {
     // make parameter more user-friendly by ensuring the ecid prefix is present
     ecid = ExternalCompactionId.from(ecid).canonical();
-    var ecMap = monitor.getEcRunningMap();
-    var externalCompaction = ecMap.get(ecid);
-    if (externalCompaction == null) {
-      // map could be old so fetch all running compactions and try again
-      ecMap = monitor.fetchRunningInfo();
-      externalCompaction = ecMap.get(ecid);
-      if (externalCompaction == null) {
-        throw new IllegalStateException("Failed to find details for ECID: " + ecid);
-      }
+    var runningCompactorDetails =
+        monitor.getRunningCompactorDetails(ExternalCompactionId.from(ecid));
+    if (runningCompactorDetails == null) {
+      throw new IllegalStateException("Failed to find details for ECID: " + ecid);
     }
-    return new RunningCompactorDetails(externalCompaction);
+    return runningCompactorDetails;
   }
 }


### PR DESCRIPTION
Each request to the monitor for the list of external compactions would create a copy of the per compaction information in the o.a.a.m.r.c.RunningCompaction constructor.  For many concurrent request when there are lots of external compactions running this could cause memory problems on the monitor.

This commit changes the code to only create a single RunningCompaction object every 30 seconds that is used by all request.  This should lower the amount of memory used when there are concurrent request or even refreshing the page really frequently.