### PR TITLE
Logs information tablet group watcher uses to make filtering decisions

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
@@ -400,12 +400,21 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
 
     var tServersSnapshot = manager.tserversSnapshot();
 
-    return new TabletManagementParameters(manager.getManagerState(), parentLevelUpgrade,
-        manager.onlineTables(), tServersSnapshot, shutdownServers, manager.migrationsSnapshot(),
-        store.getLevel(), manager.getCompactionHints(store.getLevel()), canSuspendTablets(),
-        lookForTabletsNeedingVolReplacement ? manager.getContext().getVolumeReplacements()
-            : Map.of(),
-        manager.getSteadyTime());
+    var tabletMgmtParams =
+        new TabletManagementParameters(manager.getManagerState(), parentLevelUpgrade,
+            manager.onlineTables(), tServersSnapshot, shutdownServers, manager.migrationsSnapshot(),
+            store.getLevel(), manager.getCompactionHints(store.getLevel()), canSuspendTablets(),
+            lookForTabletsNeedingVolReplacement ? manager.getContext().getVolumeReplacements()
+                : Map.of(),
+            manager.getSteadyTime());
+
+    if (LOG.isTraceEnabled()) {
+      // Log the json that will be passed to iterators to make tablet filtering decisions.
+      LOG.trace("{}:{}", TabletManagementParameters.class.getSimpleName(),
+          tabletMgmtParams.serialize());
+    }
+
+    return tabletMgmtParams;
   }
 
   private Set<TServerInstance> getFilteredServersToShutdown() {


### PR DESCRIPTION
When the tablet group watcher is not making decisions that one would expect it is useful to see the information that it is using to make decisions.  This change adds trace logging of the information used to filter tablets in the TabletManagementIterator used by the TabletGroupWatcher.