### PR TITLE
Standardize shell command loggers

### DIFF
--- a/assemble/conf/log4j2.properties
+++ b/assemble/conf/log4j2.properties
@@ -33,6 +33,9 @@ appender.console.layout.pattern = %style{%d{ISO8601}}{dim,cyan} %style{[}{red}%s
 logger.shellaudit.name = org.apache.accumulo.shell.Shell.audit
 logger.shellaudit.level = warn
 
+logger.shell.name = org.apache.accumulo.shell.Shell
+logger.shell.level = info
+
 logger.zookeeper.name = org.apache.zookeeper
 logger.zookeeper.level = error
 

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ActiveCompactionHelper.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ActiveCompactionHelper.java
@@ -32,12 +32,9 @@ import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.admin.ActiveCompaction;
 import org.apache.accumulo.core.client.admin.InstanceOperations;
 import org.apache.accumulo.core.util.DurationFormat;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.accumulo.shell.Shell;
 
 class ActiveCompactionHelper {
-
-  private static final Logger log = LoggerFactory.getLogger(ActiveCompactionHelper.class);
 
   private static final Comparator<ActiveCompaction> COMPACTION_AGE_DESCENDING =
       Comparator.comparingLong(ActiveCompaction::getAge).reversed();
@@ -120,7 +117,7 @@ class ActiveCompactionHelper {
       return instanceOps.getActiveCompactions(tserver).stream().sorted(COMPACTION_AGE_DESCENDING)
           .map(ActiveCompactionHelper::formatActiveCompactionLine);
     } catch (Exception e) {
-      log.debug("Failed to list active compactions for server {}", tserver, e);
+      Shell.log.debug("Failed to list active compactions for server {}", tserver, e);
       return Stream.of(tserver + " ERROR " + e.getMessage());
     }
   }

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteTableCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteTableCommand.java
@@ -28,11 +28,8 @@ import org.apache.accumulo.shell.Shell;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DeleteTableCommand extends TableOperation {
-  private static final Logger log = LoggerFactory.getLogger(DeleteTableCommand.class);
 
   private Option forceOpt;
 
@@ -78,7 +75,7 @@ public class DeleteTableCommand extends TableOperation {
       String table = tableNames.next();
       Pair<String,String> qualifiedName = TableNameUtil.qualify(table);
       if (Namespace.ACCUMULO.name().equals(qualifiedName.getFirst())) {
-        log.trace("Removing table from deletion set: {}", table);
+        Shell.log.trace("Removing table from deletion set: {}", table);
         tableNames.remove();
       }
     }

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ListTabletsCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ListTabletsCommand.java
@@ -47,8 +47,6 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.hadoop.io.Text;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -57,8 +55,6 @@ import com.google.common.annotations.VisibleForTesting;
  * grep, etc inorder to answer questions like which tablets have the most files.
  */
 public class ListTabletsCommand extends Command {
-
-  private static final Logger log = LoggerFactory.getLogger(ListTabletsCommand.class);
 
   private Option outputFileOpt;
   private Option optTablePattern;
@@ -70,7 +66,7 @@ public class ListTabletsCommand extends Command {
   public int execute(String fullCommand, CommandLine cl, Shell shellState) throws Exception {
     final Set<TableInfo> tableInfoSet = populateTables(cl, shellState);
     if (tableInfoSet.isEmpty()) {
-      log.warn("No tables found that match your criteria");
+      Shell.log.warn("No tables found that match your criteria");
       return 0;
     }
     boolean humanReadable = cl.hasOption(optHumanReadable.getOpt());
@@ -149,7 +145,7 @@ public class ListTabletsCommand extends Command {
           TableId id = TableId.of(tableIdString);
           tableSet.add(new TableInfo(name, id));
         } else {
-          log.warn("Table not found: {}", name);
+          Shell.log.warn("Table not found: {}", name);
         }
       });
       return tableSet;
@@ -162,7 +158,7 @@ public class ListTabletsCommand extends Command {
         TableId id = TableId.of(idString);
         tableSet.add(new TableInfo(table, id));
       } else {
-        log.warn("Table not found: {}", table);
+        Shell.log.warn("Table not found: {}", table);
       }
       return tableSet;
     }
@@ -216,14 +212,14 @@ public class ListTabletsCommand extends Command {
 
   private List<TabletRowInfo> getTabletRowInfo(Shell shellState, TableInfo tableInfo)
       throws Exception {
-    log.trace("scan metadata for tablet info table name: \'{}\', tableId: \'{}\' ", tableInfo.name,
-        tableInfo.id);
+    Shell.log.trace("scan metadata for tablet info table name: \'{}\', tableId: \'{}\' ",
+        tableInfo.name, tableInfo.id);
 
     List<TabletRowInfo> tResults = getMetadataInfo(shellState, tableInfo);
 
-    if (log.isTraceEnabled()) {
+    if (Shell.log.isTraceEnabled()) {
       for (TabletRowInfo tabletRowInfo : tResults) {
-        log.trace("Tablet info: {}", tabletRowInfo);
+        Shell.log.trace("Tablet info: {}", tabletRowInfo);
       }
     }
 

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/MaxRowCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/MaxRowCommand.java
@@ -23,12 +23,8 @@ import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.shell.Shell;
 import org.apache.commons.cli.CommandLine;
 import org.apache.hadoop.io.Text;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class MaxRowCommand extends ScanCommand {
-
-  private static final Logger log = LoggerFactory.getLogger(MaxRowCommand.class);
 
   @Override
   public int execute(final String fullCommand, final CommandLine cl, final Shell shellState)
@@ -36,10 +32,10 @@ public class MaxRowCommand extends ScanCommand {
     final String tableName = OptUtil.getTableOpt(cl, shellState);
 
     @SuppressWarnings("deprecation")
-    final org.apache.accumulo.core.util.interpret.ScanInterpreter interpeter =
+    final org.apache.accumulo.core.util.interpret.ScanInterpreter interpreter =
         getInterpreter(cl, tableName, shellState);
 
-    final Range range = getRange(cl, interpeter);
+    final Range range = getRange(cl, interpreter);
     final Authorizations auths = getAuths(cl, shellState);
     final Text startRow = range.getStartKey() == null ? null : range.getStartKey().getRow();
     final Text endRow = range.getEndKey() == null ? null : range.getEndKey().getRow();
@@ -51,7 +47,7 @@ public class MaxRowCommand extends ScanCommand {
         shellState.getWriter().println(max);
       }
     } catch (Exception e) {
-      log.debug("Could not get shell state.", e);
+      Shell.log.debug("Could not get shell state.", e);
     }
 
     return 0;

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ShellPluginConfigurationCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ShellPluginConfigurationCommand.java
@@ -34,7 +34,6 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.OptionGroup;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.slf4j.LoggerFactory;
 
 public abstract class ShellPluginConfigurationCommand extends Command {
   private Option removePluginOption, pluginClassOption, listPluginOption;
@@ -115,20 +114,16 @@ public abstract class ShellPluginConfigurationCommand extends Command {
           pluginClazz =
               shellState.getClassLoader(cl, shellState).loadClass(ent.getValue()).asSubclass(clazz);
         } catch (ClassNotFoundException e) {
-          LoggerFactory.getLogger(ShellPluginConfigurationCommand.class).error("Class not found {}",
-              e.getMessage());
+          Shell.log.error("Class not found {}", e.getMessage());
           return null;
         } catch (ParseException e) {
-          LoggerFactory.getLogger(ShellPluginConfigurationCommand.class)
-              .error("Error parsing table: {} {}", Arrays.toString(args), e.getMessage());
+          Shell.log.error("Error parsing table: {} {}", Arrays.toString(args), e.getMessage());
           return null;
         } catch (TableNotFoundException e) {
-          LoggerFactory.getLogger(ShellPluginConfigurationCommand.class)
-              .error("Table not found: {} {}", tableName, e.getMessage());
+          Shell.log.error("Table not found: {} {}", tableName, e.getMessage());
           return null;
         } catch (Exception e) {
-          LoggerFactory.getLogger(ShellPluginConfigurationCommand.class).error("Error: {}",
-              e.getMessage());
+          Shell.log.error("Error: {}", e.getMessage());
           return null;
         }
 


### PR DESCRIPTION
Switches all logging statement to use the logger provided by the shell.
This ensures that logging behavior is uniform across all shell commands. 

Also adds the shell logger name to the properties file to assist users since the `--debug` shell flag has been deprecated.