### PR TITLE
fixes ExternalCompactionMetricsIT.java

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionMetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionMetricsIT.java
@@ -138,7 +138,7 @@ public class ExternalCompactionMetricsIT extends SharedMiniClusterBase {
             if (shutdownTailer.get()) {
               break;
             }
-            if (s.startsWith("accumulo.tserver.compactions.")) {
+            if (s.startsWith("accumulo.compactor.")) {
               queueMetrics.add(TestStatsDSink.parseStatsDMetric(s));
             }
           }


### PR DESCRIPTION
The test was failing because it was looking for a metrics prefix that did not exist.