### PR TITLE
fixes slow bulk import with many tablets and file

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
@@ -340,7 +340,7 @@ class LoadFiles extends ManagerRepo {
 
       // The tablet iterator and load mapping iterator are both iterating over data that is sorted
       // in the same way. The two iterators are each independently advanced to find common points in
-      // the data.
+      // the sorted data.
       var tabletIter = tabletsMetadata.iterator();
 
       t1 = System.currentTimeMillis();

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
@@ -338,11 +338,15 @@ class LoadFiles extends ManagerRepo {
         TabletsMetadata.builder(manager.getContext()).forTable(tableId).overlapping(startRow, null)
             .checkConsistency().fetch(PREV_ROW, LOCATION, LOADED, TIME).build()) {
 
+      // The tablet iterator and load mapping iterator are both iterating over data that is sorted
+      // in the same way. The two iterators are each independently advanced to find common points in
+      // the data.
+      var tabletIter = tabletsMetadata.iterator();
+
       t1 = System.currentTimeMillis();
       while (lmi.hasNext()) {
         loadMapEntry = lmi.next();
-        List<TabletMetadata> tablets =
-            findOverlappingTablets(loadMapEntry.getKey(), tabletsMetadata.iterator());
+        List<TabletMetadata> tablets = findOverlappingTablets(loadMapEntry.getKey(), tabletIter);
         loader.load(tablets, loadMapEntry.getValue());
       }
     }

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
@@ -868,7 +868,7 @@ public class BulkNewIT extends SharedMiniClusterBase {
 
       c.tableOperations().importDirectory(dir).to(tableName).plan(loadPlan).load();
 
-      // use a batch scanner can read from lots of tablets w/ less RPCs
+      // using a batch scanner can read from lots of tablets w/ less RPCs
       try (var scanner = c.createBatchScanner(tableName)) {
         // use a scan server so that tablets do not need to be hosted
         scanner.setConsistencyLevel(ScannerBase.ConsistencyLevel.EVENTUAL);

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
@@ -37,6 +37,7 @@ import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -847,8 +848,10 @@ public class BulkNewIT extends SharedMiniClusterBase {
 
       var loadPlanBuilder = LoadPlan.builder();
       var rowsExpected = new HashSet<>();
-      for (int i = 2; i < 8999; i++) {
-        int data = i;
+      var imports = IntStream.range(2, 8999).boxed().collect(Collectors.toList());
+      // The order in which imports are added to the load plan should not matter so test that.
+      Collections.shuffle(imports);
+      for (var data : imports) {
         String filename = "f" + data + ".";
         loadPlanBuilder.loadFileTo(filename + RFile.EXTENSION, RangeType.TABLE, row(data - 1),
             row(data));
@@ -863,6 +866,8 @@ public class BulkNewIT extends SharedMiniClusterBase {
       for (var future : futures) {
         future.get();
       }
+
+      executor.shutdown();
 
       var loadPlan = loadPlanBuilder.build();
 


### PR DESCRIPTION
The bulk import code was reading all tablets in the bulk import range for each range being bulk imported. This resulted in O(N^2) metadata table scans which made really large bulk imports really slow.

Added a new test that bulk imports thousands of files into thousands of tablets.  Running this test w/o the fixes in this PR the following time is seen for the fate step.

```
DEBUG: Running LoadFiles.isReady() FATE:USER:6320e73d-e661-4c66-bf25-c0c27a0a79d5 took 289521 ms and returned 0
```

With this fix in this PR seeing the following times for the new test, so goes from 290s to 1.2s.

```
DEBUG: Running LoadFiles.isReady() FATE:USER:18e52fc2-5876-4b01-ba7b-3b3c099a82be took 1225 ms and returned 0
```

This bug does not seem to exists in 2.1 or 3.1.  Did not run the test though, may be worthwhile to backport the test.