### PR TITLE
scan session id now available when session cleanup is deferred

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftScanner.java
@@ -389,8 +389,8 @@ public class ThriftScanner {
       // call the scan server selector and just go back to the previous scan server
       addr = scanState.prevLoc;
       log.trace(
-          "For tablet {} continuing scan on scan server {} without consulting scan server selector, using busyTimeout {}",
-          loc.getExtent(), addr.serverAddress, scanState.busyTimeout);
+          "For tablet {} continuing scan {} on scan server {} without consulting scan server selector, using busyTimeout {}",
+          loc.getExtent(), scanState.scanID, addr.serverAddress, scanState.busyTimeout);
     } else {
       var tabletId = new TabletIdImpl(loc.getExtent());
       // obtain a snapshot once and only expose this snapshot to the plugin for consistency
@@ -898,7 +898,6 @@ public class ThriftScanner {
         }
 
       } else {
-        // log.debug("Calling continue scan : "+scanState.range+" loc = "+loc);
         String msg =
             "Continuing scan tserver=" + addr.serverAddress + " scanid=" + scanState.scanID;
         Thread.currentThread().setName(msg);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -136,7 +136,7 @@ import com.google.common.net.HostAndPort;
 public class ScanServer extends AbstractServer
     implements TabletScanClientService.Iface, TabletHostingServer {
 
-  private static final Logger log = LoggerFactory.getLogger(ScanServer.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ScanServer.class);
 
   private static class TabletMetadataLoader implements CacheLoader<KeyExtent,TabletMetadata> {
 
@@ -172,8 +172,6 @@ public class ScanServer extends AbstractServer
       return tms;
     }
   }
-
-  private static final Logger LOG = LoggerFactory.getLogger(ScanServer.class);
 
   protected ThriftScanClientHandler delegate;
   private UUID serverLockUUID;
@@ -212,8 +210,8 @@ public class ScanServer extends AbstractServer
     super("sserver", opts, ServerContext::new, args);
 
     context = super.getContext();
-    log.info("Version " + Constants.VERSION);
-    log.info("Instance " + getContext().getInstanceID());
+    LOG.info("Version " + Constants.VERSION);
+    LOG.info("Instance " + getContext().getInstanceID());
     this.sessionManager = new SessionManager(context);
 
     this.resourceManager = new TabletServerResourceManager(context, this);
@@ -433,11 +431,11 @@ public class ScanServer extends AbstractServer
         // thread to look for log sorting work in the future
         logSorter.startWatchingForRecoveryLogs(threadPoolSize);
       } catch (Exception ex) {
-        log.error("Error starting LogSorter");
+        LOG.error("Error starting LogSorter");
         throw new RuntimeException(ex);
       }
     } else {
-      log.info(
+      LOG.info(
           "Log sorting for tablet recovery is disabled, SSERV_WAL_SORT_MAX_CONCURRENT is less than 1.");
     }
 
@@ -987,6 +985,7 @@ public class ScanServer extends AbstractServer
           batchTimeOut, classLoaderContext, executionHints, getScanTabletResolver(tablet),
           busyTimeout);
 
+      LOG.trace("started scan: {}", is.getScanID());
       return is;
     } catch (ScanServerBusyException be) {
       scanServerMetrics.incrementBusy();
@@ -1058,16 +1057,16 @@ public class ScanServer extends AbstractServer
           ssio, authorizations, waitForWrites, tSamplerConfig, batchTimeOut, contextArg,
           executionHints, getBatchScanTabletResolver(tablets), busyTimeout);
 
