### PR TITLE
Use opid column to detect split mutation in MetadataConstraints

### DIFF
--- a/server/base/src/test/java/org/apache/accumulo/server/constraints/MetadataConstraintsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/constraints/MetadataConstraintsTest.java
@@ -270,6 +270,19 @@ public class MetadataConstraintsTest {
             .of(new Path("hdfs://1.2.3.4/accumulo/tables/2a/t-0003/someFile")).getMetadataText(),
         new Value(fateId1.canonical()));
     ServerColumnFamily.DIRECTORY_COLUMN.put(m, new Value("/t1"));
+    // Missing split column, should fail
+    assertViolation(mc, m, (short) 8);
+
+    // mutation that looks like split
+    m = new Mutation(new Text("0;foo"));
+    m.put(
+        BulkFileColumnFamily.NAME, StoredTabletFile
+            .of(new Path("hdfs://1.2.3.4/accumulo/tables/2a/t-0003/someFile")).getMetadataText(),
+        new Value(fateId1.canonical()));
+    ServerColumnFamily.DIRECTORY_COLUMN.put(m, new Value("/t1"));
+    // Add opid column
+    ServerColumnFamily.OPID_COLUMN.put(m,
+        new Value("SPLITTING:FATE:META:12345678-9abc-def1-2345-6789abcdef12"));
     violations = mc.check(createEnv(), m);
     assertTrue(violations.isEmpty());
 


### PR DESCRIPTION
MetadataConstraints used to use the presence of a directory column to detect a split mutation. In version 4.0 split mutations will now set an operation id so this change updates the metadata constraints code to check that id vs the directory.

This closes #4857

Also, I added in a TODO marker in the code. It's also a placeholder because #4913 will add in a new validation check when merged and also because I was wondering if it would make sense to still validate that the directory exists in addition to the opid or not. The marker is obliviously temporary and can be removed when those questions are figured out.