### PR TITLE
Add metrics to track time compaction jobs are queued

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metrics/Metric.java
+++ b/core/src/main/java/org/apache/accumulo/core/metrics/Metric.java
@@ -60,8 +60,9 @@ public enum Metric {
   COMPACTOR_JOB_PRIORITY_QUEUE_JOBS_AVG_AGE("accumulo.compactor.queue.jobs.avg.age",
       MetricType.GAUGE, "Average age of currently queued jobs in seconds.",
       MetricCategory.COMPACTOR),
-  COMPACTOR_JOB_PRIORITY_QUEUE_JOBS_POLL_TIMER("accumulo.compactor.queue.jobs.poll.time",
-      MetricType.TIMER, "Time for poll to return compaction jobs.", MetricCategory.COMPACTOR),
+  COMPACTOR_JOB_PRIORITY_QUEUE_JOBS_POLL_TIMER("accumulo.compactor.queue.jobs.exit.time",
+      MetricType.TIMER, "Tracks time a job spent in the queue before exiting the queue.",
+      MetricCategory.COMPACTOR),
 
   // Fate Metrics
   FATE_TYPE_IN_PROGRESS("accumulo.fate.ops.in.progress.by.type", MetricType.GAUGE,

--- a/core/src/main/java/org/apache/accumulo/core/metrics/Metric.java
+++ b/core/src/main/java/org/apache/accumulo/core/metrics/Metric.java
@@ -51,6 +51,17 @@ public enum Metric {
       MetricType.GAUGE, "Count of rejected jobs.", MetricCategory.COMPACTOR),
   COMPACTOR_JOB_PRIORITY_QUEUE_JOBS_PRIORITY("accumulo.compactor.queue.jobs.priority",
       MetricType.GAUGE, "Lowest priority queued job.", MetricCategory.COMPACTOR),
+  COMPACTOR_JOB_PRIORITY_QUEUE_JOBS_MIN_AGE("accumulo.compactor.queue.jobs.min.age",
+      MetricType.GAUGE, "Minimum age of currently queued jobs in seconds.",
+      MetricCategory.COMPACTOR),
+  COMPACTOR_JOB_PRIORITY_QUEUE_JOBS_MAX_AGE("accumulo.compactor.queue.jobs.max.age",
+      MetricType.GAUGE, "Maximum age of currently queued jobs in seconds.",
+      MetricCategory.COMPACTOR),
+  COMPACTOR_JOB_PRIORITY_QUEUE_JOBS_AVG_AGE("accumulo.compactor.queue.jobs.avg.age",
+      MetricType.GAUGE, "Average age of currently queued jobs in seconds.",
+      MetricCategory.COMPACTOR),
+  COMPACTOR_JOB_PRIORITY_QUEUE_JOBS_POLL_TIMER("accumulo.compactor.queue.jobs.poll.time",
+      MetricType.TIMER, "Time for poll to return compaction jobs.", MetricCategory.COMPACTOR),
 
   // Fate Metrics
   FATE_TYPE_IN_PROGRESS("accumulo.fate.ops.in.progress.by.type", MetricType.GAUGE,

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
@@ -1049,7 +1049,7 @@ public class CompactionCoordinator
           // associated priority queue of jobs
           CompactionJobPriorityQueue queue = getJobQueues().getQueue(cgid);
           if (queue != null) {
-            queue.clear();
+            queue.clearIfInactive(Duration.ofMinutes(10));
             queue.setMaxSize(this.jobQueueInitialSize);
           }
         } else {

--- a/server/manager/src/test/java/org/apache/accumulo/manager/compaction/queue/CompactionJobPriorityQueueTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/compaction/queue/CompactionJobPriorityQueueTest.java
@@ -266,6 +266,11 @@ public class CompactionJobPriorityQueueTest {
     }
 
     assertEquals(100, matchesSeen);
+
+    var stats = queue.getJobQueueStats();
+    assertTrue(stats.getMinAge().toMillis() > 0);
+    assertTrue(stats.getMaxAge().toMillis() > 0);
+    assertTrue(stats.getAvgAge().toMillis() > 0);
   }
 
   /**

--- a/server/manager/src/test/java/org/apache/accumulo/manager/compaction/queue/CompactionJobQueuesTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/compaction/queue/CompactionJobQueuesTest.java
@@ -375,7 +375,6 @@ public class CompactionJobQueuesTest {
 
     // Should be back to 0 size after futures complete
     assertTrue(jobQueues.getQueue(cg1).getJobAges().isEmpty());
-    ;
 
     assertTrue(future1.isDone());
     assertTrue(future2.isDone());

--- a/server/manager/src/test/java/org/apache/accumulo/manager/compaction/queue/CompactionJobQueuesTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/compaction/queue/CompactionJobQueuesTest.java
@@ -362,11 +362,20 @@ public class CompactionJobQueuesTest {
 
     jobQueues.add(tm1, List.of(newJob((short) 1, 5, cg1)));
     jobQueues.add(tm2, List.of(newJob((short) 2, 6, cg1)));
+    // Futures were immediately completed so nothing should be queued
+    assertTrue(jobQueues.getQueue(cg1).getJobAges().isEmpty());
+
     jobQueues.add(tm3, List.of(newJob((short) 3, 7, cg1)));
     jobQueues.add(tm4, List.of(newJob((short) 4, 8, cg1)));
+    // No futures available, so jobAges should exist for 2 tablets
+    assertEquals(2, jobQueues.getQueue(cg1).getJobAges().size());
 
     var future3 = jobQueues.getAsync(cg1);
     var future4 = jobQueues.getAsync(cg1);
+
+    // Should be back to 0 size after futures complete
+    assertTrue(jobQueues.getQueue(cg1).getJobAges().isEmpty());
+    ;
 
     assertTrue(future1.isDone());
     assertTrue(future2.isDone());


### PR DESCRIPTION
This adds 2 new groups of stats to track information about queued compaction jobs. The first stat is a timer that keeps track of when jobs are being polled and give information on how often/fast jobs are exiting the queue. The second group of stats is a min/max/avg and is tracking age information about how long jobs are waiting on the queue.

This closes #4945

This is a draft for now because there is a couple outstanding things to do and it probably still needs a little bit of polishing but I wanted to post what I had to get feedback. The tests could also be improved a bit I think. I was trying to think of a good way to check that the stats are correct but the values are going to be non-deterministic as it's all timing in based so it would be hard to check exact values. 

Todo/questions:

1. Should we record a time of 0 if there's a job immediately available in poll()? 
2. How should we handle async? I'm not sure the metrics really even apply to async as we are trying to track how long jobs are waiting on a queue before they are polled to check latency. However, if we were using async, then in theory the latency is near 0 as if there are compactors that are ready they don't need to poll and they'd just be waiting for the future to complete. Maybe we just record a time of 0 for async when a future is completed?
3. What do we do with the timer on clear(), there is a TODO in the code.