### PR TITLE
Fixed MemoryStarvedScanIT

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/functional/MemoryStarvedScanIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MemoryStarvedScanIT.java
@@ -547,7 +547,7 @@ public class MemoryStarvedScanIT extends SharedMiniClusterBase {
         Thread.sleep(1500);
         assertEquals(currentCount, fetched.get());
         assertTrue(SCAN_START_DELAYED.doubleValue() >= paused);
-        assertEquals(returned, SCAN_RETURNED_EARLY.doubleValue());
+        assertTrue(SCAN_RETURNED_EARLY.doubleValue() >= returned);
 
         // check across multiple low memory checks and metric updates that low memory detected
         // remains set


### PR DESCRIPTION
Test started failing after recent metrics changes. The comment above the code block mentioned repeating the same check, but the code wasn't doing that. Modifying the code to do the same check fixed the issue.