### PR TITLE
closes reader deep copies outside of lock in FileManager

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/fs/FileManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/FileManager.java
@@ -349,21 +349,21 @@ public class FileManager {
       boolean sawIOException) {
     // put files in openFiles
 
+    for (FileSKVIterator reader : readers) {
+      try {
+        reader.closeDeepCopies();
+      } catch (IOException e) {
+        log.warn("{}", e.getMessage(), e);
+        sawIOException = true;
+      }
+    }
+
     synchronized (this) {
 
       // check that readers were actually reserved ... want to make sure a thread does
       // not try to release readers they never reserved
       if (!reservedReaders.keySet().containsAll(readers)) {
         throw new IllegalArgumentException("Asked to release readers that were never reserved ");
-      }
-
-      for (FileSKVIterator reader : readers) {
-        try {
-          reader.closeDeepCopies();
-        } catch (IOException e) {
-          log.warn("{}", e.getMessage(), e);
-          sawIOException = true;
-        }
       }
 
       for (FileSKVIterator reader : readers) {


### PR DESCRIPTION
FileManager has a goal of doing all I/O outside of locks in its code to avoid one scan blocking another w/ I/O related to opening and closing files.  The code violated this goal when closing deep copies on an rfile and did this inside a lock.  This change moves the close outside of the lock.