### PR TITLE
refactors filtering in getServers API call

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/admin/InstanceOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/InstanceOperations.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.core.client.admin;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -241,10 +242,15 @@ public interface InstanceOperations {
   /**
    * Returns the servers of a given type that match the given criteria
    *
+   * @param resourceGroupPredicate only returns servers where the resource group matches this
+   *        predicate. For the manager it does not have a resoruce group and this parameters is not
+   *        used.
+   * @param hostPortPredicate only returns servers where its host and port match this predicate.
    * @return set of servers of the supplied type matching the supplied test
    * @since 4.0.0
    */
-  Set<ServerId> getServers(ServerId.Type type, Predicate<ServerId> test);
+  Set<ServerId> getServers(ServerId.Type type, Predicate<String> resourceGroupPredicate,
+      BiPredicate<String,Integer> hostPortPredicate);
 
   /**
    * List the active scans on a tablet server.

--- a/core/src/main/java/org/apache/accumulo/core/lock/ServiceLockPaths.java
+++ b/core/src/main/java/org/apache/accumulo/core/lock/ServiceLockPaths.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.client.admin.servers.ServerId;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.fate.zookeeper.ZooCache;
 import org.apache.accumulo.core.fate.zookeeper.ZooCache.ZcStat;
@@ -396,14 +397,14 @@ public class ServiceLockPaths {
         if (resourceGroupPredicate.test(group)) {
           final List<String> servers = cache.getChildren(typePath + "/" + group);
           for (final String server : servers) {
-            final ZcStat stat = new ZcStat();
-            final ServiceLockPath slp =
-                parse(Optional.of(serverType), typePath + "/" + group + "/" + server);
             if (addressPredicate.test(server)) {
+              final ServiceLockPath slp =
+                  parse(Optional.of(serverType), typePath + "/" + group + "/" + server);
               if (!withLock || slp.getType().equals(Constants.ZDEADTSERVERS)) {
                 // Dead TServers don't have lock data
                 results.add(slp);
               } else {
+                final ZcStat stat = new ZcStat();
                 Optional<ServiceLockData> sld = ServiceLock.getLockData(cache, slp, stat);
                 if (!sld.isEmpty()) {
                   results.add(slp);


### PR DESCRIPTION
Changes filtering in the getServers API call so that it can prune branches while walking the tree of servers in zookeeper.