### PR TITLE
Modifies pom to allow git sha in version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 
 # Maven ignores
 /target/
+.flattened-pom.xml
 
 # IDE ignores
 /.settings/

--- a/assemble/pom.xml
+++ b/assemble/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
   </parent>
   <artifactId>accumulo</artifactId>
   <packaging>pom</packaging>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
   </parent>
   <artifactId>accumulo-core</artifactId>
   <name>Apache Accumulo Core</name>

--- a/hadoop-mapreduce/pom.xml
+++ b/hadoop-mapreduce/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
   </parent>
   <artifactId>accumulo-hadoop-mapreduce</artifactId>
   <name>Apache Accumulo Hadoop MapReduce</name>

--- a/iterator-test-harness/pom.xml
+++ b/iterator-test-harness/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
   </parent>
   <artifactId>accumulo-iterator-test-harness</artifactId>
   <name>Apache Accumulo Iterator Test Harness</name>

--- a/minicluster/pom.xml
+++ b/minicluster/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
   </parent>
   <artifactId>accumulo-minicluster</artifactId>
   <name>Apache Accumulo MiniCluster</name>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   </parent>
   <groupId>org.apache.accumulo</groupId>
   <artifactId>accumulo-project</artifactId>
-  <version>2.1.4-SNAPSHOT</version>
+  <version>${revision}${sha1}${changelist}</version>
   <packaging>pom</packaging>
   <name>Apache Accumulo Project</name>
   <description>Apache Accumulo is a sorted, distributed key/value store based
@@ -114,6 +114,7 @@
   <properties>
     <!-- used for filtering the java source with the current version -->
     <accumulo.release.version>${project.version}</accumulo.release.version>
+    <changelist>-SNAPSHOT</changelist>
     <!-- avoid error shutting down built-in ForkJoinPool.commonPool() during exec:java tasks -->
     <exec.cleanupDaemonThreads>false</exec.cleanupDaemonThreads>
     <extraTestArgs>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.management/java.lang.management=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens java.base/java.time=ALL-UNNAMED</extraTestArgs>
@@ -138,6 +139,8 @@
     <!-- timestamp for reproducible outputs, updated on release by the release plugin -->
     <project.build.outputTimestamp>2024-07-29T06:03:16Z</project.build.outputTimestamp>
     <rat.consoleOutput>true</rat.consoleOutput>
+    <revision>2.1.4</revision>
+    <sha1 />
     <sourceReleaseAssemblyDescriptor>source-release-tar</sourceReleaseAssemblyDescriptor>
     <surefire.excludedGroups />
     <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>
@@ -933,6 +936,30 @@
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <version>1.6.0</version>
+        <configuration />
+        <executions>
+          <!-- enable flattening -->
+          <execution>
+            <id>flatten</id>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <phase>process-resources</phase>
+          </execution>
+          <!-- ensure proper cleanup -->
+          <execution>
+            <id>flatten.clean</id>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+            <phase>clean</phase>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>

--- a/server/base/pom.xml
+++ b/server/base/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>accumulo-server-base</artifactId>

--- a/server/compaction-coordinator/pom.xml
+++ b/server/compaction-coordinator/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>accumulo-compaction-coordinator</artifactId>

--- a/server/compactor/pom.xml
+++ b/server/compactor/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>accumulo-compactor</artifactId>

--- a/server/gc/pom.xml
+++ b/server/gc/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>accumulo-gc</artifactId>

--- a/server/manager/pom.xml
+++ b/server/manager/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>accumulo-manager</artifactId>

--- a/server/master/pom.xml
+++ b/server/master/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <!-- should be removed in 3.0 -->

--- a/server/monitor/pom.xml
+++ b/server/monitor/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>accumulo-monitor</artifactId>

--- a/server/native/pom.xml
+++ b/server/native/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>accumulo-native</artifactId>

--- a/server/tserver/pom.xml
+++ b/server/tserver/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>accumulo-tserver</artifactId>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
   </parent>
   <artifactId>accumulo-shell</artifactId>
   <name>Apache Accumulo Shell</name>

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
   </parent>
   <artifactId>accumulo-start</artifactId>
   <name>Apache Accumulo Start</name>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
   </parent>
   <artifactId>accumulo-test</artifactId>
   <name>Apache Accumulo Testing</name>


### PR DESCRIPTION
Modifies the pom to allow specifying a git sha in the version.  When testing with downstream software and using a SNAPSHOT version of accumulo it can be difficult to control what SNAPSHOT you actually get. These changes allow including the git sha in the accumulo version number which removes the suprises around using SNAPSHOT versions.

With these changes can include the sha in the version with the following command.

```
mvn clean install -PskipQA -Dsha1="-$(git rev-parse --short HEAD)"
```

For more information see :

https://maven.apache.org/maven-ci-friendly.html