### PR TITLE
Narrows the set of files checked during compaction reservervation

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
@@ -26,6 +26,7 @@ import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LOCATION;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.OPID;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.SELECTED;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.USER_COMPACTION_REQUESTED;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -555,9 +556,16 @@ public class CompactionCoordinator
             compactorAddress, externalCompactionId);
 
         // any data that is read from the tablet to make a decision about if it can compact or not
-        // must be included in the requireSame call
-        var tabletMutator = tabletsMutator.mutateTablet(extent).requireAbsentOperation()
-            .requireSame(tabletMetadata, FILES, SELECTED, ECOMP);
+        // must be checked for changes in the conditional mutation.
+        var tabletMutator =
+            tabletsMutator.mutateTablet(extent).requireAbsentOperation().requireFiles(jobFiles);
+        if (metaJob.getJob().getKind() == CompactionKind.SYSTEM) {
+          // For system compactions the user compaction requested column is examined when deciding
+          // if a compaction can start so need to check for changes to this column.
+          tabletMutator.requireSame(tabletMetadata, SELECTED, ECOMP, USER_COMPACTION_REQUESTED);
+        } else {
+          tabletMutator.requireSame(tabletMetadata, SELECTED, ECOMP);
+        }
 
         if (metaJob.getJob().getKind() == CompactionKind.SYSTEM) {
           var selectedFiles = tabletMetadata.getSelectedFiles();


### PR DESCRIPTION
Using the new method added in #5153 the set of files checked in the conditional mutation for compacaction reserervation was reduced from all tablet files to only the files in the compaction job.  Noticed the conditinal mutation was not checking the user compaction requested field while making this change and added it.