### PR TITLE
Set ACCUMULO_SERVICE_INSTANCE consistently for all processes

### DIFF
--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -163,10 +163,7 @@ function control_service() {
   [[ $service == "compactor" ]] && last_instance_id=${NUM_COMPACTORS:-1}
 
   for ((inst_id = 1; inst_id <= last_instance_id; inst_id++)); do
-    # Only increment the service name when more than one service is desired.
-    ACCUMULO_SERVICE_INSTANCE=""
-    [[ last_instance_id -gt 1 ]] && ACCUMULO_SERVICE_INSTANCE="_${group}_${inst_id}"
-    [[ $service =~ ^compactor|sserver$ ]] && ACCUMULO_SERVICE_INSTANCE="${ACCUMULO_SERVICE_INSTANCE}_${inst_id}"
+    ACCUMULO_SERVICE_INSTANCE="_${group}_${inst_id}"
 
     if [[ $host == localhost || $host == "$(hostname -s)" || $host == "$(hostname -f)" || "$(hostname -I)" =~ $host ]]; then
       #

--- a/assemble/bin/accumulo-service
+++ b/assemble/bin/accumulo-service
@@ -127,7 +127,7 @@ function stop_service() {
     done
   else
     echo "Stopping service process: $service_name"
-    local pid_file="${ACCUMULO_PID_DIR}/accumulo-${service_name}-${group}.pid"
+    local pid_file="${ACCUMULO_PID_DIR}/accumulo-${service_name}.pid"
     control_process "TERM" "$service_name" "$pid_file"
   fi
 }
@@ -143,7 +143,7 @@ function kill_service() {
       control_process "KILL" "$process" "$pid_file"
     done
   else
-    local pid_file="${ACCUMULO_PID_DIR}/accumulo-${service_name}-${group}.pid"
+    local pid_file="${ACCUMULO_PID_DIR}/accumulo-${service_name}.pid"
     control_process "KILL" "$service_name" "$pid_file"
   fi
 }
@@ -195,15 +195,6 @@ function main() {
     HOST=$(ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
   fi
 
-  # Find the group parameter if any
-  GROUP_PATTERN="^(compactor.group|sserver.group|tserver.group)=(.*)$"
-  group="default"
-  for param in "$@"; do
-    if [[ $param =~ $GROUP_PATTERN ]]; then
-      group="${BASH_REMATCH[2]}"
-    fi
-  done
-
   local service_type="$1"
   local command_name="$2"
   shift 2
@@ -223,7 +214,7 @@ function main() {
     fi
   # Use the special bash env var from accumulo-cluster
   else
-    service_name=${service_type}${ACCUMULO_SERVICE_INSTANCE}-${group}
+    service_name="${service_type}${ACCUMULO_SERVICE_INSTANCE}"
   fi
 
   case "$service_type" in

--- a/assemble/conf/accumulo-env.sh
+++ b/assemble/conf/accumulo-env.sh
@@ -102,9 +102,11 @@ esac
 ## JVM options set for logging. Review log4j2.properties file to see how they are used.
 JAVA_OPTS=("-Daccumulo.log.dir=${ACCUMULO_LOG_DIR}"
   "-Daccumulo.application=${cmd}${ACCUMULO_SERVICE_INSTANCE}_$(hostname)"
-  "-Daccumulo.metrics.service.instance=${ACCUMULO_SERVICE_INSTANCE}"
+  "-Daccumulo.metrics.service.instance=${cmd}${ACCUMULO_SERVICE_INSTANCE}"
   "-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector"
   "-Dotel.service.name=${cmd}${ACCUMULO_SERVICE_INSTANCE}"
+  "-Dtest.meter.registry.host=localhost"
+  "-Dtest.meter.registry.port=8125"
   "${JAVA_OPTS[@]}"
 )
 

--- a/assemble/conf/accumulo-env.sh
+++ b/assemble/conf/accumulo-env.sh
@@ -105,8 +105,6 @@ JAVA_OPTS=("-Daccumulo.log.dir=${ACCUMULO_LOG_DIR}"
   "-Daccumulo.metrics.service.instance=${cmd}${ACCUMULO_SERVICE_INSTANCE}"
   "-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector"
   "-Dotel.service.name=${cmd}${ACCUMULO_SERVICE_INSTANCE}"
-  "-Dtest.meter.registry.host=localhost"
-  "-Dtest.meter.registry.port=8125"
   "${JAVA_OPTS[@]}"
 )
 


### PR DESCRIPTION
Consistently setting the env variable to include the group
and process number for all processes enables us to remove
code in the other scripts that try and find / apply the
group to various things. The specific issue this solves
is that the PID file name ended up being incorrect when
trying to stop the manager and garbage collector. The
PID file could not be found, because the calculated name
was incorrect, and the processes were not stopped.

Closes #4951