### PR TITLE
adds a static method for creating a configuration object

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/PluginEnvironment.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/PluginEnvironment.java
@@ -24,7 +24,10 @@ import java.util.Map.Entry;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import org.apache.accumulo.core.conf.ConfigurationCopy;
+import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.util.ConfigurationImpl;
 
 /**
  * This interface exposes Accumulo system level information to plugins in a stable manner. The
@@ -131,6 +134,20 @@ public interface PluginEnvironment {
      * reflected in the returned value.
      */
     <T> Supplier<T> getDerived(Function<Configuration,T> computeDerivedValue);
+
+    /**
+     * Creates a configuration object from a map of properties, this is useful for testing.
+     *
+     * @param includeDefaults If true will include accumulo's default properties and layer the
+     *        passed in map on top of these.
+     * @since 3.1.0
+     */
+    static Configuration from(Map<String,String> properties, boolean includeDefaults) {
+      ConfigurationCopy config = includeDefaults
+          ? new ConfigurationCopy(DefaultConfiguration.getInstance()) : new ConfigurationCopy();
+      properties.forEach(config::set);
+      return new ConfigurationImpl(config);
+    }
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/spi/common/ServiceEnvironment.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/common/ServiceEnvironment.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.core.spi.common;
 
+import java.util.Map;
+
 import org.apache.accumulo.core.client.PluginEnvironment;
 import org.apache.accumulo.core.data.TableId;
 
