### PR TITLE
fixes bug where service lock code created too many threads

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPoolNames.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPoolNames.java
@@ -36,6 +36,7 @@ public enum ThreadPoolNames {
   COORDINATOR_FINALIZER_NOTIFIER_POOL("accumulo.pool.compaction.coordinator.compaction.finalizer"),
   GC_DELETE_POOL("accumulo.pool.gc.threads.delete"),
   GENERAL_SERVER_POOL("accumulo.pool.general.server"),
+  SERVICE_LOCK_POOL("accumulo.pool.service.lock"),
   IMPORT_TABLE_RENAME_POOL("accumulo.pool.import.table.rename"),
   INSTANCE_OPS_COMPACTIONS_FINDER_POOL("accumulo.pool.instance.ops.active.compactions.finder"),
   MANAGER_FATE_POOL("accumulo.pool.manager.fate"),


### PR DESCRIPTION
Changes made in #5058 caused too many threads to be created in the manager when lots service lock paths were being requested. Updated code to avoid creating so many threads.