### PR TITLE
removes bare usage of Text.getBytes()

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/RFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/RFile.java
@@ -1711,7 +1711,7 @@ public class RFile {
 
       // If exclusive we need to strip the last byte to get the last key that is part of the
       // actual range to return
-      final byte[] ba = key.getRow().getBytes();
+      final byte[] ba = key.getRowData().toArray();
       Preconditions.checkArgument(ba.length > 0 && ba[ba.length - 1] == (byte) 0x00);
       byte[] fba = new byte[ba.length - 1];
       System.arraycopy(ba, 0, fba, 0, ba.length - 1);


### PR DESCRIPTION
Calls to Text.getBytes() should always be accompanied with a call to getLength() because an array that is longer than the data could be returned if set() was ever called on the Text object.

Replaced with a call to getRowData().toArray() that is more efficient and does not have the length problem.

Did a partial review of the code and found this one case.  Could be other cases like this lurking.