### PR TITLE
fixes test failure for AuthenticationTokenSecretManager

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenSecretManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenSecretManager.java
@@ -82,7 +82,7 @@ public class AuthenticationTokenSecretManager extends SecretManager<Authenticati
       DelegationTokenConfig cfg) {
     long now = System.currentTimeMillis();
     identifier.setIssueDate(now);
-    identifier.setExpirationDate(calculateExpirationDate());
+    identifier.setExpirationDate(calculateExpirationDate(now));
     // Limit the lifetime if the user requests it
     if (cfg != null) {
       long requestedLifetime = cfg.getTokenLifetime(TimeUnit.MILLISECONDS);
@@ -104,8 +104,7 @@ public class AuthenticationTokenSecretManager extends SecretManager<Authenticati
     return createPassword(identifier);
   }
 
-  private long calculateExpirationDate() {
-    long now = System.currentTimeMillis();
+  private long calculateExpirationDate(long now) {
     long expiration = now + tokenMaxLifetime;
     // Catch overflow
     if (expiration < now) {
@@ -123,11 +122,12 @@ public class AuthenticationTokenSecretManager extends SecretManager<Authenticati
     identifier.setKeyId(secretKey.getKeyId());
     identifier.setInstanceId(instanceID);
 
+    long now = System.currentTimeMillis();
     if (!identifier.isSetIssueDate()) {
-      identifier.setIssueDate(System.currentTimeMillis());
+      identifier.setIssueDate(now);
     }
     if (!identifier.isSetExpirationDate()) {
-      identifier.setExpirationDate(calculateExpirationDate());
+      identifier.setExpirationDate(calculateExpirationDate(now));
     }
     return createPassword(identifier.getBytes(), secretKey.getKey());
   }


### PR DESCRIPTION
AuthenticationTokenSecretManager was calling System.currentTimeMillis() twice causing the following sporadic failure. Modified to only get time once to avoid test failure.

```
[ERROR] org.apache.accumulo.server.security.delegation.AuthenticationTokenSecretManagerTest.testGenerateToken -- Time elapsed: 0.011 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <1729199138567> but was: <1729199138568>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:166)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:161)
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:632)
	at org.apache.accumulo.server.security.delegation.AuthenticationTokenSecretManagerTest.testGenerateToken(AuthenticationTokenSecretManagerTest.java:174)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```