### PR TITLE
invalidates config cache and retries when classloader context not found

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/classloader/DefaultContextClassLoaderFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/classloader/DefaultContextClassLoaderFactory.java
@@ -58,15 +58,16 @@ public class DefaultContextClassLoaderFactory implements ContextClassLoaderFacto
     }
     Supplier<Map<String,String>> contextConfigSupplier =
         () -> accConf.getAllPropertiesWithPrefix(VFS_CONTEXT_CLASSPATH_PROPERTY);
-    setContextConfig(contextConfigSupplier);
+    setContextConfig(contextConfigSupplier, accConf::invalidateCache);
     LOG.debug("ContextManager configuration set");
     startCleanupThread(accConf, contextConfigSupplier);
   }
 
   @SuppressWarnings("deprecation")
-  private static void setContextConfig(Supplier<Map<String,String>> contextConfigSupplier) {
+  private static void setContextConfig(Supplier<Map<String,String>> contextConfigSupplier,
+      Runnable contextConfigInvalidator) {
     org.apache.accumulo.start.classloader.vfs.AccumuloVFSClassLoader
-        .setContextConfig(contextConfigSupplier);
+        .setContextConfig(contextConfigSupplier, contextConfigInvalidator);
   }
 
   private static void startCleanupThread(final AccumuloConfiguration conf,

--- a/start/src/main/java/org/apache/accumulo/start/classloader/vfs/AccumuloVFSClassLoader.java
+++ b/start/src/main/java/org/apache/accumulo/start/classloader/vfs/AccumuloVFSClassLoader.java
@@ -398,8 +398,10 @@ public class AccumuloVFSClassLoader {
     }
   }
 
-  public static void setContextConfig(Supplier<Map<String,String>> contextConfigSupplier) {
-    var config = new ContextManager.DefaultContextsConfig(contextConfigSupplier);
+  public static void setContextConfig(Supplier<Map<String,String>> contextConfigSupplier,
+      Runnable contextConfigInvalidator) {
+    var config =
+        new ContextManager.DefaultContextsConfig(contextConfigSupplier, contextConfigInvalidator);
     try {
       getContextManager().setContextConfig(config);
     } catch (IOException e) {


### PR DESCRIPTION
When a new classloader context is set and then used its possible the config change has not propagated to all servers by the time a scan attempts to use the context.  This change invalidates the config cache and retries when when a context is not found.