### PR TITLE
fixes nanoTime bug in Monitor

### DIFF
--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -613,9 +613,9 @@ public class Monitor extends AbstractServer implements HighlyAvailableService {
   private final RecentLogs recentLogs = new RecentLogs();
   private final ExternalCompactionInfo ecInfo = new ExternalCompactionInfo();
   private final Map<String,TExternalCompaction> ecRunningMap = new ConcurrentHashMap<>();
-  private long scansFetchedNanos = 0L;
-  private long compactsFetchedNanos = 0L;
-  private long ecInfoFetchedNanos = 0L;
+  private long scansFetchedNanos = System.nanoTime();
+  private long compactsFetchedNanos = System.nanoTime();
+  private long ecInfoFetchedNanos = System.nanoTime();
   private final long fetchTimeNanos = TimeUnit.MINUTES.toNanos(1);
   private final long ageOffEntriesMillis = TimeUnit.MINUTES.toMillis(15);
 


### PR DESCRIPTION
Variables used with nanoTime were being initialized to zero.  If nanoTime were negative it would lead to the elasped time computation with these variables always being negative. Initialized the variables using nanoTime instead of zero to fix the elapsed time computation.