### PR TITLE
reduce scan thread contention on native maps

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/NativeMapCleanerUtil.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/NativeMapCleanerUtil.java
@@ -44,10 +44,12 @@ public class NativeMapCleanerUtil {
     });
   }
 
-  // Chose 8 cleaners because each cleaner creates a thread, so do not want too many threads. This
-  // should reduce lock contention for scans by an 8th vs a single cleaner, so that is good
-  // reduction and 8 does not seem like too many threads to add.
-  private static final Cleaner[] NMI_CLEANERS = new Cleaner[8];
+  // Chose 7 cleaners because each cleaner creates a thread, so do not want too many threads. This
+  // should reduce lock contention for scans by a 7th vs a single cleaner, so that is good
+  // reduction and 7 does not seem like too many threads to add. This array is indexed using
+  // pointers addresses from native code, so there is a good chance those are memory aligned on
+  // a multiple of 4, 8, 16, etc. So if changing the array size avoid multiples of 2.
+  private static final Cleaner[] NMI_CLEANERS = new Cleaner[7];
 
   static {
     for (int i = 0; i < NMI_CLEANERS.length; i++) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/NativeMapCleanerUtil.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/NativeMapCleanerUtil.java
@@ -60,11 +60,10 @@ public class NativeMapCleanerUtil {
   public static Cleanable deleteNMIterator(Object obj, AtomicLong nmiPtr) {
     requireNonNull(nmiPtr);
 
-    long ptr = Math.abs(nmiPtr.get());
-    if (ptr == Long.MIN_VALUE) {
-      ptr = 0;
+    int cleanerIndex = (int) (nmiPtr.get() % NMI_CLEANERS.length);
+    if (cleanerIndex < 0) {
+      cleanerIndex += NMI_CLEANERS.length;
     }
-    int cleanerIndex = (int) (ptr % NMI_CLEANERS.length);
 
     // This method can be called very frequently by many scan threads. The register call on cleaner
     // acquires a lock which can cause lock contention between threads. Having multiple cleaners for


### PR DESCRIPTION
Observed many scan threads in the native map code attempting to create a native map iterator and blocking in registering a cleaner for the iterator.  The block was happening in jdk.internal.rf.PhantomCleanable.insert() which has a synchronized code block.  There is a single static cleaner object on the accumulo code so all scan threads that internact with a native map could end up contending on this single lock in the process.

This change creates 7 cleaners and therefore 7 locks to reduce the contention between scan threads.