### PR TITLE
Narrow the files checked by compaction commit

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.core.metadata.schema;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -513,6 +514,11 @@ public interface Ample {
         ColumnType... otherTypes);
 
     ConditionalTabletMutator requireAbsentLogs();
+
+    /**
+     * Require that a tablet contain all the files in the set
+     */
+    ConditionalTabletMutator requireFiles(Set<StoredTabletFile> files);
 
     /**
      * <p>

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/CommitCompaction.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/CommitCompaction.java
@@ -110,7 +110,7 @@ public class CommitCompaction extends ManagerRepo {
     while (canCommitCompaction(ecid, tablet)) {
       CompactionMetadata ecm = tablet.getExternalCompactions().get(ecid);
 
-      // the compacted files should not exists in the tablet already
+      // the compacted files should not exist in the tablet already
       var tablet2 = tablet;
       newDatafile.ifPresent(
           newFile -> Preconditions.checkState(!tablet2.getFiles().contains(newFile.insert()),
@@ -118,7 +118,8 @@ public class CommitCompaction extends ManagerRepo {
 
       try (var tabletsMutator = ctx.getAmple().conditionallyMutateTablets()) {
         var tabletMutator = tabletsMutator.mutateTablet(getExtent()).requireAbsentOperation()
-            .requireCompaction(ecid).requireSame(tablet, FILES, LOCATION);
+            .requireCompaction(ecid).requireSame(tablet, LOCATION)
+            .requireFiles(commitData.getJobFiles());
 
         if (ecm.getKind() == CompactionKind.USER) {
           tabletMutator.requireSame(tablet, SELECTED, COMPACTED);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/CompactionCommitData.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/CompactionCommitData.java
@@ -19,7 +19,6 @@
 package org.apache.accumulo.manager.compaction.coordinator.commit;
 
 import java.io.Serializable;
-import java.util.Collection;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -56,7 +55,7 @@ public class CompactionCommitData implements Serializable {
     return KeyExtent.fromThrift(textent).tableId();
   }
 
-  public Collection<StoredTabletFile> getJobFiles() {
-    return inputPaths.stream().map(StoredTabletFile::of).collect(Collectors.toList());
+  public Set<StoredTabletFile> getJobFiles() {
+    return inputPaths.stream().map(StoredTabletFile::of).collect(Collectors.toSet());
   }
 }


### PR DESCRIPTION
Previously the conditional mutation to commit a compaction would require all files in the tablet be the same as read earlier and on a busy tablet this could fail and retry often. The check has now been narrowed to only verify that the files involved with the compaction still exist. A new method was added to Ample called requireFiles(Set<StoredTabletFile> files) which creates a condition for each file column to verify each one exists.

This closes #5117