### PR TITLE
Reuse the zooCache from serverContext

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/util/cleaner/CleanerUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/cleaner/CleanerUtil.java
@@ -28,7 +28,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.MutationsRejectedException;
-import org.apache.accumulo.core.fate.zookeeper.ZooCache;
 import org.slf4j.Logger;
 
 /**
@@ -132,12 +131,4 @@ public class CleanerUtil {
       }
     });
   }
-
-  // this is dubious; MetadataConstraints should probably use the ZooCache provided by context
-  // can be done in a follow-on action; for now, this merely replaces the previous finalizer
-  public static Cleanable zooCacheClearer(Object o, ZooCache zc) {
-    requireNonNull(zc);
-    return CLEANER.register(o, zc::clear);
-  }
-
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
@@ -271,7 +271,8 @@ public class MetadataConstraints implements Constraint {
           String lockId = new String(columnUpdate.getValue(), UTF_8);
 
           try {
-            lockHeld = ServiceLock.isLockHeld(context.getZooCache(), new ZooUtil.LockID(context.getZooKeeperRoot(), lockId));
+            lockHeld = ServiceLock.isLockHeld(context.getZooCache(),
+                new ZooUtil.LockID(context.getZooKeeperRoot(), lockId));
           } catch (Exception e) {
             log.debug("Failed to verify lock was held {} {}", lockId, e.getMessage());
           }


### PR DESCRIPTION
Reuses the zooCache from the serverContext instead of creating a new one for each instantiation of MetadataConstraints

This should result in less zookeeper connections as there is a higher chance of the serverContext's zooCache already being populated.

@ctubbsii I found this issue when testing 4.0 code and found that the fix could be applied in the 2.1 branch. 

Given your comment in CleanerUtil it looks like this change should be okay to do in 2.1, but I'm happy to target a later accumulo version. 