### PR TITLE
lower level on thrift scanner log message and fix message

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftScanner.java
@@ -980,7 +980,8 @@ public class ThriftScanner {
     if (!scanState.finished && scanState.scanID != null && scanState.prevLoc != null) {
       TInfo tinfo = TraceUtil.traceInfo();
 
-      log.debug("Closing active scan {} {}", scanState.prevLoc, scanState.scanID);
+      log.trace("Closing active scan {} {} {}", scanState.prevLoc.serverType,
+          scanState.prevLoc.serverAddress, scanState.scanID);
       HostAndPort parsedLocation = HostAndPort.fromString(scanState.prevLoc.serverAddress);
       TabletScanClientService.Client client = null;
       try {


### PR DESCRIPTION
ThriftScanner was logging a debug message when closing a scan and was too chatty.  Also the message was printing an object w/o a toString method.  Fixed the log message and lowered its level.