### PR TITLE
Modifies ColumnVisibility.normalize() to have no side effects

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/security/ColumnVisibility.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/ColumnVisibility.java
@@ -231,22 +231,22 @@ public class ColumnVisibility {
   public static Node normalize(Node root, byte[] expression, NodeComparator comparator) {
     if (root.type != NodeType.TERM) {
       TreeSet<Node> rolledUp = new TreeSet<>(comparator);
-      java.util.Iterator<Node> itr = root.children.iterator();
-      while (itr.hasNext()) {
-        Node c = normalize(itr.next(), expression, comparator);
-        if (c.type == root.type) {
-          rolledUp.addAll(c.children);
-          itr.remove();
+      for (Node child : root.children) {
+        Node newChild = normalize(child, expression, comparator);
+        if (newChild.type == root.type) {
+          rolledUp.addAll(newChild.children);
+        } else {
+          rolledUp.add(newChild);
         }
       }
-      rolledUp.addAll(root.children);
-      root.children.clear();
-      root.children.addAll(rolledUp);
 
-      // need to promote a child if it's an only child
-      if (root.children.size() == 1) {
-        return root.children.get(0);
+      if (rolledUp.size() == 1) {
+        return rolledUp.first();
       }
+
+      Node newRoot = new Node(root.type, root.start);
+      newRoot.children = List.copyOf(rolledUp);
+      return newRoot;
     }
 
     return root;

--- a/core/src/test/java/org/apache/accumulo/core/security/ColumnVisibilityTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/security/ColumnVisibilityTest.java
@@ -90,7 +90,9 @@ public class ColumnVisibilityTest {
   public void normalized(String... values) {
     for (int i = 0; i < values.length; i += 2) {
       ColumnVisibility cv = new ColumnVisibility(values[i].getBytes(UTF_8));
-      assertArrayEquals(cv.flatten(), values[i + 1].getBytes(UTF_8));
+      byte[] flattened = cv.flatten();
+      assertArrayEquals(flattened, values[i + 1].getBytes(UTF_8),
+          new String(flattened, UTF_8) + " != " + values[i + 1]);
     }
   }
 


### PR DESCRIPTION
ColumnVisibility objects have an assoiciated parse tree. Normalizing a column visibility would change the parse tree in place.  This would cause the parse tree to no longer match the expression, which would not matter for most operations on the parse tree.  This side effect would also cause problems for multiple threads attempting to normalize a column visibility.  This change creates a new parse tree during the normalization process and does not modify the existing one.