### PR TITLE
Simplify ZooKeeperTestingServer

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ZooMutatorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ZooMutatorIT.java
@@ -26,14 +26,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
-import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.harness.WithTestNames;
 import org.apache.accumulo.test.zookeeper.ZooKeeperTestingServer;
 import org.junit.jupiter.api.Tag;
@@ -85,8 +82,6 @@ public class ZooMutatorIT extends WithTestNames {
     File newFolder = new File(tempDir, testName() + "/");
     assertTrue(newFolder.isDirectory() || newFolder.mkdir(), "failed to create dir: " + newFolder);
     try (ZooKeeperTestingServer szk = new ZooKeeperTestingServer(newFolder)) {
-      final var iid = InstanceId.of(UUID.randomUUID());
-      szk.initPaths(ZooUtil.getRoot(iid));
       ZooReaderWriter zk = szk.getZooReaderWriter();
 
       var executor = Executors.newFixedThreadPool(16);


### PR DESCRIPTION
* Remove automatically-generated client object
* Simplify the way new client objects are constructed by using a functional interface to specify the constructor, and then automatically attaching the digest and checking that it's connected before returning
* Inline the private constructor into the public one
* Remove unused public methods
* Remove initPaths (redundant with ZooReaderWriter.mkdirs)

Also, make related changes to tests that use ZooKeeperTestingServer:

* Remove unnecessary exception handling
* Remove unused generated instanceId and path initialization in ZooMutatorIT and ServiceLockIT
* Update ServiceLockIT to remove unneeded inner classes and to simplify constructing ZooKeeper clients, relying on the fact that ZooKeeperTestingServer returns clients that have been verified connected, and also have the authentication on them