### PR TITLE
Validate the format of a directory column

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
@@ -299,6 +299,8 @@ public class MetadataConstraints implements Constraint {
         return "Invalid unsplittable column";
       case 16:
         return "Malformed availability value";
+      case 17:
+        return "Invalid directory column value";
     }
     return null;
   }
@@ -409,6 +411,12 @@ public class MetadataConstraints implements Constraint {
         }
         break;
       case ServerColumnFamily.DIRECTORY_QUAL:
+        try {
+          ServerColumnFamily.validateDirCol(new String(columnUpdate.getValue(), UTF_8));
+        } catch (IllegalArgumentException e) {
+          addViolation(violations, 17);
+        }
+
         // splits, which also write the time reference, are allowed to write this reference
         // even when the transaction is not running because the other half of the tablet is
         // holding a reference to the file.

--- a/server/base/src/test/java/org/apache/accumulo/server/constraints/MetadataConstraintsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/constraints/MetadataConstraintsTest.java
@@ -269,7 +269,7 @@ public class MetadataConstraintsTest {
         BulkFileColumnFamily.NAME, StoredTabletFile
             .of(new Path("hdfs://1.2.3.4/accumulo/tables/2a/t-0003/someFile")).getMetadataText(),
         new Value(fateId1.canonical()));
-    ServerColumnFamily.DIRECTORY_COLUMN.put(m, new Value("/t1"));
+    ServerColumnFamily.DIRECTORY_COLUMN.put(m, new Value("t-000009x"));
     violations = mc.check(createEnv(), m);
     assertTrue(violations.isEmpty());
 
@@ -606,6 +606,24 @@ public class MetadataConstraintsTest {
     assertFalse(violations.isEmpty());
     assertEquals(1, violations.size());
     assertEquals(Short.valueOf((short) 15), violations.get(0));
+  }
+
+  @Test
+  public void testDirectoryColumn() {
+    MetadataConstraints mc = new MetadataConstraints();
+    Mutation m;
+    List<Short> violations;
+    m = new Mutation(new Text("0;foo"));
+    ServerColumnFamily.DIRECTORY_COLUMN.put(m, new Value("t-000009x"));
+    violations = mc.check(createEnv(), m);
+    assertTrue(violations.isEmpty());
+
+    m = new Mutation(new Text("0;foo"));
+    ServerColumnFamily.DIRECTORY_COLUMN.put(m, new Value("/invalid"));
+    violations = mc.check(createEnv(), m);
+    assertFalse(violations.isEmpty());
+    assertEquals(1, violations.size());
+    assertEquals((short) 17, violations.get(0));
   }
 
   // Encode a row how it would appear in Json


### PR DESCRIPTION
MetadataConstraints has been updated to validate the format of the directory column. I noticed this validation was missing when looking at #4857

I made a comment [here](https://github.com/apache/accumulo/issues/4857#issuecomment-2365151923) about why this is targeted for main currently and not for 3.1. I can backport or target this in 3.1 once we decide how to handle the constraint code number (assuming we want to put this change into 3.1)