### PR TITLE
only registers cleaner in native map when needed

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/NativeMap.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/NativeMap.java
@@ -304,7 +304,13 @@ public class NativeMap implements Iterable<Map.Entry<Key,Value>> {
       hasNext = nmiPointer != 0;
 
       nmiPtr.set(nmiPointer);
-      cleanableNMI = NativeMapCleanerUtil.deleteNMIterator(this, nmiPtr);
+      if (nmiPointer == 0) {
+        // registering a cleaner takes resources and may lock, so only bother registering if there
+        // is something to delete
+        cleanableNMI = null;
+      } else {
+        cleanableNMI = NativeMapCleanerUtil.deleteNMIterator(this, nmiPtr);
+      }
     }
 
     // delete is synchronized on a per iterator basis want to ensure only one

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/NativeMap.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/NativeMap.java
@@ -304,13 +304,8 @@ public class NativeMap implements Iterable<Map.Entry<Key,Value>> {
       hasNext = nmiPointer != 0;
 
       nmiPtr.set(nmiPointer);
-      if (nmiPointer == 0) {
-        // registering a cleaner takes resources and may lock, so only bother registering if there
-        // is something to delete
-        cleanableNMI = null;
-      } else {
-        cleanableNMI = NativeMapCleanerUtil.deleteNMIterator(this, nmiPtr);
-      }
+      // avoid registering a cleanable if there's nothing to delete
+      cleanableNMI = hasNext ? NativeMapCleanerUtil.deleteNMIterator(this, nmiPtr) : null;
     }
 
     // delete is synchronized on a per iterator basis want to ensure only one

--- a/test/src/main/java/org/apache/accumulo/test/functional/NativeMapIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/NativeMapIT.java
@@ -548,6 +548,14 @@ public class NativeMapIT {
     assertEquals(0, nm.size());
     assertEquals(0, nm.getMemoryUsed());
 
+    var iter1 = nm.iterator();
+    assertFalse(iter1.hasNext());
+    assertThrows(NoSuchElementException.class, () -> iter1.next());
+
+    var iter2 = nm.iterator(new Key("abc"));
+    assertFalse(iter2.hasNext());
+    assertThrows(NoSuchElementException.class, () -> iter2.next());
+
     nm.delete();
   }
 


### PR DESCRIPTION
Registering cleaners takes up resources and currently bumps into a global lock. The native map code is registering a cleaner for iterators, even in the case where the native code did not allocate an iterator. This code is called very frequently by scan threads.

This change does not register the cleaner in the case where the native code did not allocate a native iterator.  This should cause less contention between scan threads that are unrelated to each other.