### PR TITLE
Bug fix admin cmd

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
@@ -508,6 +508,7 @@ public class Admin implements KeywordExecutable {
       log.error("{}", e.getMessage(), e);
       System.exit(3);
     } finally {
+      context.close();
       SingletonManager.setMode(Mode.CLOSED);
     }
   }


### PR DESCRIPTION
This fixes a bug with the admin "checkTablets" command (and maybe others) where the ZK connection is closed but is attempted to be accessed again leading to an exception. This makes sure the threads that try to access ZK are stopped before closing the connection

Discovered working on https://github.com/apache/accumulo/issues/4892. Fixed by @keith-turner 