### PR TITLE
Trivial: Added missing info to `admin fate delete` help msg

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
@@ -237,7 +237,7 @@ public class Admin implements KeywordExecutable {
     boolean fail;
 
     @Parameter(names = {"-d", "--delete"},
-        description = "<txId>... Delete locks associated with transactions (Requires Manager to be down)")
+        description = "<txId>... Delete FaTE transaction and its associated table locks (requires Manager to be down)")
     boolean delete;
 
     @Parameter(names = {"-p", "--print", "-print", "-l", "--list", "-list"},


### PR DESCRIPTION
The description for `admin fate delete` was missing some info about what it does.
Pointed out by @keith-turner in:
https://github.com/apache/accumulo/pull/5028#discussion_r1835766336
Considered just changing in that PR, but 2.1 is also incomplete.
