### PR TITLE
Refactor error codes to allow future expansion in 4.0

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
@@ -151,7 +151,7 @@ public class MetadataConstraints implements Constraint {
     try {
       stfConsumer.accept(StoredTabletFile.of(metadata));
     } catch (RuntimeException e) {
-      addViolation(violations, 12);
+      addViolation(violations, 3100);
     }
   }
 
@@ -284,24 +284,25 @@ public class MetadataConstraints implements Constraint {
         return "Lock not held in zookeeper by writer";
       case 8:
         return "Bulk load mutation contains either inconsistent files or multiple fateTX ids";
-      case 9:
-        return "Malformed operation id";
-      case 10:
-        return "Suspended timestamp is not valid";
-      case 11:
-        return "Malformed file selection value";
-      case 12:
+      case 3100:
         return "Invalid data file metadata format";
-      case 13:
-        return "Invalid compacted column";
-      case 14:
-        return "Invalid user compaction requested column";
-      case 15:
-        return "Invalid unsplittable column";
-      case 16:
-        return "Malformed availability value";
-      case 17:
+      case 3101:
+        return "Suspended timestamp is not valid";
+      case 3102:
         return "Invalid directory column value";
+      case 4000:
+        return "Malformed operation id";
+      case 4001:
+        return "Malformed file selection value";
+      case 4002:
+        return "Invalid compacted column";
+      case 4003:
+        return "Invalid user compaction requested column";
+      case 4004:
+        return "Invalid unsplittable column";
+      case 4005:
+        return "Malformed availability value";
+
     }
     return null;
   }
@@ -377,7 +378,7 @@ public class MetadataConstraints implements Constraint {
         try {
           TabletAvailabilityUtil.fromValue(new Value(columnUpdate.getValue()));
         } catch (IllegalArgumentException e) {
-          addViolation(violations, 16);
+          addViolation(violations, 4005);
         }
         break;
     }
@@ -415,7 +416,7 @@ public class MetadataConstraints implements Constraint {
         try {
           ServerColumnFamily.validateDirCol(new String(columnUpdate.getValue(), UTF_8));
         } catch (IllegalArgumentException e) {
-          addViolation(violations, 17);
+          addViolation(violations, (short) 3102);
         }
         break;
       case ServerColumnFamily.OPID_QUAL:
@@ -431,14 +432,14 @@ public class MetadataConstraints implements Constraint {
             }
           }
         } catch (IllegalArgumentException e) {
-          addViolation(violations, 9);
+          addViolation(violations, 4000);
         }
         break;
       case ServerColumnFamily.SELECTED_QUAL:
         try {
           SelectedFiles.from(new String(columnUpdate.getValue(), UTF_8));
         } catch (RuntimeException e) {
-          addViolation(violations, 11);
+          addViolation(violations, 4001);
         }
         break;
     }
@@ -454,7 +455,7 @@ public class MetadataConstraints implements Constraint {
       try {
         SuspendingTServer.fromValue(new Value(columnUpdate.getValue()));
       } catch (IllegalArgumentException e) {
-        addViolation(violations, 10);
+        addViolation(violations, 3101);
       }
     }
   }
@@ -512,14 +513,14 @@ public class MetadataConstraints implements Constraint {
 
   private void validateCompactedFamily(ArrayList<Short> violations, ColumnUpdate columnUpdate) {
     if (!FateId.isFateId(new String(columnUpdate.getColumnQualifier(), UTF_8))) {
-      addViolation(violations, 13);
+      addViolation(violations, 4002);
     }
   }
 
   private void validateUserCompactionRequestedFamily(ArrayList<Short> violations,
       ColumnUpdate columnUpdate) {
     if (!FateId.isFateId(new String(columnUpdate.getColumnQualifier(), UTF_8))) {
-      addViolation(violations, 14);
+      addViolation(violations, 4003);
     }
   }
 
@@ -530,7 +531,7 @@ public class MetadataConstraints implements Constraint {
       try {
         UnSplittableMetadata.toUnSplittable(new String(columnUpdate.getValue(), UTF_8));
       } catch (RuntimeException e) {
-        addViolation(violations, 15);
+        addViolation(violations, 4004);
       }
     }
   }

