### PR TITLE
fixes SplitIT.bulkImportThatCantSplitHangsCompaction

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/split/SplitUtils.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/split/SplitUtils.java
@@ -283,6 +283,8 @@ public class SplitUtils {
       lastRow = key.getRowData();
     }
 
+    log.trace("numKeys:{} desiredSplits:{} splits:{}", numKeys, desiredSplits, splits);
+
     return splits;
   }
 


### PR DESCRIPTION
This test was making a incorrect assumption that a table with no splits and data for a single row could not split.  What would actually happen is that the table would split once for the single row in the data and then still need to split but be unable to.  Added single split at table creation time to fix this.

Before these changes the test would add data to a table and then immediately check that its splits were zero.  The table would eventually split, but usually the check in the test would happen prior to this. This race condition in the test hid the flawed assumption in the test. Added a wait to the test to fix this.