### PR TITLE
Use EnumSet for TStatus instead of Set

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/AbstractFateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/AbstractFateStore.java
@@ -218,7 +218,7 @@ public abstract class AbstractFateStore<T> implements FateStore<T> {
 
   @Override
   public Stream<FateIdStatus> list() {
-    return getTransactions(TStatus.ALL_STATUSES);
+    return getTransactions(EnumSet.allOf(TStatus.class));
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/fate/AbstractFateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/AbstractFateStore.java
@@ -34,7 +34,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -151,9 +150,9 @@ public abstract class AbstractFateStore<T> implements FateStore<T> {
     return reserveAttempt.orElseThrow();
   }
 
-  private static final Set<TStatus> IN_PROGRESS_SET = Set.of(TStatus.IN_PROGRESS);
-  private static final Set<TStatus> OTHER_RUNNABLE_SET =
-      Set.of(TStatus.SUBMITTED, TStatus.FAILED_IN_PROGRESS);
+  private static final EnumSet<TStatus> IN_PROGRESS_SET = EnumSet.of(TStatus.IN_PROGRESS);
+  private static final EnumSet<TStatus> OTHER_RUNNABLE_SET =
+      EnumSet.of(TStatus.SUBMITTED, TStatus.FAILED_IN_PROGRESS);
 
   @Override
   public void runnable(AtomicBoolean keepWaiting, Consumer<FateId> idConsumer) {
@@ -223,7 +222,7 @@ public abstract class AbstractFateStore<T> implements FateStore<T> {
   }
 
   @Override
-  public Stream<FateIdStatus> list(Set<TStatus> statuses) {
+  public Stream<FateIdStatus> list(EnumSet<TStatus> statuses) {
     return getTransactions(statuses);
   }
 
@@ -276,7 +275,7 @@ public abstract class AbstractFateStore<T> implements FateStore<T> {
         "Collision detected for fate id " + fateId);
   }
 
-  protected abstract Stream<FateIdStatus> getTransactions(Set<TStatus> statuses);
+  protected abstract Stream<FateIdStatus> getTransactions(EnumSet<TStatus> statuses);
 
   protected abstract TStatus _getStatus(FateId fateId);
 

--- a/core/src/main/java/org/apache/accumulo/core/fate/FateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/FateStore.java
@@ -25,9 +25,11 @@ import java.io.Serializable;
 import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import org.apache.accumulo.core.fate.user.FateMutatorImpl;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
@@ -64,6 +66,8 @@ public interface FateStore<T> extends ReadOnlyFateStore<T> {
    *         hash to the same FateId or if a random FateId already exists.
    */
   Optional<FateTxStore<T>> createAndReserve(FateKey fateKey);
+
+  Stream<FateIdStatus> list(EnumSet<TStatus> statuses);
 
   /**
    * An interface that allows read/write access to the data related to a single fate operation.

--- a/core/src/main/java/org/apache/accumulo/core/fate/FateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/FateStore.java
@@ -25,11 +25,9 @@ import java.io.Serializable;
 import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.EnumSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Stream;
 
 import org.apache.accumulo.core.fate.user.FateMutatorImpl;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
@@ -66,8 +64,6 @@ public interface FateStore<T> extends ReadOnlyFateStore<T> {
    *         hash to the same FateId or if a random FateId already exists.
    */
   Optional<FateTxStore<T>> createAndReserve(FateKey fateKey);
-
-  Stream<FateIdStatus> list(EnumSet<TStatus> statuses);
 
   /**
    * An interface that allows read/write access to the data related to a single fate operation.

--- a/core/src/main/java/org/apache/accumulo/core/fate/MetaFateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/MetaFateStore.java
@@ -29,11 +29,11 @@ import java.io.Serializable;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -503,7 +503,7 @@ public class MetaFateStore<T> extends AbstractFateStore<T> {
   }
 
   @Override
-  protected Stream<FateIdStatus> getTransactions(Set<TStatus> statuses) {
+  protected Stream<FateIdStatus> getTransactions(EnumSet<TStatus> statuses) {
     try {
       Stream<FateIdStatus> stream = zk.getChildren(path).stream().map(strTxid -> {
         String txUUIDStr = strTxid.split("_")[1];

--- a/core/src/main/java/org/apache/accumulo/core/fate/MetaFateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/MetaFateStore.java
@@ -20,7 +20,6 @@ package org.apache.accumulo.core.fate;
 
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus.ALL_STATUSES;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
@@ -525,11 +524,10 @@ public class MetaFateStore<T> extends AbstractFateStore<T> {
         };
       });
 
-      if (!ALL_STATUSES.equals(statuses)) {
-        stream = stream.filter(s -> statuses.contains(s.getStatus()));
+      if (statuses.equals(EnumSet.allOf(TStatus.class))) {
+        return stream;
       }
-
-      return stream;
+      return stream.filter(s -> statuses.contains(s.getStatus()));
     } catch (KeeperException | InterruptedException e) {
       throw new IllegalStateException(e);
     }
@@ -537,7 +535,8 @@ public class MetaFateStore<T> extends AbstractFateStore<T> {
 
   @Override
   public Stream<FateKey> list(FateKey.FateKeyType type) {
-    return getTransactions(ALL_STATUSES).flatMap(fis -> getKey(fis.getFateId()).stream())
+    return getTransactions(EnumSet.allOf(TStatus.class))
+        .flatMap(fis -> getKey(fis.getFateId()).stream())
         .filter(fateKey -> fateKey.getType() == type);
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/fate/ReadOnlyFateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/ReadOnlyFateStore.java
@@ -19,15 +19,12 @@
 package org.apache.accumulo.core.fate;
 
 import java.io.Serializable;
-import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -57,8 +54,7 @@ public interface ReadOnlyFateStore<T> {
     /** Transaction that is eligible to be executed */
     SUBMITTED;
 
-    public static final Set<TStatus> ALL_STATUSES =
-        Arrays.stream(values()).collect(Collectors.toUnmodifiableSet());
+    public static final EnumSet<TStatus> ALL_STATUSES = EnumSet.allOf(TStatus.class);
   }
 
   /**
@@ -148,7 +144,7 @@ public interface ReadOnlyFateStore<T> {
    *
    * @return all outstanding transactions, including those reserved by others.
    */
-  Stream<FateIdStatus> list(Set<TStatus> statuses);
+  Stream<FateIdStatus> list(EnumSet<TStatus> statuses);
 
   /**
    * list transaction in the store that have a given fate key type.

--- a/core/src/main/java/org/apache/accumulo/core/fate/ReadOnlyFateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/ReadOnlyFateStore.java
@@ -53,8 +53,6 @@ public interface ReadOnlyFateStore<T> {
     UNKNOWN,
     /** Transaction that is eligible to be executed */
     SUBMITTED;
-
-    public static final EnumSet<TStatus> ALL_STATUSES = EnumSet.allOf(TStatus.class);
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/RowFateStatusFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/RowFateStatusFilter.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.client.IteratorSetting;
@@ -68,7 +67,7 @@ public class RowFateStatusFilter extends WholeRowIterator {
   }
 
   public static void configureScanner(ScannerBase scanner,
-      Set<ReadOnlyFateStore.TStatus> statuses) {
+      EnumSet<ReadOnlyFateStore.TStatus> statuses) {
     // only filter when getting a subset of statuses
     if (!statuses.equals(ALL_STATUSES)) {
       String statusesStr = statuses.stream().map(Enum::name).collect(Collectors.joining(","));

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/RowFateStatusFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/RowFateStatusFilter.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.core.fate.user;
 
-import static org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus.ALL_STATUSES;
+import static org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus;
 
 import java.io.IOException;
 import java.util.EnumSet;
@@ -69,7 +69,7 @@ public class RowFateStatusFilter extends WholeRowIterator {
   public static void configureScanner(ScannerBase scanner,
       EnumSet<ReadOnlyFateStore.TStatus> statuses) {
     // only filter when getting a subset of statuses
-    if (!statuses.equals(ALL_STATUSES)) {
+    if (!statuses.equals(EnumSet.allOf(TStatus.class))) {
       String statusesStr = statuses.stream().map(Enum::name).collect(Collectors.joining(","));
       var iterSettings = new IteratorSetting(100, "statuses", RowFateStatusFilter.class);
       iterSettings.addOption("statuses", statusesStr);

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/UserFateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/UserFateStore.java
@@ -21,11 +21,11 @@ package org.apache.accumulo.core.fate.user;
 import java.io.IOException;
 import java.io.Serializable;
 import java.time.Duration;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.SortedMap;
 import java.util.UUID;
 import java.util.function.Function;
@@ -286,7 +286,7 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
   }
 
   @Override
-  protected Stream<FateIdStatus> getTransactions(Set<TStatus> statuses) {
+  protected Stream<FateIdStatus> getTransactions(EnumSet<TStatus> statuses) {
     try {
       Scanner scanner = context.createScanner(tableName, Authorizations.EMPTY);
       scanner.setRange(new Range());

--- a/core/src/main/java/org/apache/accumulo/core/logging/FateLogger.java
+++ b/core/src/main/java/org/apache/accumulo/core/logging/FateLogger.java
@@ -19,9 +19,9 @@
 package org.apache.accumulo.core.logging;
 
 import java.io.Serializable;
+import java.util.EnumSet;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -123,7 +123,7 @@ public class FateLogger {
       }
 
       @Override
-      public Stream<FateIdStatus> list(Set<TStatus> statuses) {
+      public Stream<FateIdStatus> list(EnumSet<TStatus> statuses) {
         return store.list(statuses);
       }
 

--- a/core/src/test/java/org/apache/accumulo/core/fate/TestStore.java
+++ b/core/src/test/java/org/apache/accumulo/core/fate/TestStore.java
@@ -234,7 +234,7 @@ public class TestStore implements FateStore<String> {
   }
 
   @Override
-  public Stream<FateIdStatus> list(Set<TStatus> statuses) {
+  public Stream<FateIdStatus> list(EnumSet<TStatus> statuses) {
     return list().filter(fis -> statuses.contains(fis.getStatus()));
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/fate/FateStoreIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FateStoreIT.java
@@ -19,7 +19,6 @@
 package org.apache.accumulo.test.fate;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus.ALL_STATUSES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -250,8 +249,10 @@ public abstract class FateStoreIT extends SharedMiniClusterBase implements FateT
     try {
       Map<FateId,TStatus> expectedStatus = new HashMap<>();
 
+      final EnumSet<TStatus> allStatuses = EnumSet.allOf(TStatus.class);
+
       for (int i = 0; i < 5; i++) {
-        for (var status : ALL_STATUSES) {
+        for (var status : allStatuses) {
           var fateId = store.create();
           var txStore = store.reserve(fateId);
           txStore.setStatus(status);
@@ -259,8 +260,7 @@ public abstract class FateStoreIT extends SharedMiniClusterBase implements FateT
           expectedStatus.put(fateId, status);
         }
       }
-
-      for (Set<TStatus> statuses : Sets.powerSet(ALL_STATUSES)) {
+      for (Set<TStatus> statuses : Sets.powerSet(allStatuses)) {
         EnumSet<TStatus> enumSet =
             statuses.isEmpty() ? EnumSet.noneOf(TStatus.class) : EnumSet.copyOf(statuses);
 

--- a/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateStoreIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateStoreIT.java
@@ -23,9 +23,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 
 import org.apache.accumulo.core.client.Accumulo;
@@ -171,7 +171,7 @@ public class UserFateStoreIT extends SharedMiniClusterBase {
     }
 
     private void testOperationWithStatuses(Runnable beforeOperation, Executable operation,
-        Set<TStatus> acceptableStatuses) throws Exception {
+        EnumSet<TStatus> acceptableStatuses) throws Exception {
       for (TStatus status : TStatus.values()) {
         // Run any needed setup for the operation before each iteration
         beforeOperation.run();
@@ -192,7 +192,7 @@ public class UserFateStoreIT extends SharedMiniClusterBase {
     public void push() throws Exception {
       testOperationWithStatuses(() -> {}, // No special setup needed for push
           () -> txStore.push(new FateIT.TestRepo("testOp")),
-          Set.of(TStatus.IN_PROGRESS, TStatus.NEW));
+          EnumSet.of(TStatus.IN_PROGRESS, TStatus.NEW));
     }
 
     @Test
@@ -205,14 +205,14 @@ public class UserFateStoreIT extends SharedMiniClusterBase {
         } catch (Exception e) {
           throw new RuntimeException("Failed to setup for pop", e);
         }
-      }, txStore::pop, Set.of(TStatus.FAILED_IN_PROGRESS, TStatus.SUCCESSFUL));
+      }, txStore::pop, EnumSet.of(TStatus.FAILED_IN_PROGRESS, TStatus.SUCCESSFUL));
     }
 
     @Test
     public void delete() throws Exception {
       testOperationWithStatuses(() -> {}, // No special setup needed for delete
           txStore::delete,
-          Set.of(TStatus.NEW, TStatus.SUBMITTED, TStatus.SUCCESSFUL, TStatus.FAILED));
+          EnumSet.of(TStatus.NEW, TStatus.SUBMITTED, TStatus.SUCCESSFUL, TStatus.FAILED));
     }
   }
 


### PR DESCRIPTION
This PR changes the usages of `Set<ReadOnlyFateStore.TStatus>` to `EnumSet<ReadOnlyFateStore.TStatus>`. EnumSet is typically more efficient.

The only thing that is a bit different after this conversion is the `public static final EnumSet<TStatus> ALL_STATUSES` within the TStatus enum used to be unmodifiable since it was constructed via `Collectors.toUnmodifiableSet()`. I could not find a way to create an unmodifiable EnumSet, so `ALL_STATUSES` is technically modifiable now. `ALL_STATUSES` is just used for convenience so we don't have to write out the code to create a set of this Enum each time. Looking at the calling code I don't think it is an issue that it is modifiable now.