### PR TITLE
Fix bug in InstanceOperationsImpl.getServer()

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
@@ -511,7 +511,7 @@ public class InstanceOperationsImpl implements InstanceOperations {
           throw new IllegalStateException("Multiple servers matching provided address");
         }
       case TABLET_SERVER:
-        Set<ServiceLockPath> tservers = context.getServerPaths().getScanServer(rg, hp, true);
+        Set<ServiceLockPath> tservers = context.getServerPaths().getTabletServer(rg, hp, true);
         if (tservers.isEmpty()) {
           return null;
         } else if (tservers.size() == 1) {

--- a/test/src/main/java/org/apache/accumulo/test/InstanceOperationsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/InstanceOperationsIT.java
@@ -67,41 +67,45 @@ public class InstanceOperationsIT extends AccumuloClusterHarness {
       // Verify scan servers
       final Set<ServerId> sservers = iops.getServers(ServerId.Type.SCAN_SERVER);
       assertEquals(NUM_SCANSERVERS, sservers.size());
-      sservers.forEach(serverId -> {
-        ServerId server = iops.getServer(serverId.getType(), serverId.getResourceGroup(),
-            serverId.getHost(), serverId.getPort());
-        assertNotNull(server, "Expected to find scan server " + serverId);
-        assertEquals(ServerId.Type.SCAN_SERVER, server.getType());
+      sservers.forEach(expectedServerId -> {
+        ServerId actualServerId =
+            iops.getServer(expectedServerId.getType(), expectedServerId.getResourceGroup(),
+                expectedServerId.getHost(), expectedServerId.getPort());
+        assertNotNull(actualServerId, "Expected to find scan server " + expectedServerId);
+        assertEquals(expectedServerId, actualServerId);
       });
 
       // Verify tablet servers
       final Set<ServerId> tservers = iops.getServers(ServerId.Type.TABLET_SERVER);
       assertEquals(NUM_TABLETSERVERS, tservers.size());
-      tservers.forEach(serverId -> {
-        ServerId server = iops.getServer(serverId.getType(), serverId.getResourceGroup(),
-            serverId.getHost(), serverId.getPort());
-        assertNotNull(server, "Expected to find tablet server " + serverId);
-        assertEquals(ServerId.Type.TABLET_SERVER, server.getType());
+      tservers.forEach(expectedServerId -> {
+        ServerId actualServerId =
+            iops.getServer(expectedServerId.getType(), expectedServerId.getResourceGroup(),
+                expectedServerId.getHost(), expectedServerId.getPort());
+        assertNotNull(actualServerId, "Expected to find tablet server " + expectedServerId);
+        assertEquals(expectedServerId, actualServerId);
       });
 
       // Verify compactors
       final Set<ServerId> compactors = iops.getServers(ServerId.Type.COMPACTOR);
       assertEquals(NUM_COMPACTORS, compactors.size());
-      compactors.forEach(serverId -> {
-        ServerId server = iops.getServer(serverId.getType(), serverId.getResourceGroup(),
-            serverId.getHost(), serverId.getPort());
-        assertNotNull(server, "Expected to find compactor " + serverId);
-        assertEquals(ServerId.Type.COMPACTOR, server.getType());
+      compactors.forEach(expectedServerId -> {
+        ServerId actualServerId =
+            iops.getServer(expectedServerId.getType(), expectedServerId.getResourceGroup(),
+                expectedServerId.getHost(), expectedServerId.getPort());
+        assertNotNull(actualServerId, "Expected to find compactor " + expectedServerId);
+        assertEquals(expectedServerId, actualServerId);
       });
 
       // Verify managers
       final Set<ServerId> managers = iops.getServers(ServerId.Type.MANAGER);
       assertEquals(1, managers.size()); // Assuming there is only one manager
-      managers.forEach(serverId -> {
-        ServerId server = iops.getServer(serverId.getType(), serverId.getResourceGroup(),
-            serverId.getHost(), serverId.getPort());
-        assertNotNull(server, "Expected to find manager " + serverId);
-        assertEquals(ServerId.Type.MANAGER, server.getType());
+      managers.forEach(expectedServerId -> {
+        ServerId actualServerId =
+            iops.getServer(expectedServerId.getType(), expectedServerId.getResourceGroup(),
+                expectedServerId.getHost(), expectedServerId.getPort());
+        assertNotNull(actualServerId, "Expected to find manager " + expectedServerId);
+        assertEquals(expectedServerId, actualServerId);
       });
     }
   }


### PR DESCRIPTION
There was a bug in InstanceOperationsImpl.getServer() where `getScanServer()` was being used for the `TABLET_SERVER` case.

https://github.com/apache/accumulo/blob/e45b3b400732fddb9b07f8319462e9191d1dcb82/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java#L504-L521