### PR TITLE
Adds the queue to the common tags for compactor

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metrics/MetricsInfo.java
+++ b/core/src/main/java/org/apache/accumulo/core/metrics/MetricsInfo.java
@@ -53,6 +53,18 @@ public interface MetricsInfo {
   }
 
   /**
+   * Convenience method to create tag name / value pair for the resource group name
+   *
+   * @param resourceGroupName the resource group name
+   */
+  static Tag resourceGroupTag(final String resourceGroupName) {
+    if (resourceGroupName == null || resourceGroupName.isEmpty()) {
+      return Tag.of("resource.group", "NOT_PROVIDED");
+    }
+    return Tag.of("resource.group", resourceGroupName);
+  }
+
+  /**
    * Convenience method to create tag name / value pairs for the host and port from address
    * host:port pair.
    *
@@ -76,8 +88,10 @@ public interface MetricsInfo {
    *
    * @param applicationName the application (process) name.
    * @param hostAndPort the host:port pair
+   * @oaram resourceGroup the resource group name
    */
-  void addServiceTags(final String applicationName, final HostAndPort hostAndPort);
+  void addServiceTags(final String applicationName, final HostAndPort hostAndPort,
+      final String resourceGroup);
 
   /**
    * Add the list of tag name / value pair to the common tags that will be emitted with all metrics.

--- a/server/base/src/main/java/org/apache/accumulo/server/metrics/MetricsInfoImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metrics/MetricsInfoImpl.java
@@ -111,15 +111,14 @@ public class MetricsInfoImpl implements MetricsInfo {
    * Common tags for all services.
    */
   @Override
-  public void addServiceTags(final String applicationName, final HostAndPort hostAndPort) {
+  public void addServiceTags(final String applicationName, final HostAndPort hostAndPort,
+      final String resourceGroupName) {
     List<Tag> tags = new ArrayList<>();
 
-    if (applicationName != null && !applicationName.isEmpty()) {
-      tags.add(MetricsInfo.processTag(applicationName));
-    }
-    if (hostAndPort != null) {
-      tags.addAll(MetricsInfo.addressTags(hostAndPort));
-    }
+    tags.add(MetricsInfo.processTag(applicationName));
+    tags.addAll(MetricsInfo.addressTags(hostAndPort));
+    tags.add(MetricsInfo.resourceGroupTag(resourceGroupName));
+
     addCommonTags(tags);
   }
 

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
@@ -275,7 +275,7 @@ public class CompactionCoordinator extends AbstractServer
     }
 
     MetricsInfo metricsInfo = getContext().getMetricsInfo();
