### PR TITLE
Use util code to identify root ZooKeeper path

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
@@ -510,8 +510,7 @@ public class ClientContext implements AccumuloClient {
    */
   public List<String> getManagerLocations() {
     ensureOpen();
-    var zLockManagerPath =
-        ServiceLock.path(Constants.ZROOT + "/" + getInstanceID() + Constants.ZMANAGER_LOCK);
+    var zLockManagerPath = ServiceLock.path(getZooKeeperRoot() + Constants.ZMANAGER_LOCK);
 
     Timer timer = null;
 

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/ZookeeperLockCheckerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/ZookeeperLockCheckerTest.java
@@ -20,34 +20,51 @@ package org.apache.accumulo.core.clientImpl;
 
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.reset;
 import static org.easymock.EasyMock.verify;
 
+import java.util.UUID;
+
 import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.fate.zookeeper.ZooCache;
+import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class ZookeeperLockCheckerTest {
+
   private ClientContext context;
   private ZooCache zc;
-  private ZookeeperLockChecker zklc;
 
   @BeforeEach
   public void setUp() {
-    context = createMock(ClientContext.class);
-    expect(context.getZooKeeperRoot()).andReturn("/accumulo/iid").anyTimes();
+    var instanceId = InstanceId.of(UUID.randomUUID());
     zc = createMock(ZooCache.class);
+    context = createMock(ClientContext.class);
+    expect(context.getZooKeeperRoot()).andReturn(ZooUtil.getRoot(instanceId)).anyTimes();
     expect(context.getZooCache()).andReturn(zc).anyTimes();
-    replay(context);
-    zklc = new ZookeeperLockChecker(context);
+    replay(context, zc);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    verify(context, zc);
   }
 
   @Test
   public void testInvalidateCache() {
-    zc.clear(context.getZooKeeperRoot() + Constants.ZTSERVERS + "/server");
-    replay(zc);
-    zklc.invalidateCache("server");
+    var zklc = new ZookeeperLockChecker(context);
+
     verify(zc);
+    reset(zc);
+    zc.clear(context.getZooKeeperRoot() + Constants.ZTSERVERS + "/server");
+    expectLastCall().once();
+    replay(zc);
+
+    zklc.invalidateCache("server");
   }
 }

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterExistingZooKeepersTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterExistingZooKeepersTest.java
@@ -26,8 +26,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.util.Map;
 
+import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.commons.io.FileUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -74,8 +76,9 @@ public class MiniAccumuloClusterExistingZooKeepersTest extends WithTestNames {
         Map<String,String> tableIds = client.tableOperations().tableIdMap();
         assertTrue(tableIds.containsKey(tableName));
 
-        String zkTablePath = String.format("/accumulo/%s/tables/%s/name",
-            client.instanceOperations().getInstanceId().canonical(), tableIds.get(tableName));
+        String zkTablePath = String.format("%s%s/%s/name",
+            ZooUtil.getRoot(client.instanceOperations().getInstanceId()), Constants.ZTABLES,
+            tableIds.get(tableName));
         try (CuratorFramework curatorClient =
             CuratorFrameworkFactory.newClient(zooKeeper.getConnectString(), new RetryOneTime(1))) {
           curatorClient.start();

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
@@ -52,6 +52,7 @@ import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.zookeeper.ZooReader;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
+import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metrics.MetricsInfo;
 import org.apache.accumulo.core.rpc.SslConnectionParams;
@@ -118,7 +119,7 @@ public class ServerContext extends ClientContext {
     serverDirs = info.getServerDirs();
 
     propStore = memoize(() -> ZooPropStore.initialize(getInstanceID(), getZooReaderWriter()));
-    zkUserPath = memoize(() -> Constants.ZROOT + "/" + getInstanceID() + Constants.ZUSERS);
+    zkUserPath = memoize(() -> ZooUtil.getRoot(getInstanceID()) + Constants.ZUSERS);
 
     tableManager = memoize(() -> new TableManager(this));
     nameAllocator = memoize(() -> new UniqueNameAllocator(this));

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerInfo.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerInfo.java
@@ -36,6 +36,7 @@ import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.fate.zookeeper.ZooCache;
 import org.apache.accumulo.core.fate.zookeeper.ZooCacheFactory;
+import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.core.singletons.SingletonManager;
 import org.apache.accumulo.core.singletons.SingletonManager.Mode;
 import org.apache.accumulo.server.fs.VolumeManager;
@@ -79,7 +80,7 @@ public class ServerInfo implements ClientInfo {
               + "Run \"accumulo org.apache.accumulo.server.util.ListInstances\" to see a list.");
     }
     instanceID = InstanceId.of(new String(iidb, UTF_8));
-    if (zooCache.get(Constants.ZROOT + "/" + instanceID) == null) {
+    if (zooCache.get(ZooUtil.getRoot(instanceID)) == null) {
       if (instanceName == null) {
         throw new IllegalStateException(
             "Instance id " + instanceID + " does not exist in zookeeper");

--- a/server/base/src/main/java/org/apache/accumulo/server/init/ZooKeeperInitializer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/ZooKeeperInitializer.java
@@ -71,7 +71,7 @@ public class ZooKeeperInitializer {
       zoo.putPersistentData(Constants.ZROOT, new byte[0], ZooUtil.NodeExistsPolicy.SKIP,
           ZooDefs.Ids.OPEN_ACL_UNSAFE);
 
-      String zkInstanceRoot = Constants.ZROOT + "/" + instanceId;
+      String zkInstanceRoot = ZooUtil.getRoot(instanceId);
       zoo.putPersistentData(zkInstanceRoot, EMPTY_BYTE_ARRAY, ZooUtil.NodeExistsPolicy.SKIP);
       var sysPropPath = SystemPropKey.of(instanceId).getPath();
       VersionedProperties vProps = new VersionedProperties();
@@ -109,7 +109,7 @@ public class ZooKeeperInitializer {
         ZooUtil.NodeExistsPolicy.FAIL);
 
     // setup the instance
-    String zkInstanceRoot = Constants.ZROOT + "/" + instanceId;
+    String zkInstanceRoot = context.getZooKeeperRoot();
     zoo.putPersistentData(zkInstanceRoot + Constants.ZTABLES, Constants.ZTABLES_INITIAL_ID,
         ZooUtil.NodeExistsPolicy.FAIL);
     zoo.putPersistentData(zkInstanceRoot + Constants.ZNAMESPACES,

--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKPermHandler.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKPermHandler.java
@@ -27,12 +27,12 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
 
+import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.NamespaceNotFoundException;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.clientImpl.Namespace;
 import org.apache.accumulo.core.clientImpl.thrift.SecurityErrorCode;
-import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.zookeeper.ZooCache;
@@ -66,10 +66,9 @@ public class ZKPermHandler implements PermissionHandler {
   public void initialize(ServerContext context) {
     zooCache = new ZooCache(context.getZooReader(), null);
     zoo = context.getZooReaderWriter();
-    InstanceId instanceId = context.getInstanceID();
     zkUserPath = context.zkUserPath();
-    ZKTablePath = ZKSecurityTool.getInstancePath(instanceId) + "/tables";
-    ZKNamespacePath = ZKSecurityTool.getInstancePath(instanceId) + "/namespaces";
+    ZKTablePath = context.getZooKeeperRoot() + Constants.ZTABLES;
+    ZKNamespacePath = context.getZooKeeperRoot() + Constants.ZNAMESPACES;
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKSecurityTool.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKSecurityTool.java
@@ -31,9 +31,7 @@ import java.time.Duration;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.AccumuloException;
-import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.NamespacePermission;
 import org.apache.accumulo.core.security.SystemPermission;
@@ -191,7 +189,4 @@ class ZKSecurityTool {
     return toReturn;
   }
 
-  public static String getInstancePath(InstanceId instanceId) {
-    return Constants.ZROOT + "/" + instanceId;
-  }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
@@ -37,6 +37,7 @@ import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.zookeeper.ZooCache;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
+import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil.NodeMissingPolicy;
 import org.apache.accumulo.core.manager.state.tables.TableState;
@@ -77,7 +78,7 @@ public class TableManager {
     final InstanceId instanceId = context.getInstanceID();
     log.debug("Creating ZooKeeper entries for new namespace {} (ID: {})", namespace, namespaceId);
     context.getZooReaderWriter().putPersistentData(
-        Constants.ZROOT + "/" + instanceId + Constants.ZNAMESPACES + "/" + namespaceId, new byte[0],
+        context.getZooKeeperRoot() + Constants.ZNAMESPACES + "/" + namespaceId, new byte[0],
         existsPolicy);
     var propKey = NamespacePropKey.of(instanceId, namespaceId);
     if (!propStore.exists(propKey)) {
@@ -94,7 +95,7 @@ public class TableManager {
         tableName, tableId, namespaceId);
     Pair<String,String> qualifiedTableName = TableNameUtil.qualify(tableName);
     tableName = qualifiedTableName.getSecond();
-    String zTablePath = Constants.ZROOT + "/" + instanceId + Constants.ZTABLES + "/" + tableId;
+    String zTablePath = ZooUtil.getRoot(instanceId) + Constants.ZTABLES + "/" + tableId;
     zoo.putPersistentData(zTablePath, new byte[0], existsPolicy);
     zoo.putPersistentData(zTablePath + Constants.ZTABLE_NAMESPACE,
         namespaceId.canonical().getBytes(UTF_8), existsPolicy);
@@ -220,10 +221,10 @@ public class TableManager {
     prepareNewTableState(zoo, context.getPropStore(), instanceID, tableId, namespaceId, tableName,
         TableState.NEW, NodeExistsPolicy.OVERWRITE);
 
-    String srcTablePath = Constants.ZROOT + "/" + instanceID + Constants.ZTABLES + "/" + srcTableId
-        + Constants.ZCONFIG;
+    String srcTablePath =
+        context.getZooKeeperRoot() + Constants.ZTABLES + "/" + srcTableId + Constants.ZCONFIG;
     String newTablePath =
-        Constants.ZROOT + "/" + instanceID + Constants.ZTABLES + "/" + tableId + Constants.ZCONFIG;
+        context.getZooKeeperRoot() + Constants.ZTABLES + "/" + tableId + Constants.ZCONFIG;
     zoo.recursiveCopyPersistentOverwrite(srcTablePath, newTablePath);
 
     PropUtil.setProperties(context, TablePropKey.of(context, tableId), propertiesToSet);

--- a/server/base/src/main/java/org/apache/accumulo/server/tablets/UniqueNameAllocator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tablets/UniqueNameAllocator.java
@@ -50,7 +50,7 @@ public class UniqueNameAllocator {
 
   public UniqueNameAllocator(ServerContext context) {
     this.context = context;
-    nextNamePath = Constants.ZROOT + "/" + context.getInstanceID() + Constants.ZNEXT_FILE;
+    nextNamePath = context.getZooKeeperRoot() + Constants.ZNEXT_FILE;
   }
 
   public synchronized String getNextName() {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ChangeSecret.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ChangeSecret.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
+import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.fate.zookeeper.ZooReader;
@@ -145,7 +146,7 @@ public class ChangeSecret {
         }
       }
     });
-    String path = "/accumulo/instances/" + context.getInstanceName();
+    String path = Constants.ZROOT + Constants.ZINSTANCES + "/" + context.getInstanceName();
     orig.recursiveDelete(path, NodeMissingPolicy.SKIP);
     new_.putPersistentData(path, newInstanceId.canonical().getBytes(UTF_8),
         NodeExistsPolicy.OVERWRITE);
@@ -201,6 +202,6 @@ public class ChangeSecret {
 
   private static void deleteInstance(ServerContext context, String oldPass) throws Exception {
     ZooReaderWriter orig = context.getZooReader().asWriter(oldPass);
-    orig.recursiveDelete("/accumulo/" + context.getInstanceID(), NodeMissingPolicy.SKIP);
+    orig.recursiveDelete(context.getZooKeeperRoot(), NodeMissingPolicy.SKIP);
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ListInstances.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ListInstances.java
@@ -35,6 +35,7 @@ import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.fate.zookeeper.ZooCache;
 import org.apache.accumulo.core.fate.zookeeper.ZooReader;
+import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.core.lock.ServiceLock;
 import org.apache.accumulo.core.lock.ServiceLockData;
 import org.apache.accumulo.core.lock.ServiceLockData.ThriftService;
@@ -165,8 +166,7 @@ public class ListInstances {
     }
 
     try {
-      var zLockManagerPath =
-          ServiceLock.path(Constants.ZROOT + "/" + iid + Constants.ZMANAGER_LOCK);
+      var zLockManagerPath = ServiceLock.path(ZooUtil.getRoot(iid) + Constants.ZMANAGER_LOCK);
       Optional<ServiceLockData> sld = ServiceLock.getLockData(cache, zLockManagerPath, null);
       if (sld.isEmpty()) {
         return null;

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ZooKeeperMain.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ZooKeeperMain.java
@@ -69,7 +69,7 @@ public class ZooKeeperMain implements KeywordExecutable {
       }
       System.out.println("The accumulo instance id is " + context.getInstanceID());
       if (!opts.servers.contains("/")) {
-        opts.servers += "/accumulo/" + context.getInstanceID();
+        opts.servers += context.getZooKeeperRoot();
       }
       org.apache.zookeeper.ZooKeeperMain
           .main(new String[] {"-server", opts.servers, "-timeout", "" + (opts.timeout * 1000)});

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
@@ -26,6 +26,7 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
+import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil.NodeMissingPolicy;
 import org.apache.accumulo.core.lock.ServiceLock;
 import org.apache.accumulo.core.singletons.SingletonManager;
@@ -107,7 +108,7 @@ public class ZooZap implements KeywordExecutable {
       ZooReaderWriter zoo = new ZooReaderWriter(siteConf);
 
       if (opts.zapManager) {
-        String managerLockPath = Constants.ZROOT + "/" + iid + Constants.ZMANAGER_LOCK;
+        String managerLockPath = ZooUtil.getRoot(iid) + Constants.ZMANAGER_LOCK;
 
         try {
           zapDirectory(zoo, managerLockPath, opts);
@@ -117,7 +118,7 @@ public class ZooZap implements KeywordExecutable {
       }
 
       if (opts.zapTservers) {
-        String tserversPath = Constants.ZROOT + "/" + iid + Constants.ZTSERVERS;
+        String tserversPath = ZooUtil.getRoot(iid) + Constants.ZTSERVERS;
         try {
           List<String> children = zoo.getChildren(tserversPath);
           for (String child : children) {
@@ -140,7 +141,7 @@ public class ZooZap implements KeywordExecutable {
       }
 
       if (opts.zapCoordinators) {
-        final String coordinatorPath = Constants.ZROOT + "/" + iid + Constants.ZCOORDINATOR_LOCK;
+        final String coordinatorPath = ZooUtil.getRoot(iid) + Constants.ZCOORDINATOR_LOCK;
         try {
           if (zoo.exists(coordinatorPath)) {
             zapDirectory(zoo, coordinatorPath, opts);
@@ -151,7 +152,7 @@ public class ZooZap implements KeywordExecutable {
       }
 
       if (opts.zapCompactors) {
-        String compactorsBasepath = Constants.ZROOT + "/" + iid + Constants.ZCOMPACTORS;
+        String compactorsBasepath = ZooUtil.getRoot(iid) + Constants.ZCOMPACTORS;
         try {
           if (zoo.exists(compactorsBasepath)) {
             List<String> queues = zoo.getChildren(compactorsBasepath);
@@ -167,7 +168,7 @@ public class ZooZap implements KeywordExecutable {
       }
 
       if (opts.zapScanServers) {
-        String sserversPath = Constants.ZROOT + "/" + iid + Constants.ZSSERVERS;
+        String sserversPath = ZooUtil.getRoot(iid) + Constants.ZSSERVERS;
         try {
           if (zoo.exists(sserversPath)) {
             List<String> children = zoo.getChildren(sserversPath);

--- a/server/base/src/test/java/org/apache/accumulo/server/MockServerContext.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/MockServerContext.java
@@ -23,11 +23,13 @@ import static org.easymock.EasyMock.expect;
 
 import java.util.Properties;
 
+import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
+import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.server.conf.store.PropStore;
 import org.easymock.EasyMock;
 
@@ -47,9 +49,9 @@ public class MockServerContext {
 
   public static ServerContext getWithZK(InstanceId instanceID, String zk, int zkTimeout) {
     var sc = get();
-    expect(sc.getZooKeeperRoot()).andReturn("/accumulo/" + instanceID).anyTimes();
+    expect(sc.getZooKeeperRoot()).andReturn(ZooUtil.getRoot(instanceID)).anyTimes();
     expect(sc.getInstanceID()).andReturn(instanceID).anyTimes();
-    expect(sc.zkUserPath()).andReturn("/accumulo/" + instanceID + "/users").anyTimes();
+    expect(sc.zkUserPath()).andReturn(ZooUtil.getRoot(instanceID) + Constants.ZUSERS).anyTimes();
     expect(sc.getZooKeepers()).andReturn(zk).anyTimes();
     expect(sc.getZooKeepersSessionTimeOut()).andReturn(zkTimeout).anyTimes();
     return sc;
@@ -61,7 +63,7 @@ public class MockServerContext {
     ServerContext sc = createMock(ServerContext.class);
     expect(sc.getInstanceID()).andReturn(instanceID).anyTimes();
     expect(sc.getZooReaderWriter()).andReturn(zrw).anyTimes();
-    expect(sc.getZooKeeperRoot()).andReturn("/accumulo/" + instanceID).anyTimes();
+    expect(sc.getZooKeeperRoot()).andReturn(ZooUtil.getRoot(instanceID)).anyTimes();
     expect(sc.getPropStore()).andReturn(propStore).anyTimes();
     return sc;
   }

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/ServerConfigurationFactoryTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/ServerConfigurationFactoryTest.java
@@ -37,6 +37,7 @@ import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.conf.codec.VersionedProperties;
 import org.apache.accumulo.server.conf.store.NamespacePropKey;
@@ -79,7 +80,7 @@ public class ServerConfigurationFactoryTest {
     expectLastCall().anyTimes();
 
     context = createMock(ServerContext.class);
-    expect(context.getZooKeeperRoot()).andReturn("/accumulo/" + IID).anyTimes();
+    expect(context.getZooKeeperRoot()).andReturn(ZooUtil.getRoot(IID)).anyTimes();
     expect(context.getInstanceID()).andReturn(IID).anyTimes();
     expect(context.getZooKeepers()).andReturn(ZK_HOST).anyTimes();
     expect(context.getZooKeepersSessionTimeOut()).andReturn(ZK_TIMEOUT).anyTimes();

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/store/PropStoreKeyTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/store/PropStoreKeyTest.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.server.conf.store;
 
 import static org.apache.accumulo.core.Constants.ZCONFIG;
 import static org.apache.accumulo.core.Constants.ZNAMESPACES;
+import static org.apache.accumulo.core.Constants.ZROOT;
 import static org.apache.accumulo.core.Constants.ZTABLES;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
@@ -35,6 +36,7 @@ import java.util.UUID;
 import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.server.ServerContext;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -93,48 +95,46 @@ public class PropStoreKeyTest {
 
   @Test
   public void fromPathTest() {
-
-    var iid = "3f9976c6-3bf1-41ab-9751-1b0a9be3551d";
-
-    PropStoreKey<?> t1 = PropStoreKey.fromPath("/accumulo/" + iid + "/tables/t1" + ZCONFIG);
+    var t1 = PropStoreKey.fromPath(ZooUtil.getRoot(instanceId) + ZTABLES + "/t1" + ZCONFIG);
     assertNotNull(t1);
     assertEquals(TableId.of("t1"), t1.getId());
 
-    PropStoreKey<?> n1 = PropStoreKey.fromPath("/accumulo/" + iid + "/namespaces/n1" + ZCONFIG);
+    var n1 = PropStoreKey.fromPath(ZooUtil.getRoot(instanceId) + ZNAMESPACES + "/n1" + ZCONFIG);
     assertNotNull(n1);
     assertEquals(NamespaceId.of("n1"), n1.getId());
     assertNotNull(n1.getId());
 
-    PropStoreKey<?> s1 = PropStoreKey.fromPath("/accumulo/" + iid + ZCONFIG);
+    var s1 = PropStoreKey.fromPath(ZooUtil.getRoot(instanceId) + ZCONFIG);
     assertNotNull(s1);
     // system config returns instance id as id placeholder
-    assertEquals(iid, s1.getId().canonical());
+    assertEquals(instanceId, s1.getId());
   }
 
   @Test
   public void invalidKeysTest() {
-    var iid = "3f9976c6-3bf1-41ab-9751-1b0a9be3551d";
-
     // too short
-    assertNull(PropStoreKey.fromPath("/accumulo"));
+    assertNull(PropStoreKey.fromPath(ZROOT));
 
     // not a system config
-    assertTrue(PropStoreKey.fromPath("/accumulo/" + iid + ZCONFIG) instanceof SystemPropKey);
+    assertTrue(
+        PropStoreKey.fromPath(ZooUtil.getRoot(instanceId) + ZCONFIG) instanceof SystemPropKey);
     assertNull(PropStoreKey.fromPath("/foo"));
-    assertNull(PropStoreKey.fromPath("/accumulo/" + iid + "/foo"));
-    assertNull(PropStoreKey.fromPath("/accumulo/" + iid + ZCONFIG + "/foo"));
+    assertNull(PropStoreKey.fromPath(ZooUtil.getRoot(instanceId) + "/foo"));
+    assertNull(PropStoreKey.fromPath(ZooUtil.getRoot(instanceId) + ZCONFIG + "/foo"));
 
     assertTrue(PropStoreKey
-        .fromPath("/accumulo/" + iid + ZTABLES + "/a" + ZCONFIG) instanceof TablePropKey);
-    assertNull(PropStoreKey.fromPath("/accumulo/" + iid + ZTABLES + ZCONFIG));
-    assertNull(PropStoreKey.fromPath("/accumulo/" + iid + "/invalid/a" + ZCONFIG));
-    assertNull(PropStoreKey.fromPath("/accumulo/" + iid + ZTABLES + "/a" + ZCONFIG + "/foo"));
+        .fromPath(ZooUtil.getRoot(instanceId) + ZTABLES + "/a" + ZCONFIG) instanceof TablePropKey);
+    assertNull(PropStoreKey.fromPath(ZooUtil.getRoot(instanceId) + ZTABLES + ZCONFIG));
+    assertNull(PropStoreKey.fromPath(ZooUtil.getRoot(instanceId) + "/invalid/a" + ZCONFIG));
+    assertNull(
+        PropStoreKey.fromPath(ZooUtil.getRoot(instanceId) + ZTABLES + "/a" + ZCONFIG + "/foo"));
 
-    assertTrue(PropStoreKey
-        .fromPath("/accumulo/" + iid + ZNAMESPACES + "/a" + ZCONFIG) instanceof NamespacePropKey);
-    assertNull(PropStoreKey.fromPath("/accumulo/" + iid + ZNAMESPACES + ZCONFIG));
-    assertNull(PropStoreKey.fromPath("/accumulo/" + iid + "/invalid/a" + ZCONFIG));
-    assertNull(PropStoreKey.fromPath("/accumulo/" + iid + ZNAMESPACES + "/a" + ZCONFIG + "/foo"));
+    assertTrue(PropStoreKey.fromPath(
+        ZooUtil.getRoot(instanceId) + ZNAMESPACES + "/a" + ZCONFIG) instanceof NamespacePropKey);
+    assertNull(PropStoreKey.fromPath(ZooUtil.getRoot(instanceId) + ZNAMESPACES + ZCONFIG));
+    assertNull(PropStoreKey.fromPath(ZooUtil.getRoot(instanceId) + "/invalid/a" + ZCONFIG));
+    assertNull(
+        PropStoreKey.fromPath(ZooUtil.getRoot(instanceId) + ZNAMESPACES + "/a" + ZCONFIG + "/foo"));
   }
 
   @Test

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/store/impl/PropStoreEventTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/store/impl/PropStoreEventTest.java
@@ -39,6 +39,7 @@ import java.util.UUID;
 import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
+import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.conf.codec.VersionedPropCodec;
 import org.apache.accumulo.server.conf.codec.VersionedProperties;
@@ -72,7 +73,7 @@ public class PropStoreEventTest {
     expect(context.getZooKeepersSessionTimeOut()).andReturn(500).anyTimes();
     expect(context.getInstanceID()).andReturn(instanceId).anyTimes();
 
-    expect(zrw.exists(eq("/accumulo/" + instanceId), anyObject())).andReturn(true).anyTimes();
+    expect(zrw.exists(eq(ZooUtil.getRoot(instanceId)), anyObject())).andReturn(true).anyTimes();
 
     readyMonitor = createMock(ReadyMonitor.class);
   }

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/store/impl/ZooPropStoreTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/store/impl/ZooPropStoreTest.java
@@ -45,6 +45,7 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
+import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.conf.codec.VersionedPropCodec;
 import org.apache.accumulo.server.conf.codec.VersionedProperties;
@@ -75,7 +76,7 @@ public class ZooPropStoreTest {
     expect(zrw.getSessionTimeout()).andReturn(2_000).anyTimes();
     expect(context.getInstanceID()).andReturn(instanceId).anyTimes();
 
-    expect(zrw.exists(eq("/accumulo/" + instanceId), anyObject())).andReturn(true).anyTimes();
+    expect(zrw.exists(eq(ZooUtil.getRoot(instanceId)), anyObject())).andReturn(true).anyTimes();
   }
 
   @AfterEach

--- a/server/base/src/test/java/org/apache/accumulo/server/security/delegation/ZooAuthenticationKeyWatcherTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/security/delegation/ZooAuthenticationKeyWatcherTest.java
@@ -42,6 +42,7 @@ import javax.crypto.KeyGenerator;
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.fate.zookeeper.ZooReader;
+import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.zookeeper.KeeperException.NoNodeException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher.Event.EventType;
@@ -75,7 +76,7 @@ public class ZooAuthenticationKeyWatcherTest {
   public void setupMocks() {
     zk = createMock(ZooReader.class);
     instanceId = InstanceId.of(UUID.randomUUID());
-    baseNode = "/accumulo/" + instanceId + Constants.ZDELEGATION_TOKEN_KEYS;
+    baseNode = ZooUtil.getRoot(instanceId) + Constants.ZDELEGATION_TOKEN_KEYS;
     secretManager = new AuthenticationTokenSecretManager(instanceId, tokenLifetime);
     keyWatcher = new ZooAuthenticationKeyWatcher(secretManager, zk, baseNode);
   }

--- a/server/base/src/test/java/org/apache/accumulo/server/util/ServiceStatusCmdTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/ServiceStatusCmdTest.java
@@ -38,6 +38,7 @@ import java.util.UUID;
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.fate.zookeeper.ZooReader;
+import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.util.serviceStatus.ServiceStatusReport;
 import org.apache.accumulo.server.util.serviceStatus.StatusSummary;
@@ -59,7 +60,7 @@ public class ServiceStatusCmdTest {
   @BeforeEach
   public void populateContext() {
     InstanceId iid = InstanceId.of(UUID.randomUUID());
-    zRoot = "/accumulo/" + iid.canonical();
+    zRoot = ZooUtil.getRoot(iid);
     context = createMock(ServerContext.class);
     expect(context.getInstanceID()).andReturn(iid).anyTimes();
     expect(context.getZooKeeperRoot()).andReturn(zRoot).anyTimes();

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -217,8 +217,8 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
         }
 
         if (job.getKind() == TCompactionKind.USER) {
-          String zTablePath = Constants.ZROOT + "/" + getContext().getInstanceID()
-              + Constants.ZTABLES + "/" + extent.tableId() + Constants.ZTABLE_COMPACT_CANCEL_ID;
+          String zTablePath = getContext().getZooKeeperRoot() + Constants.ZTABLES + "/"
+              + extent.tableId() + Constants.ZTABLE_COMPACT_CANCEL_ID;
           byte[] id = getContext().getZooCache().get(zTablePath);
           if (id == null) {
             // table probably deleted

--- a/server/manager/src/main/java/org/apache/accumulo/manager/ManagerClientServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/ManagerClientServiceHandler.java
@@ -106,8 +106,8 @@ public class ManagerClientServiceHandler implements ManagerClientService.Iface {
       throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
     }
 
-    String zTablePath = Constants.ZROOT + "/" + manager.getInstanceID() + Constants.ZTABLES + "/"
-        + tableId + Constants.ZTABLE_FLUSH_ID;
+    String zTablePath = manager.getContext().getZooKeeperRoot() + Constants.ZTABLES + "/" + tableId
+        + Constants.ZTABLE_FLUSH_ID;
 
     ZooReaderWriter zoo = manager.getContext().getZooReaderWriter();
     byte[] fid;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/ManagerTime.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/ManagerTime.java
@@ -89,7 +89,7 @@ public class ManagerTime {
   private final AtomicReference<Duration> skewAmount;
 
   public ManagerTime(Manager manager, AccumuloConfiguration conf) throws IOException {
-    this.zPath = manager.getZooKeeperRoot() + Constants.ZMANAGER_TICK;
+    this.zPath = manager.getContext().getZooKeeperRoot() + Constants.ZMANAGER_TICK;
     this.zk = manager.getContext().getZooReaderWriter();
     this.manager = manager;
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/recovery/RecoveryManager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/recovery/RecoveryManager.java
@@ -78,7 +78,7 @@ public class RecoveryManager {
     zooCache = new ZooCache(manager.getContext().getZooReader(), null);
     try {
       List<String> workIDs =
-          new DistributedWorkQueue(manager.getZooKeeperRoot() + Constants.ZRECOVERY,
+          new DistributedWorkQueue(manager.getContext().getZooKeeperRoot() + Constants.ZRECOVERY,
               manager.getConfiguration(), manager.getContext()).getWorkQueued();
       sortsQueued.addAll(workIDs);
     } catch (Exception e) {
@@ -131,14 +131,15 @@ public class RecoveryManager {
   private void initiateSort(String sortId, String source, final String destination)
       throws KeeperException, InterruptedException {
     String work = source + "|" + destination;
-    new DistributedWorkQueue(manager.getZooKeeperRoot() + Constants.ZRECOVERY,
+    new DistributedWorkQueue(manager.getContext().getZooKeeperRoot() + Constants.ZRECOVERY,
         manager.getConfiguration(), manager.getContext()).addWork(sortId, work.getBytes(UTF_8));
 
     synchronized (this) {
       sortsQueued.add(sortId);
     }
 
-    final String path = manager.getZooKeeperRoot() + Constants.ZRECOVERY + "/" + sortId;
+    final String path =
+        manager.getContext().getZooKeeperRoot() + Constants.ZRECOVERY + "/" + sortId;
     log.info("Created zookeeper entry {} with data {}", path, work);
   }
 
@@ -180,9 +181,8 @@ public class RecoveryManager {
         sortQueued = sortsQueued.contains(sortId);
       }
 
-      if (sortQueued
-          && zooCache.get(manager.getZooKeeperRoot() + Constants.ZRECOVERY + "/" + sortId)
-              == null) {
+      if (sortQueued && zooCache.get(
+          manager.getContext().getZooKeeperRoot() + Constants.ZRECOVERY + "/" + sortId) == null) {
         synchronized (this) {
           sortsQueued.remove(sortId);
         }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/state/MergeStats.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/state/MergeStats.java
@@ -33,7 +33,6 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
-import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.core.metadata.AccumuloTable;
 import org.apache.accumulo.core.metadata.TabletLocationState;
 import org.apache.accumulo.core.metadata.TabletLocationState.BadLocationStateException;
@@ -238,8 +237,8 @@ public class MergeStats {
         ZooReaderWriter zooReaderWriter = opts.getServerContext().getZooReaderWriter();
         for (Entry<String,String> entry : tableIdMap.entrySet()) {
           final String table = entry.getKey(), tableId = entry.getValue();
-          String path = ZooUtil.getRoot(client.instanceOperations().getInstanceId())
-              + Constants.ZTABLES + "/" + tableId + "/merge";
+          String path = opts.getServerContext().getZooKeeperRoot() + Constants.ZTABLES + "/"
+              + tableId + "/merge";
           MergeInfo info = new MergeInfo();
           if (zooReaderWriter.exists(path)) {
             byte[] data = zooReaderWriter.getData(path);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactRange.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactRange.java
@@ -97,8 +97,8 @@ public class CompactRange extends ManagerRepo {
 
   @Override
   public Repo<Manager> call(final long tid, Manager env) throws Exception {
-    String zTablePath = Constants.ZROOT + "/" + env.getInstanceID() + Constants.ZTABLES + "/"
-        + tableId + Constants.ZTABLE_COMPACT_ID;
+    String zTablePath = env.getContext().getZooKeeperRoot() + Constants.ZTABLES + "/" + tableId
+        + Constants.ZTABLE_COMPACT_ID;
 
     ZooReaderWriter zoo = env.getContext().getZooReaderWriter();
     byte[] cid;
@@ -147,8 +147,8 @@ public class CompactRange extends ManagerRepo {
 
   static void removeIterators(Manager environment, final long txid, TableId tableId)
       throws Exception {
-    String zTablePath = Constants.ZROOT + "/" + environment.getInstanceID() + Constants.ZTABLES
-        + "/" + tableId + Constants.ZTABLE_COMPACT_ID;
+    String zTablePath = environment.getContext().getZooKeeperRoot() + Constants.ZTABLES + "/"
+        + tableId + Constants.ZTABLE_COMPACT_ID;
 
     ZooReaderWriter zoo = environment.getContext().getZooReaderWriter();
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/cancel/CancelCompactions.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/cancel/CancelCompactions.java
@@ -68,9 +68,9 @@ public class CancelCompactions extends ManagerRepo {
 
   public static void mutateZooKeeper(long tid, TableId tableId, Manager environment)
       throws Exception {
-    String zCompactID = Constants.ZROOT + "/" + environment.getInstanceID() + Constants.ZTABLES
-        + "/" + tableId + Constants.ZTABLE_COMPACT_ID;
-    String zCancelID = Constants.ZROOT + "/" + environment.getInstanceID() + Constants.ZTABLES + "/"
+    String zCompactID = environment.getContext().getZooKeeperRoot() + Constants.ZTABLES + "/"
+        + tableId + Constants.ZTABLE_COMPACT_ID;
+    String zCancelID = environment.getContext().getZooKeeperRoot() + Constants.ZTABLES + "/"
         + tableId + Constants.ZTABLE_COMPACT_CANCEL_ID;
 
     ZooReaderWriter zoo = environment.getContext().getZooReaderWriter();

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/PreDeleteTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/PreDeleteTable.java
@@ -26,6 +26,7 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
+import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
@@ -36,7 +37,7 @@ import org.apache.zookeeper.KeeperException;
 public class PreDeleteTable extends ManagerRepo {
 
   public static String createDeleteMarkerPath(InstanceId instanceId, TableId tableId) {
-    return Constants.ZROOT + "/" + instanceId + Constants.ZTABLES + "/" + tableId.canonical()
+    return ZooUtil.getRoot(instanceId) + Constants.ZTABLES + "/" + tableId.canonical()
         + Constants.ZTABLE_DELETE_MARKER;
   }
 
@@ -58,7 +59,8 @@ public class PreDeleteTable extends ManagerRepo {
 
   private void preventFutureCompactions(Manager environment)
       throws KeeperException, InterruptedException {
-    String deleteMarkerPath = createDeleteMarkerPath(environment.getInstanceID(), tableId);
+    String deleteMarkerPath =
+        createDeleteMarkerPath(environment.getContext().getInstanceID(), tableId);
     ZooReaderWriter zoo = environment.getContext().getZooReaderWriter();
     zoo.putPersistentData(deleteMarkerPath, new byte[] {}, NodeExistsPolicy.SKIP);
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/PopulateZookeeperWithNamespace.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/PopulateZookeeperWithNamespace.java
@@ -54,8 +54,8 @@ class PopulateZookeeperWithNamespace extends ManagerRepo {
     try {
       var context = manager.getContext();
       NamespaceMapping.put(context.getZooReaderWriter(),
-          Constants.ZROOT + "/" + context.getInstanceID() + Constants.ZNAMESPACES,
-          namespaceInfo.namespaceId, namespaceInfo.namespaceName);
+          context.getZooKeeperRoot() + Constants.ZNAMESPACES, namespaceInfo.namespaceId,
+          namespaceInfo.namespaceName);
       TableManager.prepareNewNamespaceState(context, namespaceInfo.namespaceId,
           namespaceInfo.namespaceName, NodeExistsPolicy.OVERWRITE);
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/rename/RenameNamespace.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/rename/RenameNamespace.java
@@ -56,8 +56,8 @@ public class RenameNamespace extends ManagerRepo {
 
     Utils.getTableNameLock().lock();
     try {
-      NamespaceMapping.rename(zoo, manager.getZooKeeperRoot() + Constants.ZNAMESPACES, namespaceId,
-          oldName, newName);
+      NamespaceMapping.rename(zoo, manager.getContext().getZooKeeperRoot() + Constants.ZNAMESPACES,
+          namespaceId, oldName, newName);
 
       manager.getContext().clearTableListCache();
     } finally {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/rename/RenameTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/rename/RenameTable.java
@@ -83,8 +83,8 @@ public class RenameTable extends ManagerRepo {
       final String newName = qualifiedNewTableName.getSecond();
       final String oldName = qualifiedOldTableName.getSecond();
 
-      final String tap =
-          manager.getZooKeeperRoot() + Constants.ZTABLES + "/" + tableId + Constants.ZTABLE_NAME;
+      final String tap = manager.getContext().getZooKeeperRoot() + Constants.ZTABLES + "/" + tableId
+          + Constants.ZTABLE_NAME;
 
       zoo.mutateExisting(tap, current -> {
         final String currentName = new String(current, UTF_8);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tserverOps/ShutdownTServer.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tserverOps/ShutdownTServer.java
@@ -96,11 +96,10 @@ public class ShutdownTServer extends ManagerRepo {
     // suppress assignment of tablets to the server
     if (force) {
       ZooReaderWriter zoo = manager.getContext().getZooReaderWriter();
-      var path =
-          ServiceLock.path(manager.getZooKeeperRoot() + Constants.ZTSERVERS + "/" + hostAndPort);
+      var zRoot = manager.getContext().getZooKeeperRoot();
+      var path = ServiceLock.path(zRoot + Constants.ZTSERVERS + "/" + hostAndPort);
       ServiceLock.deleteLock(zoo, path);
-      path = ServiceLock
-          .path(manager.getZooKeeperRoot() + Constants.ZDEADTSERVERS + "/" + hostAndPort);
+      path = ServiceLock.path(zRoot + Constants.ZDEADTSERVERS + "/" + hostAndPort);
       zoo.putPersistentData(path.toString(), "forced down".getBytes(UTF_8),
           NodeExistsPolicy.OVERWRITE);
     }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader11to12.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader11to12.java
@@ -124,7 +124,7 @@ public class Upgrader11to12 implements Upgrader {
         log.info("Root metadata in ZooKeeper after upgrade: {}", rtm.toJson());
       }
 
-      String zPath = Constants.ZROOT + "/" + context.getInstanceID() + Constants.ZNAMESPACES;
+      String zPath = context.getZooKeeperRoot() + Constants.ZNAMESPACES;
       byte[] namespacesData = zrw.getData(zPath);
       if (namespacesData.length != 0) {
         throw new IllegalStateException(

--- a/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriverTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriverTest.java
@@ -19,6 +19,10 @@
 package org.apache.accumulo.manager.tableOps.compact;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -35,7 +39,6 @@ import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.delete.PreDeleteTable;
 import org.apache.accumulo.server.ServerContext;
-import org.easymock.EasyMock;
 import org.junit.jupiter.api.Test;
 
 public class CompactionDriverTest {
@@ -51,17 +54,17 @@ public class CompactionDriverTest {
     final byte[] startRow = new byte[0];
     final byte[] endRow = new byte[0];
 
-    Manager manager = EasyMock.createNiceMock(Manager.class);
-    ServerContext ctx = EasyMock.createNiceMock(ServerContext.class);
-    ZooReaderWriter zrw = EasyMock.createNiceMock(ZooReaderWriter.class);
-    EasyMock.expect(manager.getInstanceID()).andReturn(instance).anyTimes();
-    EasyMock.expect(manager.getContext()).andReturn(ctx);
-    EasyMock.expect(ctx.getZooReaderWriter()).andReturn(zrw);
+    Manager manager = createMock(Manager.class);
+    ServerContext ctx = createMock(ServerContext.class);
+    ZooReaderWriter zrw = createMock(ZooReaderWriter.class);
+    expect(ctx.getInstanceID()).andReturn(instance).anyTimes();
+    expect(ctx.getZooReaderWriter()).andReturn(zrw).anyTimes();
+    expect(manager.getContext()).andReturn(ctx).anyTimes();
 
     final String zCancelID = CompactionDriver.createCompactionCancellationPath(instance, tableId);
-    EasyMock.expect(zrw.getData(zCancelID)).andReturn(Long.toString(cancelId).getBytes(UTF_8));
+    expect(zrw.getData(zCancelID)).andReturn(Long.toString(cancelId).getBytes(UTF_8));
 
-    EasyMock.replay(manager, ctx, zrw);
+    replay(manager, ctx, zrw);
 
     final CompactionDriver driver =
         new CompactionDriver(compactId, namespaceId, tableId, startRow, endRow);
@@ -75,7 +78,7 @@ public class CompactionDriverTest {
     assertEquals(e.getType(), TableOperationExceptionType.OTHER);
     assertEquals(TableOperationsImpl.COMPACTION_CANCELED_MSG, e.getDescription());
 
-    EasyMock.verify(manager, ctx, zrw);
+    verify(manager, ctx, zrw);
   }
 
   @Test
@@ -89,20 +92,20 @@ public class CompactionDriverTest {
     final byte[] startRow = new byte[0];
     final byte[] endRow = new byte[0];
 
-    Manager manager = EasyMock.createNiceMock(Manager.class);
-    ServerContext ctx = EasyMock.createNiceMock(ServerContext.class);
-    ZooReaderWriter zrw = EasyMock.createNiceMock(ZooReaderWriter.class);
-    EasyMock.expect(manager.getInstanceID()).andReturn(instance).anyTimes();
-    EasyMock.expect(manager.getContext()).andReturn(ctx);
-    EasyMock.expect(ctx.getZooReaderWriter()).andReturn(zrw);
+    Manager manager = createMock(Manager.class);
+    ServerContext ctx = createMock(ServerContext.class);
+    ZooReaderWriter zrw = createMock(ZooReaderWriter.class);
+    expect(ctx.getInstanceID()).andReturn(instance).anyTimes();
+    expect(ctx.getZooReaderWriter()).andReturn(zrw).anyTimes();
+    expect(manager.getContext()).andReturn(ctx).anyTimes();
 
     final String zCancelID = CompactionDriver.createCompactionCancellationPath(instance, tableId);
-    EasyMock.expect(zrw.getData(zCancelID)).andReturn(Long.toString(cancelId).getBytes(UTF_8));
+    expect(zrw.getData(zCancelID)).andReturn(Long.toString(cancelId).getBytes(UTF_8));
 
     String deleteMarkerPath = PreDeleteTable.createDeleteMarkerPath(instance, tableId);
-    EasyMock.expect(zrw.exists(deleteMarkerPath)).andReturn(true);
+    expect(zrw.exists(deleteMarkerPath)).andReturn(true);
 
-    EasyMock.replay(manager, ctx, zrw);
+    replay(manager, ctx, zrw);
 
     final CompactionDriver driver =
         new CompactionDriver(compactId, namespaceId, tableId, startRow, endRow);
@@ -116,7 +119,7 @@ public class CompactionDriverTest {
     assertEquals(e.getType(), TableOperationExceptionType.OTHER);
     assertEquals(TableOperationsImpl.TABLE_DELETED_MSG, e.getDescription());
 
-    EasyMock.verify(manager, ctx, zrw);
+    verify(manager, ctx, zrw);
   }
 
 }

--- a/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/Upgrader11to12Test.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/Upgrader11to12Test.java
@@ -353,49 +353,46 @@ public class Upgrader11to12Test {
 
     ServerContext context = createMock(ServerContext.class);
     ZooReaderWriter zrw = createStrictMock(ZooReaderWriter.class);
+    final var zkRoot = ZooUtil.getRoot(iid);
 
     expect(context.getInstanceID()).andReturn(iid).anyTimes();
     expect(context.getZooReaderWriter()).andReturn(zrw).anyTimes();
+    expect(context.getZooKeeperRoot()).andReturn(zkRoot).anyTimes();
 
-    zrw.recursiveDelete(Constants.ZROOT + "/" + iid.canonical() + "/tracers",
-        ZooUtil.NodeMissingPolicy.SKIP);
+    zrw.recursiveDelete(zkRoot + "/tracers", ZooUtil.NodeMissingPolicy.SKIP);
     expectLastCall().once();
 
     Capture<Stat> statCapture = newCapture();
-    expect(zrw.getData(eq(Constants.ZROOT + "/" + iid.canonical() + "/root_tablet"),
-        capture(statCapture))).andAnswer(() -> {
-          Stat stat = statCapture.getValue();
-          stat.setCtime(System.currentTimeMillis());
-          stat.setMtime(System.currentTimeMillis());
-          stat.setVersion(123); // default version
-          stat.setDataLength(zKRootV1.length);
-          statCapture.setValue(stat);
-          return zKRootV1;
-        }).once();
+    expect(zrw.getData(eq(zkRoot + "/root_tablet"), capture(statCapture))).andAnswer(() -> {
+      Stat stat = statCapture.getValue();
+      stat.setCtime(System.currentTimeMillis());
+      stat.setMtime(System.currentTimeMillis());
+      stat.setVersion(123); // default version
+      stat.setDataLength(zKRootV1.length);
+      statCapture.setValue(stat);
+      return zKRootV1;
+    }).once();
 
     Capture<byte[]> byteCapture = newCapture();
-    expect(zrw.overwritePersistentData(eq(Constants.ZROOT + "/" + iid.canonical() + "/root_tablet"),
-        capture(byteCapture), eq(123))).andReturn(true).once();
+    expect(zrw.overwritePersistentData(eq(zkRoot + "/root_tablet"), capture(byteCapture), eq(123)))
+        .andReturn(true).once();
 
-    expect(zrw.getData(eq(Constants.ZROOT + "/" + iid.canonical() + Constants.ZNAMESPACES)))
-        .andReturn(new byte[0]).once();
+    expect(zrw.getData(eq(zkRoot + Constants.ZNAMESPACES))).andReturn(new byte[0]).once();
     Map<String,String> mockNamespaces = Map.of("ns1", "ns1name", "ns2", "ns2name");
-    expect(zrw.getChildren(eq(Constants.ZROOT + "/" + iid.canonical() + Constants.ZNAMESPACES)))
+    expect(zrw.getChildren(eq(zkRoot + Constants.ZNAMESPACES)))
         .andReturn(List.copyOf(mockNamespaces.keySet())).once();
     for (String ns : mockNamespaces.keySet()) {
-      Supplier<String> pathMatcher = () -> eq(Constants.ZROOT + "/" + iid.canonical()
-          + Constants.ZNAMESPACES + "/" + ns + ZNAMESPACE_NAME);
+      Supplier<String> pathMatcher =
+          () -> eq(zkRoot + Constants.ZNAMESPACES + "/" + ns + ZNAMESPACE_NAME);
       expect(zrw.getData(pathMatcher.get())).andReturn(mockNamespaces.get(ns).getBytes(UTF_8))
           .once();
     }
     byte[] mapping = NamespaceMapping.serialize(mockNamespaces);
-    expect(
-        zrw.putPersistentData(eq(Constants.ZROOT + "/" + iid.canonical() + Constants.ZNAMESPACES),
-            aryEq(mapping), eq(ZooUtil.NodeExistsPolicy.OVERWRITE)))
-        .andReturn(true).once();
+    expect(zrw.putPersistentData(eq(zkRoot + Constants.ZNAMESPACES), aryEq(mapping),
+        eq(ZooUtil.NodeExistsPolicy.OVERWRITE))).andReturn(true).once();
     for (String ns : mockNamespaces.keySet()) {
-      Supplier<String> pathMatcher = () -> eq(Constants.ZROOT + "/" + iid.canonical()
-          + Constants.ZNAMESPACES + "/" + ns + ZNAMESPACE_NAME);
+      Supplier<String> pathMatcher =
+          () -> eq(zkRoot + Constants.ZNAMESPACES + "/" + ns + ZNAMESPACE_NAME);
       zrw.delete(pathMatcher.get());
       expectLastCall().once();
     }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -679,8 +679,8 @@ public class Tablet extends TabletBase {
 
   public long getFlushID() throws NoNodeException {
     try {
-      String zTablePath = Constants.ZROOT + "/" + tabletServer.getInstanceID() + Constants.ZTABLES
-          + "/" + extent.tableId() + Constants.ZTABLE_FLUSH_ID;
+      String zTablePath = tabletServer.getContext().getZooKeeperRoot() + Constants.ZTABLES + "/"
+          + extent.tableId() + Constants.ZTABLE_FLUSH_ID;
       String id = new String(context.getZooReaderWriter().getData(zTablePath), UTF_8);
       return Long.parseLong(id);
     } catch (InterruptedException | NumberFormatException e) {
@@ -695,16 +695,16 @@ public class Tablet extends TabletBase {
   }
 
   long getCompactionCancelID() {
-    String zTablePath = Constants.ZROOT + "/" + tabletServer.getInstanceID() + Constants.ZTABLES
-        + "/" + extent.tableId() + Constants.ZTABLE_COMPACT_CANCEL_ID;
+    String zTablePath = tabletServer.getContext().getZooKeeperRoot() + Constants.ZTABLES + "/"
+        + extent.tableId() + Constants.ZTABLE_COMPACT_CANCEL_ID;
     String id = new String(context.getZooCache().get(zTablePath), UTF_8);
     return Long.parseLong(id);
   }
 
   public Pair<Long,CompactionConfig> getCompactionID() throws NoNodeException {
     try {
-      String zTablePath = Constants.ZROOT + "/" + tabletServer.getInstanceID() + Constants.ZTABLES
-          + "/" + extent.tableId() + Constants.ZTABLE_COMPACT_ID;
+      String zTablePath = tabletServer.getContext().getZooKeeperRoot() + Constants.ZTABLES + "/"
+          + extent.tableId() + Constants.ZTABLE_COMPACT_ID;
 
       String[] tokens =
           new String(context.getZooReaderWriter().getData(zTablePath), UTF_8).split(",");

--- a/test/src/main/java/org/apache/accumulo/test/ExistingMacIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ExistingMacIT.java
@@ -31,7 +31,6 @@ import java.util.Collection;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchWriter;
@@ -117,8 +116,7 @@ public class ExistingMacIT extends ConfigurableMacBase {
     }
 
     ZooReaderWriter zrw = getCluster().getServerContext().getZooReaderWriter();
-    final String zInstanceRoot =
-        Constants.ZROOT + "/" + client.instanceOperations().getInstanceId();
+    final String zInstanceRoot = getCluster().getServerContext().getZooKeeperRoot();
     while (!AccumuloStatus.isAccumuloOffline(zrw, zInstanceRoot)) {
       log.debug("Accumulo services still have their ZK locks held");
       Thread.sleep(1000);

--- a/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
@@ -47,6 +47,7 @@ import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.admin.CompactionConfig;
 import org.apache.accumulo.core.client.admin.ImportConfiguration;
+import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
@@ -371,9 +372,11 @@ public class ImportExportIT extends AccumuloClusterHarness {
     AccumuloCluster cluster = getCluster();
     assertTrue(cluster instanceof MiniAccumuloClusterImpl);
     MiniAccumuloClusterImpl mac = (MiniAccumuloClusterImpl) cluster;
-    String rootPath = mac.getConfig().getDir().getAbsolutePath();
     FileSystem fs = getCluster().getFileSystem();
-    FileStatus[] status = fs.listStatus(new Path(rootPath + "/accumulo/tables/" + destTableId));
+    // the following path expects mini to be configured with a single volume
+    final Path tablePath = new Path(mac.getSiteConfiguration().get(Property.INSTANCE_VOLUMES) + "/"
+        + Constants.TABLE_DIR + "/" + destTableId);
+    FileStatus[] status = fs.listStatus(tablePath);
     for (FileStatus tabletDir : status) {
       var contents = fs.listStatus(tabletDir.getPath());
       for (FileStatus file : contents) {

--- a/test/src/main/java/org/apache/accumulo/test/ThriftServerBindsBeforeZooKeeperLockIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ThriftServerBindsBeforeZooKeeperLockIT.java
@@ -32,7 +32,6 @@ import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.conf.Property;
-import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.util.MonitorUtil;
 import org.apache.accumulo.gc.SimpleGarbageCollector;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
@@ -135,13 +134,12 @@ public class ThriftServerBindsBeforeZooKeeperLockIT extends AccumuloClusterHarne
   public void testManagerService() throws Exception {
     final MiniAccumuloClusterImpl cluster = (MiniAccumuloClusterImpl) getCluster();
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-      final InstanceId instanceID = client.instanceOperations().getInstanceId();
 
       // Wait for the Manager to grab its lock
       while (true) {
         try {
           List<String> locks = cluster.getServerContext().getZooReader()
-              .getChildren(Constants.ZROOT + "/" + instanceID + Constants.ZMANAGER_LOCK);
+              .getChildren(cluster.getServerContext().getZooKeeperRoot() + Constants.ZMANAGER_LOCK);
           if (!locks.isEmpty()) {
             break;
           }
@@ -194,13 +192,12 @@ public class ThriftServerBindsBeforeZooKeeperLockIT extends AccumuloClusterHarne
   public void testGarbageCollectorPorts() throws Exception {
     final MiniAccumuloClusterImpl cluster = (MiniAccumuloClusterImpl) getCluster();
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-      InstanceId instanceID = client.instanceOperations().getInstanceId();
 
       // Wait for the Manager to grab its lock
       while (true) {
         try {
           List<String> locks = cluster.getServerContext().getZooReader()
-              .getChildren(Constants.ZROOT + "/" + instanceID + Constants.ZGC_LOCK);
+              .getChildren(cluster.getServerContext().getZooKeeperRoot() + Constants.ZGC_LOCK);
           if (!locks.isEmpty()) {
             break;
           }

--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
@@ -45,6 +45,7 @@ import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.AgeOffStore;
@@ -55,6 +56,7 @@ import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.ZooStore;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
+import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.TraceRepo;
@@ -178,7 +180,8 @@ public class FateIT {
 
   private static ZooKeeperTestingServer szk = null;
   private static ZooReaderWriter zk = null;
-  private static final String ZK_ROOT = "/accumulo/" + UUID.randomUUID();
+  private static final InstanceId IID = InstanceId.of(UUID.randomUUID());
+  private static final String ZK_ROOT = ZooUtil.getRoot(IID);
   private static final NamespaceId NS = NamespaceId.of("testNameSpace");
   private static final TableId TID = TableId.of("testTable");
 

--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ZooMutatorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ZooMutatorIT.java
@@ -33,6 +33,7 @@ import java.util.concurrent.Future;
 
 import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
+import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.harness.WithTestNames;
 import org.apache.accumulo.test.zookeeper.ZooKeeperTestingServer;
 import org.junit.jupiter.api.Tag;
@@ -84,7 +85,8 @@ public class ZooMutatorIT extends WithTestNames {
     File newFolder = new File(tempDir, testName() + "/");
     assertTrue(newFolder.isDirectory() || newFolder.mkdir(), "failed to create dir: " + newFolder);
     try (ZooKeeperTestingServer szk = new ZooKeeperTestingServer(newFolder)) {
-      szk.initPaths("/accumulo/" + InstanceId.of(UUID.randomUUID()));
+      final var iid = InstanceId.of(UUID.randomUUID());
+      szk.initPaths(ZooUtil.getRoot(iid));
       ZooReaderWriter zk = szk.getZooReaderWriter();
 
       var executor = Executors.newFixedThreadPool(16);

--- a/test/src/main/java/org/apache/accumulo/test/functional/BackupManagerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BackupManagerIT.java
@@ -46,7 +46,7 @@ public class BackupManagerIT extends ConfigurableMacBase {
     Process backup = exec(Manager.class);
     try (AccumuloClient client = Accumulo.newClient().from(getClientProperties()).build()) {
       ZooReaderWriter writer = getCluster().getServerContext().getZooReaderWriter();
-      String root = "/accumulo/" + client.instanceOperations().getInstanceId();
+      String root = getCluster().getServerContext().getZooKeeperRoot();
 
       // wait for 2 lock entries
       var path = ServiceLock.path(root + Constants.ZMANAGER_LOCK);

--- a/test/src/main/java/org/apache/accumulo/test/functional/CloneTestIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CloneTestIT.java
@@ -39,6 +39,7 @@ import java.util.TreeSet;
 import java.util.regex.Pattern;
 
 import org.apache.accumulo.cluster.AccumuloCluster;
+import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.AccumuloException;
@@ -226,7 +227,6 @@ public class CloneTestIT extends AccumuloClusterHarness {
       AccumuloCluster cluster = getCluster();
       assumeTrue(cluster instanceof MiniAccumuloClusterImpl);
       MiniAccumuloClusterImpl mac = (MiniAccumuloClusterImpl) cluster;
-      String rootPath = mac.getConfig().getDir().getAbsolutePath();
 
       // verify that deleting a new table removes the files
       c.tableOperations().create(table3);
@@ -234,8 +234,12 @@ public class CloneTestIT extends AccumuloClusterHarness {
       c.tableOperations().flush(table3, null, null, true);
       // check for files
       FileSystem fs = getCluster().getFileSystem();
-      String id = c.tableOperations().tableIdMap().get(table3);
-      FileStatus[] status = fs.listStatus(new Path(rootPath + "/accumulo/tables/" + id));
+      final String id = c.tableOperations().tableIdMap().get(table3);
+
+      // the following path expects mini to be configured with a single volume
+      final Path tablePath = new Path(mac.getSiteConfiguration().get(Property.INSTANCE_VOLUMES)
+          + "/" + Constants.TABLE_DIR + "/" + id);
+      FileStatus[] status = fs.listStatus(tablePath);
       assertTrue(status.length > 0);
       // verify disk usage
       List<DiskUsage> diskUsage = c.tableOperations().getDiskUsage(Collections.singleton(table3));
@@ -244,7 +248,6 @@ public class CloneTestIT extends AccumuloClusterHarness {
       // delete the table
       c.tableOperations().delete(table3);
       // verify its gone from the file system
-      Path tablePath = new Path(rootPath + "/accumulo/tables/" + id);
       if (fs.exists(tablePath)) {
         status = fs.listStatus(tablePath);
         assertTrue(status == null || status.length == 0);

--- a/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorIT.java
@@ -141,7 +141,9 @@ public class GarbageCollectorIT extends ConfigurableMacBase {
       TestIngest.ingest(c, cluster.getFileSystem(), params);
       log.info("Compacting the table {}", table);
       c.tableOperations().compact(table, null, null, true, true);
-      String pathString = cluster.getConfig().getDir() + "/accumulo/tables/1/*/*.rf";
+      // the following path expects mini to be configured with a single volume
+      final String pathString = cluster.getSiteConfiguration().get(Property.INSTANCE_VOLUMES) + "/"
+          + Constants.TABLE_DIR + "/1/*/*.rf";
       log.info("Counting files in path: {}", pathString);
 
       int before = countFiles(pathString);

--- a/test/src/main/java/org/apache/accumulo/test/lock/ServiceLockIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/lock/ServiceLockIT.java
@@ -81,7 +81,8 @@ public class ServiceLockIT {
   @BeforeAll
   public static void setup() throws Exception {
     szk = new ZooKeeperTestingServer(tempDir);
-    szk.initPaths("/accumulo/" + InstanceId.of(UUID.randomUUID()));
+    final var iid = InstanceId.of(UUID.randomUUID());
+    szk.initPaths(ZooUtil.getRoot(iid));
   }
 
   @AfterAll


### PR DESCRIPTION
Avoid direct use of `Constants.ZROOT + "/" + instanceId` and use the existing `ZooUtil.getRoot(instanceId)` that was made for this purpose instead wherever possible. If a ServerContext is available, use `context.getZooKeeperRoot()` instead.

* Use ZooUtil.getRoot() or ServerContext.getZooKeeperRoot()
* Use Constants where not currently being used
* Remove redundant ZKSecurityTool.getInstancePath
* Remove redundant Manager methods that passthrough to ServerContext
* Update related tests
* Fix use of EasyMock in modified tests: RootTabletLocatorTest and ZookeeperLockCheckerTest
* Avoid hard-coded "/accumulo/" in hdfs paths in some ITs that were false-positive potential uses of Constants.ZROOT when I was looking for possibility of replacing literals with constants. For these false-positives, retrieve the actual path from the MiniAccumuloConfig's "instance.volumes" property value, rather than make assumptions about the layout of MiniAccumuloCluster's setup.