### PR TITLE
avoids uneeded work when splitting tablets

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -447,8 +447,10 @@ public enum Property {
           + "indefinitely. Default is 0 to block indefinitely. Only valid when tserver available "
           + "threshold is set greater than 0.",
       "1.10.0"),
-  MANAGER_SPLIT_WORKER_THREADS("manager.split.inspection.threadpool.size", "8", PropertyType.COUNT,
-      "The number of threads used to inspect tablets files to find split points.", "4.0.0"),
+  MANAGER_SPLIT_WORKER_THREADS("manager.split.seed.threadpool.size", "8", PropertyType.COUNT,
+      "The number of threads used to seed fate split task, the actual split work is done by fate"
+          + " threads.",
+      "4.0.0"),
 
   MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_INITIAL_SIZE(
       "manager.compaction.major.service.queue.initial.size", "10000", PropertyType.COUNT,

--- a/server/manager/src/main/java/org/apache/accumulo/manager/split/SeedSplitTask.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/split/SeedSplitTask.java
@@ -59,4 +59,8 @@ public class SeedSplitTask implements Runnable {
       log.error("Failed to split {}", extent, e);
     }
   }
+
+  public KeyExtent getExtent() {
+    return extent;
+  }
 }


### PR DESCRIPTION
When tablets needed to split they were queued in a thread pool to seed a fate operation.  When the tablet group watcher ran again if the tablet was still in queue it would add it again. This would not cause any correctness issues, but it would cause a lot of wasted work. Also if one tablet was queued multiple times it could prevent another tablet that was not queued at all from being added.  This made splitting very when a large number of tablets needed to split very inefficient and slow.