### PR TITLE
avoid reading from zookeeper when clearing zoocache entries

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ZookeeperLockChecker.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ZookeeperLockChecker.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.core.clientImpl;
 
 import java.util.Set;
 
+import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.clientImpl.ClientTabletCacheImpl.TabletServerLockChecker;
 import org.apache.accumulo.core.lock.ServiceLock;
 import org.apache.accumulo.core.lock.ServiceLockPaths.AddressSelector;
@@ -61,6 +62,7 @@ public class ZookeeperLockChecker implements TabletServerLockChecker {
   public void invalidateCache(String tserver) {
     // The path for the tserver contains a resource group. The resource group is unknown, so can not
     // construct a prefix. Therefore clear any path that contains the tserver.
-    ctx.getZooCache().clear(path -> path.contains(tserver));
+    ctx.getZooCache().clear(path -> path.startsWith(ctx.getZooKeeperRoot() + Constants.ZTSERVERS)
+        && path.contains(tserver));
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ZookeeperLockChecker.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ZookeeperLockChecker.java
@@ -59,11 +59,6 @@ public class ZookeeperLockChecker implements TabletServerLockChecker {
 
   @Override
   public void invalidateCache(String tserver) {
-    var hostAndPort = HostAndPort.fromString(tserver);
-    ctx.getServerPaths().getTabletServer(rg -> true, AddressSelector.exact(hostAndPort), false)
-        .forEach(slp -> {
-          ctx.getZooCache().clear(slp.toString());
-        });
+    ctx.getZooCache().clear(path -> path.contains(tserver));
   }
-
 }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ZookeeperLockChecker.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ZookeeperLockChecker.java
@@ -59,6 +59,8 @@ public class ZookeeperLockChecker implements TabletServerLockChecker {
 
   @Override
   public void invalidateCache(String tserver) {
+    // The path for the tserver contains a resource group. The resource group is unknown, so can not
+    // construct a prefix. Therefore clear any path that contains the tserver.
     ctx.getZooCache().clear(path -> path.contains(tserver));
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/ZookeeperLockCheckerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/ZookeeperLockCheckerTest.java
@@ -21,15 +21,10 @@ package org.apache.accumulo.core.clientImpl;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
 
-import java.util.List;
-
-import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.fate.zookeeper.ZooCache;
 import org.apache.accumulo.core.lock.ServiceLockPaths;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 public class ZookeeperLockCheckerTest {
   private ClientContext context;
@@ -45,20 +40,5 @@ public class ZookeeperLockCheckerTest {
     expect(context.getServerPaths()).andReturn(new ServiceLockPaths(context)).anyTimes();
     replay(context);
     zklc = new ZookeeperLockChecker(context);
-  }
-
-  @Test
-  public void testInvalidateCache() {
-    expect(zc.getChildren(context.getZooKeeperRoot())).andReturn(List.of(Constants.ZTSERVERS))
-        .anyTimes();
-    expect(zc.getChildren(context.getZooKeeperRoot() + Constants.ZTSERVERS))
-        .andReturn(List.of(Constants.DEFAULT_RESOURCE_GROUP_NAME)).anyTimes();
-    expect(zc.get(context.getZooKeeperRoot() + Constants.ZTSERVERS + "/"
-        + Constants.DEFAULT_RESOURCE_GROUP_NAME + "/server")).andReturn(new byte[0]).anyTimes();
-    zc.clear(context.getZooKeeperRoot() + Constants.ZTSERVERS + "/"
-        + Constants.DEFAULT_RESOURCE_GROUP_NAME + "/server");
-    replay(zc);
-    zklc.invalidateCache("server");
-    verify(zc);
   }
 }


### PR DESCRIPTION
This change indirectly fixes ZombieScanIT.  That test was creating scanners running in a thread and interrupting those threads.  The interrupts were routinely being ingnored by code in zoocache that ignores interrupts when reading from zookeeper.  Looking at the code that was reading from zookeeper, that code was attempting clear entries in the cache.  Modified this code to avoid reading from zookeeper when clearing the cache.