--- a/server/base/src/test/java/org/apache/accumulo/server/constraints/MetadataConstraintsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/constraints/MetadataConstraintsTest.java
@@ -174,7 +174,7 @@ public class MetadataConstraintsTest {
     violations = mc.check(createEnv(), m);
     assertFalse(violations.isEmpty());
     assertEquals(1, violations.size());
-    assertEquals(Short.valueOf((short) 10), violations.get(0));
+    assertEquals(Short.valueOf((short) 3101), violations.get(0));
   }
 
   @Test
@@ -310,7 +310,7 @@ public class MetadataConstraintsTest {
             .getMetadata()
             .replace("hdfs://1.2.3.4/accumulo/tables/2a/t-0003/someFile", "/someFile")),
         new Value(fateId1.canonical()));
-    assertViolation(mc, m, (short) 12);
+    assertViolation(mc, m, (short) 3100);
 
     // Missing tables directory in path
     m = new Mutation(new Text("0;foo"));
@@ -319,7 +319,7 @@ public class MetadataConstraintsTest {
             .getMetadata().replace("hdfs://1.2.3.4/accumulo/tables/2a/t-0003/someFile",
                 "hdfs://1.2.3.4/accumulo/2a/t-0003/someFile")),
         new Value(fateId1.canonical()));
-    assertViolation(mc, m, (short) 12);
+    assertViolation(mc, m, (short) 3100);
 
     m = new Mutation(new Text("0;foo"));
     m.put(
@@ -332,7 +332,7 @@ public class MetadataConstraintsTest {
     m = new Mutation(new Text("0;foo"));
     m.put(BulkFileColumnFamily.NAME, new Text("hdfs://1.2.3.4/accumulo/tables/2a/t-0003/someFile"),
         new Value(fateId1.canonical()));
-    assertViolation(mc, m, (short) 12);
+    assertViolation(mc, m, (short) 3100);
 
     // Bad Json - test startRow key is missing so validation should fail
     // {"path":"hdfs://1.2.3.4/accumulo/tables/2a/t-0003/someFile","endRow":""}
@@ -341,7 +341,7 @@ public class MetadataConstraintsTest {
         new Text(
             "{\"path\":\"hdfs://1.2.3.4/accumulo/tables/2a/t-0003/someFile\",\"endRow\":\"\"}"),
         new Value(fateId1.canonical()));
-    assertViolation(mc, m, (short) 12);
+    assertViolation(mc, m, (short) 3100);
 
     // Bad Json - test path key replaced with empty string so validation should fail
     // {"":"hdfs://1.2.3.4/accumulo/tables/2a/t-0003/someFile","startRow":"","endRow":""}
@@ -350,7 +350,7 @@ public class MetadataConstraintsTest {
         BulkFileColumnFamily.NAME, new Text(StoredTabletFile
             .serialize("hdfs://1.2.3.4/accumulo/tables/2a/t-0003/someFile").replace("path", "")),
         new Value(fateId1.canonical()));
-    assertViolation(mc, m, (short) 12);
+    assertViolation(mc, m, (short) 3100);
 
     // Bad Json - test path value missing
     // {"path":"","startRow":"","endRow":""}
@@ -359,7 +359,7 @@ public class MetadataConstraintsTest {
         new Text(StoredTabletFile.of(new Path("hdfs://1.2.3.4/accumulo/tables/2a/t-0003/someFile"))
             .getMetadata().replaceFirst("\"path\":\".*\",\"startRow", "\"path\":\"\",\"startRow")),
         new Value(fateId1.canonical()));
-    assertViolation(mc, m, (short) 12);
+    assertViolation(mc, m, (short) 3100);
 
     // Bad Json - test startRow key replaced with empty string so validation should fail
     // {"path":"hdfs://1.2.3.4/accumulo/tables/2a/t-0003/someFile","":"","endRow":""}
@@ -367,7 +367,7 @@ public class MetadataConstraintsTest {
     m.put(BulkFileColumnFamily.NAME, new Text(StoredTabletFile
         .serialize("hdfs://1.2.3.4/accumulo/tables/2a/t-0003/someFile").replace("startRow", "")),
         new Value(fateId1.canonical()));
-    assertViolation(mc, m, (short) 12);
+    assertViolation(mc, m, (short) 3100);
 
     // Bad Json - test endRow key missing so validation should fail
     m = new Mutation(new Text("0;foo"));
@@ -375,7 +375,7 @@ public class MetadataConstraintsTest {
         BulkFileColumnFamily.NAME, new Text(StoredTabletFile
             .serialize("hdfs://1.2.3.4/accumulo/tables/2a/t-0003/someFile").replace("endRow", "")),
         new Value(fateId1.canonical()));
-    assertViolation(mc, m, (short) 12);
+    assertViolation(mc, m, (short) 3100);
 
     // Bad Json - endRow will be replaced with encoded row without the exclusive byte 0x00 which is
     // required for an endRow so will fail validation
@@ -385,7 +385,7 @@ public class MetadataConstraintsTest {
             new Range("a", false, "b", true)).getMetadata().replaceFirst("\"endRow\":\".*\"",
                 "\"endRow\":\"" + encodeRowForMetadata("bad") + "\"")),
         new Value(fateId1.canonical()));
-    assertViolation(mc, m, (short) 12);
+    assertViolation(mc, m, (short) 3100);
 
   }
 
