### PR TITLE
fixes bug in CompactionJobPriorityQueue

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/queue/CompactionJobPriorityQueue.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/queue/CompactionJobPriorityQueue.java
@@ -245,9 +245,9 @@ public class CompactionJobPriorityQueue {
   }
 
   public synchronized CompletableFuture<CompactionJobQueues.MetaJob> getAsync() {
-    var job = jobQueue.pollFirstEntry();
+    var job = poll();
     if (job != null) {
-      return CompletableFuture.completedFuture(job.getValue());
+      return CompletableFuture.completedFuture(job);
     }
 
     // There is currently nothing in the queue, so create an uncompleted future and queue it up to


### PR DESCRIPTION
CompactionJobPriorityQueue.getAsync was not doing clean up of internal data strucs when it removed a job from the queue.  Changed it call an existing method that does this cleanup.