### PR TITLE
speeds up finding any server to connect to

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/rpc/clients/TServerClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/clients/TServerClient.java
@@ -97,8 +97,8 @@ public interface TServerClient<C extends TServiceClient> {
       serverPaths.addAll(
           context.getServerPaths().getTabletServer(rg -> true, AddressSelector.all(), false));
       if (type == ThriftClientTypes.CLIENT) {
-        serverPaths
-            .addAll(context.getServerPaths().getCompactor(rg -> true, AddressSelector.all(), false));
+        serverPaths.addAll(
+            context.getServerPaths().getCompactor(rg -> true, AddressSelector.all(), false));
         serverPaths.addAll(
             context.getServerPaths().getScanServer(rg -> true, AddressSelector.all(), false));
       }

--- a/core/src/main/java/org/apache/accumulo/core/rpc/clients/TServerClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/clients/TServerClient.java
@@ -95,12 +95,12 @@ public interface TServerClient<C extends TServiceClient> {
           context.getServerPaths().getTabletServer(rg -> true, AddressSelector.exact(hp), true));
     } else {
       serverPaths.addAll(
-          context.getServerPaths().getTabletServer(rg -> true, AddressSelector.all(), true));
+          context.getServerPaths().getTabletServer(rg -> true, AddressSelector.all(), false));
       if (type == ThriftClientTypes.CLIENT) {
         serverPaths
-            .addAll(context.getServerPaths().getCompactor(rg -> true, AddressSelector.all(), true));
+            .addAll(context.getServerPaths().getCompactor(rg -> true, AddressSelector.all(), false));
         serverPaths.addAll(
-            context.getServerPaths().getScanServer(rg -> true, AddressSelector.all(), true));
+            context.getServerPaths().getScanServer(rg -> true, AddressSelector.all(), false));
       }
       if (serverPaths.isEmpty()) {
         if (warned.compareAndSet(false, true)) {


### PR DESCRIPTION
When looking for any accumulo server to connect to client code would read all servers and check their locks. This change avoid checking locks for all servers and only checks the locks for the ones the code tries to connect to.