@@ -411,12 +411,12 @@ public class MetadataConstraintsTest {
             .getMetadata()
             .replace("hdfs://1.2.3.4/accumulo/tables/2a/t-0003/someFile", "/someFile")),
         value);
-    assertViolation(mc, m, (short) 12);
+    assertViolation(mc, m, (short) 3100);
 
     // Bad Json - only path (old format) so should fail parsing
     m = new Mutation(new Text("0;foo"));
     m.put(columnFamily, new Text("hdfs://1.2.3.4/accumulo/tables/2a/t-0003/someFile"), value);
-    assertViolation(mc, m, (short) 12);
+    assertViolation(mc, m, (short) 3100);
 
     // Bad Json - test path key replaced with empty string so validation should fail
     // {"":"hdfs://1.2.3.4/accumulo/tables/2a/t-0003/someFile","startRow":"","endRow":""}
@@ -425,7 +425,7 @@ public class MetadataConstraintsTest {
         columnFamily, new Text(StoredTabletFile
             .serialize("hdfs://1.2.3.4/accumulo/tables/2a/t-0003/someFile").replace("path", "")),
         value);
-    assertViolation(mc, m, (short) 12);
+    assertViolation(mc, m, (short) 3100);
 
     // Bad Json - test path value missing
     // {"path":"","startRow":"","endRow":""}
@@ -434,7 +434,7 @@ public class MetadataConstraintsTest {
         new Text(StoredTabletFile.of(new Path("hdfs://1.2.3.4/accumulo/tables/2a/t-0003/someFile"))
             .getMetadata().replaceFirst("\"path\":\".*\",\"startRow", "\"path\":\"\",\"startRow")),
         value);
-    assertViolation(mc, m, (short) 12);
+    assertViolation(mc, m, (short) 3100);
 
     // Bad Json - test startRow key replaced with empty string so validation should fail
     // {"path":"hdfs://1.2.3.4/accumulo/tables/2a/t-0003/someFile","":"","endRow":""}
@@ -442,7 +442,7 @@ public class MetadataConstraintsTest {
     m.put(columnFamily, new Text(StoredTabletFile
         .serialize("hdfs://1.2.3.4/accumulo/tables/2a/t-0003/someFile").replace("startRow", "")),
         value);
-    assertViolation(mc, m, (short) 12);
+    assertViolation(mc, m, (short) 3100);
 
     // Bad Json - test startRow key is missing so validation should fail
     // {"path":"hdfs://1.2.3.4/accumulo/tables/2a/t-0003/someFile","endRow":""}
@@ -451,7 +451,7 @@ public class MetadataConstraintsTest {
         new Text(
             "{\"path\":\"hdfs://1.2.3.4/accumulo/tables/2a/t-0003/someFile\",\"endRow\":\"\"}"),
         value);
-    assertViolation(mc, m, (short) 12);
+    assertViolation(mc, m, (short) 3100);
 
     // Bad Json - test endRow key replaced with empty string so validation should fail
     // {"path":"hdfs://1.2.3.4/accumulo/tables/2a/t-0003/someFile","":"","endRow":""}
@@ -460,7 +460,7 @@ public class MetadataConstraintsTest {
         columnFamily, new Text(StoredTabletFile
             .serialize("hdfs://1.2.3.4/accumulo/tables/2a/t-0003/someFile").replace("endRow", "")),
         value);
-    assertViolation(mc, m, (short) 12);
+    assertViolation(mc, m, (short) 3100);
 
     // Bad Json - endRow will be replaced with encoded row without the exclusive byte 0x00 which is
     // required for an endRow so this will fail validation
@@ -470,7 +470,7 @@ public class MetadataConstraintsTest {
             new Range("a", false, "b", true)).getMetadata()
             .replaceFirst("\"endRow\":\".*\"", "\"endRow\":\"" + encodeRowForMetadata("b") + "\"")),
         value);
