### PR TITLE
Added gc and monitor server types to public api

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/admin/InstanceOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/InstanceOperations.java
@@ -231,8 +231,8 @@ public interface InstanceOperations {
   ServerId getServer(ServerId.Type type, String resourceGroup, String host, int port);
 
   /**
-   * Returns all servers of the given types. For the Manager, the result will contain only one
-   * element for the current active Manager.
+   * Returns all servers of the given types. For the Manager, Monitor, and Garbage Collector, the
+   * result will contain only one element for the current active process.
    *
    * @return set of servers of the supplied type
    * @since 4.0.0
@@ -243,8 +243,7 @@ public interface InstanceOperations {
    * Returns the servers of a given type that match the given criteria
    *
    * @param resourceGroupPredicate only returns servers where the resource group matches this
-   *        predicate. For the manager it does not have a resoruce group and this parameters is not
-   *        used.
+   *        predicate. For the Manager, Monitor, and Garbage Collector, this parameter is not used.
    * @param hostPortPredicate only returns servers where its host and port match this predicate.
    * @return set of servers of the supplied type matching the supplied test
    * @since 4.0.0

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/servers/ServerId.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/servers/ServerId.java
@@ -32,13 +32,12 @@ import com.google.common.base.Preconditions;
 public final class ServerId implements Comparable<ServerId> {
 
   /**
-   * Server process type names that a client can be expected to interact with. Clients are not
-   * expected to interact directly with the GarbageCollector or Monitor processes.
+   * Server process type names.
    *
    * @since 4.0.0
    */
   public enum Type {
-    MANAGER, COMPACTOR, SCAN_SERVER, TABLET_SERVER;
+    MANAGER, MONITOR, GARBAGE_COLLECTOR, COMPACTOR, SCAN_SERVER, TABLET_SERVER;
   }
 
   private final Type type;

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
@@ -501,6 +501,20 @@ public class InstanceOperationsImpl implements InstanceOperations {
         } else {
           return managers.iterator().next();
         }
+      case MONITOR:
+        Set<ServerId> monitors = getServers(type, rg2 -> true, hp);
+        if (monitors.isEmpty()) {
+          return null;
+        } else {
+          return monitors.iterator().next();
+        }
+      case GARBAGE_COLLECTOR:
+        Set<ServerId> gc = getServers(type, rg2 -> true, hp);
+        if (gc.isEmpty()) {
+          return null;
+        } else {
+          return gc.iterator().next();
+        }
       case SCAN_SERVER:
         Set<ServiceLockPath> sservers = context.getServerPaths().getScanServer(rg, hp, true);
         if (sservers.isEmpty()) {
@@ -561,6 +575,36 @@ public class InstanceOperationsImpl implements InstanceOperations {
           String location = null;
           if (sld.isPresent()) {
             location = sld.orElseThrow().getAddressString(ThriftService.MANAGER);
+            if (addressSelector.getPredicate().test(location)) {
+              HostAndPort hp = HostAndPort.fromString(location);
+              results.add(new ServerId(type, Constants.DEFAULT_RESOURCE_GROUP_NAME, hp.getHost(),
+                  hp.getPort()));
+            }
+          }
+        }
+        break;
+      case MONITOR:
+        ServiceLockPath mon = context.getServerPaths().getMonitor(true);
+        if (mon != null) {
+          Optional<ServiceLockData> sld = context.getZooCache().getLockData(mon);
+          String location = null;
+          if (sld.isPresent()) {
+            location = sld.orElseThrow().getAddressString(ThriftService.NONE);
+            if (addressSelector.getPredicate().test(location)) {
+              HostAndPort hp = HostAndPort.fromString(location);
+              results.add(new ServerId(type, Constants.DEFAULT_RESOURCE_GROUP_NAME, hp.getHost(),
+                  hp.getPort()));
+            }
+          }
+        }
+        break;
+      case GARBAGE_COLLECTOR:
+        ServiceLockPath gc = context.getServerPaths().getGarbageCollector(true);
+        if (gc != null) {
+          Optional<ServiceLockData> sld = context.getZooCache().getLockData(gc);
+          String location = null;
+          if (sld.isPresent()) {
+            location = sld.orElseThrow().getAddressString(ThriftService.GC);
             if (addressSelector.getPredicate().test(location)) {
               HostAndPort hp = HostAndPort.fromString(location);
               results.add(new ServerId(type, Constants.DEFAULT_RESOURCE_GROUP_NAME, hp.getHost(),

--- a/core/src/main/java/org/apache/accumulo/core/lock/ServiceLockPaths.java
+++ b/core/src/main/java/org/apache/accumulo/core/lock/ServiceLockPaths.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 import org.apache.accumulo.core.Constants;
-import org.apache.accumulo.core.client.admin.servers.ServerId;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.fate.zookeeper.ZooCache;
 import org.apache.accumulo.core.fate.zookeeper.ZooCache.ZcStat;
@@ -320,6 +319,11 @@ public class ServiceLockPaths {
     }
   }
 
+  /**
+   * Note that the ServiceLockPath object returned by this method does not populate the server
+   * attribute. To get the location of the GarbageCollector you will need to parse the lock data at
+   * the ZooKeeper path.
+   */
   public ServiceLockPath getMonitor(boolean withLock) {
     Set<ServiceLockPath> results =
         get(Constants.ZMONITOR_LOCK, rg -> true, AddressSelector.all(), withLock);

--- a/test/src/main/java/org/apache/accumulo/test/InstanceOperationsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/InstanceOperationsIT.java
@@ -74,6 +74,11 @@ public class InstanceOperationsIT extends AccumuloClusterHarness {
       assertEquals(1, iops.getManagerLocations().size());
       validateAddresses(iops.getManagerLocations(), iops.getServers(ServerId.Type.MANAGER));
 
+      assertEquals(1, iops.getServers(ServerId.Type.GARBAGE_COLLECTOR).size());
+
+      // Monitor not started in MAC
+      assertEquals(0, iops.getServers(ServerId.Type.MONITOR).size());
+
       for (ServerId compactor : iops.getServers(ServerId.Type.COMPACTOR)) {
         assertNotNull(iops.getActiveCompactions(compactor));
         assertThrows(IllegalArgumentException.class, () -> iops.getActiveScans(compactor));


### PR DESCRIPTION
Added gc and monitor server types and ability to get their ServerId objects via InstanceOperations.getServers. The gc type will resolve an issue that I'm having in the new monitor PR, and the new types could be used for service discovery by clients. A recent comment by @keith-turner suggests that these could be used to get status via the API.