### PR TITLE
Enable check of Fate queue size for recommending property change

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -425,6 +425,18 @@ public enum Property {
       "The number of threads used to run fault-tolerant executions (FATE)."
           + " These are primarily table operations like merge.",
       "1.4.3"),
+  MANAGER_FATE_QUEUE_CHECK_INTERVAL("manager.fate.queue.check.interval", "0",
+      PropertyType.TIMEDURATION,
+      "The interval at which to check if the queue size has consistently been larger than"
+          + " MANAGER_FATE_THREADPOOL_SIZE * MANAGER_FATE_QUEUE_CHECK_FACTOR. A value of zero"
+          + " disables this check and has a maximum value of 60m.",
+      "4.0.0"),
+  MANAGER_FATE_QUEUE_CHECK_FACTOR("manager.fate.queue.check.factor", "4", PropertyType.COUNT,
+      "The Manager will check the Fate queue size at the MANAGER_FATE_QUEUE_CHECK_INTERVAL interval"
+          + " and log a warning if the queue size has consistently been this many times larger than"
+          + " the number of threads specified by MANAGER_FATE_THREADPOOL_SIZE to recommend to the"
+          + " user that they may need to increase MANAGER_FATE_THREADPOOL_SIZE.",
+      "4.0.0"),
   MANAGER_STATUS_THREAD_POOL_SIZE("manager.status.threadpool.size", "0", PropertyType.COUNT,
       "The number of threads to use when fetching the tablet server status for balancing.  Zero "
           + "indicates an unlimited number of threads will be used.",

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -425,7 +425,7 @@ public enum Property {
       "The number of threads used to run fault-tolerant executions (FATE)."
           + " These are primarily table operations like merge.",
       "1.4.3"),
-  MANAGER_FATE_QUEUE_CHECK_INTERVAL("manager.fate.queue.check.interval", "60m",
+  MANAGER_FATE_IDLE_CHECK_INTERVAL("manager.fate.idle.check.interval", "60m",
       PropertyType.TIMEDURATION,
       "The interval at which to check if the number of idle Fate threads has consistently been zero."
           + " The way this is checked is an approximation. Logs a warning in the Manager log to increase"

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -427,15 +427,9 @@ public enum Property {
       "1.4.3"),
   MANAGER_FATE_QUEUE_CHECK_INTERVAL("manager.fate.queue.check.interval", "60m",
       PropertyType.TIMEDURATION,
-      "The interval at which to check if the queue size has consistently been larger than"
-          + " MANAGER_FATE_THREADPOOL_SIZE * MANAGER_FATE_QUEUE_CHECK_FACTOR. A value of zero"
-          + " disables this check and has a maximum value of 60m.",
-      "4.0.0"),
-  MANAGER_FATE_QUEUE_CHECK_FACTOR("manager.fate.queue.check.factor", "4", PropertyType.COUNT,
-      "The Manager will check the Fate queue size at the MANAGER_FATE_QUEUE_CHECK_INTERVAL interval"
-          + " and log a warning if the queue size has consistently been this many times larger than"
-          + " the number of threads specified by MANAGER_FATE_THREADPOOL_SIZE to recommend to the"
-          + " user that they may need to increase MANAGER_FATE_THREADPOOL_SIZE.",
+      "The interval at which to check if the number of available Fate threads has consistently been zero."
+          + " The way this is checked is an approximation. Logs a warning in the Manager log to increase"
+          + " MANAGER_FATE_THREADPOOL_SIZE. A value of zero disables this check and has a maximum value of 60m.",
       "4.0.0"),
   MANAGER_STATUS_THREAD_POOL_SIZE("manager.status.threadpool.size", "0", PropertyType.COUNT,
       "The number of threads to use when fetching the tablet server status for balancing.  Zero "

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -427,7 +427,7 @@ public enum Property {
       "1.4.3"),
   MANAGER_FATE_QUEUE_CHECK_INTERVAL("manager.fate.queue.check.interval", "60m",
       PropertyType.TIMEDURATION,
-      "The interval at which to check if the number of available Fate threads has consistently been zero."
+      "The interval at which to check if the number of idle Fate threads has consistently been zero."
           + " The way this is checked is an approximation. Logs a warning in the Manager log to increase"
           + " MANAGER_FATE_THREADPOOL_SIZE. A value of zero disables this check and has a maximum value of 60m.",
       "4.0.0"),

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -425,7 +425,7 @@ public enum Property {
       "The number of threads used to run fault-tolerant executions (FATE)."
           + " These are primarily table operations like merge.",
       "1.4.3"),
-  MANAGER_FATE_QUEUE_CHECK_INTERVAL("manager.fate.queue.check.interval", "0",
+  MANAGER_FATE_QUEUE_CHECK_INTERVAL("manager.fate.queue.check.interval", "60m",
       PropertyType.TIMEDURATION,
       "The interval at which to check if the queue size has consistently been larger than"
           + " MANAGER_FATE_THREADPOOL_SIZE * MANAGER_FATE_QUEUE_CHECK_FACTOR. A value of zero"

--- a/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
@@ -393,7 +393,8 @@ public class Fate<T> {
                 zeroFateThreadsIdleCount++;
               }
             }
-            boolean needMoreThreads = (zeroFateThreadsIdleCount / idleCountHistory.size()) >= 0.95;
+            boolean needMoreThreads =
+                (zeroFateThreadsIdleCount / (double) idleCountHistory.size()) >= 0.95;
             if (needMoreThreads) {
               log.warn(
                   "All Fate threads appear to be busy for the last {} minutes,"

--- a/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
@@ -409,7 +409,7 @@ public class Fate<T> {
               }
             }
           }
-          queueSizeHistory.add(pool.getQueue().size());
+          queueSizeHistory.add(workQueue.size());
         }
       }
     }, 3, 30, SECONDS));

--- a/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
@@ -382,7 +382,7 @@ public class Fate<T> {
         // that the
         // MANAGER_FATE_THREADPOOL_SIZE be increased.
         final long interval = Math.min(60, TimeUnit.MILLISECONDS
-            .toMinutes(conf.getTimeInMillis(Property.MANAGER_FATE_QUEUE_CHECK_INTERVAL)));
+            .toMinutes(conf.getTimeInMillis(Property.MANAGER_FATE_IDLE_CHECK_INTERVAL)));
         if (interval == 0) {
           idleCountHistory.clear();
         } else {


### PR DESCRIPTION
Added two new properties that control the checking of the Fate transaction queue size in the background thread that resizes the Fate thread pool. This new logic will print a warning in the log that the Fate thread pool size property should be increased if the number of transactions in the queue is consistently larger than some multiple of the Fate transaction thread pool size.