### PR TITLE
Simplifies metrics initialization

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metrics/MetricsInfo.java
+++ b/core/src/main/java/org/apache/accumulo/core/metrics/MetricsInfo.java
@@ -83,29 +83,17 @@ public interface MetricsInfo {
   boolean isMetricsEnabled();
 
   /**
-   * Convenience method to set the common tags for application (process), host and port.
-   *
-   * @param applicationName the application (process) name.
-   * @param hostAndPort the host:port pair
-   * @param resourceGroup the resource group name
+   * Common tags for all services.
    */
-  void addServiceTags(final String applicationName, final HostAndPort hostAndPort,
-      final String resourceGroup);
-
-  /**
-   * Add the list of tag name / value pair to the common tags that will be emitted with all metrics.
-   * Common tags must ne added before initialization of any registries. Tags that are added after a
-   * registry is initialized may not be emitted by the underlying metrics system. This would cause
-   * inconsistent grouping and filtering based on tags,
-   *
-   * @param updates list of tags (name / value pairs)
-   */
-  void addCommonTags(final List<Tag> updates);
-
-  /**
-   * Get the current list of common tags.
-   */
-  Collection<Tag> getCommonTags();
+  static Collection<Tag> serviceTags(final String instanceName, final String applicationName,
+      final HostAndPort hostAndPort, final String resourceGroupName) {
+    List<Tag> tags = new ArrayList<>();
+    tags.add(instanceNameTag(instanceName));
+    tags.add(processTag(applicationName));
+    tags.addAll(addressTags(hostAndPort));
+    tags.add(resourceGroupTag(resourceGroupName));
+    return tags;
+  }
 
   void addMetricsProducers(MetricsProducer... producer);
 
@@ -113,7 +101,7 @@ public interface MetricsInfo {
    * Initialize the metrics system. This sets the list of common tags that are emitted with the
    * metrics.
    */
-  void init();
+  void init(Collection<Tag> commonTags);
 
   /**
    * Close the underlying registry and release resources. The registry will not accept new meters

--- a/core/src/main/java/org/apache/accumulo/core/metrics/MetricsInfo.java
+++ b/core/src/main/java/org/apache/accumulo/core/metrics/MetricsInfo.java
@@ -26,7 +26,6 @@ import java.util.Objects;
 
 import org.apache.accumulo.core.util.HostAndPort;
 
-import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 
 public interface MetricsInfo {
@@ -108,8 +107,6 @@ public interface MetricsInfo {
    */
   Collection<Tag> getCommonTags();
 
-  void addRegistry(MeterRegistry registry);
-
   void addMetricsProducers(MetricsProducer... producer);
 
   /**
@@ -117,8 +114,6 @@ public interface MetricsInfo {
    * metrics.
    */
   void init();
-
-  MeterRegistry getRegistry();
 
   /**
    * Close the underlying registry and release resources. The registry will not accept new meters

--- a/server/base/src/main/java/org/apache/accumulo/server/metrics/MetricsInfoImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metrics/MetricsInfoImpl.java
@@ -24,18 +24,13 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.Objects;
 
 import org.apache.accumulo.core.classloader.ClassLoaderUtil;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.metrics.MetricsInfo;
 import org.apache.accumulo.core.metrics.MetricsProducer;
-import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.server.ServerContext;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.slf4j.Logger;
@@ -52,7 +47,6 @@ import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 
@@ -62,16 +56,12 @@ public class MetricsInfoImpl implements MetricsInfo {
 
   private final ServerContext context;
 
-  private final Lock lock = new ReentrantLock();
-
-  private final Map<String,Tag> commonTags;
+  private List<Tag> commonTags = null;
 
   // JvmGcMetrics are declared with AutoCloseable - keep reference to use with close()
   private JvmGcMetrics jvmGcMetrics;
 
   private final boolean metricsEnabled;
-
-  private MeterRegistry meterRegistry = null;
 
   private final List<MetricsProducer> producers = new ArrayList<>();
 
@@ -79,9 +69,6 @@ public class MetricsInfoImpl implements MetricsInfo {
     this.context = context;
     metricsEnabled = context.getConfiguration().getBoolean(Property.GENERAL_MICROMETER_ENABLED);
     printMetricsConfig();
-    commonTags = new HashMap<>();
-    Tag t = MetricsInfo.instanceNameTag(context.getInstanceName());
-    commonTags.put(t.getKey(), t);
   }
 
   private void printMetricsConfig() {
@@ -103,55 +90,8 @@ public class MetricsInfoImpl implements MetricsInfo {
     return metricsEnabled;
   }
 
-  /**
-   * Common tags for all services.
-   */
   @Override
-  public void addServiceTags(final String applicationName, final HostAndPort hostAndPort,
-      final String resourceGroupName) {
-    if (!metricsEnabled) {
-      return;
-    }
-    List<Tag> tags = new ArrayList<>();
-
-    tags.add(MetricsInfo.processTag(applicationName));
-    tags.addAll(MetricsInfo.addressTags(hostAndPort));
-    tags.add(MetricsInfo.resourceGroupTag(resourceGroupName));
-
-    addCommonTags(tags);
-  }
-
-  @Override
-  public void addCommonTags(List<Tag> updates) {
-    if (!metricsEnabled) {
-      return;
-    }
-    lock.lock();
-    try {
-      if (meterRegistry != null) {
-        LOG.warn(
-            "Common tags after registry has been initialized may be ignored. Current common tags: {}",
-            commonTags);
-        return;
-      }
-      updates.forEach(t -> commonTags.put(t.getKey(), t));
-    } finally {
-      lock.unlock();
-    }
-  }
-
-  @Override
-  public Collection<Tag> getCommonTags() {
-    lock.lock();
-    try {
-      return Collections.unmodifiableCollection(commonTags.values());
-    } finally {
-      lock.unlock();
-    }
-  }
-
-  @Override
-  public void addMetricsProducers(MetricsProducer... producer) {
+  public synchronized void addMetricsProducers(MetricsProducer... producer) {
     if (!metricsEnabled) {
       return;
     }
@@ -160,92 +100,75 @@ public class MetricsInfoImpl implements MetricsInfo {
           "called addMetricsProducers() without providing at least one producer - this has no effect");
       return;
     }
-    lock.lock();
-    try {
-      if (meterRegistry == null) {
-        producers.addAll(Arrays.asList(producer));
-      } else {
-        Arrays.stream(producer).forEach(p -> p.registerMetrics(meterRegistry));
-      }
-    } finally {
-      lock.unlock();
+
+    if (commonTags == null) {
+      producers.addAll(Arrays.asList(producer));
+    } else {
+      Arrays.stream(producer).forEach(p -> p.registerMetrics(Metrics.globalRegistry));
     }
   }
 
   @Override
-  public void init() {
+  public synchronized void init(Collection<Tag> tags) {
+    Objects.requireNonNull(tags);
+
     if (!metricsEnabled) {
       LOG.info("Metrics not initialized, metrics are disabled.");
       return;
     }
-    lock.lock();
-    try {
-      if (meterRegistry != null) {
-        LOG.warn("metrics registry has already been initialized");
-        return;
-      }
-
-      LOG.info("Metrics initialization. common tags: {}", commonTags);
-
-      boolean jvmMetricsEnabled =
-          context.getConfiguration().getBoolean(Property.GENERAL_MICROMETER_JVM_METRICS_ENABLED);
-
-      MeterFilter replicationFilter = new MeterFilter() {
-        @Override
-        public DistributionStatisticConfig configure(Meter.Id id,
-            @NonNull DistributionStatisticConfig config) {
-          if (id.getName().equals("replicationQueue")) {
-            return DistributionStatisticConfig.builder().percentiles(0.5, 0.75, 0.9, 0.95, 0.99)
-                .expiry(Duration.ofMinutes(10)).build().merge(config);
-          }
-          return config;
-        }
-      };
-
-      // user specified registries
-      String userRegistryFactories =
-          context.getConfiguration().get(Property.GENERAL_MICROMETER_FACTORY);
-
-      List<MeterRegistry> registries = new ArrayList<>();
-
-      for (String factoryName : getTrimmedStrings(userRegistryFactories)) {
-        try {
-          MeterRegistry registry = getRegistryFromFactory(factoryName, context);
-          registry.config().commonTags(commonTags.values());
-          registry.config().meterFilter(replicationFilter);
-          registries.add(registry);
-        } catch (ReflectiveOperationException ex) {
-          LOG.warn("Could not load registry {}", factoryName, ex);
-        }
-      }
-
-      if (registries.size() == 1) {
-        meterRegistry = registries.get(0);
-      } else {
-        var composite = new CompositeMeterRegistry();
-        composite.config().commonTags(commonTags.values());
-        registries.forEach(composite::add);
-        meterRegistry = composite;
-      }
-
-      if (jvmMetricsEnabled) {
-        LOG.info("enabling detailed jvm, classloader, jvm gc and process metrics");
-        new ClassLoaderMetrics().bindTo(meterRegistry);
-        new JvmMemoryMetrics().bindTo(meterRegistry);
-        jvmGcMetrics = new JvmGcMetrics();
-        jvmGcMetrics.bindTo(meterRegistry);
-        new ProcessorMetrics().bindTo(meterRegistry);
-        new JvmThreadMetrics().bindTo(meterRegistry);
-      }
-
-      LOG.info("Metrics initialization. Register producers: {}", producers);
-      producers.forEach(p -> p.registerMetrics(meterRegistry));
-
-      Metrics.globalRegistry.add(meterRegistry);
-
-    } finally {
-      lock.unlock();
+    if (commonTags != null) {
+      LOG.warn("metrics registry has already been initialized");
+      return;
     }
+
+    commonTags = List.copyOf(tags);
+
+    LOG.info("Metrics initialization. common tags: {}", commonTags);
+
+    Metrics.globalRegistry.config().commonTags(commonTags);
+
+    boolean jvmMetricsEnabled =
+        context.getConfiguration().getBoolean(Property.GENERAL_MICROMETER_JVM_METRICS_ENABLED);
+
+    MeterFilter replicationFilter = new MeterFilter() {
+      @Override
+      public DistributionStatisticConfig configure(Meter.Id id,
+          @NonNull DistributionStatisticConfig config) {
+        if (id.getName().equals("replicationQueue")) {
+          return DistributionStatisticConfig.builder().percentiles(0.5, 0.75, 0.9, 0.95, 0.99)
+              .expiry(Duration.ofMinutes(10)).build().merge(config);
+        }
+        return config;
+      }
+    };
+
+    // user specified registries
+    String userRegistryFactories =
+        context.getConfiguration().get(Property.GENERAL_MICROMETER_FACTORY);
+
+    for (String factoryName : getTrimmedStrings(userRegistryFactories)) {
+      try {
+        MeterRegistry registry = getRegistryFromFactory(factoryName, context);
+        registry.config().meterFilter(replicationFilter);
+        registry.config().commonTags(commonTags);
+        Metrics.globalRegistry.add(registry);
+      } catch (ReflectiveOperationException ex) {
+        LOG.warn("Could not load registry {}", factoryName, ex);
+      }
+    }
+
+    if (jvmMetricsEnabled) {
+      LOG.info("enabling detailed jvm, classloader, jvm gc and process metrics");
+      new ClassLoaderMetrics().bindTo(Metrics.globalRegistry);
+      new JvmMemoryMetrics().bindTo(Metrics.globalRegistry);
+      jvmGcMetrics = new JvmGcMetrics();
+      jvmGcMetrics.bindTo(Metrics.globalRegistry);
+      new ProcessorMetrics().bindTo(Metrics.globalRegistry);
+      new JvmThreadMetrics().bindTo(Metrics.globalRegistry);
+    }
+
+    LOG.info("Metrics initialization. Register producers: {}", producers);
+    producers.forEach(p -> p.registerMetrics(Metrics.globalRegistry));
   }
 
   // support for org.apache.accumulo.core.metrics.MeterRegistryFactory can be removed in 3.1
@@ -287,14 +210,12 @@ public class MetricsInfoImpl implements MetricsInfo {
       jvmGcMetrics.close();
       jvmGcMetrics = null;
     }
-    if (meterRegistry != null) {
-      meterRegistry.close();
-      meterRegistry = null;
-    }
+
+    Metrics.globalRegistry.close();
   }
 
   @Override
-  public String toString() {
-    return "MetricsCommonTags{tags=" + getCommonTags() + '}';
+  public synchronized String toString() {
+    return "MetricsCommonTags{tags=" + commonTags + '}';
   }
 }

--- a/server/compaction-coordinator/pom.xml
+++ b/server/compaction-coordinator/pom.xml
@@ -44,6 +44,10 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.accumulo</groupId>
       <artifactId>accumulo-core</artifactId>
     </dependency>

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
@@ -275,8 +275,8 @@ public class CompactionCoordinator extends AbstractServer
     }
 
     MetricsInfo metricsInfo = getContext().getMetricsInfo();
-    metricsInfo.addServiceTags(getApplicationName(), clientAddress, "");
-    metricsInfo.init();
+    metricsInfo.init(MetricsInfo.serviceTags(getContext().getInstanceName(), getApplicationName(),
+        clientAddress, ""));
 
     // On a re-start of the coordinator it's possible that external compactions are in-progress.
     // Attempt to get the running compactions on the compactors and then resolve which tserver

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
@@ -23,6 +23,7 @@ import static org.apache.accumulo.core.util.UtilWaitThread.sleepUninterruptibly;
 import static org.apache.accumulo.core.util.threads.ThreadPoolNames.COMPACTION_COORDINATOR_SUMMARY_POOL;
 
 import java.net.UnknownHostException;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -98,6 +99,8 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.collect.Sets;
+
+import io.micrometer.core.instrument.Tag;
 
 public class CompactionCoordinator extends AbstractServer
     implements CompactionCoordinatorService.Iface, LiveTServerSet.Listener {
@@ -257,6 +260,11 @@ public class CompactionCoordinator extends AbstractServer
     return sp;
   }
 
+  protected Collection<Tag> getServiceTags(HostAndPort clientAddress) {
+    return (MetricsInfo.serviceTags(getContext().getInstanceName(), getApplicationName(),
+        clientAddress, ""));
+  }
+
   @Override
   public void run() {
 
@@ -275,8 +283,7 @@ public class CompactionCoordinator extends AbstractServer
     }
 
     MetricsInfo metricsInfo = getContext().getMetricsInfo();
-    metricsInfo.init(MetricsInfo.serviceTags(getContext().getInstanceName(), getApplicationName(),
-        clientAddress, ""));
+    metricsInfo.init(getServiceTags(clientAddress));
 
     // On a re-start of the coordinator it's possible that external compactions are in-progress.
     // Attempt to get the running compactions on the compactors and then resolve which tserver

--- a/server/compaction-coordinator/src/test/java/org/apache/accumulo/coordinator/CompactionCoordinatorTest.java
+++ b/server/compaction-coordinator/src/test/java/org/apache/accumulo/coordinator/CompactionCoordinatorTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -78,6 +79,8 @@ import org.powermock.core.classloader.annotations.SuppressStaticInitializationFo
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.google.common.collect.Sets;
+
+import io.micrometer.core.instrument.Tag;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({CompactionCoordinator.class, DeadCompactionDetector.class, ThriftUtil.class,
@@ -199,6 +202,10 @@ public class CompactionCoordinatorTest {
       metadataCompactionIds = null;
     }
 
+    @Override
+    public Collection<Tag> getServiceTags(HostAndPort clientAddr) {
+      return List.of();
+    }
   }
 
   @Test

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -28,6 +28,7 @@ import java.net.UnknownHostException;
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -124,6 +125,7 @@ import com.google.common.base.Preconditions;
 import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 
 public class Compactor extends AbstractServer implements MetricsProducer, CompactorService.Iface {
 
@@ -669,6 +671,11 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
     return sleepTime;
   }
 
+  protected Collection<Tag> getServiceTags(HostAndPort clientAddress) {
+    return MetricsInfo.serviceTags(getContext().getInstanceName(), getApplicationName(),
+        clientAddress, queueName);
+  }
+
   @Override
   public void run() {
 
@@ -688,8 +695,7 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
     MetricsInfo metricsInfo = getContext().getMetricsInfo();
 
     metricsInfo.addMetricsProducers(this);
-    metricsInfo.init(MetricsInfo.serviceTags(getContext().getInstanceName(), getApplicationName(),
-        clientAddress, queueName));
+    metricsInfo.init(getServiceTags(clientAddress));
 
     var watcher = new CompactionWatcher(getConfiguration());
     var schedExecutor = ThreadPools.getServerThreadPools()

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -686,10 +686,10 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
     }
 
     MetricsInfo metricsInfo = getContext().getMetricsInfo();
-    metricsInfo.addServiceTags(getApplicationName(), clientAddress, queueName);
 
     metricsInfo.addMetricsProducers(this);
-    metricsInfo.init();
+    metricsInfo.init(MetricsInfo.serviceTags(getContext().getInstanceName(), getApplicationName(),
+        clientAddress, queueName));
 
     var watcher = new CompactionWatcher(getConfiguration());
     var schedExecutor = ThreadPools.getServerThreadPools()

--- a/server/compactor/src/test/java/org/apache/accumulo/compactor/CompactorTest.java
+++ b/server/compactor/src/test/java/org/apache/accumulo/compactor/CompactorTest.java
@@ -26,6 +26,8 @@ import static org.junit.Assert.assertTrue;
 
 import java.net.UnknownHostException;
 import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.UUID;
@@ -71,6 +73,8 @@ import org.powermock.core.classloader.annotations.SuppressStaticInitializationFo
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.micrometer.core.instrument.Tag;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Compactor.class})
@@ -270,6 +274,11 @@ public class CompactorTest {
 
     public boolean isFailedCalled() {
       return failedCalled;
+    }
+
+    @Override
+    protected Collection<Tag> getServiceTags(HostAndPort clientAddress) {
+      return List.of();
     }
 
   }

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -167,10 +167,10 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
     }
 
     MetricsInfo metricsInfo = getContext().getMetricsInfo();
-    metricsInfo.addServiceTags(getApplicationName(), address, "");
 
     metricsInfo.addMetricsProducers(new GcMetrics(this));
-    metricsInfo.init();
+    metricsInfo.init(
+        MetricsInfo.serviceTags(getContext().getInstanceName(), getApplicationName(), address, ""));
     try {
       long delay = getStartDelay();
       log.debug("Sleeping for {} milliseconds before beginning garbage collection cycles", delay);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -1245,12 +1245,12 @@ public class Manager extends AbstractServer
     }
 
     MetricsInfo metricsInfo = getContext().getMetricsInfo();
-    metricsInfo.addServiceTags(getApplicationName(), sa.getAddress(), "");
 
     var producers = ManagerMetrics.getProducers(getConfiguration(), this);
     producers.add(balancerMetrics);
     metricsInfo.addMetricsProducers(producers.toArray(new MetricsProducer[0]));
-    metricsInfo.init();
+    metricsInfo.init(MetricsInfo.serviceTags(getContext().getInstanceName(), getApplicationName(),
+        sa.getAddress(), ""));
 
     recoveryManager = new RecoveryManager(this, timeToCacheRecoveryWalExistence);
 

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -498,8 +498,8 @@ public class Monitor extends AbstractServer implements HighlyAvailableService {
     }
 
     MetricsInfo metricsInfo = getContext().getMetricsInfo();
-    metricsInfo.addServiceTags(getApplicationName(), monitorHostAndPort, "");
-    metricsInfo.init();
+    metricsInfo.init(MetricsInfo.serviceTags(getContext().getInstanceName(), getApplicationName(),
+        monitorHostAndPort, ""));
 
     try {
       URL url = new URL(server.isSecure() ? "https" : "http", advertiseHost, server.getPort(), "/");

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -402,7 +402,6 @@ public class ScanServer extends AbstractServer
     }
 
     MetricsInfo metricsInfo = getContext().getMetricsInfo();
-    metricsInfo.addServiceTags(getApplicationName(), clientAddress, groupName);
 
     scanMetrics = new TabletServerScanMetrics(resourceManager::getOpenFiles);
     sessionManager.setZombieCountConsumer(scanMetrics::setZombieScanThreads);
@@ -411,7 +410,8 @@ public class ScanServer extends AbstractServer
         resourceManager.getDataCache(), resourceManager.getSummaryCache());
 
     metricsInfo.addMetricsProducers(this, scanMetrics, scanServerMetrics, blockCacheMetrics);
