### PR TITLE
Increase majc priority for tablets over file size threshold

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionPlanner.java
@@ -81,6 +81,11 @@ public interface CompactionPlanner {
    */
   public interface PlanningParameters {
 
+    /**
+     * @return The id of the namespace that the table is assigned to
+     * @throws TableNotFoundException
+     * @since 2.1.4
+     */
     NamespaceId getNamespaceId() throws TableNotFoundException;
 
     /**

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionPlanner.java
@@ -21,8 +21,10 @@ package org.apache.accumulo.core.spi.compaction;
 import java.util.Collection;
 import java.util.Map;
 
+import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.admin.CompactionConfig;
 import org.apache.accumulo.core.client.admin.compaction.CompactableFile;
+import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.spi.common.ServiceEnvironment;
 
@@ -79,6 +81,9 @@ public interface CompactionPlanner {
    */
   public interface PlanningParameters {
 
+    
+    NamespaceId getNamespaceId() throws TableNotFoundException;
+    
     /**
      * @return The id of the table that compactions are being planned for.
      * @see ServiceEnvironment#getTableName(TableId)

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionPlanner.java
@@ -83,7 +83,7 @@ public interface CompactionPlanner {
 
     /**
      * @return The id of the namespace that the table is assigned to
-     * @throws TableNotFoundException
+     * @throws TableNotFoundException thrown when the namespace for a table cannot be calculated
      * @since 2.1.4
      */
     NamespaceId getNamespaceId() throws TableNotFoundException;

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionPlanner.java
@@ -81,9 +81,8 @@ public interface CompactionPlanner {
    */
   public interface PlanningParameters {
 
-    
     NamespaceId getNamespaceId() throws TableNotFoundException;
-    
+
     /**
      * @return The id of the table that compactions are being planned for.
      * @see ServiceEnvironment#getTableName(TableId)

--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionJobPrioritizer.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionJobPrioritizer.java
@@ -119,6 +119,8 @@ public class CompactionJobPrioritizer {
     CompactionKind calculationKind = kind;
     if (kind == CompactionKind.CHOP) {
       calculationKind = CompactionKind.USER;
+    } else if (kind == CompactionKind.SELECTOR) {
+      calculationKind = CompactionKind.SYSTEM;
     }
 
     Range<Short> range = null;
@@ -134,8 +136,7 @@ public class CompactionJobPrioritizer {
       if (totalFiles > maxFilesPerTablet && calculationKind == CompactionKind.SYSTEM) {
         range = TABLE_OVER_SIZE;
         func = tabletOverSizeFunction;
-      } else if (calculationKind == CompactionKind.SYSTEM
-          || calculationKind == CompactionKind.SELECTOR) {
+      } else if (calculationKind == CompactionKind.SYSTEM) {
         range = USER_TABLE_SYSTEM;
       } else {
         range = USER_TABLE_USER;

--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionJobPrioritizer.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionJobPrioritizer.java
@@ -36,28 +36,53 @@ import com.google.common.base.Preconditions;
 
 public class CompactionJobPrioritizer {
 
-  public static enum Condition {
-    NONE, TABLET_OVER_SIZE;
-  }
-
   public static final Comparator<CompactionJob> JOB_COMPARATOR =
       Comparator.comparingInt(CompactionJob::getPriority)
           .thenComparingInt(job -> job.getFiles().size()).reversed();
-  
-  private static final Map<Pair<TableId, CompactionKind>, Pair<Short,Short>> SYSTEM_TABLE_RANGES = new HashMap<>();
-  private static final Map<Pair<NamespaceId, CompactionKind>, Pair<Short,Short>> ACCUMULO_NAMESPACE_RANGES = new HashMap<>();
-  
-  private static final Pair<Short, Short> TABLE_OVER_SIZE = new Pair<>((short) (Short.MAX_VALUE - 2000), Short.MAX_VALUE);
-  private static final Pair<Short, Short> ROOT_TABLE_USER = new Pair<>((short) (Short.MAX_VALUE - 4000), (short) (Short.MAX_VALUE - 2001));
-  private static final Pair<Short, Short> ROOT_TABLE_SYSTEM = new Pair<>((short) (Short.MAX_VALUE - 6000), (short) (Short.MAX_VALUE - 4001));
-  private static final Pair<Short, Short> METADATA_TABLE_USER = new Pair<>((short) (Short.MAX_VALUE - 6000), (short) (Short.MAX_VALUE - 4001));
-  private static final Pair<Short, Short> METADATA_TABLE_SYSTEM = new Pair<>((short) (Short.MAX_VALUE - 8000), (short) (Short.MAX_VALUE - 6001));
-  private static final Pair<Short, Short> SYSTEM_NS_USER = new Pair<>((short) (Short.MAX_VALUE - 10000), (short) (Short.MAX_VALUE - 8001));
-  private static final Pair<Short, Short> SYSTEM_NS_SYSTEM = new Pair<>((short) (Short.MAX_VALUE - 12000), (short) (Short.MAX_VALUE - 10001));
-  
-  private static final Pair<Short, Short> USER_TABLE_USER = new Pair<>(Short.MIN_VALUE, Short.MIN_VALUE);
-  private static final Pair<Short, Short> USER_TABLE_SYSTEM = new Pair<>(Short.MIN_VALUE, Short.MIN_VALUE);
-  
+
+  private static final Map<Pair<TableId,CompactionKind>,Pair<Short,Short>> SYSTEM_TABLE_RANGES =
+      new HashMap<>();
+  private static final Map<Pair<NamespaceId,CompactionKind>,
+      Pair<Short,Short>> ACCUMULO_NAMESPACE_RANGES = new HashMap<>();
+
+  // Create ranges of possible priority values where each range has
+  // 2000 possible values. Give higher priority to tables where
+  // they have more files than allowed, user compactions over system
+  // compactions, root table over metadata table, metadata table over
+  // other system tables and user tables.
+  private static final Short TABLE_OVER_SIZE_MAX = Short.MAX_VALUE;
+  private static final Short ROOT_TABLE_USER_MAX = Short.MAX_VALUE - 2001;
+  private static final Short ROOT_TABLE_SYSTEM_MAX = (short) (ROOT_TABLE_USER_MAX - 2001);
+  private static final Short META_TABLE_USER_MAX = (short) (ROOT_TABLE_SYSTEM_MAX - 2001);
+  private static final Short META_TABLE_SYSTEM_MAX = (short) (META_TABLE_USER_MAX - 2001);
+  private static final Short SYSTEM_NS_USER_MAX = (short) (META_TABLE_SYSTEM_MAX - 2001);
+  private static final Short SYSTEM_NS_SYSTEM_MAX = (short) (SYSTEM_NS_USER_MAX - 2001);
+  private static final Short USER_TABLE_USER_MAX = (short) (SYSTEM_NS_SYSTEM_MAX - 2001);
+  private static final Short USER_TABLE_SYSTEM_MAX = 0;
+
+  static final Pair<Short,Short> TABLE_OVER_SIZE =
+      new Pair<>((short) (ROOT_TABLE_USER_MAX + 1), TABLE_OVER_SIZE_MAX);
+
+  static final Pair<Short,Short> ROOT_TABLE_USER =
+      new Pair<>((short) (ROOT_TABLE_SYSTEM_MAX + 1), ROOT_TABLE_USER_MAX);
+  static final Pair<Short,Short> ROOT_TABLE_SYSTEM =
+      new Pair<>((short) (META_TABLE_USER_MAX + 1), ROOT_TABLE_SYSTEM_MAX);
+
+  static final Pair<Short,Short> METADATA_TABLE_USER =
+      new Pair<>((short) (META_TABLE_SYSTEM_MAX + 1), META_TABLE_USER_MAX);
+  static final Pair<Short,Short> METADATA_TABLE_SYSTEM =
+      new Pair<>((short) (SYSTEM_NS_USER_MAX + 1), META_TABLE_SYSTEM_MAX);
+
+  static final Pair<Short,Short> SYSTEM_NS_USER =
+      new Pair<>((short) (SYSTEM_NS_SYSTEM_MAX + 1), SYSTEM_NS_USER_MAX);
+  static final Pair<Short,Short> SYSTEM_NS_SYSTEM =
+      new Pair<>((short) (USER_TABLE_USER_MAX + 1), SYSTEM_NS_SYSTEM_MAX);
+
+  static final Pair<Short,Short> USER_TABLE_USER =
+      new Pair<>((short) (USER_TABLE_SYSTEM_MAX + 1), USER_TABLE_USER_MAX);
+  static final Pair<Short,Short> USER_TABLE_SYSTEM =
+      new Pair<>(Short.MIN_VALUE, USER_TABLE_SYSTEM_MAX);
+
   static {
     // root table
     SYSTEM_TABLE_RANGES.put(new Pair<>(RootTable.ID, CompactionKind.USER), ROOT_TABLE_USER);
@@ -65,46 +90,49 @@ public class CompactionJobPrioritizer {
 
     // metadata table
     SYSTEM_TABLE_RANGES.put(new Pair<>(MetadataTable.ID, CompactionKind.USER), METADATA_TABLE_USER);
-    SYSTEM_TABLE_RANGES.put(new Pair<>(MetadataTable.ID,  CompactionKind.SYSTEM), METADATA_TABLE_SYSTEM);
+    SYSTEM_TABLE_RANGES.put(new Pair<>(MetadataTable.ID, CompactionKind.SYSTEM),
+        METADATA_TABLE_SYSTEM);
 
     // metadata table
-    ACCUMULO_NAMESPACE_RANGES.put(new Pair<>(Namespace.ACCUMULO.id(), CompactionKind.USER), SYSTEM_NS_USER);
-    ACCUMULO_NAMESPACE_RANGES.put(new Pair<>(Namespace.ACCUMULO.id(), CompactionKind.SYSTEM), SYSTEM_NS_SYSTEM);
+    ACCUMULO_NAMESPACE_RANGES.put(new Pair<>(Namespace.ACCUMULO.id(), CompactionKind.USER),
+        SYSTEM_NS_USER);
+    ACCUMULO_NAMESPACE_RANGES.put(new Pair<>(Namespace.ACCUMULO.id(), CompactionKind.SYSTEM),
+        SYSTEM_NS_SYSTEM);
   }
 
-  public static short createPriority(NamespaceId nsId, TableId tableId, CompactionKind kind, int totalFiles, int compactingFiles,
-      Condition condition, int maxFilesPerTablet) {
+  public static short createPriority(NamespaceId nsId, TableId tableId, CompactionKind kind,
+      int totalFiles, int compactingFiles, int maxFilesPerTablet) {
 
     Objects.requireNonNull(nsId, "nsId cannot be null");
     Objects.requireNonNull(tableId, "tableId cannot be null");
     Preconditions.checkArgument(totalFiles >= 0, "totalFiles is negative %s", totalFiles);
-    Preconditions.checkArgument(compactingFiles >= 0, "compactingFiles is negative %s", compactingFiles);
-    Objects.requireNonNull(condition, "condition cannot be null");
+    Preconditions.checkArgument(compactingFiles >= 0, "compactingFiles is negative %s",
+        compactingFiles);
 
-    Pair<Short,Short> range = null;
-    
-    switch (condition) {
-      case NONE:
-        if (Namespace.ACCUMULO.id() == nsId) {
-          range = SYSTEM_TABLE_RANGES.get(new Pair<>(tableId, kind));
-          if (range == null) {
-            range = ACCUMULO_NAMESPACE_RANGES.get(new Pair<>(nsId, kind));
-          }
-        } else {
-          if (kind == CompactionKind.SYSTEM) {
-            range = USER_TABLE_SYSTEM;
-          } else {
-            range = USER_TABLE_USER;
-          }
+    if (totalFiles > maxFilesPerTablet && kind == CompactionKind.SYSTEM) {
+      int priority =
+          TABLE_OVER_SIZE.getFirst() + compactingFiles + (totalFiles - maxFilesPerTablet);
+      if (priority > Short.MAX_VALUE) {
+        return Short.MAX_VALUE;
+      }
+      return (short) priority;
+    } else {
+      Pair<Short,Short> range = null;
+      if (Namespace.ACCUMULO.id() == nsId) {
+        range = SYSTEM_TABLE_RANGES.get(new Pair<>(tableId, kind));
+        if (range == null) {
+          range = ACCUMULO_NAMESPACE_RANGES.get(new Pair<>(nsId, kind));
         }
-        return (short) Math.min(range.getSecond(), range.getFirst() + totalFiles + compactingFiles);
-      case TABLET_OVER_SIZE:
-        range = TABLE_OVER_SIZE;
-        return (short) Math.min(range.getSecond(), range.getFirst() + totalFiles + compactingFiles - maxFilesPerTablet);
-      default:
-        throw new IllegalStateException("Unhandled condition type: " + condition);
+      } else {
+        if (kind == CompactionKind.SYSTEM) {
+          range = USER_TABLE_SYSTEM;
+        } else {
+          range = USER_TABLE_USER;
+        }
+      }
+      return (short) Math.min(range.getSecond(), range.getFirst() + totalFiles + compactingFiles);
     }
-    
+
   }
 
 }

--- a/core/src/test/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlannerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlannerTest.java
@@ -744,7 +744,6 @@ public class DefaultCompactionPlannerTest {
       CompactionKind kind, Configuration conf) {
     return new CompactionPlanner.PlanningParameters() {
 
-      
       @Override
       public NamespaceId getNamespaceId() throws TableNotFoundException {
         return Namespace.ACCUMULO.id();

--- a/core/src/test/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlannerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlannerTest.java
@@ -35,12 +35,15 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.admin.compaction.CompactableFile;
+import org.apache.accumulo.core.clientImpl.Namespace;
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.ConfigurationTypeHelper;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.conf.SiteConfiguration;
+import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.spi.common.ServiceEnvironment;
 import org.apache.accumulo.core.spi.common.ServiceEnvironment.Configuration;
@@ -740,6 +743,12 @@ public class DefaultCompactionPlannerTest {
       Set<CompactableFile> candidates, Set<CompactionJob> compacting, double ratio,
       CompactionKind kind, Configuration conf) {
     return new CompactionPlanner.PlanningParameters() {
+
+      
+      @Override
+      public NamespaceId getNamespaceId() throws TableNotFoundException {
+        return Namespace.ACCUMULO.id();
+      }
 
       @Override
       public TableId getTableId() {

--- a/core/src/test/java/org/apache/accumulo/core/util/compaction/CompactionPrioritizerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/compaction/CompactionPrioritizerTest.java
@@ -94,6 +94,8 @@ public class CompactionPrioritizerTest {
         return Short.compare(r1.getMinimum(), r2.getMinimum());
       }
     });
+    assertEquals(Short.MIN_VALUE, ranges.get(0).getMinimum());
+    assertEquals(Short.MAX_VALUE, ranges.get(ranges.size() - 1).getMaximum());
     // check that the max of the previous range is one less than the
     // minimum of the current range to make sure there are no holes.
     short lastMax = Short.MIN_VALUE;

--- a/core/src/test/java/org/apache/accumulo/core/util/compaction/CompactionPrioritizerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/compaction/CompactionPrioritizerTest.java
@@ -64,34 +64,34 @@ public class CompactionPrioritizerTest {
 
   @Test
   public void testRootTablePriorities() {
-    assertEquals(ROOT_TABLE_USER.getMin(), CompactionJobPrioritizer.createPriority(
+    assertEquals(ROOT_TABLE_USER.getMinimum(), CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), RootTable.ID, CompactionKind.USER, 0, 0, TABLET_FILE_MAX));
-    assertEquals(ROOT_TABLE_USER.getMin() + 1000, CompactionJobPrioritizer.createPriority(
+    assertEquals(ROOT_TABLE_USER.getMinimum() + 1000, CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), RootTable.ID, CompactionKind.USER, 1000, 0, TABLET_FILE_MAX));
-    assertEquals(ROOT_TABLE_USER.getMax(), CompactionJobPrioritizer.createPriority(
+    assertEquals(ROOT_TABLE_USER.getMaximum(), CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), RootTable.ID, CompactionKind.USER, 3000, 0, TABLET_FILE_MAX));
-    assertEquals(ROOT_TABLE_SYSTEM.getMin(), CompactionJobPrioritizer.createPriority(
+    assertEquals(ROOT_TABLE_SYSTEM.getMinimum(), CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), RootTable.ID, CompactionKind.SYSTEM, 0, 0, TABLET_FILE_MAX));
-    assertEquals(ROOT_TABLE_SYSTEM.getMin() + 1000, CompactionJobPrioritizer.createPriority(
+    assertEquals(ROOT_TABLE_SYSTEM.getMinimum() + 1000, CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), RootTable.ID, CompactionKind.SYSTEM, 1000, 0, TABLET_FILE_MAX));
-    assertEquals(ROOT_TABLE_SYSTEM.getMax(), CompactionJobPrioritizer.createPriority(
+    assertEquals(ROOT_TABLE_SYSTEM.getMaximum(), CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), RootTable.ID, CompactionKind.SYSTEM, 3000, 0, TABLET_FILE_MAX));
   }
 
   @Test
   public void testMetaTablePriorities() {
-    assertEquals(METADATA_TABLE_USER.getMin(), CompactionJobPrioritizer.createPriority(
+    assertEquals(METADATA_TABLE_USER.getMinimum(), CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), MetadataTable.ID, CompactionKind.USER, 0, 0, TABLET_FILE_MAX));
-    assertEquals(METADATA_TABLE_USER.getMin() + 1000, CompactionJobPrioritizer.createPriority(
+    assertEquals(METADATA_TABLE_USER.getMinimum() + 1000, CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), MetadataTable.ID, CompactionKind.USER, 1000, 0, TABLET_FILE_MAX));
-    assertEquals(METADATA_TABLE_USER.getMax(), CompactionJobPrioritizer.createPriority(
+    assertEquals(METADATA_TABLE_USER.getMaximum(), CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), MetadataTable.ID, CompactionKind.USER, 3000, 0, TABLET_FILE_MAX));
-    assertEquals(METADATA_TABLE_SYSTEM.getMin(), CompactionJobPrioritizer.createPriority(
+    assertEquals(METADATA_TABLE_SYSTEM.getMinimum(), CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), MetadataTable.ID, CompactionKind.SYSTEM, 0, 0, TABLET_FILE_MAX));
-    assertEquals(METADATA_TABLE_SYSTEM.getMin() + 1000,
+    assertEquals(METADATA_TABLE_SYSTEM.getMinimum() + 1000,
         CompactionJobPrioritizer.createPriority(Namespace.ACCUMULO.id(), MetadataTable.ID,
             CompactionKind.SYSTEM, 1000, 0, TABLET_FILE_MAX));
-    assertEquals(METADATA_TABLE_SYSTEM.getMax(),
+    assertEquals(METADATA_TABLE_SYSTEM.getMaximum(),
         CompactionJobPrioritizer.createPriority(Namespace.ACCUMULO.id(), MetadataTable.ID,
             CompactionKind.SYSTEM, 3000, 0, TABLET_FILE_MAX));
   }
@@ -99,35 +99,35 @@ public class CompactionPrioritizerTest {
   @Test
   public void testSystemNamespacePriorities() {
     TableId tid = TableId.of("someOtherSystemTable");
-    assertEquals(SYSTEM_NS_USER.getMin(), CompactionJobPrioritizer
+    assertEquals(SYSTEM_NS_USER.getMinimum(), CompactionJobPrioritizer
         .createPriority(Namespace.ACCUMULO.id(), tid, CompactionKind.USER, 0, 0, TABLET_FILE_MAX));
-    assertEquals(SYSTEM_NS_USER.getMin() + 1000, CompactionJobPrioritizer.createPriority(
+    assertEquals(SYSTEM_NS_USER.getMinimum() + 1000, CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), tid, CompactionKind.USER, 1000, 0, TABLET_FILE_MAX));
-    assertEquals(SYSTEM_NS_USER.getMax(), CompactionJobPrioritizer.createPriority(
+    assertEquals(SYSTEM_NS_USER.getMaximum(), CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), tid, CompactionKind.USER, 3000, 0, TABLET_FILE_MAX));
-    assertEquals(SYSTEM_NS_SYSTEM.getMin(), CompactionJobPrioritizer.createPriority(
+    assertEquals(SYSTEM_NS_SYSTEM.getMinimum(), CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), tid, CompactionKind.SYSTEM, 0, 0, TABLET_FILE_MAX));
-    assertEquals(SYSTEM_NS_SYSTEM.getMin() + 1000, CompactionJobPrioritizer.createPriority(
+    assertEquals(SYSTEM_NS_SYSTEM.getMinimum() + 1000, CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), tid, CompactionKind.SYSTEM, 1000, 0, TABLET_FILE_MAX));
-    assertEquals(SYSTEM_NS_SYSTEM.getMax(), CompactionJobPrioritizer.createPriority(
+    assertEquals(SYSTEM_NS_SYSTEM.getMaximum(), CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), tid, CompactionKind.SYSTEM, 3000, 0, TABLET_FILE_MAX));
   }
 
   @Test
   public void testUserTablePriorities() {
     TableId tid = TableId.of("someUserTable");
-    assertEquals(USER_TABLE_USER.getMin(), CompactionJobPrioritizer
+    assertEquals(USER_TABLE_USER.getMinimum(), CompactionJobPrioritizer
         .createPriority(Namespace.DEFAULT.id(), tid, CompactionKind.USER, 0, 0, TABLET_FILE_MAX));
-    assertEquals(USER_TABLE_USER.getMin() + 1000, CompactionJobPrioritizer.createPriority(
+    assertEquals(USER_TABLE_USER.getMinimum() + 1000, CompactionJobPrioritizer.createPriority(
         Namespace.DEFAULT.id(), tid, CompactionKind.USER, 1000, 0, TABLET_FILE_MAX));
-    assertEquals(USER_TABLE_USER.getMin() + 3000, CompactionJobPrioritizer.createPriority(
+    assertEquals(USER_TABLE_USER.getMinimum() + 3000, CompactionJobPrioritizer.createPriority(
         Namespace.DEFAULT.id(), tid, CompactionKind.USER, 3000, 0, TABLET_FILE_MAX));
 
-    assertEquals(USER_TABLE_SYSTEM.getMin(), CompactionJobPrioritizer
+    assertEquals(USER_TABLE_SYSTEM.getMinimum(), CompactionJobPrioritizer
         .createPriority(Namespace.DEFAULT.id(), tid, CompactionKind.SYSTEM, 0, 0, TABLET_FILE_MAX));
-    assertEquals(USER_TABLE_SYSTEM.getMin() + 1000, CompactionJobPrioritizer.createPriority(
+    assertEquals(USER_TABLE_SYSTEM.getMinimum() + 1000, CompactionJobPrioritizer.createPriority(
         Namespace.DEFAULT.id(), tid, CompactionKind.SYSTEM, 1000, 0, TABLET_FILE_MAX));
-    assertEquals(USER_TABLE_SYSTEM.getMin() + 3000, CompactionJobPrioritizer.createPriority(
+    assertEquals(USER_TABLE_SYSTEM.getMinimum() + 3000, CompactionJobPrioritizer.createPriority(
         Namespace.DEFAULT.id(), tid, CompactionKind.SYSTEM, 3000, 0, TABLET_FILE_MAX));
   }
 
@@ -135,21 +135,21 @@ public class CompactionPrioritizerTest {
   public void testTableOverSize() {
     final int tabletFileMax = 30;
     final TableId tid = TableId.of("someTable");
-    assertEquals(ROOT_TABLE_SYSTEM.getMin() + 150, CompactionJobPrioritizer.createPriority(
+    assertEquals(ROOT_TABLE_SYSTEM.getMinimum() + 150, CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), RootTable.ID, CompactionKind.SYSTEM, 100, 50, tabletFileMax));
-    assertEquals(METADATA_TABLE_SYSTEM.getMin() + 150, CompactionJobPrioritizer.createPriority(
+    assertEquals(METADATA_TABLE_SYSTEM.getMinimum() + 150, CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), MetadataTable.ID, CompactionKind.SYSTEM, 100, 50, tabletFileMax));
-    assertEquals(SYSTEM_NS_SYSTEM.getMin() + 150, CompactionJobPrioritizer.createPriority(
+    assertEquals(SYSTEM_NS_SYSTEM.getMinimum() + 150, CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), tid, CompactionKind.SYSTEM, 100, 50, tabletFileMax));
-    assertEquals(TABLE_OVER_SIZE.getMin() + 120, CompactionJobPrioritizer.createPriority(
+    assertEquals(TABLE_OVER_SIZE.getMinimum() + 120, CompactionJobPrioritizer.createPriority(
         Namespace.DEFAULT.id(), tid, CompactionKind.SYSTEM, 100, 50, tabletFileMax));
-    assertEquals(ROOT_TABLE_SYSTEM.getMax(), CompactionJobPrioritizer.createPriority(
+    assertEquals(ROOT_TABLE_SYSTEM.getMaximum(), CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), RootTable.ID, CompactionKind.SYSTEM, 3000, 50, tabletFileMax));
-    assertEquals(METADATA_TABLE_SYSTEM.getMax(), CompactionJobPrioritizer.createPriority(
+    assertEquals(METADATA_TABLE_SYSTEM.getMaximum(), CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), MetadataTable.ID, CompactionKind.SYSTEM, 3000, 50, tabletFileMax));
-    assertEquals(SYSTEM_NS_SYSTEM.getMax(), CompactionJobPrioritizer.createPriority(
+    assertEquals(SYSTEM_NS_SYSTEM.getMaximum(), CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), tid, CompactionKind.SYSTEM, 3000, 50, tabletFileMax));
-    assertEquals(TABLE_OVER_SIZE.getMax(), CompactionJobPrioritizer.createPriority(
+    assertEquals(TABLE_OVER_SIZE.getMaximum(), CompactionJobPrioritizer.createPriority(
         Namespace.DEFAULT.id(), tid, CompactionKind.SYSTEM, 3000, 50, tabletFileMax));
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/util/compaction/CompactionPrioritizerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/compaction/CompactionPrioritizerTest.java
@@ -64,34 +64,34 @@ public class CompactionPrioritizerTest {
 
   @Test
   public void testRootTablePriorities() {
-    assertEquals(ROOT_TABLE_USER.getFirst(), CompactionJobPrioritizer.createPriority(
+    assertEquals(ROOT_TABLE_USER.getMin(), CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), RootTable.ID, CompactionKind.USER, 0, 0, TABLET_FILE_MAX));
-    assertEquals(ROOT_TABLE_USER.getFirst() + 1000, CompactionJobPrioritizer.createPriority(
+    assertEquals(ROOT_TABLE_USER.getMin() + 1000, CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), RootTable.ID, CompactionKind.USER, 1000, 0, TABLET_FILE_MAX));
-    assertEquals(ROOT_TABLE_USER.getSecond(), CompactionJobPrioritizer.createPriority(
+    assertEquals(ROOT_TABLE_USER.getMax(), CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), RootTable.ID, CompactionKind.USER, 3000, 0, TABLET_FILE_MAX));
-    assertEquals(ROOT_TABLE_SYSTEM.getFirst(), CompactionJobPrioritizer.createPriority(
+    assertEquals(ROOT_TABLE_SYSTEM.getMin(), CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), RootTable.ID, CompactionKind.SYSTEM, 0, 0, TABLET_FILE_MAX));
-    assertEquals(ROOT_TABLE_SYSTEM.getFirst() + 1000, CompactionJobPrioritizer.createPriority(
+    assertEquals(ROOT_TABLE_SYSTEM.getMin() + 1000, CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), RootTable.ID, CompactionKind.SYSTEM, 1000, 0, TABLET_FILE_MAX));
-    assertEquals(ROOT_TABLE_SYSTEM.getSecond(), CompactionJobPrioritizer.createPriority(
+    assertEquals(ROOT_TABLE_SYSTEM.getMax(), CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), RootTable.ID, CompactionKind.SYSTEM, 3000, 0, TABLET_FILE_MAX));
   }
 
   @Test
   public void testMetaTablePriorities() {
-    assertEquals(METADATA_TABLE_USER.getFirst(), CompactionJobPrioritizer.createPriority(
+    assertEquals(METADATA_TABLE_USER.getMin(), CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), MetadataTable.ID, CompactionKind.USER, 0, 0, TABLET_FILE_MAX));
-    assertEquals(METADATA_TABLE_USER.getFirst() + 1000, CompactionJobPrioritizer.createPriority(
+    assertEquals(METADATA_TABLE_USER.getMin() + 1000, CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), MetadataTable.ID, CompactionKind.USER, 1000, 0, TABLET_FILE_MAX));
-    assertEquals(METADATA_TABLE_USER.getSecond(), CompactionJobPrioritizer.createPriority(
+    assertEquals(METADATA_TABLE_USER.getMax(), CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), MetadataTable.ID, CompactionKind.USER, 3000, 0, TABLET_FILE_MAX));
-    assertEquals(METADATA_TABLE_SYSTEM.getFirst(), CompactionJobPrioritizer.createPriority(
+    assertEquals(METADATA_TABLE_SYSTEM.getMin(), CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), MetadataTable.ID, CompactionKind.SYSTEM, 0, 0, TABLET_FILE_MAX));
-    assertEquals(METADATA_TABLE_SYSTEM.getFirst() + 1000,
+    assertEquals(METADATA_TABLE_SYSTEM.getMin() + 1000,
         CompactionJobPrioritizer.createPriority(Namespace.ACCUMULO.id(), MetadataTable.ID,
             CompactionKind.SYSTEM, 1000, 0, TABLET_FILE_MAX));
-    assertEquals(METADATA_TABLE_SYSTEM.getSecond(),
+    assertEquals(METADATA_TABLE_SYSTEM.getMax(),
         CompactionJobPrioritizer.createPriority(Namespace.ACCUMULO.id(), MetadataTable.ID,
             CompactionKind.SYSTEM, 3000, 0, TABLET_FILE_MAX));
   }
@@ -99,34 +99,35 @@ public class CompactionPrioritizerTest {
   @Test
   public void testSystemNamespacePriorities() {
     TableId tid = TableId.of("someOtherSystemTable");
-    assertEquals(SYSTEM_NS_USER.getFirst(), CompactionJobPrioritizer
+    assertEquals(SYSTEM_NS_USER.getMin(), CompactionJobPrioritizer
         .createPriority(Namespace.ACCUMULO.id(), tid, CompactionKind.USER, 0, 0, TABLET_FILE_MAX));
-    assertEquals(SYSTEM_NS_USER.getFirst() + 1000, CompactionJobPrioritizer.createPriority(
+    assertEquals(SYSTEM_NS_USER.getMin() + 1000, CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), tid, CompactionKind.USER, 1000, 0, TABLET_FILE_MAX));
-    assertEquals(SYSTEM_NS_USER.getSecond(), CompactionJobPrioritizer.createPriority(
+    assertEquals(SYSTEM_NS_USER.getMax(), CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), tid, CompactionKind.USER, 3000, 0, TABLET_FILE_MAX));
-    assertEquals(SYSTEM_NS_SYSTEM.getFirst(), CompactionJobPrioritizer.createPriority(
+    assertEquals(SYSTEM_NS_SYSTEM.getMin(), CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), tid, CompactionKind.SYSTEM, 0, 0, TABLET_FILE_MAX));
-    assertEquals(SYSTEM_NS_SYSTEM.getFirst() + 1000, CompactionJobPrioritizer.createPriority(
+    assertEquals(SYSTEM_NS_SYSTEM.getMin() + 1000, CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), tid, CompactionKind.SYSTEM, 1000, 0, TABLET_FILE_MAX));
-    assertEquals(SYSTEM_NS_SYSTEM.getSecond(), CompactionJobPrioritizer.createPriority(
+    assertEquals(SYSTEM_NS_SYSTEM.getMax(), CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), tid, CompactionKind.SYSTEM, 3000, 0, TABLET_FILE_MAX));
   }
 
   @Test
   public void testUserTablePriorities() {
     TableId tid = TableId.of("someUserTable");
-    assertEquals(USER_TABLE_USER.getFirst(), CompactionJobPrioritizer
+    assertEquals(USER_TABLE_USER.getMin(), CompactionJobPrioritizer
         .createPriority(Namespace.DEFAULT.id(), tid, CompactionKind.USER, 0, 0, TABLET_FILE_MAX));
-    assertEquals(USER_TABLE_USER.getFirst() + 1000, CompactionJobPrioritizer.createPriority(
+    assertEquals(USER_TABLE_USER.getMin() + 1000, CompactionJobPrioritizer.createPriority(
         Namespace.DEFAULT.id(), tid, CompactionKind.USER, 1000, 0, TABLET_FILE_MAX));
-    assertEquals(USER_TABLE_USER.getFirst() + 3000, CompactionJobPrioritizer.createPriority(
+    assertEquals(USER_TABLE_USER.getMin() + 3000, CompactionJobPrioritizer.createPriority(
         Namespace.DEFAULT.id(), tid, CompactionKind.USER, 3000, 0, TABLET_FILE_MAX));
-    assertEquals(USER_TABLE_SYSTEM.getFirst(), CompactionJobPrioritizer
+
+    assertEquals(USER_TABLE_SYSTEM.getMin(), CompactionJobPrioritizer
         .createPriority(Namespace.DEFAULT.id(), tid, CompactionKind.SYSTEM, 0, 0, TABLET_FILE_MAX));
-    assertEquals(USER_TABLE_SYSTEM.getFirst() + 1000, CompactionJobPrioritizer.createPriority(
+    assertEquals(USER_TABLE_SYSTEM.getMin() + 1000, CompactionJobPrioritizer.createPriority(
         Namespace.DEFAULT.id(), tid, CompactionKind.SYSTEM, 1000, 0, TABLET_FILE_MAX));
-    assertEquals(USER_TABLE_SYSTEM.getFirst() + 3000, CompactionJobPrioritizer.createPriority(
+    assertEquals(USER_TABLE_SYSTEM.getMin() + 3000, CompactionJobPrioritizer.createPriority(
         Namespace.DEFAULT.id(), tid, CompactionKind.SYSTEM, 3000, 0, TABLET_FILE_MAX));
   }
 
@@ -134,21 +135,21 @@ public class CompactionPrioritizerTest {
   public void testTableOverSize() {
     final int tabletFileMax = 30;
     final TableId tid = TableId.of("someTable");
-    assertEquals(TABLE_OVER_SIZE.getFirst() + 120, CompactionJobPrioritizer.createPriority(
+    assertEquals(ROOT_TABLE_SYSTEM.getMin() + 150, CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), RootTable.ID, CompactionKind.SYSTEM, 100, 50, tabletFileMax));
-    assertEquals(TABLE_OVER_SIZE.getFirst() + 120, CompactionJobPrioritizer.createPriority(
+    assertEquals(METADATA_TABLE_SYSTEM.getMin() + 150, CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), MetadataTable.ID, CompactionKind.SYSTEM, 100, 50, tabletFileMax));
-    assertEquals(TABLE_OVER_SIZE.getFirst() + 120, CompactionJobPrioritizer.createPriority(
+    assertEquals(SYSTEM_NS_SYSTEM.getMin() + 150, CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), tid, CompactionKind.SYSTEM, 100, 50, tabletFileMax));
-    assertEquals(TABLE_OVER_SIZE.getFirst() + 120, CompactionJobPrioritizer.createPriority(
+    assertEquals(TABLE_OVER_SIZE.getMin() + 120, CompactionJobPrioritizer.createPriority(
         Namespace.DEFAULT.id(), tid, CompactionKind.SYSTEM, 100, 50, tabletFileMax));
-    assertEquals(TABLE_OVER_SIZE.getSecond(), CompactionJobPrioritizer.createPriority(
+    assertEquals(ROOT_TABLE_SYSTEM.getMax(), CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), RootTable.ID, CompactionKind.SYSTEM, 3000, 50, tabletFileMax));
-    assertEquals(TABLE_OVER_SIZE.getSecond(), CompactionJobPrioritizer.createPriority(
+    assertEquals(METADATA_TABLE_SYSTEM.getMax(), CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), MetadataTable.ID, CompactionKind.SYSTEM, 3000, 50, tabletFileMax));
-    assertEquals(TABLE_OVER_SIZE.getSecond(), CompactionJobPrioritizer.createPriority(
+    assertEquals(SYSTEM_NS_SYSTEM.getMax(), CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), tid, CompactionKind.SYSTEM, 3000, 50, tabletFileMax));
-    assertEquals(TABLE_OVER_SIZE.getSecond(), CompactionJobPrioritizer.createPriority(
+    assertEquals(TABLE_OVER_SIZE.getMax(), CompactionJobPrioritizer.createPriority(
         Namespace.DEFAULT.id(), tid, CompactionKind.SYSTEM, 3000, 50, tabletFileMax));
   }
 
@@ -164,7 +165,7 @@ public class CompactionPrioritizerTest {
     var j8 = createJob(CompactionKind.SELECTOR, "t-014", 5, 21); // 26
     var j9 = createJob(CompactionKind.SELECTOR, "t-015", 7, 20); // 27
 
-    var expected = List.of(j6, j2, j3, j1, j9, j8, j7, j4, j5);
+    var expected = List.of(j6, j2, j3, j1, j7, j4, j9, j8, j5);
 
     var shuffled = new ArrayList<>(expected);
     Collections.shuffle(shuffled);

--- a/core/src/test/java/org/apache/accumulo/core/util/compaction/CompactionPrioritizerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/compaction/CompactionPrioritizerTest.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import org.apache.accumulo.core.client.admin.compaction.CompactableFile;
 import org.apache.accumulo.core.spi.compaction.CompactionJob;
 import org.apache.accumulo.core.spi.compaction.CompactionKind;
+import org.apache.accumulo.core.util.compaction.CompactionJobPrioritizer.Condition;
 import org.junit.jupiter.api.Test;
 
 public class CompactionPrioritizerTest {
@@ -43,28 +44,40 @@ public class CompactionPrioritizerTest {
     }
     // TODO pass numFiles
     return new CompactionJobImpl(
-        CompactionJobPrioritizer.createPriority(kind, totalFiles, numFiles),
+        CompactionJobPrioritizer.createPriority(kind, totalFiles, numFiles, Condition.NONE),
         CompactionExecutorIdImpl.externalId("test"), files, kind, Optional.of(false));
   }
 
   @Test
   public void testPrioritizer() throws Exception {
-    assertEquals((short) 0, CompactionJobPrioritizer.createPriority(CompactionKind.USER, 0, 0));
+    assertEquals((short) 0,
+        CompactionJobPrioritizer.createPriority(CompactionKind.USER, 0, 0, Condition.NONE));
     assertEquals((short) 10000,
-        CompactionJobPrioritizer.createPriority(CompactionKind.USER, 10000, 0));
+        CompactionJobPrioritizer.createPriority(CompactionKind.USER, 10000, 0, Condition.NONE));
     assertEquals((short) 32767,
-        CompactionJobPrioritizer.createPriority(CompactionKind.USER, 32767, 0));
-    assertEquals((short) 32767,
-        CompactionJobPrioritizer.createPriority(CompactionKind.USER, Integer.MAX_VALUE, 0));
+        CompactionJobPrioritizer.createPriority(CompactionKind.USER, 32767, 0, Condition.NONE));
+    assertEquals((short) 32767, CompactionJobPrioritizer.createPriority(CompactionKind.USER,
+        Integer.MAX_VALUE, 0, Condition.NONE));
+
+    assertEquals((short) 0, CompactionJobPrioritizer.createPriority(CompactionKind.USER, 0, 0,
+        Condition.TABLET_OVER_SIZE));
+    assertEquals((short) 10000, CompactionJobPrioritizer.createPriority(CompactionKind.USER, 10000,
+        0, Condition.TABLET_OVER_SIZE));
+    assertEquals((short) 32767, CompactionJobPrioritizer.createPriority(CompactionKind.USER, 32767,
+        0, Condition.TABLET_OVER_SIZE));
+    assertEquals((short) 32767, CompactionJobPrioritizer.createPriority(CompactionKind.USER,
+        Integer.MAX_VALUE, 0, Condition.TABLET_OVER_SIZE));
 
     assertEquals((short) -32768,
-        CompactionJobPrioritizer.createPriority(CompactionKind.SYSTEM, 0, 0));
+        CompactionJobPrioritizer.createPriority(CompactionKind.SYSTEM, 0, 0, Condition.NONE));
     assertEquals((short) -22768,
-        CompactionJobPrioritizer.createPriority(CompactionKind.SYSTEM, 10000, 0));
+        CompactionJobPrioritizer.createPriority(CompactionKind.SYSTEM, 10000, 0, Condition.NONE));
     assertEquals((short) -1,
-        CompactionJobPrioritizer.createPriority(CompactionKind.SYSTEM, 32767, 0));
-    assertEquals((short) -1,
-        CompactionJobPrioritizer.createPriority(CompactionKind.SYSTEM, Integer.MAX_VALUE, 0));
+        CompactionJobPrioritizer.createPriority(CompactionKind.SYSTEM, 32767, 0, Condition.NONE));
+    assertEquals((short) -1, CompactionJobPrioritizer.createPriority(CompactionKind.SYSTEM,
+        Integer.MAX_VALUE, 0, Condition.NONE));
+    assertEquals(Short.MAX_VALUE, CompactionJobPrioritizer.createPriority(CompactionKind.SYSTEM, 0,
+        0, Condition.TABLET_OVER_SIZE));
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/util/compaction/CompactionPrioritizerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/compaction/CompactionPrioritizerTest.java
@@ -18,6 +18,15 @@
  */
 package org.apache.accumulo.core.util.compaction;
 
+import static org.apache.accumulo.core.util.compaction.CompactionJobPrioritizer.METADATA_TABLE_SYSTEM;
+import static org.apache.accumulo.core.util.compaction.CompactionJobPrioritizer.METADATA_TABLE_USER;
+import static org.apache.accumulo.core.util.compaction.CompactionJobPrioritizer.ROOT_TABLE_SYSTEM;
+import static org.apache.accumulo.core.util.compaction.CompactionJobPrioritizer.ROOT_TABLE_USER;
+import static org.apache.accumulo.core.util.compaction.CompactionJobPrioritizer.SYSTEM_NS_SYSTEM;
+import static org.apache.accumulo.core.util.compaction.CompactionJobPrioritizer.SYSTEM_NS_USER;
+import static org.apache.accumulo.core.util.compaction.CompactionJobPrioritizer.TABLE_OVER_SIZE;
+import static org.apache.accumulo.core.util.compaction.CompactionJobPrioritizer.USER_TABLE_SYSTEM;
+import static org.apache.accumulo.core.util.compaction.CompactionJobPrioritizer.USER_TABLE_USER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
@@ -28,12 +37,17 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apache.accumulo.core.client.admin.compaction.CompactableFile;
+import org.apache.accumulo.core.clientImpl.Namespace;
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.metadata.MetadataTable;
+import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.spi.compaction.CompactionJob;
 import org.apache.accumulo.core.spi.compaction.CompactionKind;
-import org.apache.accumulo.core.util.compaction.CompactionJobPrioritizer.Condition;
 import org.junit.jupiter.api.Test;
 
 public class CompactionPrioritizerTest {
+
+  private static final int TABLET_FILE_MAX = 3001;
 
   public CompactionJob createJob(CompactionKind kind, String tablet, int numFiles, int totalFiles) {
 
@@ -42,57 +56,115 @@ public class CompactionPrioritizerTest {
       files.add(CompactableFile
           .create(URI.create("hdfs://foonn/accumulo/tables/5/" + tablet + "/" + i + ".rf"), 4, 4));
     }
-    // TODO pass numFiles
     return new CompactionJobImpl(
-        CompactionJobPrioritizer.createPriority(kind, totalFiles, numFiles, Condition.NONE),
+        CompactionJobPrioritizer.createPriority(Namespace.DEFAULT.id(), TableId.of("5"), kind,
+            totalFiles, numFiles, totalFiles * 2),
         CompactionExecutorIdImpl.externalId("test"), files, kind, Optional.of(false));
   }
 
   @Test
-  public void testPrioritizer() throws Exception {
-    assertEquals((short) 0,
-        CompactionJobPrioritizer.createPriority(CompactionKind.USER, 0, 0, Condition.NONE));
-    assertEquals((short) 10000,
-        CompactionJobPrioritizer.createPriority(CompactionKind.USER, 10000, 0, Condition.NONE));
-    assertEquals((short) 32767,
-        CompactionJobPrioritizer.createPriority(CompactionKind.USER, 32767, 0, Condition.NONE));
-    assertEquals((short) 32767, CompactionJobPrioritizer.createPriority(CompactionKind.USER,
-        Integer.MAX_VALUE, 0, Condition.NONE));
+  public void testRootTablePriorities() {
+    assertEquals(ROOT_TABLE_USER.getFirst(), CompactionJobPrioritizer.createPriority(
+        Namespace.ACCUMULO.id(), RootTable.ID, CompactionKind.USER, 0, 0, TABLET_FILE_MAX));
+    assertEquals(ROOT_TABLE_USER.getFirst() + 1000, CompactionJobPrioritizer.createPriority(
+        Namespace.ACCUMULO.id(), RootTable.ID, CompactionKind.USER, 1000, 0, TABLET_FILE_MAX));
+    assertEquals(ROOT_TABLE_USER.getSecond(), CompactionJobPrioritizer.createPriority(
+        Namespace.ACCUMULO.id(), RootTable.ID, CompactionKind.USER, 3000, 0, TABLET_FILE_MAX));
+    assertEquals(ROOT_TABLE_SYSTEM.getFirst(), CompactionJobPrioritizer.createPriority(
+        Namespace.ACCUMULO.id(), RootTable.ID, CompactionKind.SYSTEM, 0, 0, TABLET_FILE_MAX));
+    assertEquals(ROOT_TABLE_SYSTEM.getFirst() + 1000, CompactionJobPrioritizer.createPriority(
+        Namespace.ACCUMULO.id(), RootTable.ID, CompactionKind.SYSTEM, 1000, 0, TABLET_FILE_MAX));
+    assertEquals(ROOT_TABLE_SYSTEM.getSecond(), CompactionJobPrioritizer.createPriority(
+        Namespace.ACCUMULO.id(), RootTable.ID, CompactionKind.SYSTEM, 3000, 0, TABLET_FILE_MAX));
+  }
 
-    assertEquals((short) 0, CompactionJobPrioritizer.createPriority(CompactionKind.USER, 0, 0,
-        Condition.TABLET_OVER_SIZE));
-    assertEquals((short) 10000, CompactionJobPrioritizer.createPriority(CompactionKind.USER, 10000,
-        0, Condition.TABLET_OVER_SIZE));
-    assertEquals((short) 32767, CompactionJobPrioritizer.createPriority(CompactionKind.USER, 32767,
-        0, Condition.TABLET_OVER_SIZE));
-    assertEquals((short) 32767, CompactionJobPrioritizer.createPriority(CompactionKind.USER,
-        Integer.MAX_VALUE, 0, Condition.TABLET_OVER_SIZE));
+  @Test
+  public void testMetaTablePriorities() {
+    assertEquals(METADATA_TABLE_USER.getFirst(), CompactionJobPrioritizer.createPriority(
+        Namespace.ACCUMULO.id(), MetadataTable.ID, CompactionKind.USER, 0, 0, TABLET_FILE_MAX));
+    assertEquals(METADATA_TABLE_USER.getFirst() + 1000, CompactionJobPrioritizer.createPriority(
+        Namespace.ACCUMULO.id(), MetadataTable.ID, CompactionKind.USER, 1000, 0, TABLET_FILE_MAX));
+    assertEquals(METADATA_TABLE_USER.getSecond(), CompactionJobPrioritizer.createPriority(
+        Namespace.ACCUMULO.id(), MetadataTable.ID, CompactionKind.USER, 3000, 0, TABLET_FILE_MAX));
+    assertEquals(METADATA_TABLE_SYSTEM.getFirst(), CompactionJobPrioritizer.createPriority(
+        Namespace.ACCUMULO.id(), MetadataTable.ID, CompactionKind.SYSTEM, 0, 0, TABLET_FILE_MAX));
+    assertEquals(METADATA_TABLE_SYSTEM.getFirst() + 1000,
+        CompactionJobPrioritizer.createPriority(Namespace.ACCUMULO.id(), MetadataTable.ID,
+            CompactionKind.SYSTEM, 1000, 0, TABLET_FILE_MAX));
+    assertEquals(METADATA_TABLE_SYSTEM.getSecond(),
+        CompactionJobPrioritizer.createPriority(Namespace.ACCUMULO.id(), MetadataTable.ID,
+            CompactionKind.SYSTEM, 3000, 0, TABLET_FILE_MAX));
+  }
 
-    assertEquals((short) -32768,
-        CompactionJobPrioritizer.createPriority(CompactionKind.SYSTEM, 0, 0, Condition.NONE));
-    assertEquals((short) -22768,
-        CompactionJobPrioritizer.createPriority(CompactionKind.SYSTEM, 10000, 0, Condition.NONE));
-    assertEquals((short) -1,
-        CompactionJobPrioritizer.createPriority(CompactionKind.SYSTEM, 32767, 0, Condition.NONE));
-    assertEquals((short) -1, CompactionJobPrioritizer.createPriority(CompactionKind.SYSTEM,
-        Integer.MAX_VALUE, 0, Condition.NONE));
-    assertEquals(Short.MAX_VALUE, CompactionJobPrioritizer.createPriority(CompactionKind.SYSTEM, 0,
-        0, Condition.TABLET_OVER_SIZE));
+  @Test
+  public void testSystemNamespacePriorities() {
+    TableId tid = TableId.of("someOtherSystemTable");
+    assertEquals(SYSTEM_NS_USER.getFirst(), CompactionJobPrioritizer
+        .createPriority(Namespace.ACCUMULO.id(), tid, CompactionKind.USER, 0, 0, TABLET_FILE_MAX));
+    assertEquals(SYSTEM_NS_USER.getFirst() + 1000, CompactionJobPrioritizer.createPriority(
+        Namespace.ACCUMULO.id(), tid, CompactionKind.USER, 1000, 0, TABLET_FILE_MAX));
+    assertEquals(SYSTEM_NS_USER.getSecond(), CompactionJobPrioritizer.createPriority(
+        Namespace.ACCUMULO.id(), tid, CompactionKind.USER, 3000, 0, TABLET_FILE_MAX));
+    assertEquals(SYSTEM_NS_SYSTEM.getFirst(), CompactionJobPrioritizer.createPriority(
+        Namespace.ACCUMULO.id(), tid, CompactionKind.SYSTEM, 0, 0, TABLET_FILE_MAX));
+    assertEquals(SYSTEM_NS_SYSTEM.getFirst() + 1000, CompactionJobPrioritizer.createPriority(
+        Namespace.ACCUMULO.id(), tid, CompactionKind.SYSTEM, 1000, 0, TABLET_FILE_MAX));
+    assertEquals(SYSTEM_NS_SYSTEM.getSecond(), CompactionJobPrioritizer.createPriority(
+        Namespace.ACCUMULO.id(), tid, CompactionKind.SYSTEM, 3000, 0, TABLET_FILE_MAX));
+  }
+
+  @Test
+  public void testUserTablePriorities() {
+    TableId tid = TableId.of("someUserTable");
+    assertEquals(USER_TABLE_USER.getFirst(), CompactionJobPrioritizer
+        .createPriority(Namespace.DEFAULT.id(), tid, CompactionKind.USER, 0, 0, TABLET_FILE_MAX));
+    assertEquals(USER_TABLE_USER.getFirst() + 1000, CompactionJobPrioritizer.createPriority(
+        Namespace.DEFAULT.id(), tid, CompactionKind.USER, 1000, 0, TABLET_FILE_MAX));
+    assertEquals(USER_TABLE_USER.getFirst() + 3000, CompactionJobPrioritizer.createPriority(
+        Namespace.DEFAULT.id(), tid, CompactionKind.USER, 3000, 0, TABLET_FILE_MAX));
+    assertEquals(USER_TABLE_SYSTEM.getFirst(), CompactionJobPrioritizer
+        .createPriority(Namespace.DEFAULT.id(), tid, CompactionKind.SYSTEM, 0, 0, TABLET_FILE_MAX));
+    assertEquals(USER_TABLE_SYSTEM.getFirst() + 1000, CompactionJobPrioritizer.createPriority(
+        Namespace.DEFAULT.id(), tid, CompactionKind.SYSTEM, 1000, 0, TABLET_FILE_MAX));
+    assertEquals(USER_TABLE_SYSTEM.getFirst() + 3000, CompactionJobPrioritizer.createPriority(
+        Namespace.DEFAULT.id(), tid, CompactionKind.SYSTEM, 3000, 0, TABLET_FILE_MAX));
+  }
+
+  @Test
+  public void testTableOverSize() {
+    final int tabletFileMax = 30;
+    final TableId tid = TableId.of("someTable");
+    assertEquals(TABLE_OVER_SIZE.getFirst() + 120, CompactionJobPrioritizer.createPriority(
+        Namespace.ACCUMULO.id(), RootTable.ID, CompactionKind.SYSTEM, 100, 50, tabletFileMax));
+    assertEquals(TABLE_OVER_SIZE.getFirst() + 120, CompactionJobPrioritizer.createPriority(
+        Namespace.ACCUMULO.id(), MetadataTable.ID, CompactionKind.SYSTEM, 100, 50, tabletFileMax));
+    assertEquals(TABLE_OVER_SIZE.getFirst() + 120, CompactionJobPrioritizer.createPriority(
+        Namespace.ACCUMULO.id(), tid, CompactionKind.SYSTEM, 100, 50, tabletFileMax));
+    assertEquals(TABLE_OVER_SIZE.getFirst() + 120, CompactionJobPrioritizer.createPriority(
+        Namespace.DEFAULT.id(), tid, CompactionKind.SYSTEM, 100, 50, tabletFileMax));
+    assertEquals(TABLE_OVER_SIZE.getSecond(), CompactionJobPrioritizer.createPriority(
+        Namespace.ACCUMULO.id(), RootTable.ID, CompactionKind.SYSTEM, 3000, 50, tabletFileMax));
+    assertEquals(TABLE_OVER_SIZE.getSecond(), CompactionJobPrioritizer.createPriority(
+        Namespace.ACCUMULO.id(), MetadataTable.ID, CompactionKind.SYSTEM, 3000, 50, tabletFileMax));
+    assertEquals(TABLE_OVER_SIZE.getSecond(), CompactionJobPrioritizer.createPriority(
+        Namespace.ACCUMULO.id(), tid, CompactionKind.SYSTEM, 3000, 50, tabletFileMax));
+    assertEquals(TABLE_OVER_SIZE.getSecond(), CompactionJobPrioritizer.createPriority(
+        Namespace.DEFAULT.id(), tid, CompactionKind.SYSTEM, 3000, 50, tabletFileMax));
   }
 
   @Test
   public void testCompactionJobComparator() {
-    var j1 = createJob(CompactionKind.USER, "t-009", 10, 20);
-    var j2 = createJob(CompactionKind.USER, "t-010", 11, 25);
-    var j3 = createJob(CompactionKind.USER, "t-011", 11, 20);
-    var j4 = createJob(CompactionKind.SYSTEM, "t-012", 11, 30);
-    var j5 = createJob(CompactionKind.SYSTEM, "t-013", 5, 10);
-    var j6 = createJob(CompactionKind.CHOP, "t-014", 5, 40);
-    var j7 = createJob(CompactionKind.CHOP, "t-015", 5, 7);
-    var j8 = createJob(CompactionKind.SELECTOR, "t-014", 5, 21);
-    var j9 = createJob(CompactionKind.SELECTOR, "t-015", 7, 20);
+    var j1 = createJob(CompactionKind.USER, "t-009", 10, 20); // 30
+    var j2 = createJob(CompactionKind.USER, "t-010", 11, 25); // 36
+    var j3 = createJob(CompactionKind.USER, "t-011", 11, 20); // 31
+    var j4 = createJob(CompactionKind.SYSTEM, "t-012", 11, 30); // 40
+    var j5 = createJob(CompactionKind.SYSTEM, "t-013", 5, 10); // 15
+    var j6 = createJob(CompactionKind.CHOP, "t-014", 5, 40); // 45
+    var j7 = createJob(CompactionKind.CHOP, "t-015", 5, 7); // 12
+    var j8 = createJob(CompactionKind.SELECTOR, "t-014", 5, 21); // 26
+    var j9 = createJob(CompactionKind.SELECTOR, "t-015", 7, 20); // 27
 
-    var expected = List.of(j6, j2, j3, j1, j7, j4, j9, j8, j5);
+    var expected = List.of(j6, j2, j3, j1, j9, j8, j7, j4, j5);
 
     var shuffled = new ArrayList<>(expected);
     Collections.shuffle(shuffled);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionService.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionService.java
@@ -41,9 +41,11 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.admin.compaction.CompactableFile;
 import org.apache.accumulo.core.conf.ConfigurationTypeHelper;
 import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.spi.common.ServiceEnvironment;
@@ -234,6 +236,11 @@ public class CompactionService {
     }
 
     private final ServiceEnvironment senv = new ServiceEnvironmentImpl(context);
+
+    @Override
+    public NamespaceId getNamespaceId() throws TableNotFoundException {
+      return context.getNamespaceId(comp.getTableId());
+    }
 
     @Override
     public TableId getTableId() {


### PR DESCRIPTION
CompactionManager.mainLoop runs in the TabletServer looking for tablets that need to be compacted. It ends up calling CompactionService.submitCompaction at some interval for each hosted Tablet. CompactionService.getCompactionPlan will make a CompactionPlan for the tablet and log a warning if no CompactionPlan is created but the number of files is larger than TSERV_SCAN_MAX_OPENFILES. When there are no compactions running for the tablet and no plan is calculated, then DefaultCompactionPlanner.makePlan takes into account TABLE_FILE_MAX and TSERV_SCAN_MAX_OPENFILES and will create a system compaction that considers all of the files and calculates which ones need to be compacted to get below the limit. Finally, a priority is calculated by calling CompactionJobPrioritizer.createPriority. However, given that this compaction is a SYSTEM compaction it will have a lower priority than all current USER compactions and it's priority will still be based on the total number of files. Given that the TABLE_FILE_MAX is per-table it's possible to have two tablets from different tables and the tablet that is over the size threshold has a lower priority than the tablet that is not over the size threshold. This change modifies
CompactionJobPrioritizer.createPriority to take into account whether or not the tablet is over the threshold to give it a higher priority.

Closes #4610