### PR TITLE
Make EventCounter thread safe

### DIFF
--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -197,11 +197,11 @@ public class Monitor extends AbstractServer implements HighlyAvailableService {
     Map<String,Pair<Long,Long>> samples = new HashMap<>();
     Set<String> serversUpdated = new HashSet<>();
 
-    void startingUpdates() {
+    synchronized void startingUpdates() {
       serversUpdated.clear();
     }
 
-    void updateTabletServer(String name, long sampleTime, long numEvents) {
+    synchronized void updateTabletServer(String name, long sampleTime, long numEvents) {
       Pair<Long,Long> newSample = new Pair<>(sampleTime, numEvents);
       Pair<Long,Long> lastSample = samples.get(name);
 
@@ -214,13 +214,13 @@ public class Monitor extends AbstractServer implements HighlyAvailableService {
       serversUpdated.add(name);
     }
 
-    void finishedUpdating() {
+    synchronized void finishedUpdating() {
       // remove any tablet servers not updated
       samples.keySet().retainAll(serversUpdated);
       prevSamples.keySet().retainAll(serversUpdated);
     }
 
-    double calculateRate() {
+    synchronized double calculateRate() {
       double totalRate = 0;
 
       for (Entry<String,Pair<Long,Long>> entry : prevSamples.entrySet()) {
@@ -234,7 +234,7 @@ public class Monitor extends AbstractServer implements HighlyAvailableService {
       return totalRate;
     }
 
-    long calculateCount() {
+    synchronized long calculateCount() {
       long count = 0;
 
       for (Entry<String,Pair<Long,Long>> entry : prevSamples.entrySet()) {


### PR DESCRIPTION
Fixes #4956

The stack track included in the ticket indicates that a ConcurrentmodificationException occurred in Monitor.EventCounter:
```
java.util.ConcurrentmodificationException
at java.util.HashMap$HashIterator.nextNode(HashMap.java:1511)
at java.util.HashMap$HashIterator.next(HashMap.java:1544)
at java.util.HashMap$HashIterator.next(HashMap.java:1542)
at org.apache.accumulo.monitor.Monitor$EventCounter.calculateRate(monitor.java:23)
at org.apache.accumulo.monitor.Monitor.getLookupRate(Monitor.java:977)
at org.apache.accumulo.monitor.rest.tservers.TabletServerInformation.updateTabletServerInfo(TabletServerinformation.java:162)
at org.apache.accumulo.monitor.rest.tservers.TabletServerInformation.(TabletServerInformation:101)
at org.apache.accumulo.monitor.rest.tservers.TabletServer.(TabletServer.java:43)
at org.apache.accumulo.monitor.rest.tservers.TabletServerResource.getTserverSummary(TabletServerResource.java:88)
```
This PR adds synchronization to several methods in the `EventCounter` class to avoid this from happening again.

Another approach that would probably work would be to make the 3 collections in this class thread safe by making the HashMaps into ConcurrentHashMaps and the HashSet into a `Collections.synchronizedSet(new HashSet<>())`. That would function just fine in the current code as far as I can tell but if we would ever need to iterate over the `synchronizedSet`, we would need to use a `synchronize` block anyways so i figured just making the methods themselves synchronized would future proof and fix the current issue too.