### PR TITLE
Fixes a Fate bug (part 2)

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
@@ -110,7 +110,6 @@ public class Fate<T> {
                   break;
                 }
               } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
                 throw new IllegalStateException(e);
               }
             }


### PR DESCRIPTION
fixes an issue with how Fates `WorkFinder` handles `InterruptedException`s which can lead to an infinite error loop and leave the `WorkFinder` broken

I'm wondering if this is a problem elsewhere as there are many places that handle an `InterruptedException` the same way
```
} catch (InterruptedException e) {
    Thread.currentThread().interrupt();
    ...
}
````

The conversation which brought about this PR was from:
#4965

This PR in conjunction with #4965 close #4906