### PR TITLE
switches volumes prior to recovery check

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -1089,7 +1089,7 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
     }
 
     // This method is called prior to volumes being switched for a tablet during the load process,
-    // so switch volumes for the needs recovery check.
+    // so switch volumes before calling needsRecovery()
     var switchedLogEntries = new ArrayList<LogEntry>(logEntries.size());
     for (LogEntry logEntry : logEntries) {
       var switchedWalog = VolumeUtil.switchVolume(logEntry, context.getVolumeReplacements());


### PR DESCRIPTION
In #4873 a check was added to inspect walogs during tablet load to see if they had any data for the tablet.  This check happens prior to volume replacement that also runs during tablet load. Therefore if volume replacement is needed for the walogs then this check will fail because it can not find the files and the tablet will fail to load.

To fix this problem modified the new check to switch volumes if needed prior to running the check.