### PR TITLE
Check for tserver failure in balance loop after some iterations

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -349,6 +349,14 @@ public enum Property {
       "The balancer class that accumulo will use to make tablet assignment and "
           + "migration decisions.",
       "1.3.5"),
+  MANAGER_TABLET_BALANCER_TSERVER_REFRESH("manager.tablet.balancer.tserver.refresh", "10",
+      PropertyType.COUNT,
+      "The Manager will balance tablets, and in the case of the root and metadata tables, continue to balance tablets"
+          + " in a loop until all tablets are balanced. It's possible that tablet servers may be started or stopped while"
+          + " in this loop. This property indicates how many iterations should be completed before rechecking the tablet"
+          + " server state. This could be an expensive operation for large systems, so setting this too low may have a"
+          + " negative impact.",
+      "2.1.4"),
   MANAGER_TABLET_GROUP_WATCHER_INTERVAL("manager.tablet.watcher.interval", "60s",
       PropertyType.TIMEDURATION,
       "Time to wait between scanning tablet states to identify tablets that need to be assigned, un-assigned, migrated, etc.",

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -349,14 +349,6 @@ public enum Property {
       "The balancer class that accumulo will use to make tablet assignment and "
           + "migration decisions.",
       "1.3.5"),
-  MANAGER_TABLET_BALANCER_TSERVER_REFRESH("manager.tablet.balancer.tserver.refresh", "10",
-      PropertyType.COUNT,
-      "The Manager will balance tablets, and in the case of the root and metadata tables, continue to balance tablets"
-          + " in a loop until all tablets are balanced. It's possible that tablet servers may be started or stopped while"
-          + " in this loop. This property indicates how many iterations should be completed before rechecking the tablet"
-          + " server state. This could be an expensive operation for large systems, so setting this too low may have a"
-          + " negative impact.",
-      "2.1.4"),
   MANAGER_TABLET_GROUP_WATCHER_INTERVAL("manager.tablet.watcher.interval", "60s",
       PropertyType.TIMEDURATION,
       "Time to wait between scanning tablet states to identify tablets that need to be assigned, un-assigned, migrated, etc.",

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -1116,7 +1116,10 @@ public class Manager extends AbstractServer
         if (m.getTablet() == null) {
           log.error("Balancer gave back a null tablet {}", m);
         } else if (DataLevel.of(m.getTablet().getTable()) != level) {
-          log.warn("Balancer wants to move a tablet outside of the current processing level");
+          log.debug(
+              "Balancer wants to move a tablet ({}) outside of the current processing level ({}), "
+                  + "ignoring and should be processed at the correct level ({})",
+              m.getTablet(), level, DataLevel.of(m.getTablet().getTable()));
         } else if (m.getNewTabletServer() == null) {
           log.error("Balancer did not set the destination {}", m);
         } else if (m.getOldTabletServer() == null) {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -1116,7 +1116,7 @@ public class Manager extends AbstractServer
         if (m.getTablet() == null) {
           log.error("Balancer gave back a null tablet {}", m);
         } else if (DataLevel.of(m.getTablet().getTable()) != level) {
-          log.debug(
+          log.trace(
               "Balancer wants to move a tablet ({}) outside of the current processing level ({}), "
                   + "ignoring and should be processed at the correct level ({})",
               m.getTablet(), level, DataLevel.of(m.getTablet().getTable()));

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -1078,6 +1078,7 @@ public class Manager extends AbstractServer
           params = BalanceParamsImpl.fromThrift(statusForBalancerLevel, tserverStatusForLevel,
               partitionedMigrations.get(dl));
           wait = Math.max(tabletBalancer.balance(params), wait);
+          migrationsOutForLevel = 0;
           for (TabletMigration m : checkMigrationSanity(statusForBalancerLevel.keySet(),
               params.migrationsOut(), dl)) {
             final KeyExtent ke = KeyExtent.fromTabletId(m.getTablet());


### PR DESCRIPTION
The StatusThread.balanceTablets method could loop indefinitely in some cases, like when a TabletServer dies but is the target of a current migration. The status of the TabletServers is checked before this method is invoked and never updated. Created a new property to indicate how many iterations should pass before the Tablet Server status is re-checked.