### PR TITLE
Consistently log when property stores is invalidated

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/conf/store/PropStoreKey.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/store/PropStoreKey.java
@@ -152,6 +152,6 @@ public abstract class PropStoreKey<ID_TYPE extends AbstractId<ID_TYPE>>
   @Override
   public String toString() {
     return this.getClass().getSimpleName() + "{" + getId().getClass().getSimpleName() + "="
-        + getId().canonical() + "'}";
+        + getId().canonical() + "}";
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/util/PropSnapshot.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/util/PropSnapshot.java
@@ -113,6 +113,7 @@ public class PropSnapshot implements PropChangeListener {
   public void zkChangeEvent(final PropStoreKey<?> eventPropKey) {
     if (propStoreKey.equals(eventPropKey)) {
       requireUpdate();
+      log.debug("Saw zk change event for {} - update properties required", propStoreKey);
     }
   }
 
@@ -120,6 +121,7 @@ public class PropSnapshot implements PropChangeListener {
   public void cacheChangeEvent(final PropStoreKey<?> eventPropKey) {
     if (propStoreKey.equals(eventPropKey)) {
       requireUpdate();
+      log.debug("Saw cache change event for {} - update properties required", propStoreKey);
     }
   }
 
@@ -127,14 +129,14 @@ public class PropSnapshot implements PropChangeListener {
   public void deleteEvent(final PropStoreKey<?> eventPropKey) {
     if (propStoreKey.equals(eventPropKey)) {
       requireUpdate();
-      log.debug("Received property delete event for {}", propStoreKey);
+      log.debug("Received property delete event for {} - update properties required", propStoreKey);
     }
   }
 
   @Override
   public void connectionEvent() {
     requireUpdate();
-    log.debug("Received connection event - update properties required");
+    log.debug("Received connection event for {} - update properties required", propStoreKey);
   }
 
 }


### PR DESCRIPTION
PropStore was logging on some events that caused a need to refresh the properties and not others.  Modified to consistently log whenever an event caused the properties to be invalidated.