### PR TITLE
fixes exception for canceled scan task

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/scan/LookupTask.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/scan/LookupTask.java
@@ -64,12 +64,13 @@ public class LookupTask extends ScanTask<MultiScanResult> {
     MultiScanSession session = (MultiScanSession) server.getSession(scanID);
     String oldThreadName = Thread.currentThread().getName();
 
+    if (!transitionToRunning()) {
+      return;
+    }
+    // Do not add any code here. Need to ensure that transitionFromRunning() runs in the finally
+    // block when transitionToRunning() returns true.
     try {
       if (isCancelled() || session == null) {
-        return;
-      }
-
-      if (!transitionToRunning()) {
         return;
       }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/scan/NextBatchTask.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/scan/NextBatchTask.java
@@ -54,12 +54,13 @@ public class NextBatchTask extends ScanTask<ScanBatch> {
     final SingleScanSession scanSession = (SingleScanSession) server.getSession(scanID);
     String oldThreadName = Thread.currentThread().getName();
 
+    if (!transitionToRunning()) {
+      return;
+    }
+    // Do not add any code here. Need to ensure that transitionFromRunning() runs in the finally
+    // block when transitionToRunning() returns true.
     try {
       if (isCancelled() || scanSession == null) {
-        return;
-      }
-
-      if (!transitionToRunning()) {
         return;
       }
 


### PR DESCRIPTION
An exception was happening when a scan task was canceled before it ever ran.  This was caused by transitionFromRunning() executing when transitionToRunning() had never executed.  When this happened a precondition check that the scanThread was non-null would fail.  These changes only execute transitionFromRunning() when transitionToRunning() has executed.