### PR TITLE
Fix NPE caused by ExternalCompactions page in monitor

### DIFF
--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -687,9 +687,10 @@ public class Monitor extends AbstractServer implements HighlyAvailableService {
     public final RunningCompactions runningCompactions;
     public final Map<String,TExternalCompaction> ecRunningMap;
 
-    private ExternalCompactionsSnapshot(Map<String,TExternalCompaction> ecRunningMap) {
-      this.ecRunningMap = Collections.unmodifiableMap(ecRunningMap);
-      this.runningCompactions = new RunningCompactions(ecRunningMap);
+    private ExternalCompactionsSnapshot(Optional<Map<String,TExternalCompaction>> ecRunningMapOpt) {
+      this.ecRunningMap =
+          ecRunningMapOpt.map(Collections::unmodifiableMap).orElse(Collections.emptyMap());
+      this.runningCompactions = new RunningCompactions(this.ecRunningMap);
     }
   }
 
@@ -707,7 +708,7 @@ public class Monitor extends AbstractServer implements HighlyAvailableService {
       throw new IllegalStateException("Unable to get running compactions from " + ccHost, e);
     }
 
-    return new ExternalCompactionsSnapshot(running.getCompactions());
+    return new ExternalCompactionsSnapshot(Optional.ofNullable(running.getCompactions()));
   }
 
   public RunningCompactions getRunnningCompactions() {


### PR DESCRIPTION
Fixes #5098 
* Modified the `ExternalCompactionsSnapshot` constructor to accept an `Optional<Map<String, TExternalCompaction>>`, ensuring the map is unmodifiable or empty if the optional is not present.