### PR TITLE
waits on log message to send in monitor append

### DIFF
--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/util/logging/AccumuloMonitorAppender.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/util/logging/AccumuloMonitorAppender.java
@@ -122,8 +122,9 @@ public class AccumuloMonitorAppender extends AbstractAppender {
 
         var req = HttpRequest.newBuilder(uri).POST(BodyPublishers.ofString(jsonEvent, UTF_8))
             .setHeader("Content-Type", "application/json").build();
-        @SuppressWarnings("unused")
+
         var future = httpClient.sendAsync(req, BodyHandlers.discarding());
+        future.get();
       } catch (final Exception e) {
         error("Unable to send HTTP in appender [" + getName() + "]", event, e);
       }


### PR DESCRIPTION
Modify the monitor appender to wait on the http client to send a log message.  The hope with this changes is that log4j async append code that wraps the monitor appender will start to drop messages when the http client can not send.