-      LOG.trace("started scan: {}", ims.getScanID());
+      LOG.trace("started multi scan: {}", ims.getScanID());
       return ims;
     } catch (ScanServerBusyException be) {
       scanServerMetrics.incrementBusy();
       throw be;
     } catch (TException e) {
-      LOG.error("Error starting scan", e);
+      LOG.error("Error starting multi scan", e);
       throw e;
     } catch (AccumuloException e) {
-      LOG.error("Error starting scan", e);
+      LOG.error("Error starting multi scan", e);
       throw new RuntimeException(e);
     }
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ThriftScanClientHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ThriftScanClientHandler.java
@@ -336,8 +336,8 @@ public class ThriftScanClientHandler implements TabletScanClientService.Iface {
       long t2 = System.currentTimeMillis();
 
       if (log.isTraceEnabled()) {
-        log.trace(String.format("ScanSess tid %s %s %,d entries in %.2f secs, nbTimes = [%s] ",
-            TServerUtils.clientAddress.get(), ss.extent.tableId(), ss.entriesReturned,
+        log.trace(String.format("ScanSess %d tid %s %s %,d entries in %.2f secs, nbTimes = [%s] ",
+            scanID, TServerUtils.clientAddress.get(), ss.extent.tableId(), ss.entriesReturned,
             (t2 - ss.startTime) / 1000.0, ss.runStats.toString()));
       }
 
@@ -533,10 +533,11 @@ public class ThriftScanClientHandler implements TabletScanClientService.Iface {
 
     if (log.isTraceEnabled()) {
       log.trace(String.format(
-          "MultiScanSess %s %,d entries in %.2f secs"
+          "MultiScanSess %d %s %,d entries in %.2f secs"
               + " (lookup_time:%.2f secs tablets:%,d ranges:%,d) ",
-          TServerUtils.clientAddress.get(), session.numEntries, (t2 - session.startTime) / 1000.0,
-          session.totalLookupTime / 1000.0, session.numTablets, session.numRanges));
+          scanID, TServerUtils.clientAddress.get(), session.numEntries,
+          (t2 - session.startTime) / 1000.0, session.totalLookupTime / 1000.0, session.numTablets,
+          session.numRanges));
     }
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/Session.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/Session.java
@@ -24,6 +24,8 @@ import org.apache.accumulo.core.securityImpl.thrift.TCredentials;
 import org.apache.accumulo.core.util.Timer;
 import org.apache.accumulo.server.rpc.TServerUtils;
 
+import com.google.common.base.Preconditions;
+
 public class Session {
 
   enum State {
@@ -38,6 +40,7 @@ public class Session {
   private final Timer stateChangeTimer = Timer.startNew();
   private final TCredentials credentials;
   private long sessionId;
+  private boolean sessionIdSet = false;
 
   Session(TCredentials credentials) {
     this.credentials = credentials;
@@ -68,10 +71,13 @@ public class Session {
   }
 
   public void setSessionId(long sessionId) {
+    Preconditions.checkState(!sessionIdSet);
     this.sessionId = sessionId;
+    this.sessionIdSet = true;
   }
 
   public long getSessionId() {
+    Preconditions.checkState(sessionIdSet);
     return sessionId;
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/Session.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/Session.java
@@ -37,6 +37,7 @@ public class Session {
   boolean allowReservation = true;
   private final Timer stateChangeTimer = Timer.startNew();
   private final TCredentials credentials;
+  private long sessionId;
 
   Session(TCredentials credentials) {
     this.credentials = credentials;
@@ -66,13 +67,21 @@ public class Session {
     return state;
   }
 
+  public void setSessionId(long sessionId) {
+    this.sessionId = sessionId;
+  }
+
+  public long getSessionId() {
+    return sessionId;
+  }
+
   public long elaspedSinceStateChange(TimeUnit unit) {
     return stateChangeTimer.elapsed(unit);
   }
 
   @Override
   public String toString() {
-    return getClass().getSimpleName() + " " + state + " startTime:" + startTime + " lastAccessTime:"
-        + lastAccessTime + " client:" + client;
+    return getClass().getSimpleName() + " " + state + " sessionId:" + sessionId + " startTime:"
+        + startTime + " lastAccessTime:" + lastAccessTime + " client:" + client;
   }
 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/Session.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/Session.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.tserver.session;
 
+import java.util.OptionalLong;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.securityImpl.thrift.TCredentials;
@@ -39,8 +40,7 @@ public class Session {
   boolean allowReservation = true;
   private final Timer stateChangeTimer = Timer.startNew();
   private final TCredentials credentials;
-  private long sessionId;
-  private boolean sessionIdSet = false;
+  private OptionalLong sessionId = OptionalLong.empty();
 
   Session(TCredentials credentials) {
     this.credentials = credentials;
@@ -71,14 +71,13 @@ public class Session {
   }
 
   public void setSessionId(long sessionId) {
-    Preconditions.checkState(!sessionIdSet);
-    this.sessionId = sessionId;
-    this.sessionIdSet = true;
+    Preconditions.checkState(this.sessionId.isEmpty());
+    this.sessionId = OptionalLong.of(sessionId);
   }
 
   public long getSessionId() {
-    Preconditions.checkState(sessionIdSet);
-    return sessionId;
+    Preconditions.checkState(this.sessionId.isPresent());
+    return sessionId.orElseThrow();
   }
 
   public long elaspedSinceStateChange(TimeUnit unit) {


### PR DESCRIPTION
Previously, when a scan session was attempted to be cleaned up but couldn't and was deferred for later, the scan session id would still be visible from things like the `listscans` command but would have a value of -1. This change:
- makes it so that the session id is still available in this situation
- improves logging related to scan session ids and logs the scan session ids in more places
- tests that invalid (0 = never set, -1 = no longer tracking) scan session ids are no longer seen

TODOs from issue
- [x] Modify Session class to track session id
- [x] Update all log messages in SessionManager to include the session id
	- most logs were just printing the `Session` so just added the id to the toString()
- [x] Modify list scans code to ensure session id always shows up. It currently stops showing up for sessions being cleaned up.
- [x] Test that scan session id is always present in list scans.
- [x] Improve log messages added in adds metric to count zombie scans #4840 to include scan session id.
	- no changes needed here, covered by addition of the session id to Session.toString()
- [x] Survey log messages related to scans in server and client for places where the scan session id could be included in the log message.
	- Surveyed some classes of interest 
		- TabletClientHandler
			- Considered from its use of `Session` objects, but there is no use of `ScanSession`s so N/A
		- ThriftScanner
			- Added scan id to one log, but the rest of the class seemed to log the scan id when needed
		- ScanServer
			- A couple log changes, but the rest of the class looked good
		- ThriftScanClientHandler
			- A couple log changes here, but most of the other methods (e.g., startScan()) I did not think needed log messages since adding them here would cause them to be logged twice with how
			`ScanServer` uses this class

closes #4842