### PR TITLE
Add ZooKeeper Namespace Id-to-name mapping

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/Constants.java
+++ b/core/src/main/java/org/apache/accumulo/core/Constants.java
@@ -48,6 +48,7 @@ public class Constants {
   public static final String ZTABLE_NAMESPACE = "/namespace";
 
   public static final String ZNAMESPACES = "/namespaces";
+  @Deprecated
   public static final String ZNAMESPACE_NAME = "/name";
 
   public static final String ZMANAGERS = "/managers";

--- a/core/src/main/java/org/apache/accumulo/core/Constants.java
+++ b/core/src/main/java/org/apache/accumulo/core/Constants.java
@@ -48,8 +48,6 @@ public class Constants {
   public static final String ZTABLE_NAMESPACE = "/namespace";
 
   public static final String ZNAMESPACES = "/namespaces";
-  @Deprecated
-  public static final String ZNAMESPACE_NAME = "/name";
 
   public static final String ZMANAGERS = "/managers";
   public static final String ZMANAGER_LOCK = ZMANAGERS + "/lock";

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
@@ -142,6 +142,7 @@ public class ClientContext implements AccumuloClient {
   private final Supplier<SaslConnectionParams> saslSupplier;
   private final Supplier<SslConnectionParams> sslSupplier;
   private final Supplier<ScanServerSelector> scanServerSelectorSupplier;
+  private final NamespaceMapping namespaces;
   private TCredentials rpcCreds;
   private ThriftTransportPool thriftTransportPool;
   private ZookeeperLockChecker zkLockChecker;
@@ -249,6 +250,7 @@ public class ClientContext implements AccumuloClient {
         clientThreadPools = ThreadPools.getClientThreadPools(ueh);
       }
     }
+    this.namespaces = new NamespaceMapping(this);
   }
 
   public Ample getAmple() {
@@ -1112,6 +1114,10 @@ public class ClientContext implements AccumuloClient {
       this.zkLockChecker = new ZookeeperLockChecker(this);
     }
     return this.zkLockChecker;
+  }
+
+  public NamespaceMapping getNamespaces() {
+    return namespaces;
   }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/NamespaceMapping.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/NamespaceMapping.java
@@ -68,7 +68,8 @@ public class NamespaceMapping {
   }
 
   public static byte[] serialize(Map<String,String> map) {
-    String jsonData = gson.toJson(map);
+    var sortedMap = ImmutableSortedMap.<String,String>naturalOrder().putAll(map).build();
+    String jsonData = gson.toJson(sortedMap);
     return jsonData.getBytes(UTF_8);
   }
 
@@ -84,7 +85,6 @@ public class NamespaceMapping {
     final ZooCache.ZcStat stat = new ZooCache.ZcStat();
     zc.clear();
 
-    // Retrieve the current data and stat from ZooCache
     byte[] data = zc.get(zPath, stat);
     if (stat.getMzxid() > lastMzxid) {
       if (data == null) {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/NamespaceMapping.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/NamespaceMapping.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.clientImpl;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.emptySortedMap;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.SortedMap;
+
+import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.data.NamespaceId;
+import org.apache.accumulo.core.fate.zookeeper.ZooCache;
+import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
+import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
+import org.apache.zookeeper.KeeperException;
+
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+
+public class NamespaceMapping {
+  private static final Gson gson = new Gson();
+  private final ClientContext context;
+  private volatile SortedMap<NamespaceId,String> currentNamespaceMap = emptySortedMap();
+  private volatile SortedMap<String,NamespaceId> currentNamespaceReverseMap = emptySortedMap();
+  private volatile long lastMzxid;
+
+  public NamespaceMapping(ClientContext context) {
+    this.context = context;
+  }
+
+  public static void initializeNamespaceMap(ZooReaderWriter zoo, String zPath)
+      throws InterruptedException, KeeperException {
+    Map<String,String> map = Map.of(Namespace.DEFAULT.id().canonical(), Namespace.DEFAULT.name(),
+        Namespace.ACCUMULO.id().canonical(), Namespace.ACCUMULO.name());
+    zoo.putPersistentData(zPath, serialize(map), ZooUtil.NodeExistsPolicy.OVERWRITE);
+  }
+
+  public static byte[] writeNamespaceToMap(ZooReaderWriter zoo, String zPath,
+      NamespaceId namespaceId, String namespaceName) throws InterruptedException, KeeperException {
+    byte[] updatedMap = new byte[0];
+    if (!Namespace.DEFAULT.id().equals(namespaceId)
+        && !Namespace.ACCUMULO.id().equals(namespaceId)) {
+      byte[] data = zoo.getData(zPath);
+      Map<String,String> namespaceMap = deserialize(data);
+      namespaceMap.put(namespaceId.canonical(), namespaceName);
+      updatedMap = serialize(namespaceMap);
+    }
+    return updatedMap;
+  }
+
+  public static byte[] serialize(Map<String,String> map) {
+    String jsonData = gson.toJson(map);
+    return jsonData.getBytes(UTF_8);
+  }
+
+  public static Map<String,String> deserialize(byte[] data) {
+    String jsonData = new String(data, UTF_8);
+    Type type = new TypeToken<Map<String,String>>() {}.getType();
+    return gson.fromJson(jsonData, type);
+  }
+
+  private synchronized void update() {
+    final ZooCache zc = context.getZooCache();
+    final String zPath = context.getZooKeeperRoot() + Constants.ZNAMESPACES;
+    final ZooCache.ZcStat stat = new ZooCache.ZcStat();
+    zc.clear();
+
+    // Retrieve the current data and stat from ZooCache
+    byte[] data = zc.get(zPath, stat);
+    if (stat.getMzxid() > lastMzxid) {
+      if (data == null) {
+        currentNamespaceMap = emptySortedMap();
+        currentNamespaceReverseMap = emptySortedMap();
+      } else {
+        Map<String,String> idToName = deserialize(data);
+        var converted = ImmutableSortedMap.<NamespaceId,String>naturalOrder();
+        var convertedReverse = ImmutableSortedMap.<String,NamespaceId>naturalOrder();
+        idToName.forEach((idString, name) -> {
+          var id = NamespaceId.of(idString);
+          converted.put(id, name);
+          convertedReverse.put(name, id);
+        });
+        currentNamespaceMap = converted.build();
+        currentNamespaceReverseMap = convertedReverse.build();
+      }
+      lastMzxid = stat.getMzxid();
+    }
+  }
+
+  public SortedMap<NamespaceId,String> getIdToNameMap() {
+    update();
+    return currentNamespaceMap;
+  }
+
+  public SortedMap<String,NamespaceId> getNameToIdMap() {
+    update();
+    return currentNamespaceReverseMap;
+  }
+
+}

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/NamespaceMapping.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/NamespaceMapping.java
@@ -22,6 +22,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptySortedMap;
 
 import java.lang.reflect.Type;
+import java.util.Collections;
 import java.util.Map;
 import java.util.SortedMap;
 
@@ -74,6 +75,9 @@ public class NamespaceMapping {
   }
 
   public static Map<String,String> deserialize(byte[] data) {
+    if (data == null || data.length == 0) {
+      return Collections.emptyMap();
+    }
     String jsonData = new String(data, UTF_8);
     Type type = new TypeToken<Map<String,String>>() {}.getType();
     return gson.fromJson(jsonData, type);

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/Namespaces.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/Namespaces.java
@@ -18,15 +18,10 @@
  */
 package org.apache.accumulo.core.clientImpl;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.SortedMap;
-import java.util.TreeMap;
-import java.util.function.BiConsumer;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.NamespaceNotFoundException;
@@ -71,38 +66,17 @@ public class Namespaces {
   }
 
   /**
-   * Gets all the namespaces from ZK. The first arg (t) the BiConsumer accepts is the ID and the
-   * second (u) is the namespaceName.
-   */
-  private static void getAllNamespaces(ClientContext context,
-      BiConsumer<String,String> biConsumer) {
-    final ZooCache zc = context.getZooCache();
-    List<String> namespaceIds = zc.getChildren(context.getZooKeeperRoot() + Constants.ZNAMESPACES);
-    for (String id : namespaceIds) {
-      byte[] path = zc.get(context.getZooKeeperRoot() + Constants.ZNAMESPACES + "/" + id
-          + Constants.ZNAMESPACE_NAME);
-      if (path != null) {
-        biConsumer.accept(id, new String(path, UTF_8));
-      }
-    }
-  }
-
-  /**
    * Return sorted map with key = ID, value = namespaceName
    */
   public static SortedMap<NamespaceId,String> getIdToNameMap(ClientContext context) {
-    SortedMap<NamespaceId,String> idMap = new TreeMap<>();
-    getAllNamespaces(context, (id, name) -> idMap.put(NamespaceId.of(id), name));
-    return idMap;
+    return context.getNamespaces().getIdToNameMap();
   }
 
   /**
    * Return sorted map with key = namespaceName, value = ID
    */
   public static SortedMap<String,NamespaceId> getNameToIdMap(ClientContext context) {
-    SortedMap<String,NamespaceId> nameMap = new TreeMap<>();
-    getAllNamespaces(context, (id, name) -> nameMap.put(name, NamespaceId.of(id)));
-    return nameMap;
+    return context.getNamespaces().getNameToIdMap();
   }
 
   /**
@@ -110,17 +84,12 @@ public class Namespaces {
    */
   public static NamespaceId getNamespaceId(ClientContext context, String namespaceName)
       throws NamespaceNotFoundException {
-    final ArrayList<NamespaceId> singleId = new ArrayList<>(1);
-    getAllNamespaces(context, (id, name) -> {
-      if (name.equals(namespaceName)) {
-        singleId.add(NamespaceId.of(id));
-      }
-    });
-    if (singleId.isEmpty()) {
+    var id = context.getNamespaces().getNameToIdMap().get(namespaceName);
+    if (id == null) {
       throw new NamespaceNotFoundException(null, namespaceName,
           "getNamespaceId() failed to find namespace");
     }
-    return singleId.get(0);
+    return id;
   }
 
   /**
@@ -150,13 +119,8 @@ public class Namespaces {
    */
   public static String getNamespaceName(ClientContext context, NamespaceId namespaceId)
       throws NamespaceNotFoundException {
-    String name;
-    ZooCache zc = context.getZooCache();
-    byte[] path = zc.get(context.getZooKeeperRoot() + Constants.ZNAMESPACES + "/"
-        + namespaceId.canonical() + Constants.ZNAMESPACE_NAME);
-    if (path != null) {
-      name = new String(path, UTF_8);
-    } else {
+    String name = getIdToNameMap(context).get(namespaceId);
+    if (name == null) {
       throw new NamespaceNotFoundException(namespaceId.canonical(), null,
           "getNamespaceName() failed to find namespace");
     }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/Namespaces.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/Namespaces.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.clientImpl;
 
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map.Entry;
@@ -37,7 +38,8 @@ public class Namespaces {
 
   public static boolean exists(ClientContext context, NamespaceId namespaceId) {
     ZooCache zc = context.getZooCache();
-    List<String> namespaceIds = zc.getChildren(context.getZooKeeperRoot() + Constants.ZNAMESPACES);
+    List<String> namespaceIds = new ArrayList<>(NamespaceMapping
+        .deserialize(zc.get(context.getZooKeeperRoot() + Constants.ZNAMESPACES)).keySet());
     return namespaceIds.contains(namespaceId.canonical());
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/Namespaces.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/Namespaces.java
@@ -18,17 +18,14 @@
  */
 package org.apache.accumulo.core.clientImpl;
 
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.SortedMap;
 
-import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.NamespaceNotFoundException;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
-import org.apache.accumulo.core.fate.zookeeper.ZooCache;
 import org.apache.accumulo.core.util.tables.TableNameUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,10 +34,7 @@ public class Namespaces {
   private static final Logger log = LoggerFactory.getLogger(Namespaces.class);
 
   public static boolean exists(ClientContext context, NamespaceId namespaceId) {
-    ZooCache zc = context.getZooCache();
-    List<String> namespaceIds = new ArrayList<>(NamespaceMapping
-        .deserialize(zc.get(context.getZooKeeperRoot() + Constants.ZNAMESPACES)).keySet());
-    return namespaceIds.contains(namespaceId.canonical());
+    return context.getNamespaces().getIdToNameMap().containsKey(namespaceId);
   }
 
   public static List<TableId> getTableIds(ClientContext context, NamespaceId namespaceId)

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/NamespaceMappingTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/NamespaceMappingTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.clientImpl;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.gson.JsonSyntaxException;
+
+class NamespaceMappingTest {
+
+  @Test
+  void testSerialize() {
+    assertThrows(NullPointerException.class, () -> NamespaceMapping.serialize(null));
+    assertEquals("{}", new String(NamespaceMapping.serialize(Map.of()), UTF_8));
+    assertEquals("{\"a\":\"b\"}", new String(NamespaceMapping.serialize(Map.of("a", "b")), UTF_8));
+    assertEquals("{\"a\":\"b\",\"c\":\"d\"}",
+        new String(NamespaceMapping.serialize(Map.of("a", "b", "c", "d")), UTF_8));
+  }
+
+  @Test
+  void testDeserialize() {
+    assertThrows(NullPointerException.class, () -> NamespaceMapping.deserialize(null));
+    assertEquals(null, NamespaceMapping.deserialize(new byte[0]));
+    assertTrue(NamespaceMapping.deserialize("{}".getBytes(UTF_8)) instanceof TreeMap);
+    assertEquals(Map.of(), NamespaceMapping.deserialize("{}".getBytes(UTF_8)));
+    assertEquals(Map.of("a", "b"), NamespaceMapping.deserialize("{\"a\":\"b\"}".getBytes(UTF_8)));
+    assertEquals(Map.of("a", "b", "c", "d"),
+        NamespaceMapping.deserialize("{\"a\":\"b\",\"c\":\"d\"}".getBytes(UTF_8)));
+
+    // check malformed json
+    assertThrows(JsonSyntaxException.class,
+        () -> NamespaceMapping.deserialize("-".getBytes(UTF_8)));
+    // check incorrect json type for string value
+    assertThrows(JsonSyntaxException.class,
+        () -> NamespaceMapping.deserialize("{\"a\":{}}".getBytes(UTF_8)));
+    // check valid json, but not a map
+    assertThrows(JsonSyntaxException.class,
+        () -> NamespaceMapping.deserialize("\"[\"a\"]\"".getBytes(UTF_8)));
+
+    // strange edge case because empty json array can be converted into an empty map; we don't ever
+    // expect this to be found, but there's no easy way to check for this edge case that is worth
+    // the effort
+    assertTrue(NamespaceMapping.deserialize("[]".getBytes(UTF_8)) instanceof SortedMap);
+    assertEquals(Map.of(), NamespaceMapping.deserialize("[]".getBytes(UTF_8)));
+  }
+
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/init/ZooKeeperInitializer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/ZooKeeperInitializer.java
@@ -25,7 +25,6 @@ import java.util.Map;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.admin.TimeType;
-import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
 import org.apache.accumulo.core.clientImpl.Namespace;
 import org.apache.accumulo.core.clientImpl.NamespaceMapping;
 import org.apache.accumulo.core.data.InstanceId;
@@ -93,7 +92,7 @@ public class ZooKeeperInitializer {
 
   void initialize(final ServerContext context, final boolean clearInstanceName,
       final String instanceNamePath, final String rootTabletDirName, final String rootTabletFileUri)
-      throws KeeperException, InterruptedException, AcceptableThriftTableOperationException {
+      throws KeeperException, InterruptedException {
     // setup basic data in zookeeper
 
     ZooReaderWriter zoo = context.getZooReaderWriter();

--- a/server/base/src/main/java/org/apache/accumulo/server/init/ZooKeeperInitializer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/ZooKeeperInitializer.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.admin.TimeType;
+import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
 import org.apache.accumulo.core.clientImpl.Namespace;
 import org.apache.accumulo.core.clientImpl.NamespaceMapping;
 import org.apache.accumulo.core.data.InstanceId;
@@ -91,7 +92,7 @@ public class ZooKeeperInitializer {
 
   void initialize(final ServerContext context, final boolean clearInstanceName,
       final String instanceNamePath, final String rootTabletDirName, final String rootTabletFileUri)
-      throws KeeperException, InterruptedException {
+      throws KeeperException, InterruptedException, AcceptableThriftTableOperationException {
     // setup basic data in zookeeper
 
     ZooReaderWriter zoo = context.getZooReaderWriter();
@@ -111,14 +112,13 @@ public class ZooKeeperInitializer {
     String zkInstanceRoot = Constants.ZROOT + "/" + instanceId;
     zoo.putPersistentData(zkInstanceRoot + Constants.ZTABLES, Constants.ZTABLES_INITIAL_ID,
         ZooUtil.NodeExistsPolicy.FAIL);
-    zoo.putPersistentData(zkInstanceRoot + Constants.ZNAMESPACES, new byte[0],
-        ZooUtil.NodeExistsPolicy.FAIL);
+    zoo.putPersistentData(zkInstanceRoot + Constants.ZNAMESPACES,
+        NamespaceMapping.initializeNamespaceMap(), ZooUtil.NodeExistsPolicy.FAIL);
 
     TableManager.prepareNewNamespaceState(context, Namespace.DEFAULT.id(), Namespace.DEFAULT.name(),
-        ZooUtil.NodeExistsPolicy.OVERWRITE);
+        ZooUtil.NodeExistsPolicy.FAIL);
     TableManager.prepareNewNamespaceState(context, Namespace.ACCUMULO.id(),
-        Namespace.ACCUMULO.name(), ZooUtil.NodeExistsPolicy.OVERWRITE);
-    NamespaceMapping.initializeNamespaceMap(zoo, zkInstanceRoot + Constants.ZNAMESPACES);
+        Namespace.ACCUMULO.name(), ZooUtil.NodeExistsPolicy.FAIL);
 
     TableManager.prepareNewTableState(context, AccumuloTable.ROOT.tableId(),
         Namespace.ACCUMULO.id(), AccumuloTable.ROOT.tableName(), TableState.ONLINE,

--- a/server/base/src/main/java/org/apache/accumulo/server/init/ZooKeeperInitializer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/ZooKeeperInitializer.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.server.init;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.IOException;
+import java.util.Map;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.admin.TimeType;
@@ -113,7 +114,10 @@ public class ZooKeeperInitializer {
     zoo.putPersistentData(zkInstanceRoot + Constants.ZTABLES, Constants.ZTABLES_INITIAL_ID,
         ZooUtil.NodeExistsPolicy.FAIL);
     zoo.putPersistentData(zkInstanceRoot + Constants.ZNAMESPACES,
-        NamespaceMapping.initializeNamespaceMap(), ZooUtil.NodeExistsPolicy.FAIL);
+        NamespaceMapping
+            .serialize(Map.of(Namespace.DEFAULT.id().canonical(), Namespace.DEFAULT.name(),
+                Namespace.ACCUMULO.id().canonical(), Namespace.ACCUMULO.name())),
+        ZooUtil.NodeExistsPolicy.FAIL);
 
     TableManager.prepareNewNamespaceState(context, Namespace.DEFAULT.id(), Namespace.DEFAULT.name(),
         ZooUtil.NodeExistsPolicy.FAIL);

--- a/server/base/src/main/java/org/apache/accumulo/server/init/ZooKeeperInitializer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/ZooKeeperInitializer.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.admin.TimeType;
 import org.apache.accumulo.core.clientImpl.Namespace;
+import org.apache.accumulo.core.clientImpl.NamespaceMapping;
 import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
@@ -114,9 +115,10 @@ public class ZooKeeperInitializer {
         ZooUtil.NodeExistsPolicy.FAIL);
 
     TableManager.prepareNewNamespaceState(context, Namespace.DEFAULT.id(), Namespace.DEFAULT.name(),
-        ZooUtil.NodeExistsPolicy.FAIL);
+        ZooUtil.NodeExistsPolicy.OVERWRITE);
     TableManager.prepareNewNamespaceState(context, Namespace.ACCUMULO.id(),
-        Namespace.ACCUMULO.name(), ZooUtil.NodeExistsPolicy.FAIL);
+        Namespace.ACCUMULO.name(), ZooUtil.NodeExistsPolicy.OVERWRITE);
+    NamespaceMapping.initializeNamespaceMap(zoo, zkInstanceRoot + Constants.ZNAMESPACES);
 
     TableManager.prepareNewTableState(context, AccumuloTable.ROOT.tableId(),
         Namespace.ACCUMULO.id(), AccumuloTable.ROOT.tableName(), TableState.ONLINE,

--- a/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
@@ -29,6 +29,7 @@ import java.util.Set;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.NamespaceNotFoundException;
+import org.apache.accumulo.core.clientImpl.NamespaceMapping;
 import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
@@ -71,11 +72,11 @@ public class TableManager {
       InstanceId instanceId, NamespaceId namespaceId, String namespace,
       NodeExistsPolicy existsPolicy) throws KeeperException, InterruptedException {
     log.debug("Creating ZooKeeper entries for new namespace {} (ID: {})", namespace, namespaceId);
-    String zPath = Constants.ZROOT + "/" + instanceId + Constants.ZNAMESPACES + "/" + namespaceId;
+    String zPath = Constants.ZROOT + "/" + instanceId + Constants.ZNAMESPACES;
 
-    zoo.putPersistentData(zPath, new byte[0], existsPolicy);
-    zoo.putPersistentData(zPath + Constants.ZNAMESPACE_NAME, namespace.getBytes(UTF_8),
-        existsPolicy);
+    zoo.putPersistentData(zPath + "/" + namespaceId, new byte[0], existsPolicy);
+    zoo.putPersistentData(zPath,
+        NamespaceMapping.writeNamespaceToMap(zoo, zPath, namespaceId, namespace), existsPolicy);
     var propKey = NamespacePropKey.of(instanceId, namespaceId);
     if (!propStore.exists(propKey)) {
       propStore.create(propKey, Map.of());

--- a/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
@@ -77,7 +77,6 @@ public class TableManager {
     String zPath = Constants.ZROOT + "/" + instanceId + Constants.ZNAMESPACES;
 
     zoo.putPersistentData(zPath + "/" + namespaceId, new byte[0], existsPolicy);
-    NamespaceMapping.writeNamespaceToMap(zoo, zPath, namespaceId, namespace);
     var propKey = NamespacePropKey.of(instanceId, namespaceId);
     if (!propStore.exists(propKey)) {
       propStore.create(propKey, Map.of());
@@ -330,8 +329,9 @@ public class TableManager {
     }
   }
 
-  public void removeNamespace(NamespaceId namespaceId)
-      throws KeeperException, InterruptedException {
+  public void removeNamespace(ZooReaderWriter zoo, String zPath, NamespaceId namespaceId)
+      throws KeeperException, InterruptedException, AcceptableThriftTableOperationException {
+    NamespaceMapping.remove(zoo, zPath, namespaceId);
     zoo.recursiveDelete(zkRoot + Constants.ZNAMESPACES + "/" + namespaceId, NodeMissingPolicy.SKIP);
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
@@ -29,6 +29,7 @@ import java.util.Set;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.NamespaceNotFoundException;
+import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
 import org.apache.accumulo.core.clientImpl.NamespaceMapping;
 import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.NamespaceId;
@@ -70,13 +71,13 @@ public class TableManager {
 
   public static void prepareNewNamespaceState(ZooReaderWriter zoo, final PropStore propStore,
       InstanceId instanceId, NamespaceId namespaceId, String namespace,
-      NodeExistsPolicy existsPolicy) throws KeeperException, InterruptedException {
+      NodeExistsPolicy existsPolicy)
+      throws KeeperException, InterruptedException, AcceptableThriftTableOperationException {
     log.debug("Creating ZooKeeper entries for new namespace {} (ID: {})", namespace, namespaceId);
     String zPath = Constants.ZROOT + "/" + instanceId + Constants.ZNAMESPACES;
 
     zoo.putPersistentData(zPath + "/" + namespaceId, new byte[0], existsPolicy);
-    zoo.putPersistentData(zPath,
-        NamespaceMapping.writeNamespaceToMap(zoo, zPath, namespaceId, namespace), existsPolicy);
+    NamespaceMapping.writeNamespaceToMap(zoo, zPath, namespaceId, namespace);
     var propKey = NamespacePropKey.of(instanceId, namespaceId);
     if (!propStore.exists(propKey)) {
       propStore.create(propKey, Map.of());
@@ -85,7 +86,7 @@ public class TableManager {
 
   public static void prepareNewNamespaceState(final ServerContext context, NamespaceId namespaceId,
       String namespace, NodeExistsPolicy existsPolicy)
-      throws KeeperException, InterruptedException {
+      throws KeeperException, InterruptedException, AcceptableThriftTableOperationException {
     prepareNewNamespaceState(context.getZooReaderWriter(), context.getPropStore(),
         context.getInstanceID(), namespaceId, namespace, existsPolicy);
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
@@ -258,18 +258,6 @@ public class Utils {
     return Utils.getLock(env.getContext(), id, tid, LockType.READ);
   }
 
-  public static void checkNamespaceDoesNotExist(ServerContext context, String namespace,
-      NamespaceId namespaceId, TableOperation operation)
-      throws AcceptableThriftTableOperationException {
-
-    NamespaceId n = Namespaces.lookupNamespaceId(context, namespace);
-
-    if (n != null && !n.equals(namespaceId)) {
-      throw new AcceptableThriftTableOperationException(null, namespace, operation,
-          TableOperationExceptionType.NAMESPACE_EXISTS, null);
-    }
-  }
-
   /**
    * Given a fully-qualified Path and a flag indicating if the file info is base64 encoded or not,
    * retrieve the data from a file on the file system. It is assumed that the file is textual and

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/PopulateZookeeperWithNamespace.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/PopulateZookeeperWithNamespace.java
@@ -73,9 +73,7 @@ class PopulateZookeeperWithNamespace extends ManagerRepo {
   @Override
   public void undo(long tid, Manager manager) throws Exception {
     var context = manager.getContext();
-    manager.getTableManager().removeNamespace(context.getZooReaderWriter(),
-        Constants.ZROOT + "/" + context.getInstanceID() + Constants.ZNAMESPACES,
-        namespaceInfo.namespaceId);
+    manager.getTableManager().removeNamespace(namespaceInfo.namespaceId);
     context.clearTableListCache();
     Utils.unreserveNamespace(manager, namespaceInfo.namespaceId, tid, LockType.WRITE);
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/PopulateZookeeperWithNamespace.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/PopulateZookeeperWithNamespace.java
@@ -52,17 +52,17 @@ class PopulateZookeeperWithNamespace extends ManagerRepo {
 
     Utils.getTableNameLock().lock();
     try {
-      NamespaceMapping.put(manager.getContext().getZooReaderWriter(),
-          Constants.ZROOT + "/" + manager.getContext().getInstanceID() + Constants.ZNAMESPACES,
+      var context = manager.getContext();
+      NamespaceMapping.put(context.getZooReaderWriter(),
+          Constants.ZROOT + "/" + context.getInstanceID() + Constants.ZNAMESPACES,
           namespaceInfo.namespaceId, namespaceInfo.namespaceName);
-      TableManager.prepareNewNamespaceState(manager.getContext(), namespaceInfo.namespaceId,
+      TableManager.prepareNewNamespaceState(context, namespaceInfo.namespaceId,
           namespaceInfo.namespaceName, NodeExistsPolicy.OVERWRITE);
 
-      PropUtil.setProperties(manager.getContext(),
-          NamespacePropKey.of(manager.getContext(), namespaceInfo.namespaceId),
+      PropUtil.setProperties(context, NamespacePropKey.of(context, namespaceInfo.namespaceId),
           namespaceInfo.props);
 
-      manager.getContext().clearTableListCache();
+      context.clearTableListCache();
 
       return new FinishCreateNamespace(namespaceInfo);
     } finally {
@@ -72,10 +72,11 @@ class PopulateZookeeperWithNamespace extends ManagerRepo {
 
   @Override
   public void undo(long tid, Manager manager) throws Exception {
-    manager.getTableManager().removeNamespace(manager.getContext().getZooReaderWriter(),
-        Constants.ZROOT + "/" + manager.getContext().getInstanceID() + Constants.ZNAMESPACES,
+    var context = manager.getContext();
+    manager.getTableManager().removeNamespace(context.getZooReaderWriter(),
+        Constants.ZROOT + "/" + context.getInstanceID() + Constants.ZNAMESPACES,
         namespaceInfo.namespaceId);
-    manager.getContext().clearTableListCache();
+    context.clearTableListCache();
     Utils.unreserveNamespace(manager, namespaceInfo.namespaceId, tid, LockType.WRITE);
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/delete/NamespaceCleanUp.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/delete/NamespaceCleanUp.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.manager.tableOps.namespace.delete;
 
+import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.fate.Repo;
@@ -50,7 +51,9 @@ class NamespaceCleanUp extends ManagerRepo {
 
     // remove from zookeeper
     try {
-      manager.getTableManager().removeNamespace(namespaceId);
+      manager.getTableManager().removeNamespace(manager.getContext().getZooReaderWriter(),
+          Constants.ZROOT + "/" + manager.getContext().getInstanceID() + Constants.ZNAMESPACES,
+          namespaceId);
     } catch (Exception e) {
       log.error("Failed to find namespace in zookeeper", e);
     }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/delete/NamespaceCleanUp.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/delete/NamespaceCleanUp.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.manager.tableOps.namespace.delete;
 
-import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.fate.Repo;
@@ -51,9 +50,7 @@ class NamespaceCleanUp extends ManagerRepo {
 
     // remove from zookeeper
     try {
-      manager.getTableManager().removeNamespace(manager.getContext().getZooReaderWriter(),
-          Constants.ZROOT + "/" + manager.getContext().getInstanceID() + Constants.ZNAMESPACES,
-          namespaceId);
+      manager.getTableManager().removeNamespace(namespaceId);
     } catch (Exception e) {
       log.error("Failed to find namespace in zookeeper", e);
     }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/rename/RenameNamespace.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/rename/RenameNamespace.java
@@ -19,11 +19,8 @@
 package org.apache.accumulo.manager.tableOps.namespace.rename;
 
 import org.apache.accumulo.core.Constants;
-import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
 import org.apache.accumulo.core.clientImpl.NamespaceMapping;
-import org.apache.accumulo.core.clientImpl.Namespaces;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
-import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
@@ -59,12 +56,6 @@ public class RenameNamespace extends ManagerRepo {
 
     Utils.getTableNameLock().lock();
     try {
-      NamespaceId n = Namespaces.lookupNamespaceId(manager.getContext(), newName);
-      if (n != null && !n.equals(namespaceId)) {
-        throw new AcceptableThriftTableOperationException(null, newName, TableOperation.RENAME,
-            TableOperationExceptionType.NAMESPACE_EXISTS, "Namespace name already exists");
-      }
-
       NamespaceMapping.rename(zoo, manager.getZooKeeperRoot() + Constants.ZNAMESPACES, namespaceId,
           oldName, newName);
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/rename/RenameNamespace.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/rename/RenameNamespace.java
@@ -18,12 +18,9 @@
  */
 package org.apache.accumulo.manager.tableOps.namespace.rename;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
 import org.apache.accumulo.core.clientImpl.NamespaceMapping;
-import org.apache.accumulo.core.clientImpl.Namespaces;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
 import org.apache.accumulo.core.data.NamespaceId;
@@ -66,21 +63,18 @@ public class RenameNamespace extends ManagerRepo {
 
       final String tap = manager.getZooKeeperRoot() + Constants.ZNAMESPACES;
 
-      final String currentNamespaceName =
-          Namespaces.getNamespaceName(manager.getContext(), namespaceId);
-      final byte[] updatedNamespaceMap =
-          NamespaceMapping.writeNamespaceToMap(zoo, tap, namespaceId, newName);
-
       zoo.mutateExisting(tap, current -> {
-        final String currentName = new String(current, UTF_8);
-        if (currentNamespaceName.equals(newName)) {
+        var currentNamespaceMap = NamespaceMapping.deserialize(current);
+        final String currentName = currentNamespaceMap.get(namespaceId.canonical());
+        if (currentName.equals(newName)) {
           return null; // assume in this case the operation is running again, so we are done
         }
-        if (!currentNamespaceName.equals(oldName)) {
+        if (!currentName.equals(oldName)) {
           throw new AcceptableThriftTableOperationException(null, oldName, TableOperation.RENAME,
               TableOperationExceptionType.NAMESPACE_NOTFOUND, "Name changed while processing");
         }
-        return updatedNamespaceMap;
+        currentNamespaceMap.put(namespaceId.canonical(), newName);
+        return NamespaceMapping.serialize(currentNamespaceMap);
       });
       manager.getContext().clearTableListCache();
     } finally {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/rename/RenameNamespace.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/rename/RenameNamespace.java
@@ -65,9 +65,8 @@ public class RenameNamespace extends ManagerRepo {
             TableOperationExceptionType.NAMESPACE_EXISTS, "Namespace name already exists");
       }
 
-      final String tap = manager.getZooKeeperRoot() + Constants.ZNAMESPACES;
-
-      NamespaceMapping.rename(zoo, tap, namespaceId, oldName, newName);
+      NamespaceMapping.rename(zoo, manager.getZooKeeperRoot() + Constants.ZNAMESPACES, namespaceId,
+          oldName, newName);
 
       manager.getContext().clearTableListCache();
     } finally {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader11to12.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader11to12.java
@@ -88,7 +88,6 @@ public class Upgrader11to12 implements Upgrader {
   public static final String ZTRACERS = "/tracers";
 
   @Override
-  @SuppressWarnings("deprecation")
   public void upgradeZookeeper(@NonNull ServerContext context) {
     log.debug("Upgrade ZooKeeper: upgrading to data version {}", METADATA_FILE_JSON_ENCODING);
     var zooRoot = ZooUtil.getRoot(context.getInstanceID());
@@ -128,6 +127,7 @@ public class Upgrader11to12 implements Upgrader {
       Map<String,String> namespaceMap = new HashMap<>();
       List<String> namespaceIdList = zoo.getChildren(zPath);
       for (String namespaceId : namespaceIdList) {
+        @SuppressWarnings("deprecation")
         String namespaceNamePath = zPath + "/" + namespaceId + Constants.ZNAMESPACE_NAME;
         namespaceMap.put(namespaceId, new String(zoo.getData(namespaceNamePath), UTF_8));
         zoo.delete(namespaceNamePath);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader11to12.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader11to12.java
@@ -84,9 +84,10 @@ public class Upgrader11to12 implements Upgrader {
   static final Set<Text> UPGRADE_FAMILIES =
       Set.of(DataFileColumnFamily.NAME, CHOPPED, ExternalCompactionColumnFamily.NAME);
 
-  public static final String ZTRACERS = "/tracers";
+  private static final String ZTRACERS = "/tracers";
 
-  public static final String ZNAMESPACE_NAME = "/name";
+  @VisibleForTesting
+  static final String ZNAMESPACE_NAME = "/name";
 
   @Override
   public void upgradeZookeeper(@NonNull ServerContext context) {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader11to12.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader11to12.java
@@ -86,6 +86,8 @@ public class Upgrader11to12 implements Upgrader {
 
   public static final String ZTRACERS = "/tracers";
 
+  public static final String ZNAMESPACE_NAME = "/name";
+
   @Override
   public void upgradeZookeeper(@NonNull ServerContext context) {
     log.debug("Upgrade ZooKeeper: upgrading to data version {}", METADATA_FILE_JSON_ENCODING);
@@ -131,16 +133,14 @@ public class Upgrader11to12 implements Upgrader {
       if (namespaceMap == null || namespaceMap.isEmpty()) {
         namespaceMap = new HashMap<>();
         for (String namespaceId : namespaceIdList) {
-          @SuppressWarnings("deprecation")
-          String namespaceNamePath = zPath + "/" + namespaceId + Constants.ZNAMESPACE_NAME;
+          String namespaceNamePath = zPath + "/" + namespaceId + ZNAMESPACE_NAME;
           namespaceMap.put(namespaceId, new String(zrw.getData(namespaceNamePath), UTF_8));
         }
         byte[] mapping = NamespaceMapping.serialize(namespaceMap);
         zrw.putPersistentData(zPath, mapping, ZooUtil.NodeExistsPolicy.OVERWRITE);
       }
       for (String namespaceId : namespaceIdList) {
-        @SuppressWarnings("deprecation")
-        String namespaceNamePath = zPath + "/" + namespaceId + Constants.ZNAMESPACE_NAME;
+        String namespaceNamePath = zPath + "/" + namespaceId + ZNAMESPACE_NAME;
         zrw.delete(namespaceNamePath);
       }
 

--- a/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/Upgrader11to12Test.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/Upgrader11to12Test.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.manager.upgrade;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.manager.upgrade.Upgrader11to12.UPGRADE_FAMILIES;
+import static org.apache.accumulo.manager.upgrade.Upgrader11to12.ZNAMESPACE_NAME;
 import static org.easymock.EasyMock.aryEq;
 import static org.easymock.EasyMock.capture;
 import static org.easymock.EasyMock.createMock;
@@ -382,9 +383,8 @@ public class Upgrader11to12Test {
     expect(zrw.getChildren(eq("/accumulo/" + iid.canonical() + Constants.ZNAMESPACES)))
         .andReturn(List.copyOf(mockNamespaces.keySet())).once();
     for (String ns : mockNamespaces.keySet()) {
-      @SuppressWarnings("deprecation")
-      Supplier<String> pathMatcher = () -> eq("/accumulo/" + iid.canonical() + Constants.ZNAMESPACES
-          + "/" + ns + Constants.ZNAMESPACE_NAME);
+      Supplier<String> pathMatcher = () -> eq(
+          "/accumulo/" + iid.canonical() + Constants.ZNAMESPACES + "/" + ns + ZNAMESPACE_NAME);
       expect(zrw.getData(pathMatcher.get())).andReturn(mockNamespaces.get(ns).getBytes(UTF_8))
           .once();
     }
@@ -392,9 +392,8 @@ public class Upgrader11to12Test {
     expect(zrw.putPersistentData(eq("/accumulo/" + iid.canonical() + Constants.ZNAMESPACES),
         aryEq(mapping), eq(ZooUtil.NodeExistsPolicy.OVERWRITE))).andReturn(true).once();
     for (String ns : mockNamespaces.keySet()) {
-      @SuppressWarnings("deprecation")
-      Supplier<String> pathMatcher = () -> eq("/accumulo/" + iid.canonical() + Constants.ZNAMESPACES
-          + "/" + ns + Constants.ZNAMESPACE_NAME);
+      Supplier<String> pathMatcher = () -> eq(
+          "/accumulo/" + iid.canonical() + Constants.ZNAMESPACES + "/" + ns + ZNAMESPACE_NAME);
       zrw.delete(pathMatcher.get());
       expectLastCall().once();
     }

--- a/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/Upgrader11to12Test.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/Upgrader11to12Test.java
@@ -337,7 +337,6 @@ public class Upgrader11to12Test {
   }
 
   @Test
-  @SuppressWarnings("deprecation")
   public void upgradeZooKeeperTest() throws Exception {
 
     // taken from an uno instance.
@@ -380,6 +379,7 @@ public class Upgrader11to12Test {
     expect(zrw.getChildren(eq("/accumulo/" + iid.canonical() + Constants.ZNAMESPACES)))
         .andReturn(List.copyOf(mockNamespaces.keySet())).once();
     for (String ns : mockNamespaces.keySet()) {
+      @SuppressWarnings("deprecation")
       Supplier<String> pathMatcher = () -> eq("/accumulo/" + iid.canonical() + Constants.ZNAMESPACES
           + "/" + ns + Constants.ZNAMESPACE_NAME);
       expect(zrw.getData(pathMatcher.get())).andReturn(mockNamespaces.get(ns).getBytes(UTF_8))

--- a/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/Upgrader11to12Test.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/Upgrader11to12Test.java
@@ -389,7 +389,7 @@ public class Upgrader11to12Test {
     }
     byte[] mapping = NamespaceMapping.serialize(mockNamespaces);
     expect(zrw.putPersistentData(eq("/accumulo/" + iid.canonical() + Constants.ZNAMESPACES),
-        aryEq(mapping), eq(ZooUtil.NodeExistsPolicy.OVERWRITE))).andReturn(false).once();
+        aryEq(mapping), eq(ZooUtil.NodeExistsPolicy.OVERWRITE))).andReturn(true).once();
 
     replay(context, zrw);
 


### PR DESCRIPTION
This PR is part of an ongoing work to improve efficiency and reduce slowdown of retrieving and writing namespace names and table names in ZooKeeper. These particular changes modify the namespace names, and **a follow-up PR in the near future will modify the table names**. It replaces the use of the `/name` nodes under namespaces with a namespace id-to-name mapping in a Json format stored under the `/namespaces` node. With this, when any function wants to retrieve a namespace name, ZooKeeper will only need to read the single mapping instead of iterating through all `/name` nodes every time.  

**New files added for implementation:**
- `core/src/main/java/org/apache/accumulo/core/clientImpl/NamespaceMapping.java`: Class that holds functionality for initializing, retrieving, writing, serializing, and deserializing namespace id-to-name map (and name-to-id map).

**Files changed for implementation:**
- `ClientContext.java`: Allow namespace mapping to be retrieved from ZooKeeper by referencing the context.
- `Namespaces.java`: Update namespace name retrieval functionality with new mapping.
- `ZooKeeperInitializer.java`: Replace initialization of `default` and `accumulo` `/name` nodes with creation of new mapping.
- `TableManager.java`: Update namespace creation functionality to use new mapping.
- `RenameNamespace.java`: Replace usage of `/name` node to instead use new mapping.

**Files changed for upgrading:**
- `Constants.java`: Deprecate `ZNAMESPACE_NAME`, as the `/name` node will no longer be used.
- `Upgrader11to12.java`: Build namespace id-to-name mapping in ZooKeeper out of current `/name` nodes. Follow with deletion of `/name` nodes.
- `Upgrader11to12Test.java`: Add test code respective to additions made in `Upgrader11to12.java`.

Original Issue: #4698 