### PR TITLE
Added support for http/2 to the Monitor web server

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -868,6 +868,8 @@ public enum Property {
           + " The resources that are used by default can be seen in"
           + " `accumulo/server/monitor/src/main/resources/templates/default.ftl`.",
       "2.0.0"),
+  MONITOR_SUPPORT_HTTP2("monitor.http2.support", "false", PropertyType.BOOLEAN,
+      "If true will configure the Monitor web server to support http2 connections.", "3.1.0"),
   // per table properties
   TABLE_PREFIX("table.", null, PropertyType.PREFIX,
       "Properties in this category affect tablet server treatment of tablets,"

--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,7 @@
     <version.curator>5.5.0</version.curator>
     <version.errorprone>2.24.1</version.errorprone>
     <version.hadoop>3.4.0</version.hadoop>
+    <version.jetty>11.0.24</version.jetty>
     <version.log4j>2.24.0</version.log4j>
     <version.opentelemetry>1.34.1</version.opentelemetry>
     <version.powermock>2.0.9</version.powermock>
@@ -206,7 +207,7 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-bom</artifactId>
-        <version>11.0.19</version>
+        <version>${version.jetty}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/server/monitor/pom.xml
+++ b/server/monitor/pom.xml
@@ -110,6 +110,10 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-alpn-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
     </dependency>
     <dependency>
@@ -119,6 +123,10 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.http2</groupId>
+      <artifactId>http2-server</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.hk2</groupId>

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -473,7 +473,7 @@ public class Monitor extends AbstractServer implements HighlyAvailableService {
       throw new RuntimeException(
           "Unable to start embedded web server on ports: " + Arrays.toString(ports));
     } else {
-      log.debug("Monitor started on port h1/h2: {}", server.getHttpPort());
+      log.debug("Monitor started on port {}", server.getHttpPort());
     }
 
     String advertiseHost = getHostname();
@@ -508,9 +508,9 @@ public class Monitor extends AbstractServer implements HighlyAvailableService {
       // Delete before we try to re-create in case the previous session hasn't yet expired
       zoo.delete(path);
       zoo.putEphemeralData(path, url.toString().getBytes(UTF_8));
-      log.info("Set monitor http address in zookeeper to {}", url);
+      log.info("Set monitor address in zookeeper to {}", url);
     } catch (Exception ex) {
-      log.error("Unable to advertise monitor HTTP addresses in zookeeper", ex);
+      log.error("Unable to advertise monitor HTTP address in zookeeper", ex);
     }
 
     // need to regularly fetch data so plot data is updated

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -187,6 +187,22 @@
       <artifactId>easymock</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-alpn-java-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-alpn-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.http2</groupId>
+      <artifactId>http2-http-client-transport</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jline</groupId>
       <artifactId>jline</artifactId>
     </dependency>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -188,15 +188,19 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-alpn-java-server</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-alpn-server</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-io</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.http2</groupId>
+      <artifactId>http2-client</artifactId>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.http2</groupId>

--- a/test/src/main/java/org/apache/accumulo/test/functional/MonitorSslIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MonitorSslIT.java
@@ -22,18 +22,13 @@ import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
-import java.net.URL;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.X509Certificate;
-import java.time.Duration;
 import java.util.Map;
 
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
@@ -42,32 +37,39 @@ import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.util.MonitorUtil;
+import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.hadoop.conf.Configuration;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.http.HttpClientTransportOverHTTP;
+import org.eclipse.jetty.http2.client.HTTP2Client;
+import org.eclipse.jetty.http2.client.http.HttpClientTransportOverHTTP2;
+import org.eclipse.jetty.io.ClientConnector;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Check SSL for the Monitor
  */
-public class MonitorSslIT extends ConfigurableMacBase {
+public class MonitorSslIT extends AccumuloClusterHarness {
 
-  @Override
-  protected Duration defaultTimeout() {
-    return Duration.ofMinutes(6);
-  }
+  private static final Logger LOG = LoggerFactory.getLogger(MonitorSslIT.class);
+  private static SSLContext ctx;
 
   @BeforeAll
   public static void initHttps() throws NoSuchAlgorithmException, KeyManagementException {
-    SSLContext ctx = SSLContext.getInstance("TLSv1.3");
+    ctx = SSLContext.getInstance("TLSv1.3");
     TrustManager[] tm = {new TestTrustManager()};
     ctx.init(new KeyManager[0], tm, RANDOM.get());
     SSLContext.setDefault(ctx);
-    HttpsURLConnection.setDefaultSSLSocketFactory(ctx.getSocketFactory());
-    HttpsURLConnection.setDefaultHostnameVerifier(new TestHostnameVerifier());
   }
 
   @SuppressFBWarnings(value = "WEAK_TRUST_MANAGER",
@@ -85,52 +87,65 @@ public class MonitorSslIT extends ConfigurableMacBase {
     }
   }
 
-  @SuppressFBWarnings(value = "WEAK_HOSTNAME_VERIFIER", justification = "okay for test")
-  private static class TestHostnameVerifier implements HostnameVerifier {
-    @Override
-    public boolean verify(String hostname, SSLSession session) {
-      return true;
-    }
+  private static boolean sslEnabled = false;
+
+  @AfterEach
+  public void after() throws Exception {
+    cluster.getClusterControl().stopAllServers(ServerType.MONITOR);
+    sslEnabled = !sslEnabled;
   }
 
   @Override
-  public void configure(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
-    super.configure(cfg, hadoopCoreSite);
-    File baseDir = createTestDir(this.getClass().getName() + "_" + this.testName());
-    configureForSsl(cfg, getSslDir(baseDir));
-    Map<String,String> siteConfig = cfg.getSiteConfig();
-    siteConfig.put(Property.MONITOR_SSL_KEYSTORE.getKey(),
-        siteConfig.get(Property.RPC_SSL_KEYSTORE_PATH.getKey()));
-    siteConfig.put(Property.MONITOR_SSL_KEYSTOREPASS.getKey(),
-        siteConfig.get(Property.RPC_SSL_KEYSTORE_PASSWORD.getKey()));
-    if (siteConfig.containsKey(Property.RPC_SSL_KEYSTORE_TYPE.getKey())) {
-      siteConfig.put(Property.MONITOR_SSL_KEYSTORETYPE.getKey(),
-          siteConfig.get(Property.RPC_SSL_KEYSTORE_TYPE.getKey()));
-    } else {
-      siteConfig.put(Property.MONITOR_SSL_KEYSTORETYPE.getKey(),
-          Property.RPC_SSL_KEYSTORE_TYPE.getDefaultValue());
+  public void configureMiniCluster(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
+    LOG.info("*** Configuring server, SSL Enabled: {}", sslEnabled);
+    if (sslEnabled) {
+      File baseDir = createTestDir(this.getClass().getName() + "_" + this.testName());
+      ConfigurableMacBase.configureForSsl(cfg, getSslDir(baseDir));
+      Map<String,String> siteConfig = cfg.getSiteConfig();
+      siteConfig.put(Property.MONITOR_SSL_KEYSTORE.getKey(),
+          siteConfig.get(Property.RPC_SSL_KEYSTORE_PATH.getKey()));
+      siteConfig.put(Property.MONITOR_SSL_KEYSTOREPASS.getKey(),
+          siteConfig.get(Property.RPC_SSL_KEYSTORE_PASSWORD.getKey()));
+      if (siteConfig.containsKey(Property.RPC_SSL_KEYSTORE_TYPE.getKey())) {
+        siteConfig.put(Property.MONITOR_SSL_KEYSTORETYPE.getKey(),
+            siteConfig.get(Property.RPC_SSL_KEYSTORE_TYPE.getKey()));
+      } else {
+        siteConfig.put(Property.MONITOR_SSL_KEYSTORETYPE.getKey(),
+            Property.RPC_SSL_KEYSTORE_TYPE.getDefaultValue());
+      }
+      siteConfig.put(Property.MONITOR_SSL_TRUSTSTORE.getKey(),
+          siteConfig.get(Property.RPC_SSL_TRUSTSTORE_PATH.getKey()));
+      siteConfig.put(Property.MONITOR_SSL_TRUSTSTOREPASS.getKey(),
+          siteConfig.get(Property.RPC_SSL_TRUSTSTORE_PASSWORD.getKey()));
+      if (siteConfig.containsKey(Property.RPC_SSL_TRUSTSTORE_TYPE.getKey())) {
+        siteConfig.put(Property.MONITOR_SSL_TRUSTSTORETYPE.getKey(),
+            siteConfig.get(Property.RPC_SSL_TRUSTSTORE_TYPE.getKey()));
+      } else {
+        siteConfig.put(Property.MONITOR_SSL_TRUSTSTORETYPE.getKey(),
+            Property.RPC_SSL_TRUSTSTORE_TYPE.getDefaultValue());
+      }
+      cfg.setSiteConfig(siteConfig);
     }
-    siteConfig.put(Property.MONITOR_SSL_TRUSTSTORE.getKey(),
-        siteConfig.get(Property.RPC_SSL_TRUSTSTORE_PATH.getKey()));
-    siteConfig.put(Property.MONITOR_SSL_TRUSTSTOREPASS.getKey(),
-        siteConfig.get(Property.RPC_SSL_TRUSTSTORE_PASSWORD.getKey()));
-    if (siteConfig.containsKey(Property.RPC_SSL_TRUSTSTORE_TYPE.getKey())) {
-      siteConfig.put(Property.MONITOR_SSL_TRUSTSTORETYPE.getKey(),
-          siteConfig.get(Property.RPC_SSL_TRUSTSTORE_TYPE.getKey()));
-    } else {
-      siteConfig.put(Property.MONITOR_SSL_TRUSTSTORETYPE.getKey(),
-          Property.RPC_SSL_TRUSTSTORE_TYPE.getDefaultValue());
-    }
-    cfg.setSiteConfig(siteConfig);
   }
 
-  @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "url provided by test")
   @Test
+  public void test1() throws Exception {
+    test();
+  }
+
+  @Test
+  public void test2() throws Exception {
+    test();
+  }
+
   public void test() throws Exception {
-    log.debug("Starting Monitor");
+    LOG.info("*** Running test, SSL Enabled: {}", sslEnabled);
+
+    LOG.debug("Starting Monitor");
     cluster.getClusterControl().startAllServers(ServerType.MONITOR);
     String monitorLocation = null;
-    try (AccumuloClient client = Accumulo.newClient().from(getClientProperties()).build()) {
+    try (AccumuloClient client =
+        Accumulo.newClient().from(getCluster().getClientProperties()).build()) {
       while (monitorLocation == null) {
         try {
           monitorLocation = MonitorUtil.getLocation((ClientContext) client);
@@ -138,16 +153,63 @@ public class MonitorSslIT extends ConfigurableMacBase {
           // ignored
         }
         if (monitorLocation == null) {
-          log.debug("Could not fetch monitor HTTP address from zookeeper");
+          LOG.debug("Could not fetch monitor HTTP address from zookeeper");
           Thread.sleep(2000);
         }
       }
     }
-    URL url = new URL(monitorLocation);
-    log.debug("Fetching web page {}", url);
-    String result = FunctionalTestUtils.readWebPage(url).body();
-    assertTrue(result.length() > 100);
-    assertTrue(result.indexOf("Accumulo Overview") >= 0);
+
+    SslContextFactory.Client sslContextFactory = null;
+    if (sslEnabled) {
+      sslContextFactory = new SslContextFactory.Client();
+      sslContextFactory.setSslContext(ctx);
+      // Don't validate server host name
+      sslContextFactory.setEndpointIdentificationAlgorithm(null);
+    }
+
+    HttpClient h1 = createHttp11(sslContextFactory);
+    h1.start();
+    ContentResponse body = h1.GET(monitorLocation);
+    assertTrue(body.getContentAsString().length() > 100);
+    assertTrue(body.getContentAsString().indexOf("Accumulo Overview") >= 0);
+    h1.stop();
+
+    HttpClient h2 = createHttp2(sslContextFactory);
+    h2.start();
+    body = h2.GET(monitorLocation);
+    assertTrue(body.getContentAsString().length() > 100);
+    assertTrue(body.getContentAsString().indexOf("Accumulo Overview") >= 0);
+    h2.stop();
+
+  }
+
+  private HttpClient createHttp11(SslContextFactory.Client sslContextFactory) throws Exception {
+
+    ClientConnector connector = new ClientConnector();
+    if (sslContextFactory != null) {
+      connector.setSslContextFactory(sslContextFactory);
+    }
+
+    HttpClientTransportOverHTTP transport = new HttpClientTransportOverHTTP(connector);
+
+    return new HttpClient(transport);
+  }
+
+  private HttpClient createHttp2(SslContextFactory.Client sslContextFactory) throws Exception {
+
+    ClientConnector connector = new ClientConnector();
+    if (sslContextFactory != null) {
+      connector.setSslContextFactory(sslContextFactory);
+    }
+
+    HTTP2Client h2Client = new HTTP2Client(connector);
+    h2Client.setInitialSessionRecvWindow(64 * 1024 * 1024);
+    h2Client.setMaxFrameSize(14 * 1024 * 1024);
+
+    // Create and configure the HTTP/2 transport.
+    HttpClientTransportOverHTTP2 transport = new HttpClientTransportOverHTTP2(h2Client);
+
+    return new HttpClient(transport);
   }
 
 }


### PR DESCRIPTION
Added conditional support for http/2 to the Monitor web server. I
investigated adding http/3 support as it's [documented](https://jetty.org/docs/jetty/11/programming-guide/server/http.html#connector-protocol-http3), but it appears
that according to the [code](https://javadoc.jetty.org/jetty-11/org/eclipse/jetty/http3/server/HTTP3ServerConnector.html), it's still experimental and not ready for production. Note that http/2
can be used without TLS, but it appears that when http/2 is used
from a browser that the browser enforces TLS. I fixed MontorSslIT
to test with and without ssl, and with and without http/2.

Closes #4974 