### PR TITLE
Fix Manager hanging on shutdown command

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -1190,12 +1190,10 @@ public class Manager extends AbstractServer
       Iterator<Future<?>> iter = tasks.iterator();
       while (iter.hasNext()) {
         Future<?> f = iter.next();
-        if (cancel) {
+        if (f.isDone()) {
+          iter.remove();
+        } else if (cancel) {
           f.cancel(true);
-        } else {
-          if (f.isDone()) {
-            iter.remove();
-          }
         }
       }
       Uninterruptibles.sleepUninterruptibly(1, MILLISECONDS);


### PR DESCRIPTION
The status thread would always cancel tasks once the timer reached max wait and never remove them from the list of tasks. This causes the Update Status thread to wait indefinitely when calling gatherTableInformation.

This bug was found in 4.0 but originated in #3167 