### PR TITLE
Set temp directory when using shell

### DIFF
--- a/assemble/conf/accumulo-env.sh
+++ b/assemble/conf/accumulo-env.sh
@@ -97,6 +97,7 @@ case "$cmd" in
   compaction-coordinator) JAVA_OPTS=('-Xmx512m' '-Xms512m' "${JAVA_OPTS[@]}") ;;
   compactor) JAVA_OPTS=('-Xmx256m' '-Xms256m' "${JAVA_OPTS[@]}") ;;
   sserver) JAVA_OPTS=('-Xmx512m' '-Xms512m' "${JAVA_OPTS[@]}") ;;
+  shell) JAVA_OPTS=('-Xmx256m' '-Xms64m' "-Djava.io.tmpdir=${basedir}/run" "${JAVA_OPTS[@]}") ;;
   *) JAVA_OPTS=('-Xmx256m' '-Xms64m' "${JAVA_OPTS[@]}") ;;
 esac
 


### PR DESCRIPTION
JLine creates a `.so` and a `.so.lck` file when interactively prompting the user for input.
The `.so` file needs execute permissions to function correctly. 

```
jlinenative-3.25.1-164e07369eff3578-libjlinenative.so
jlinenative-3.25.1-164e07369eff3578-libjlinenative.so.lck
```

However, these files go in the directory set by `java.io.tmpdir` which is typically `/tmp` or `/var/tmp` and is commonly set with `noexec` to conform with security best practices.  
https://www.stigviewer.com/stig/red_hat_enterprise_linux_8/2023-12-01/finding/V-230513

This prevents Jline from functioning correctly and breaks the shell. 

Instead, we can use accumulo's `/run` directory for these temp files as it is used for ephemeral `.pid` files already.