### PR TITLE
Replace RecentLogs LinkedHashMap with Caffeine

### DIFF
--- a/server/monitor/pom.xml
+++ b/server/monitor/pom.xml
@@ -36,6 +36,10 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.auto.service</groupId>
       <artifactId>auto-service</artifactId>
       <optional>true</optional>

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/util/logging/RecentLogs.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/util/logging/RecentLogs.java
@@ -18,14 +18,17 @@
  */
 package org.apache.accumulo.monitor.util.logging;
 
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import org.apache.accumulo.monitor.rest.logs.LogResource;
 import org.apache.accumulo.monitor.rest.logs.SanitizedLogEvent;
 import org.apache.accumulo.monitor.rest.logs.SingleLogEvent;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 
 /**
  * A recent logs cache for the monitor that holds log messages received from
@@ -38,52 +41,44 @@ public class RecentLogs {
 
   private static final int MAX_LOGS = 50;
 
+  private final Cache<String,DedupedEvent> eventsCache =
+      Caffeine.newBuilder().maximumSize(MAX_LOGS).build();
+  private final ConcurrentMap<String,DedupedEvent> events = eventsCache.asMap();
+
   /**
    * Internal class for keeping the current count and most recent event that matches a given cache
    * key (derived from the event's application, logger, level, and message fields).
    */
   private static class DedupedEvent {
     private final SingleLogEvent event;
-    private final int count;
+    private final AtomicInteger count;
 
-    private DedupedEvent(SingleLogEvent event, int count) {
+    private DedupedEvent(SingleLogEvent event) {
       this.event = event;
-      this.count = count;
+      this.count = new AtomicInteger();
     }
   }
 
-  private final LinkedHashMap<String,DedupedEvent> events =
-      new LinkedHashMap<>(MAX_LOGS + 1, (float) .75, true) {
-
-        private static final long serialVersionUID = 1L;
-
-        @Override
-        protected boolean removeEldestEntry(Map.Entry<String,DedupedEvent> eldest) {
-          return size() > MAX_LOGS;
-        }
-      };
-
-  public synchronized void addEvent(SingleLogEvent event) {
+  public void addEvent(SingleLogEvent event) {
     String key = event.application + ":" + event.logger + ":" + event.level + ":" + event.message;
-    int count = events.containsKey(key) ? events.remove(key).count + 1 : 1;
-    events.put(key, new DedupedEvent(event, count));
+    events.computeIfAbsent(key, k -> new DedupedEvent(event)).count.incrementAndGet();
   }
 
-  public synchronized void clearEvents() {
+  public void clearEvents() {
     events.clear();
   }
 
-  public synchronized int numEvents() {
+  public int numEvents() {
     return events.size();
   }
 
-  public synchronized boolean eventsIncludeErrors() {
+  public boolean eventsIncludeErrors() {
     return events.values().stream().anyMatch(
         x -> x.event.level.equalsIgnoreCase("ERROR") || x.event.level.equalsIgnoreCase("FATAL"));
   }
 
-  public synchronized List<SanitizedLogEvent> getSanitizedEvents() {
-    return events.values().stream().map(ev -> new SanitizedLogEvent(ev.event, ev.count))
+  public List<SanitizedLogEvent> getSanitizedEvents() {
+    return events.values().stream().map(ev -> new SanitizedLogEvent(ev.event, ev.count.get()))
         .collect(Collectors.toList());
   }
 

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/util/logging/RecentLogs.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/util/logging/RecentLogs.java
@@ -77,7 +77,8 @@ public class RecentLogs {
 
   public List<SanitizedLogEvent> getSanitizedEvents() {
     return events.asMap().values().stream()
-        .map(ev -> new SanitizedLogEvent(ev.event, ev.count.get())).collect(Collectors.toList());
+        .map(ev -> new SanitizedLogEvent(ev.event, ev.count.get())).limit(MAX_LOGS)
+        .collect(Collectors.toList());
   }
 
 }


### PR DESCRIPTION
This improves concurrency by removing the synchronized blocks and replacing the LinkedHashMap with a Caffeine cache. The cache size is set to a max of 50 which matches the previous map limit.