### PR TITLE
Fixes discrepancy between `admin fate delete` and `UserFateStore.delete`

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/AdminUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/AdminUtil.java
@@ -476,7 +476,7 @@ public class AdminUtil<T> {
         case FAILED_IN_PROGRESS:
         case SUCCESSFUL:
           System.out.printf("Deleting transaction: %s (%s)%n", fateIdStr, ts);
-          txStore.delete();
+          txStore.forceDelete();
           state = true;
           break;
       }

--- a/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
@@ -344,7 +344,7 @@ public class Fate<T> {
    */
   public Fate(T environment, FateStore<T> store, boolean runDeadResCleaner,
       Function<Repo<T>,String> toLogStrFunc, AccumuloConfiguration conf) {
-    this.store = FateLogger.wrap(store, toLogStrFunc);
+    this.store = FateLogger.wrap(store, toLogStrFunc, false);
     this.environment = environment;
     final ThreadPoolExecutor pool = ThreadPools.getServerThreadPools().createExecutorService(conf,
         Property.MANAGER_FATE_THREADPOOL_SIZE, true);

--- a/core/src/main/java/org/apache/accumulo/core/fate/FateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/FateStore.java
@@ -105,6 +105,11 @@ public interface FateStore<T> extends ReadOnlyFateStore<T> {
     void delete();
 
     /**
+     * Force remove the transaction from the store. Only to be used by {@link AdminUtil}
+     */
+    void forceDelete();
+
+    /**
      * Return the given transaction to the store.
      *
      * upon successful return the store now controls the referenced transaction id. caller should no

--- a/core/src/main/java/org/apache/accumulo/core/fate/FateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/FateStore.java
@@ -105,7 +105,8 @@ public interface FateStore<T> extends ReadOnlyFateStore<T> {
     void delete();
 
     /**
-     * Force remove the transaction from the store. Only to be used by {@link AdminUtil}
+     * Force remove the transaction from the store regardless of the status. Only to be used by
+     * {@link AdminUtil}
      */
     void forceDelete();
 

--- a/core/src/main/java/org/apache/accumulo/core/fate/WrappedFateTxStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/WrappedFateTxStore.java
@@ -87,6 +87,12 @@ public class WrappedFateTxStore<T> implements FateStore.FateTxStore<T> {
   }
 
   @Override
+  public void forceDelete() {
+    throw new UnsupportedOperationException(
+        this.getClass().getSimpleName() + " should not be calling forceDelete()");
+  }
+
+  @Override
   public long timeCreated() {
     return wrapped.timeCreated();
   }

--- a/core/src/main/java/org/apache/accumulo/core/fate/WrappedFateTxStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/WrappedFateTxStore.java
@@ -24,11 +24,15 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 
+import com.google.common.base.Preconditions;
+
 public class WrappedFateTxStore<T> implements FateStore.FateTxStore<T> {
   protected final FateStore.FateTxStore<T> wrapped;
+  private final boolean allowForceDel;
 
-  public WrappedFateTxStore(FateStore.FateTxStore<T> wrapped) {
+  public WrappedFateTxStore(FateStore.FateTxStore<T> wrapped, boolean allowForceDel) {
     this.wrapped = wrapped;
+    this.allowForceDel = allowForceDel;
   }
 
   @Override
@@ -88,8 +92,8 @@ public class WrappedFateTxStore<T> implements FateStore.FateTxStore<T> {
 
   @Override
   public void forceDelete() {
-    throw new UnsupportedOperationException(
-        this.getClass().getSimpleName() + " should not be calling forceDelete()");
+    Preconditions.checkState(allowForceDel, "Force delete is not allowed");
+    wrapped.forceDelete();
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/UserFateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/UserFateStore.java
@@ -539,7 +539,8 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
       verifyReservedAndNotDeleted(true);
 
       var mutator = newMutator(fateId);
-      mutator.requireStatus(TStatus.NEW, TStatus.SUBMITTED, TStatus.SUCCESSFUL, TStatus.FAILED);
+      mutator.requireStatus(TStatus.NEW, TStatus.SUBMITTED, TStatus.SUCCESSFUL, TStatus.FAILED,
+          TStatus.FAILED_IN_PROGRESS, TStatus.IN_PROGRESS);
       mutator.delete().mutate();
       this.deleted = true;
     }

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/UserFateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/UserFateStore.java
@@ -539,6 +539,17 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
       verifyReservedAndNotDeleted(true);
 
       var mutator = newMutator(fateId);
+      mutator.requireStatus(TStatus.NEW, TStatus.SUBMITTED, TStatus.SUCCESSFUL, TStatus.FAILED);
+      mutator.delete().mutate();
+      this.deleted = true;
+    }
+
+    @Override
+    public void forceDelete() {
+      verifyReservedAndNotDeleted(true);
+
+      var mutator = newMutator(fateId);
+      // allow deletion of all txns other than UNKNOWN
       mutator.requireStatus(TStatus.NEW, TStatus.SUBMITTED, TStatus.SUCCESSFUL, TStatus.FAILED,
           TStatus.FAILED_IN_PROGRESS, TStatus.IN_PROGRESS);
       mutator.delete().mutate();

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/MetaFateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/MetaFateStore.java
@@ -370,6 +370,11 @@ public class MetaFateStore<T> extends AbstractFateStore<T> {
     }
 
     @Override
+    public void forceDelete() {
+      delete();
+    }
+
+    @Override
     public void setTransactionInfo(Fate.TxInfo txInfo, Serializable so) {
       verifyReservedAndNotDeleted(true);
 

--- a/core/src/main/java/org/apache/accumulo/core/logging/FateLogger.java
+++ b/core/src/main/java/org/apache/accumulo/core/logging/FateLogger.java
@@ -51,8 +51,9 @@ public class FateLogger {
 
     private final Function<Repo<T>,String> toLogString;
 
-    private LoggingFateTxStore(FateTxStore<T> wrapped, Function<Repo<T>,String> toLogString) {
-      super(wrapped);
+    private LoggingFateTxStore(FateTxStore<T> wrapped, Function<Repo<T>,String> toLogString,
+        boolean allowForceDel) {
+      super(wrapped, allowForceDel);
       this.toLogString = toLogString;
     }
 
@@ -97,19 +98,21 @@ public class FateLogger {
     }
   }
 
-  public static <T> FateStore<T> wrap(FateStore<T> store, Function<Repo<T>,String> toLogString) {
+  public static <T> FateStore<T> wrap(FateStore<T> store, Function<Repo<T>,String> toLogString,
+      boolean allowForceDel) {
 
     // only logging operations that change the persisted data, not operations that only read data
     return new FateStore<>() {
 
       @Override
       public FateTxStore<T> reserve(FateId fateId) {
-        return new LoggingFateTxStore<>(store.reserve(fateId), toLogString);
+        return new LoggingFateTxStore<>(store.reserve(fateId), toLogString, allowForceDel);
       }
 
       @Override
       public Optional<FateTxStore<T>> tryReserve(FateId fateId) {
-        return store.tryReserve(fateId).map(ftxs -> new LoggingFateTxStore<>(ftxs, toLogString));
+        return store.tryReserve(fateId)
+            .map(ftxs -> new LoggingFateTxStore<>(ftxs, toLogString, allowForceDel));
       }
 
       @Override

--- a/core/src/test/java/org/apache/accumulo/core/fate/TestStore.java
+++ b/core/src/test/java/org/apache/accumulo/core/fate/TestStore.java
@@ -200,6 +200,12 @@ public class TestStore implements FateStore<String> {
     }
 
     @Override
+    public void forceDelete() {
+      throw new UnsupportedOperationException(
+          this.getClass().getSimpleName() + " should not be calling forceDelete()");
+    }
+
+    @Override
     public void unreserve(Duration deferTime) {
       if (!reserved.remove(fateId)) {
         throw new IllegalStateException();


### PR DESCRIPTION
`admin fate delete` allows users to delete a transaction. If this transaction is a USER transaction, `UserFateStore.delete()` is how this is achieved. The admin code allows transactions with a status of SUBMITTED, IN_PROGRESS, NEW, FAILED, FAILED_IN_PROGRESS, SUCCESSFUL to call `delete()`, but the `delete()` code only allows NEW, SUBMITTED, SUCCESSFUL, FAILED. I changed the `UserFateStore.delete()` code to match the admin delete code. I'm not sure which one should be changed, but one of them should be.