-    assertViolation(mc, m, (short) 12);
+    assertViolation(mc, m, (short) 3100);
 
     // Missing tables directory in path
     m = new Mutation(new Text("0;foo"));
@@ -479,7 +479,7 @@ public class MetadataConstraintsTest {
             .getMetadata().replace("hdfs://1.2.3.4/accumulo/tables/2a/t-0003/someFile",
                 "hdfs://1.2.3.4/accumulo/2a/t-0003/someFile")),
         new DataFileValue(1, 1).encodeAsValue());
-    assertViolation(mc, m, (short) 12);
+    assertViolation(mc, m, (short) 3100);
 
     // Should pass validation (inf range)
     m = new Mutation(new Text("0;foo"));
@@ -499,7 +499,7 @@ public class MetadataConstraintsTest {
     violations = mc.check(createEnv(), m);
     assertTrue(violations.isEmpty());
 
-    assertNotNull(mc.getViolationDescription((short) 12));
+    assertNotNull(mc.getViolationDescription((short) 3100));
   }
 
   @Test
@@ -510,7 +510,7 @@ public class MetadataConstraintsTest {
 
     m = new Mutation(new Text("0;foo"));
     ServerColumnFamily.OPID_COLUMN.put(m, new Value("bad id"));
-    assertViolation(mc, m, (short) 9);
+    assertViolation(mc, m, (short) 4000);
 
     m = new Mutation(new Text("0;foo"));
     ServerColumnFamily.OPID_COLUMN.put(m,
@@ -531,7 +531,7 @@ public class MetadataConstraintsTest {
     violations = mc.check(createEnv(), m);
     assertFalse(violations.isEmpty());
     assertEquals(1, violations.size());
-    assertEquals(Short.valueOf((short) 11), violations.get(0));
+    assertEquals(Short.valueOf((short) 4001), violations.get(0));
 
     m = new Mutation(new Text("0;foo"));
     ServerColumnFamily.SELECTED_COLUMN.put(m,
@@ -545,12 +545,12 @@ public class MetadataConstraintsTest {
 
   @Test
   public void testCompacted() {
-    testFateCqValidation(CompactedColumnFamily.STR_NAME, (short) 13);
+    testFateCqValidation(CompactedColumnFamily.STR_NAME, (short) 4002);
   }
 
   @Test
   public void testUserCompactionRequested() {
-    testFateCqValidation(UserCompactionRequestedColumnFamily.STR_NAME, (short) 14);
+    testFateCqValidation(UserCompactionRequestedColumnFamily.STR_NAME, (short) 4003);
   }
 
   // Verify that columns that store a FateId in their CQ
@@ -595,7 +595,7 @@ public class MetadataConstraintsTest {
     violations = mc.check(createEnv(), m);
     assertFalse(violations.isEmpty());
     assertEquals(2, violations.size());
-    assertIterableEquals(List.of((short) 6, (short) 15), violations);
+    assertIterableEquals(List.of((short) 6, (short) 4004), violations);
 
     // test invalid args
     KeyExtent extent = KeyExtent.fromMetaRow(new Text("0;foo"));
@@ -618,7 +618,7 @@ public class MetadataConstraintsTest {
     violations = mc.check(createEnv(), m);
     assertFalse(violations.isEmpty());
     assertEquals(1, violations.size());
-    assertEquals(Short.valueOf((short) 15), violations.get(0));
+    assertEquals(Short.valueOf((short) 4004), violations.get(0));
   }
 
   @Test
@@ -636,7 +636,7 @@ public class MetadataConstraintsTest {
     violations = mc.check(createEnv(), m);
     assertFalse(violations.isEmpty());
     assertEquals(1, violations.size());
-    assertEquals((short) 17, violations.get(0));
+    assertEquals((short) 3102, violations.get(0));
   }
 
   // Encode a row how it would appear in Json


### PR DESCRIPTION
This change refactors the MetadataContraint error codes that are new in version 3.1 to beging with 3100 and new in 4.0 to begin with 4000. This makes future expansion easier and will allow keeping codes consistent across versions.

3.1 branch is being fixed in #4918 and will be merged forward as an empty commit.

This closes #4915 