### PR TITLE
Change names of zookeepers to connectString

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooReader.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooReader.java
@@ -45,20 +45,20 @@ public class ZooReader {
           .incrementBy(Duration.ofMillis(250)).maxWait(Duration.ofMinutes(2)).backOffFactor(1.5)
           .logInterval(Duration.ofMinutes(3)).createFactory();
 
-  protected final String keepers;
+  protected final String connectString;
   protected final int timeout;
 
-  public ZooReader(String keepers, int timeout) {
-    this.keepers = requireNonNull(keepers);
+  public ZooReader(String connectString, int timeout) {
+    this.connectString = requireNonNull(connectString);
     this.timeout = timeout;
   }
 
   public ZooReaderWriter asWriter(String secret) {
-    return new ZooReaderWriter(keepers, timeout, secret);
+    return new ZooReaderWriter(connectString, timeout, secret);
   }
 
   protected ZooKeeper getZooKeeper() {
-    return ZooSession.getAnonymousSession(keepers, timeout);
+    return ZooSession.getAnonymousSession(connectString, timeout);
   }
 
   protected RetryFactory getRetryFactory() {

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooReaderWriter.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooReaderWriter.java
@@ -49,8 +49,8 @@ public class ZooReaderWriter extends ZooReader {
   private final String secret;
   private final byte[] auth;
 
-  ZooReaderWriter(String keepers, int timeoutInMillis, String secret) {
-    super(keepers, timeoutInMillis);
+  ZooReaderWriter(String connectString, int timeoutInMillis, String secret) {
+    super(connectString, timeoutInMillis);
     this.secret = requireNonNull(secret);
     this.auth = ("accumulo:" + secret).getBytes(UTF_8);
   }
@@ -65,7 +65,7 @@ public class ZooReaderWriter extends ZooReader {
 
   @Override
   public ZooKeeper getZooKeeper() {
-    return ZooSession.getAuthenticatedSession(keepers, timeout, "digest", auth);
+    return ZooSession.getAuthenticatedSession(connectString, timeout, "digest", auth);
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooSession.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooSession.java
@@ -106,7 +106,8 @@ public class ZooSession {
    * @param auth authentication-scheme-specific token, may be null
    * @param watcher ZK notifications, may be null
    */
-  static ZooKeeper connect(String connectString, int timeout, String scheme, byte[] auth, Watcher watcher) {
+  static ZooKeeper connect(String connectString, int timeout, String scheme, byte[] auth,
+      Watcher watcher) {
     final int TIME_BETWEEN_CONNECT_CHECKS_MS = 100;
     int connectTimeWait = Math.min(10_000, timeout);
     boolean tryAgain = true;


### PR DESCRIPTION
Trivial change to zookeepers parameter to indicate that it's a connectionString
rather than merely a host or a list of hosts for zookeeper.