@@ -39,6 +41,16 @@ public interface ServiceEnvironment extends PluginEnvironment {
    */
   interface Configuration extends PluginEnvironment.Configuration {
 
+    /**
+     * Creates a configuration object from a map of properties, this is useful for testing.
+     *
+     * @param includeDefaults If true will include accumulo's default properties and layer the
+     *        passed in map on top of these.
+     * @since 3.1.0
+     */
+    static Configuration from(Map<String,String> properties, boolean includeDefaults) {
+      return (Configuration) PluginEnvironment.Configuration.from(properties, includeDefaults);
+    }
   }
 
   /**

--- a/core/src/test/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancerTest.java
@@ -39,8 +39,6 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.regex.Pattern;
 
-import org.apache.accumulo.core.conf.ConfigurationCopy;
-import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.TabletId;
 import org.apache.accumulo.core.dataImpl.thrift.TKeyExtent;
@@ -52,8 +50,8 @@ import org.apache.accumulo.core.spi.balancer.data.TServerStatus;
 import org.apache.accumulo.core.spi.balancer.data.TabletMigration;
 import org.apache.accumulo.core.spi.balancer.data.TabletServerId;
 import org.apache.accumulo.core.spi.balancer.data.TabletStatistics;
+import org.apache.accumulo.core.spi.common.ServiceEnvironment;
 import org.apache.accumulo.core.tabletserver.thrift.TabletStats;
-import org.apache.accumulo.core.util.ConfigurationImpl;
 import org.apache.accumulo.core.util.UtilWaitThread;
 import org.junit.jupiter.api.Test;
 
@@ -65,9 +63,7 @@ public class HostRegexTableLoadBalancerTest extends BaseHostRegexTableLoadBalanc
     tables.put(BAR.getTableName(), BAR.getId());
     tables.put(BAZ.getTableName(), BAZ.getId());
 
-    ConfigurationCopy config = new ConfigurationCopy(SiteConfiguration.empty().build());
-    tableProperties.forEach(config::set);
-    ConfigurationImpl configImpl = new ConfigurationImpl(config);
+    var configImpl = ServiceEnvironment.Configuration.from(tableProperties, false);
     BalancerEnvironment environment = createMock(BalancerEnvironment.class);
     expect(environment.getConfiguration()).andReturn(configImpl).anyTimes();
     expect(environment.getTableIdMap()).andReturn(tables).anyTimes();

--- a/core/src/test/java/org/apache/accumulo/core/spi/balancer/TableLoadBalancerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/balancer/TableLoadBalancerTest.java
@@ -34,7 +34,6 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
-import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.TabletId;
@@ -48,8 +47,8 @@ import org.apache.accumulo.core.spi.balancer.data.TServerStatus;
 import org.apache.accumulo.core.spi.balancer.data.TabletMigration;
 import org.apache.accumulo.core.spi.balancer.data.TabletServerId;
 import org.apache.accumulo.core.spi.balancer.data.TabletStatistics;
+import org.apache.accumulo.core.spi.common.ServiceEnvironment;
 import org.apache.accumulo.core.tabletserver.thrift.TabletStats;
-import org.apache.accumulo.core.util.ConfigurationImpl;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.Test;
 
@@ -117,9 +116,9 @@ public class TableLoadBalancerTest {
   @Test
   public void test() {
     BalancerEnvironment environment = createMock(BalancerEnvironment.class);
-    ConfigurationCopy cc = new ConfigurationCopy(
-        Map.of(Property.TABLE_LOAD_BALANCER.getKey(), TestSimpleLoadBalancer.class.getName()));
-    ConfigurationImpl tableConfig = new ConfigurationImpl(cc);
+    var tableConfig = ServiceEnvironment.Configuration.from(
+        Map.of(Property.TABLE_LOAD_BALANCER.getKey(), TestSimpleLoadBalancer.class.getName()),
+        false);
 
     Map<String,TableId> tableIdMap = TABLE_ID_MAP.entrySet().stream()
         .collect(Collectors.toMap(Map.Entry::getKey, e -> TableId.of(e.getValue())));

--- a/core/src/test/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlannerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlannerTest.java
@@ -37,17 +37,13 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.client.admin.compaction.CompactableFile;
-import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.ConfigurationTypeHelper;
-import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.Property;
-import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.spi.common.ServiceEnvironment;
 import org.apache.accumulo.core.spi.common.ServiceEnvironment.Configuration;
 import org.apache.accumulo.core.spi.compaction.CompactionPlan.Builder;
 import org.apache.accumulo.core.spi.compaction.CompactionPlanner.InitParameters;
-import org.apache.accumulo.core.util.ConfigurationImpl;
 import org.apache.accumulo.core.util.compaction.CompactionExecutorIdImpl;
 import org.apache.accumulo.core.util.compaction.CompactionJobImpl;
 import org.apache.accumulo.core.util.compaction.CompactionPlanImpl;
@@ -65,7 +61,7 @@ public class DefaultCompactionPlannerTest {
   }
 
   private static final Configuration defaultConf =
-      new ConfigurationImpl(DefaultConfiguration.getInstance());
+      ServiceEnvironment.Configuration.from(Map.of(), true);
   private static final CompactionServiceId csid = CompactionServiceId.of("cs1");
   private static final String prefix = Property.COMPACTION_SERVICE_PREFIX.getKey();
 
@@ -182,9 +178,8 @@ public class DefaultCompactionPlannerTest {
 
   @Test
   public void testUserCompaction() throws Exception {
-    ConfigurationCopy aconf = new ConfigurationCopy(DefaultConfiguration.getInstance());
-    aconf.set(prefix + "cs1.planner.opts.maxOpen", "15");
-    ConfigurationImpl config = new ConfigurationImpl(aconf);
+    ServiceEnvironment.Configuration config = ServiceEnvironment.Configuration
+        .from(Map.of(prefix + "cs1.planner.opts.maxOpen", "15"), true);
 
     String executors = "[{'name':'small','type': 'internal','maxSize':'32M','numThreads':1},"
         + "{'name':'medium','type': 'internal','maxSize':'128M','numThreads':2},"
@@ -458,7 +453,7 @@ public class DefaultCompactionPlannerTest {
     Map<String,String> overrides = new HashMap<>();
     overrides.put(Property.COMPACTION_SERVICE_PREFIX.getKey() + "cs1.planner.opts.maxOpen", "10");
     overrides.put(Property.TABLE_FILE_MAX.getKey(), "7");
-    var conf = new ConfigurationImpl(SiteConfiguration.empty().withOverrides(overrides).build());
+    var conf = ServiceEnvironment.Configuration.from(overrides, false);
 
     // For this case need to compact three files and the highest ratio that achieves that is 1.8
     var planner = createPlanner(conf, executors);
@@ -535,7 +530,7 @@ public class DefaultCompactionPlannerTest {
     Map<String,String> overrides = new HashMap<>();
     overrides.put(Property.COMPACTION_SERVICE_PREFIX.getKey() + "cs1.planner.opts.maxOpen", "10");
     overrides.put(Property.TABLE_FILE_MAX.getKey(), "7");
-    var conf = new ConfigurationImpl(SiteConfiguration.empty().withOverrides(overrides).build());
+    var conf = ServiceEnvironment.Configuration.from(overrides, false);
 
     // ensure that when a compaction would be over the max size limit that it is not planned
     var planner = createPlanner(conf, executors);
@@ -574,7 +569,7 @@ public class DefaultCompactionPlannerTest {
     overrides.put(Property.COMPACTION_SERVICE_PREFIX.getKey() + "cs1.planner.opts.maxOpen", "10");
     overrides.put(Property.TABLE_FILE_MAX.getKey(), "0");
     overrides.put(Property.TSERV_SCAN_MAX_OPENFILES.getKey(), "5");
-    var conf = new ConfigurationImpl(SiteConfiguration.empty().withOverrides(overrides).build());
+    var conf = ServiceEnvironment.Configuration.from(overrides, false);
 
     var planner = createPlanner(conf, executors);
     var all = createCFs(1000, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1);


### PR DESCRIPTION
Adds static methods for creating PluginEnv.Configuration objects from a Map<String,String> and updates tests to use them.  These new methods make it easier for downstream projects to create these object using only public APIs.