### PR TITLE
Improvements to reservation column in FATE table and bug fix

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/FateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/FateStore.java
@@ -29,7 +29,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.apache.accumulo.core.fate.user.FateMutatorImpl;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.hadoop.io.DataInputBuffer;
 
@@ -147,19 +146,6 @@ public interface FateStore<T> extends ReadOnlyFateStore<T> {
       return new FateReservation(lockID, reservationUUID);
     }
 
-    /**
-     * @param serializedFateRes the value present in the table for the reservation column
-     * @return true if the array represents a valid serialized FateReservation object, false if it
-     *         represents an unreserved value, error otherwise
-     */
-    public static boolean isFateReservation(byte[] serializedFateRes) {
-      if (Arrays.equals(serializedFateRes, FateMutatorImpl.NOT_RESERVED)) {
-        return false;
-      }
-      deserialize(serializedFateRes);
-      return true;
-    }
-
     public ZooUtil.LockID getLockID() {
       return lockID;
     }
@@ -193,10 +179,6 @@ public interface FateStore<T> extends ReadOnlyFateStore<T> {
       } catch (IOException e) {
         throw new UncheckedIOException(e);
       }
-    }
-
-    public static boolean locksAreEqual(ZooUtil.LockID lockID1, ZooUtil.LockID lockID2) {
-      return lockID1.serialize("/").equals(lockID2.serialize("/"));
     }
 
     @Override

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/FateMutator.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/FateMutator.java
@@ -44,30 +44,12 @@ public interface FateMutator<T> {
 
   /**
    * Add a conditional mutation to {@link FateSchema.TxColumnFamily#RESERVATION_COLUMN} that will
-   * put the reservation if the column doesn't exist yet. This should only be used for
-   * {@link UserFateStore#createAndReserve(FateKey)}
-   *
-   * @param reservation the reservation to attempt to put
-   * @return the FateMutator with this added mutation
-   */
-  FateMutator<T> putReservedTxOnCreation(FateStore.FateReservation reservation);
-
-  /**
-   * Add a conditional mutation to {@link FateSchema.TxColumnFamily#RESERVATION_COLUMN} that will
-   * remove the given reservation if it matches what is present in the column.
+   * delete the column if the column value matches the given reservation
    *
    * @param reservation the reservation to attempt to remove
    * @return the FateMutator with this added mutation
    */
   FateMutator<T> putUnreserveTx(FateStore.FateReservation reservation);
-
-  /**
-   * Add a conditional mutation to {@link FateSchema.TxColumnFamily#RESERVATION_COLUMN} that will
-   * put the initial column value if it has not already been set yet
-   *
-   * @return the FateMutator with this added mutation
-   */
-  FateMutator<T> putInitReservationVal();
 
   FateMutator<T> putName(byte[] data);
 

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/FateMutatorImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/FateMutatorImpl.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.core.fate.user;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.core.fate.AbstractFateStore.serialize;
 import static org.apache.accumulo.core.fate.user.UserFateStore.getRow;
 import static org.apache.accumulo.core.fate.user.UserFateStore.getRowId;
@@ -50,8 +49,6 @@ import org.apache.accumulo.core.security.Authorizations;
 import org.apache.hadoop.io.Text;
 
 public class FateMutatorImpl<T> implements FateMutator<T> {
-
-  public static final byte[] NOT_RESERVED = "".getBytes(UTF_8);
 
   private final ClientContext context;
   private final String tableName;
@@ -86,15 +83,6 @@ public class FateMutatorImpl<T> implements FateMutator<T> {
   @Override
   public FateMutator<T> putReservedTx(FateStore.FateReservation reservation) {
     Condition condition = new Condition(TxColumnFamily.RESERVATION_COLUMN.getColumnFamily(),
-        TxColumnFamily.RESERVATION_COLUMN.getColumnQualifier()).setValue(NOT_RESERVED);
-    mutation.addCondition(condition);
-    TxColumnFamily.RESERVATION_COLUMN.put(mutation, new Value(reservation.getSerialized()));
-    return this;
-  }
-
-  @Override
-  public FateMutator<T> putReservedTxOnCreation(FateStore.FateReservation reservation) {
-    Condition condition = new Condition(TxColumnFamily.RESERVATION_COLUMN.getColumnFamily(),
         TxColumnFamily.RESERVATION_COLUMN.getColumnQualifier());
     mutation.addCondition(condition);
     TxColumnFamily.RESERVATION_COLUMN.put(mutation, new Value(reservation.getSerialized()));
@@ -107,16 +95,7 @@ public class FateMutatorImpl<T> implements FateMutator<T> {
         TxColumnFamily.RESERVATION_COLUMN.getColumnQualifier())
         .setValue(reservation.getSerialized());
     mutation.addCondition(condition);
-    TxColumnFamily.RESERVATION_COLUMN.put(mutation, new Value(NOT_RESERVED));
-    return this;
-  }
-
-  @Override
-  public FateMutator<T> putInitReservationVal() {
-    Condition condition = new Condition(TxColumnFamily.RESERVATION_COLUMN.getColumnFamily(),
-        TxColumnFamily.RESERVATION_COLUMN.getColumnQualifier());
-    mutation.addCondition(condition);
-    TxColumnFamily.RESERVATION_COLUMN.put(mutation, new Value(NOT_RESERVED));
+    TxColumnFamily.RESERVATION_COLUMN.putDelete(mutation);
     return this;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooUtil.java
@@ -28,6 +28,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.data.InstanceId;
@@ -91,6 +92,24 @@ public class ZooUtil {
     @Override
     public String toString() {
       return " path = " + path + " node = " + node + " eid = " + Long.toHexString(eid);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj == this) {
+        return true;
+      }
+      if (obj instanceof LockID) {
+        LockID other = (LockID) obj;
+        return this.path.equals(other.path) && this.node.equals(other.node)
+            && this.eid == other.eid;
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(path, node, eid);
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/fate/MultipleStoresIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/MultipleStoresIT.java
@@ -421,8 +421,7 @@ public class MultipleStoresIT extends SharedMiniClusterBase {
     // Verify store1 has the transactions reserved and that they were reserved with lock1
     reservations = store1.getActiveReservations();
     assertEquals(allIds, reservations.keySet());
-    reservations.values().forEach(
-        res -> assertTrue(FateStore.FateReservation.locksAreEqual(lock1, res.getLockID())));
+    reservations.values().forEach(res -> assertEquals(lock1, res.getLockID()));
 
     if (isUserStore) {
       store2 = new UserFateStore<>(client, tableName, lock2, isLockHeld);
@@ -434,8 +433,7 @@ public class MultipleStoresIT extends SharedMiniClusterBase {
     // store1
     reservations = store2.getActiveReservations();
     assertEquals(allIds, reservations.keySet());
-    reservations.values().forEach(
-        res -> assertTrue(FateStore.FateReservation.locksAreEqual(lock1, res.getLockID())));
+    reservations.values().forEach(res -> assertEquals(lock1, res.getLockID()));
 
     // Simulate what would happen if the Manager using the Fate object (fate1) died.
     // isLockHeld would return false for the LockId of the Manager that died (in this case, lock1)
@@ -455,8 +453,8 @@ public class MultipleStoresIT extends SharedMiniClusterBase {
     // the workers for fate1 are hung up
     Wait.waitFor(() -> {
       Map<FateId,FateStore.FateReservation> store2Reservations = store2.getActiveReservations();
-      boolean allReservedWithLock2 = store2Reservations.values().stream()
-          .allMatch(entry -> FateStore.FateReservation.locksAreEqual(entry.getLockID(), lock2));
+      boolean allReservedWithLock2 =
+          store2Reservations.values().stream().allMatch(entry -> entry.getLockID().equals(lock2));
       return store2Reservations.keySet().equals(allIds) && allReservedWithLock2;
     }, fate1.getDeadResCleanupDelay().toMillis() * 2);
 

--- a/test/src/main/java/org/apache/accumulo/test/fate/user/FateMutatorImplIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/user/FateMutatorImplIT.java
@@ -181,29 +181,14 @@ public class FateMutatorImplIT extends SharedMiniClusterBase {
       ClientContext context = (ClientContext) client;
 
       FateId fateId = FateId.from(FateInstanceType.USER, UUID.randomUUID());
-      FateId fateId1 = FateId.from(FateInstanceType.USER, UUID.randomUUID());
       ZooUtil.LockID lockID = new ZooUtil.LockID("/locks", "L1", 50);
       FateStore.FateReservation reservation =
           FateStore.FateReservation.from(lockID, UUID.randomUUID());
       FateStore.FateReservation wrongReservation =
           FateStore.FateReservation.from(lockID, UUID.randomUUID());
 
-      // Ensure that we cannot do anything in the column until it is initialized
-      FateMutator.Status status =
-          new FateMutatorImpl<>(context, table, fateId).putReservedTx(reservation).tryMutate();
-      assertEquals(REJECTED, status);
-      status =
-          new FateMutatorImpl<>(context, table, fateId).putUnreserveTx(reservation).tryMutate();
-      assertEquals(REJECTED, status);
-
-      // Initialize the column and ensure we can't do it twice
-      status = new FateMutatorImpl<>(context, table, fateId).putInitReservationVal().tryMutate();
-      assertEquals(ACCEPTED, status);
-      status = new FateMutatorImpl<>(context, table, fateId).putInitReservationVal().tryMutate();
-      assertEquals(REJECTED, status);
-
       // Ensure that reserving is the only thing we can do
-      status =
+      FateMutator.Status status =
           new FateMutatorImpl<>(context, table, fateId).putUnreserveTx(reservation).tryMutate();
       assertEquals(REJECTED, status);
       status = new FateMutatorImpl<>(context, table, fateId).putReservedTx(reservation).tryMutate();
@@ -225,20 +210,6 @@ public class FateMutatorImplIT extends SharedMiniClusterBase {
       assertEquals(ACCEPTED, status);
       status =
           new FateMutatorImpl<>(context, table, fateId).putUnreserveTx(reservation).tryMutate();
-      assertEquals(REJECTED, status);
-
-      // Verify putReservedTxOnCreation works as expected
-      status = new FateMutatorImpl<>(context, table, fateId1).putReservedTxOnCreation(reservation)
-          .tryMutate();
-      assertEquals(ACCEPTED, status);
-      status = new FateMutatorImpl<>(context, table, fateId1).putReservedTxOnCreation(reservation)
-          .tryMutate();
-      assertEquals(REJECTED, status);
-      status =
-          new FateMutatorImpl<>(context, table, fateId1).putUnreserveTx(reservation).tryMutate();
-      assertEquals(ACCEPTED, status);
-      status = new FateMutatorImpl<>(context, table, fateId1).putReservedTxOnCreation(reservation)
-          .tryMutate();
       assertEquals(REJECTED, status);
     }
   }


### PR DESCRIPTION
This PR
* Makes it so the reservation column is created on reservation and deleted on unreservation (no longer store an unreserved value in the column)
* Addresses a bug with `MultipleStoresIT.testDeadReservationsCleanup()` (`ZooUtil.LockID` was missing `equals()` and `hashCode()`) (see NOTE)

NOTE about original bug when I first attempted these changes:
After making the reservation column changes, I tested `testDeadReservationsCleanup()` to see if I could recreate the same bug noted in this thread https://github.com/apache/accumulo/pull/4524#discussion_r1670884720 (TLDR - <4 transactions would show as being reserved, even though 4 threads were working on 4 transactions). I was able to recreate the bug (extremely rarely until I messed with the `DeadReservationCleaner` timings), but found that it is not related to the reservation column changes and is instead just a bug with the test. I'm not sure why I only saw this bug with the column changes the first go-around, but regardless it's fixed now. I was concerned if this test was identifying a bug with the code, but turns out it was just a problem with the test. The issue was the dead reservation cleaner was removing transactions that weren't dead because the `isLockHeld` predicate being passed was:
`final Predicate<ZooUtil.LockID> isLockHeld = liveLocks::contains;`
where
`final Set<ZooUtil.LockID> liveLocks = new HashSet<>();`
`ZooUtil.LockID` did not have `equals()` or `hashCode()` methods resulting in transactions being unexpectedly unreserved by the dead reservation cleaner.
The real code (the Manager code) never calls equals on the LockID object, so this was just a bug with the test.

closes #4907