-    metricsInfo.init();
+    metricsInfo.init(MetricsInfo.serviceTags(getContext().getInstanceName(), getApplicationName(),
+        clientAddress, groupName));
     // We need to set the compaction manager so that we don't get an NPE in CompactableImpl.close
 
     ServiceLock lock = announceExistence();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -761,7 +761,6 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
     }
 
     MetricsInfo metricsInfo = context.getMetricsInfo();
-    metricsInfo.addServiceTags(getApplicationName(), clientAddress, "");
 
     metrics = new TabletServerMetrics(this);
     updateMetrics = new TabletServerUpdateMetrics();
@@ -774,7 +773,8 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
 
     metricsInfo.addMetricsProducers(this, metrics, updateMetrics, scanMetrics, mincMetrics,
         ceMetrics, blockCacheMetrics);
-    metricsInfo.init();
+    metricsInfo.init(MetricsInfo.serviceTags(context.getInstanceName(), getApplicationName(),
+        clientAddress, ""));
 
     this.compactionManager = new CompactionManager(() -> Iterators
         .transform(onlineTablets.snapshot().values().iterator(), Tablet::asCompactable),

--- a/test/src/main/java/org/apache/accumulo/test/functional/ZombieTServer.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ZombieTServer.java
@@ -137,8 +137,8 @@ public class ZombieTServer {
     ServiceLock zlock = new ServiceLock(zoo.getZooKeeper(), zLockPath, UUID.randomUUID());
 
     MetricsInfo metricsInfo = context.getMetricsInfo();
-    metricsInfo.addServiceTags("zombie.server", serverPort.address, "");
-    metricsInfo.init();
+    metricsInfo.init(MetricsInfo.serviceTags(context.getInstanceName(), "zombie.server",
+        serverPort.address, ""));
 
     LockWatcher lw = new LockWatcher() {
 

--- a/test/src/main/java/org/apache/accumulo/test/metrics/TestStatsDSink.java
+++ b/test/src/main/java/org/apache/accumulo/test/metrics/TestStatsDSink.java
@@ -73,21 +73,26 @@ public class TestStatsDSink implements Closeable {
   }
 
   public static Metric parseStatsDMetric(String line) {
-    int idx = line.indexOf(':');
-    String name = line.substring(0, idx);
-    int idx2 = line.indexOf('|');
-    String value = line.substring(idx + 1, idx2);
-    int idx3 = line.indexOf('|', idx2 + 1);
-    String type = line.substring(idx2 + 1, idx3);
-    int idx4 = line.indexOf('#');
-    String tags = line.substring(idx4 + 1);
-    Metric m = new Metric(name, value, type);
-    String[] tag = tags.split(",");
-    for (String t : tag) {
-      String[] p = t.split(":");
-      m.getTags().put(p[0], p[1]);
+    try {
+      int idx = line.indexOf(':');
+      String name = line.substring(0, idx);
+      int idx2 = line.indexOf('|');
+      String value = line.substring(idx + 1, idx2);
+      int idx3 = line.indexOf('|', idx2 + 1);
+      String type = line.substring(idx2 + 1, idx3);
+      int idx4 = line.indexOf('#');
+      String tags = line.substring(idx4 + 1);
+      Metric m = new Metric(name, value, type);
+      String[] tag = tags.split(",");
+      for (String t : tag) {
+        String[] p = t.split(":");
+        m.getTags().put(p[0], p[1]);
+      }
+      return m;
+    } catch (Exception e) {
+      throw new IllegalArgumentException("failed to parse : " + line, e);
     }
-    return m;
+
   }
 
   private static final Logger LOG = LoggerFactory.getLogger(TestStatsDSink.class);


### PR DESCRIPTION
The metrics initialization code supported adding registries prior to initialization, however nothing used this functionality.  Simplified the code by removing support for pending registries.  This simplification allowed avoiding using the composite metrics registry when there is only a single registry.