### PR TITLE
Fixes NPE in QueueMetrics

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/QueueMetrics.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/QueueMetrics.java
@@ -158,6 +158,10 @@ public class QueueMetrics implements MetricsProducer {
     // read the volatile variable once so the rest of the method has consistent view
     var localRegistry = meterRegistry;
 
+    if (localRegistry == null) {
+      return;
+    }
+
     if (queueCountMeter == null) {
       queueCountMeter = Gauge
           .builder(COMPACTOR_JOB_PRIORITY_QUEUES.getName(), compactionJobQueues,


### PR DESCRIPTION
Fixes the following NPE seen during local testing

```
java.util.concurrent.ExecutionException: java.lang.NullPointerException: Cannot invoke "io.micrometer.core.instrument.MeterRegistry.gauge(io.micrometer.core.instrument.Meter$Id, Object, java.util.function.ToDoubleFunction)" because "registry" is null
	at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)
	at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:191)
	at org.apache.accumulo.core.util.threads.ThreadPools.checkTaskFailed(ThreadPools.java:143)
	at org.apache.accumulo.core.util.threads.ThreadPools.lambda$static$0(ThreadPools.java:113)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at org.apache.accumulo.core.util.threads.ThreadPools.lambda$static$1(ThreadPools.java:110)
	at org.apache.accumulo.core.trace.TraceWrappedRunnable.run(TraceWrappedRunnable.java:52)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at org.apache.accumulo.core.trace.TraceWrappedRunnable.run(TraceWrappedRunnable.java:52)
	at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: java.lang.NullPointerException: Cannot invoke "io.micrometer.core.instrument.MeterRegistry.gauge(io.micrometer.core.instrument.Meter$Id, Object, java.util.function.ToDoubleFunction)" because "registry" is null
	at io.micrometer.core.instrument.Gauge$Builder.register(Gauge.java:195)
	at org.apache.accumulo.manager.compaction.coordinator.QueueMetrics.update(QueueMetrics.java:165)
	at org.apache.accumulo.core.trace.TraceWrappedRunnable.run(TraceWrappedRunnable.java:52)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	... 4 more
```