### PR TITLE
Fix bug with calculating remaining timeout in TabletServerBatchReaderIterator

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java
@@ -616,8 +616,6 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
     // get a snapshot of this once,not each time the plugin request it
     var scanAttemptsSnapshot = scanAttempts.snapshot();
 
-    Duration timeoutLeft = Duration.ofMillis(retryTimeout - startTime.elapsed(MILLISECONDS));
-
     ScanServerSelector.SelectorParameters params = new ScanServerSelector.SelectorParameters() {
       @Override
       public Collection<TabletId> getTablets() {
@@ -637,6 +635,7 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
       @Override
       public <T> Optional<T> waitUntil(Supplier<Optional<T>> condition, Duration maxWaitTime,
           String description) {
+        Duration timeoutLeft = Duration.ofMillis(retryTimeout - startTime.elapsed(MILLISECONDS));
         return ThriftScanner.waitUntil(condition, maxWaitTime, description, timeoutLeft, context,
             tableId, log);
       }


### PR DESCRIPTION
Partially Fixes #4865 

So far I have implemented the change suggested in #4865.

Some things I've noticed while working on this:
1. It seems like this could be a good use for the [CountDownTimer](https://github.com/apache/accumulo/blob/main/core/src/main/java/org/apache/accumulo/core/util/CountDownTimer.java) util object since we could just create the object with `retryTimeout` and use `timeLeft()` to get the remaining time. This would simplify this code and make things more intuitive. The only issue is CountDownTimer only exists in 3.1 and above. If others agree, I could backport it into 2.1 and use it here.
2. Is it possible for the `timeoutLeft` value to be negative here? If so, what are the implications of that. 