-    metricsInfo.addServiceTags(getApplicationName(), clientAddress);
+    metricsInfo.addServiceTags(getApplicationName(), clientAddress, "");
     metricsInfo.init();
 
     // On a re-start of the coordinator it's possible that external compactions are in-progress.

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -124,6 +124,7 @@ import com.google.common.base.Preconditions;
 import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 
 public class Compactor extends AbstractServer implements MetricsProducer, CompactorService.Iface {
 
@@ -687,6 +688,7 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
 
     MetricsInfo metricsInfo = getContext().getMetricsInfo();
     metricsInfo.addServiceTags(getApplicationName(), clientAddress);
+    metricsInfo.addCommonTags(List.of(Tag.of("queue", this.queueName)));
 
     metricsInfo.addMetricsProducers(this);
     metricsInfo.init();

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -124,7 +124,6 @@ import com.google.common.base.Preconditions;
 import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Tag;
 
 public class Compactor extends AbstractServer implements MetricsProducer, CompactorService.Iface {
 
@@ -687,8 +686,7 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
     }
 
     MetricsInfo metricsInfo = getContext().getMetricsInfo();
-    metricsInfo.addServiceTags(getApplicationName(), clientAddress);
-    metricsInfo.addCommonTags(List.of(Tag.of("queue", this.queueName)));
+    metricsInfo.addServiceTags(getApplicationName(), clientAddress, queueName);
 
     metricsInfo.addMetricsProducers(this);
     metricsInfo.init();

--- a/server/compactor/src/test/java/org/apache/accumulo/compactor/CompactorTest.java
+++ b/server/compactor/src/test/java/org/apache/accumulo/compactor/CompactorTest.java
@@ -193,8 +193,8 @@ public class CompactorTest {
     private TCompactionStatusUpdate latestState = null;
 
     SuccessfulCompactor(Supplier<UUID> uuid, ServerAddress address, TExternalCompactionJob job,
-        ServerContext context, ExternalCompactionId eci) {
-      super(new CompactorServerOpts(), new String[] {"-q", "testQ"});
+        ServerContext context, ExternalCompactionId eci, CompactorServerOpts compactorServerOpts) {
+      super(compactorServerOpts, new String[] {"-q", "testQ"});
       this.uuid = uuid;
       this.address = address;
       this.job = job;
@@ -277,8 +277,8 @@ public class CompactorTest {
   public class FailedCompactor extends SuccessfulCompactor {
 
     FailedCompactor(Supplier<UUID> uuid, ServerAddress address, TExternalCompactionJob job,
-        ServerContext context, ExternalCompactionId eci) {
-      super(uuid, address, job, context, eci);
+        ServerContext context, ExternalCompactionId eci, CompactorServerOpts compactorServerOpts) {
+      super(uuid, address, job, context, eci, compactorServerOpts);
     }
 
     @Override
@@ -292,8 +292,8 @@ public class CompactorTest {
   public class InterruptedCompactor extends SuccessfulCompactor {
 
     InterruptedCompactor(Supplier<UUID> uuid, ServerAddress address, TExternalCompactionJob job,
-        ServerContext context, ExternalCompactionId eci) {
-      super(uuid, address, job, context, eci);
+        ServerContext context, ExternalCompactionId eci, CompactorServerOpts compactorServerOpts) {
+      super(uuid, address, job, context, eci, compactorServerOpts);
     }
 
     @Override
@@ -345,6 +345,10 @@ public class CompactorTest {
     MetricsInfo metricsInfo = PowerMock.createNiceMock(MetricsInfo.class);
     expect(context.getMetricsInfo()).andReturn(metricsInfo).anyTimes();
 
+    Compactor.CompactorServerOpts compactorServerOpts =
+        PowerMock.createNiceMock(Compactor.CompactorServerOpts.class);
+    expect(compactorServerOpts.getQueueName()).andReturn("testQ");
+
     ZooReaderWriter zrw = PowerMock.createNiceMock(ZooReaderWriter.class);
     ZooKeeper zk = PowerMock.createNiceMock(ZooKeeper.class);
     expect(context.getZooReaderWriter()).andReturn(zrw).anyTimes();
@@ -355,7 +359,8 @@ public class CompactorTest {
 
     PowerMock.replayAll();
 
-    SuccessfulCompactor c = new SuccessfulCompactor(supplier, client, job, context, eci);
+    SuccessfulCompactor c =
+        new SuccessfulCompactor(supplier, client, job, context, eci, compactorServerOpts);
     c.run();
 
     PowerMock.verifyAll();
@@ -396,6 +401,10 @@ public class CompactorTest {
     MetricsInfo metricsInfo = PowerMock.createNiceMock(MetricsInfo.class);
     expect(context.getMetricsInfo()).andReturn(metricsInfo).anyTimes();
 
+    Compactor.CompactorServerOpts compactorServerOpts =
+        PowerMock.createNiceMock(Compactor.CompactorServerOpts.class);
+    expect(compactorServerOpts.getQueueName()).andReturn("testQ");
+
     ZooReaderWriter zrw = PowerMock.createNiceMock(ZooReaderWriter.class);
     ZooKeeper zk = PowerMock.createNiceMock(ZooKeeper.class);
     expect(context.getZooReaderWriter()).andReturn(zrw).anyTimes();
@@ -406,7 +415,8 @@ public class CompactorTest {
 
     PowerMock.replayAll();
 
-    FailedCompactor c = new FailedCompactor(supplier, client, job, context, eci);
+    FailedCompactor c =
+        new FailedCompactor(supplier, client, job, context, eci, compactorServerOpts);
     c.run();
 
     PowerMock.verifyAll();
@@ -448,6 +458,10 @@ public class CompactorTest {
     MetricsInfo metricsInfo = PowerMock.createNiceMock(MetricsInfo.class);
     expect(context.getMetricsInfo()).andReturn(metricsInfo).anyTimes();
 
+    Compactor.CompactorServerOpts compactorServerOpts =
+        PowerMock.createNiceMock(Compactor.CompactorServerOpts.class);
+    expect(compactorServerOpts.getQueueName()).andReturn("testQ");
+
     ZooReaderWriter zrw = PowerMock.createNiceMock(ZooReaderWriter.class);
     ZooKeeper zk = PowerMock.createNiceMock(ZooKeeper.class);
     expect(context.getZooReaderWriter()).andReturn(zrw).anyTimes();
@@ -458,7 +472,8 @@ public class CompactorTest {
 
     PowerMock.replayAll();
 
-    InterruptedCompactor c = new InterruptedCompactor(supplier, client, job, context, eci);
+    InterruptedCompactor c =
+        new InterruptedCompactor(supplier, client, job, context, eci, compactorServerOpts);
     c.run();
 
     PowerMock.verifyAll();
@@ -481,9 +496,13 @@ public class CompactorTest {
     ServerContext context = PowerMock.createNiceMock(ServerContext.class);
     expect(context.getConfiguration()).andReturn(conf).anyTimes();
 
+    Compactor.CompactorServerOpts compactorServerOpts =
+        PowerMock.createNiceMock(Compactor.CompactorServerOpts.class);
+    expect(compactorServerOpts.getQueueName()).andReturn(null);
+
     PowerMock.replayAll();
 
-    try (var c = new SuccessfulCompactor(null, null, null, context, null)) {
+    try (var c = new SuccessfulCompactor(null, null, null, context, null, compactorServerOpts)) {
       Long maxWait = c.getWaitTimeBetweenCompactionChecks(1);
       // compaction jitter means maxWait is between 0.9 and 1.1 of the desired value.
       assertTrue(maxWait >= 720L);

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -167,7 +167,7 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
     }
 
     MetricsInfo metricsInfo = getContext().getMetricsInfo();
-    metricsInfo.addServiceTags(getApplicationName(), address);
+    metricsInfo.addServiceTags(getApplicationName(), address, "");
 
     metricsInfo.addMetricsProducers(new GcMetrics(this));
     metricsInfo.init();

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -1245,7 +1245,7 @@ public class Manager extends AbstractServer
     }
 
     MetricsInfo metricsInfo = getContext().getMetricsInfo();
-    metricsInfo.addServiceTags(getApplicationName(), sa.getAddress());
+    metricsInfo.addServiceTags(getApplicationName(), sa.getAddress(), "");
 
     var producers = ManagerMetrics.getProducers(getConfiguration(), this);
     producers.add(balancerMetrics);

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -498,7 +498,7 @@ public class Monitor extends AbstractServer implements HighlyAvailableService {
     }
 
     MetricsInfo metricsInfo = getContext().getMetricsInfo();
-    metricsInfo.addServiceTags(getApplicationName(), monitorHostAndPort);
+    metricsInfo.addServiceTags(getApplicationName(), monitorHostAndPort, "");
     metricsInfo.init();
 
     try {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -126,8 +126,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 
-import io.micrometer.core.instrument.Tag;
-
 public class ScanServer extends AbstractServer
     implements TabletScanClientService.Iface, TabletHostingServer {
 
@@ -404,8 +402,7 @@ public class ScanServer extends AbstractServer
     }
 
     MetricsInfo metricsInfo = getContext().getMetricsInfo();
-    metricsInfo.addServiceTags(getApplicationName(), clientAddress);
-    metricsInfo.addCommonTags(List.of(Tag.of("resource.group", groupName)));
+    metricsInfo.addServiceTags(getApplicationName(), clientAddress, groupName);
 
     scanMetrics = new TabletServerScanMetrics();
     sessionManager.setZombieCountConsumer(scanMetrics::setZombieScanThreads);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -761,7 +761,7 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
     }
 
     MetricsInfo metricsInfo = context.getMetricsInfo();
-    metricsInfo.addServiceTags(getApplicationName(), clientAddress);
+    metricsInfo.addServiceTags(getApplicationName(), clientAddress, "");
 
     metrics = new TabletServerMetrics(this);
     updateMetrics = new TabletServerUpdateMetrics();

--- a/test/src/main/java/org/apache/accumulo/test/functional/ZombieTServer.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ZombieTServer.java
@@ -137,7 +137,7 @@ public class ZombieTServer {
     ServiceLock zlock = new ServiceLock(zoo.getZooKeeper(), zLockPath, UUID.randomUUID());
 
     MetricsInfo metricsInfo = context.getMetricsInfo();
-    metricsInfo.addServiceTags("zombie.server", serverPort.address);
+    metricsInfo.addServiceTags("zombie.server", serverPort.address, "");
     metricsInfo.init();
 
     LockWatcher lw = new LockWatcher() {


### PR DESCRIPTION
The server idle metric needs to include the tag for queue information.

Without this tag, compactor metrics cannot be grouped into their respective queues.