### PR TITLE
Update Table Id validator to accept all Accumulo tables

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/util/Validators.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/Validators.java
@@ -192,7 +192,7 @@ public class Validators {
     if (id == null) {
       return Optional.of("Table id must not be null");
     }
-    if (AccumuloTable.ROOT.tableId().equals(id) || AccumuloTable.METADATA.tableId().equals(id)
+    if (AccumuloTable.allTableIds().contains(id)
         || VALID_ID_PATTERN.matcher(id.canonical()).matches()) {
       return Validator.OK;
     }

--- a/core/src/test/java/org/apache/accumulo/core/util/ValidatorsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/ValidatorsTest.java
@@ -23,8 +23,10 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.clientImpl.Namespace;
 import org.apache.accumulo.core.data.TableId;
@@ -140,8 +142,9 @@ public class ValidatorsTest {
   public void test_VALID_TABLE_ID() {
     Validator<TableId> v = Validators.VALID_TABLE_ID;
     checkNull(v::validate);
-    assertAllValidate(v, List.of(AccumuloTable.ROOT.tableId(), AccumuloTable.METADATA.tableId(),
-        TableId.of("111"), TableId.of("aaaa"), TableId.of("r2d2")));
+    assertAllValidate(v, Arrays.stream(AccumuloTable.values()).map(AccumuloTable::tableId)
+        .collect(Collectors.toList()));
+    assertAllValidate(v, List.of(TableId.of("111"), TableId.of("aaaa"), TableId.of("r2d2")));
     assertAllThrow(v, List.of(TableId.of(""), TableId.of("#0(U!$"), TableId.of(" #0(U!$. "),
         TableId.of("."), TableId.of(" "), TableId.of("C3P0")));
   }


### PR DESCRIPTION
Fixes validation for table ids by making sure all tables in the accumulo namespace are considered and not just root and metadata

This closes #5059