### PR TITLE
Remove redundant table/namespace id/name lookup

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
@@ -634,6 +634,10 @@ public class ClientContext implements AccumuloClient {
     return tableZooHelper().getTableMap().getNameToIdMap();
   }
 
+  public Map<NamespaceId,String> getNamespaceIdToNameMap() {
+    return Namespaces.getIdToNameMap(this);
+  }
+
   public Map<TableId,String> getTableIdToNameMap() {
     return tableZooHelper().getTableMap().getIdtoNameMap();
   }


### PR DESCRIPTION
* Remove redundant code to look up table and namespace names and ids that were only used for ZooPropEditor/ZooInfoViewer
* Update corresponding tests
* Add implementation for namespace ID lookup (currently not implemented the same as the table ID lookup, but should form the basis for follow-on work)