### PR TITLE
corrects open file metric

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/fs/FileManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/FileManager.java
@@ -593,4 +593,8 @@ public class FileManager {
   public ScanFileManager newScanFileManager(KeyExtent tablet, CacheProvider cacheProvider) {
     return new ScanFileManager(tablet, cacheProvider);
   }
+
+  public int getOpenFiles() {
+    return maxOpen - filePermits.availablePermits();
+  }
 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -407,7 +407,7 @@ public class ScanServer extends AbstractServer
     metricsInfo.addServiceTags(getApplicationName(), clientAddress);
     metricsInfo.addCommonTags(List.of(Tag.of("resource.group", groupName)));
 
-    scanMetrics = new TabletServerScanMetrics();
+    scanMetrics = new TabletServerScanMetrics(resourceManager::getOpenFiles);
     sessionManager.setZombieCountConsumer(scanMetrics::setZombieScanThreads);
     scanServerMetrics = new ScanServerMetrics(tabletMetadataCache);
     blockCacheMetrics = new BlockCacheMetrics(resourceManager.getIndexCache(),

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -765,7 +765,7 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
 
     metrics = new TabletServerMetrics(this);
     updateMetrics = new TabletServerUpdateMetrics();
-    scanMetrics = new TabletServerScanMetrics();
+    scanMetrics = new TabletServerScanMetrics(this.resourceManager::getOpenFiles);
     sessionManager.setZombieCountConsumer(scanMetrics::setZombieScanThreads);
     mincMetrics = new TabletServerMinCMetrics();
     ceMetrics = new CompactionExecutorsMetrics();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
@@ -400,6 +400,10 @@ public class TabletServerResourceManager {
         new AssignmentWatcher(acuConf, context, activeAssignments), 5000, TimeUnit.MILLISECONDS));
   }
 
+  public int getOpenFiles() {
+    return fileManager.getOpenFiles();
+  }
+
   /**
    * Accepts some map which is tracking active assignment task(s) (running) and monitors them to
    * ensure that the time the assignment(s) have been running don't exceed a threshold. If the time

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
@@ -100,7 +100,6 @@ class ScanDataSource implements DataSource {
       } finally {
         try {
           if (fileManager != null) {
-            tablet.getScanMetrics().decrementOpenFiles(fileManager.getNumOpenFiles());
             fileManager.releaseOpenFiles(false);
           }
         } catch (Exception e) {
@@ -154,7 +153,6 @@ class ScanDataSource implements DataSource {
       // only acquire the file manager when we know the tablet is open
       if (fileManager == null) {
         fileManager = tablet.getTabletResources().newScanFileManager(scanParams.getScanDispatch());
-        tablet.getScanMetrics().incrementOpenFiles(fileManager.getNumOpenFiles());
         log.trace("Adding active scan for  {}, scanId:{}", tablet.getExtent(), scanDataSourceId);
         tablet.addActiveScans(this);
       }
@@ -274,7 +272,6 @@ class ScanDataSource implements DataSource {
       }
       try {
         if (fileManager != null) {
-          tablet.getScanMetrics().decrementOpenFiles(fileManager.getNumOpenFiles());
           fileManager.releaseOpenFiles(sawErrors);
         }
       } finally {


### PR DESCRIPTION
The metrics for computing the current number of open files on a tablet server was incorrect over time.  Used the semaphor limiting open files to compute the number of open files.   The removes the need to correctly
increment and decrement files opened which had a bug.