### PR TITLE
fixes bug in ondemand tablet hosting

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
@@ -371,7 +371,9 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
         }
       });
 
-      processRanges(ranges);
+      if (!ranges.isEmpty()) {
+        processRanges(ranges);
+      }
     } finally {
       inProgress.forEach(hostingRequestInProgress::remove);
     }


### PR DESCRIPTION
When a hosting request was sent to the manager and the manager determined there was nothing to do it would attempt to create a batch scanner with an empty set of ranges and this would fail.  Added a check to see if the ranges were empty.