### PR TITLE
Convert CompactionCoordinator RPC service to Async Thrift

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -363,6 +363,8 @@ public enum Property {
       "Properties in this category affect the behavior of the manager server.", "2.1.0"),
   MANAGER_CLIENTPORT("manager.port.client", "9999", PropertyType.PORT,
       "The port used for handling client connections on the manager.", "1.3.5"),
+  MANAGER_ASYNC_CLIENTPORT("manager.port.async.client", "8999", PropertyType.PORT,
+      "The port used for handling client connections on the manager for async services.", "4.0.0"),
   MANAGER_TABLET_BALANCER("manager.tablet.balancer",
       "org.apache.accumulo.core.spi.balancer.TableLoadBalancer", PropertyType.CLASSNAME,
       "The balancer class that accumulo will use to make tablet assignment and "
@@ -1165,7 +1167,11 @@ public enum Property {
   @Experimental
   COMPACTION_COORDINATOR_TSERVER_COMPACTION_CHECK_INTERVAL(
       "compaction.coordinator.tserver.check.interval", "1m", PropertyType.TIMEDURATION,
-      "The interval at which to check the tservers for external compactions.", "2.1.0");
+      "The interval at which to check the tservers for external compactions.", "2.1.0"),
+  COMPACTION_COORDINATOR_MAX_JOB_REQUEST_WAIT_TIME(
+      "compaction.coordinator.wait.time.job.request.max", "2m", PropertyType.TIMEDURATION,
+      "The maximum amount of time the coordinator will wait for a requested job from the job queue.",
+      "4.0.0");
 
   private final String key;
   private final String defaultValue;

--- a/core/src/main/java/org/apache/accumulo/core/rpc/ThriftUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/ThriftUtil.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.rpc;
 
+import static org.apache.accumulo.core.rpc.clients.ThriftClientTypes.COORDINATOR;
 import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.io.IOException;
@@ -113,6 +114,15 @@ public class ThriftUtil {
       HostAndPort address, ClientContext context) throws TTransportException {
     TTransport transport = context.getTransportPool().getTransport(type, address,
         context.getClientTimeoutInMillis(), context, true);
+
+    // TODO - This is temporary until we support Async multiplexing
+    // THRIFT-2427 is tracking this issue and the plan is to reopen a new PR
+    // to add support in the next version. Once we support multiplexing we can
+    // remove this special case.
+    if (type == COORDINATOR) {
+      return type.getClientFactory().getClient(protocolFactory.getProtocol(transport));
+    }
+
     return createClient(type, transport);
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/ThriftServerType.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/ThriftServerType.java
@@ -57,4 +57,14 @@ public enum ThriftServerType {
   public static ThriftServerType getDefault() {
     return CUSTOM_HS_HA;
   }
+
+  public static boolean supportsAsync(ThriftServerType thriftServerType) {
+    switch (thriftServerType) {
+      case CUSTOM_HS_HA:
+      case THREADED_SELECTOR:
+        return true;
+      default:
+        return false;
+    }
+  }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
@@ -738,6 +738,7 @@ public class CompactionCoordinator
     while (localFates == null) {
       UtilWaitThread.sleep(100);
       if (shutdown.getCount() == 0) {
+        resultHandler.onComplete(null);
         return;
       }
       localFates = fateInstances.get();
@@ -764,10 +765,12 @@ public class CompactionCoordinator
           tableState);
       // cleanup metadata table and files related to the compaction
       compactionsFailed(Map.of(ecid, extent));
+      resultHandler.onComplete(null);
       return;
     }
 
     if (!CommitCompaction.canCommitCompaction(ecid, tabletMeta)) {
+      resultHandler.onComplete(null);
       return;
     }
 

--- a/server/manager/src/test/java/org/apache/accumulo/manager/compaction/CompactionCoordinatorTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/compaction/CompactionCoordinatorTest.java
@@ -164,12 +164,12 @@ public class CompactionCoordinatorTest {
 
     @Override
     public void compactionCompleted(TInfo tinfo, TCredentials credentials,
-        String externalCompactionId, TKeyExtent textent, TCompactionStats stats,
-        AsyncMethodCallback<Void> callback) throws ThriftSecurityException {}
+        String externalCompactionId, TKeyExtent textent, TCompactionStats stats)
+        throws ThriftSecurityException {}
 
     @Override
     public void compactionFailed(TInfo tinfo, TCredentials credentials, String externalCompactionId,
-        TKeyExtent extent, AsyncMethodCallback<Void> callback) throws ThriftSecurityException {}
+        TKeyExtent extent) throws ThriftSecurityException {}
 
     void setMetadataCompactionIds(Set<ExternalCompactionId> mci) {
       metadataCompactionIds = mci;
@@ -370,8 +370,8 @@ public class CompactionCoordinatorTest {
     // Get the next job
     ExternalCompactionId eci = ExternalCompactionId.generate(UUID.randomUUID());
     CompletableFuture<TNextCompactionJob> future = new CompletableFuture<>();
-    coordinator.getCompactionJob(new TInfo(), creds, GROUP_ID.toString(), "localhost:10241",
-        eci.toString(), new AsyncMethodCallback<>() {
+    coordinator.getAsyncThriftService().getCompactionJob(new TInfo(), creds, GROUP_ID.toString(),
+        "localhost:10241", eci.toString(), new AsyncMethodCallback<>() {
           @Override
           public void onComplete(TNextCompactionJob response) {
             future.complete(response);
@@ -429,8 +429,9 @@ public class CompactionCoordinatorTest {
 
     var coordinator = new TestCoordinator(context, security, new ArrayList<>(), manager);
     CompletableFuture<TNextCompactionJob> future = new CompletableFuture<>();
-    coordinator.getCompactionJob(TraceUtil.traceInfo(), creds, GROUP_ID.toString(),
-        "localhost:10240", UUID.randomUUID().toString(), new AsyncMethodCallback<>() {
+    coordinator.getAsyncThriftService().getCompactionJob(TraceUtil.traceInfo(), creds,
+        GROUP_ID.toString(), "localhost:10240", UUID.randomUUID().toString(),
+        new AsyncMethodCallback<>() {
           @Override
           public void onComplete(TNextCompactionJob response) {
             future.complete(response);


### PR DESCRIPTION
This changes the CompactionCoordinator RPC service to use an Async thrift processor. This allows long polling when a compactor requests a new job by no longer blocking the Thrift IO thread when there are no jobs available. When a job is available, the response will be sent asynchronously back to the client.

The only RPC service converted for now is the CompactionCoordinator RPC service but future services could be converted to use Async processors as well. This RPC is not using multiplexing as Async multiplexing is an open issue being worked on in THRIFT-2427. Once that issue is resolve the plan will be to convert to an async multiplexed processor.

A second thrift service on another port was created in the Manager for handling async processors because they are handled differently than sync and you can't combine both sync and async processors when multiplexing. The coordinator rpc service now advertises the async port so clients connect to the correct service.

With thrift you can technically implement both sync and async interfaces on the processor and register them for each but that over complicates things and doesn't make much sense. The simplest thing is to make sure to only support one type for a specific Thrift service. So in this case, even though we only really care about 1 method being async (getCompactionJob) for the coordinator service, all the other methods were converted and we just now only implement the Async api because it's easy to still make things sync when using the Async api if desired. The good news is it's also easy to support both sync processors and async processors on the same server with two different ports as this PR does. Going forward, it might make sense to convert more services over to implement the Async interface/API.

This closes #4664

A couple other things to note about the PR:

1. As noted, Thrift does not support Async multiplexing but there is an old [issue](https://issues.apache.org/jira/browse/THRIFT-2427) to track that and a PR that was closed. I was able to get that PR to work in local testing with async multiplexing with a few tweaks. I plan to open up a new PR soon so we can try and get async multiplexing into the next Thrift release.
2. I added a couple TODOs in the code. Some of them mark the spots where I had to add temporary code to get around not multiplexing the new service. There's also a TODO because we probably should change the handling of the job completable future to complete using the async methods and another thread pool but i wanted some feedback on that first.
3. The existing tests should pretty much already provide coverage on everything. I also modified the CompactionCoordinatorTest to set a shorter timeout period before the job future times out when there are no jobs. This is both to make the test go faster and also to validate that property and the timeout works.
4. One nice thing I noticed about the Async API is that you don't need to actually do a bunch of boiler plate code for setting an error response on the async callback unless you want to. The API already catches exceptions that are thrown and does it for you [here](https://github.com/apache/thrift/blob/90af876c67be3973064c44eb967b0d7169c9987f/lib/java/src/main/java/org/apache/thrift/TBaseAsyncProcessor.java#L103-L111) which is nice.
5. If the job future times out the coordinator should not need to do anything else but send back the empty job response. The job queue already has [code](https://github.com/apache/accumulo/blob/35189b2aa82b47c101aabad10f6050346484b935/server/manager/src/main/java/org/apache/accumulo/manager/compaction/queue/CompactionJobPriorityQueue.java#L264) to periodically clean up completed futures.

