### PR TITLE
fixes a Fate bug

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
@@ -246,7 +246,7 @@ public class Fate<T> {
         Property.MANAGER_FATE_THREADPOOL_SIZE, true);
     fatePoolWatcher =
         ThreadPools.getServerThreadPools().createGeneralScheduledExecutorService(conf);
-    ThreadPools.watchCriticalScheduledTask(fatePoolWatcher.schedule(() -> {
+    ThreadPools.watchCriticalScheduledTask(fatePoolWatcher.scheduleWithFixedDelay(() -> {
       // resize the pool if the property changed
       ThreadPools.resizePool(pool, conf, Property.MANAGER_FATE_THREADPOOL_SIZE);
       // If the pool grew, then ensure that there is a TransactionRunner for each thread
@@ -268,7 +268,7 @@ public class Fate<T> {
           }
         }
       }
-    }, 3, SECONDS));
+    }, 3, 30, SECONDS));
     executor = pool;
   }
 


### PR DESCRIPTION
fixes an issue with how new fate transaction runners are created if one dies. Prior to this commit, the check for dead transaction runners would only occur once. This now occurs periodically.

Another thing I looked at was the death of the `WorkFinder` and how that affects the Manager. Upon looking at `AccumuloUncaughtExceptionHandler` and testing this, only Errors halt the JVM so the Manager continues to run normally if an Exception is thrown and uncaught in the `WorkFinder`. Should this be the case? It seems that the Manager should either halt or create a new `WorkFinder` and not continue to run normally if an Exception is uncaught. I'm wondering if this is a problem elsewhere as well. Or maybe this isn't a problem at all. Some insight into this would be appreciated.

closes #4906
