### PR TITLE
Remove eval from accumulo-cluster

### DIFF
--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -54,20 +54,9 @@ function parse_fail {
   exit 1
 }
 
-isDebug() {
-  [[ $DEBUG == 1 ]]
-}
-
+# if debug, then print and return true; otherwise, return false
 debug() {
-  isDebug && echo "${@@P}"
-}
-
-debugAndRun() {
-  debug "$@"
-  if ! isDebug; then
-    # shellcheck disable=SC2294
-    eval "${@@P}"
-  fi
+  [[ $DEBUG == 1 ]] && echo "DEBUG: $*"
 }
 
 function parse_config {
@@ -122,7 +111,7 @@ function parse_config {
     fi
   done
 
-  unset manager1
+  local manager1
   manager1=$(echo "${MANAGER_HOSTS}" | cut -d" " -f1)
 
   if [[ -z $MONITOR_HOSTS ]]; then
@@ -177,16 +166,20 @@ function control_service() {
       # using the value of $host
       #
       if [[ $# -gt 3 ]]; then
-        debugAndRun ACCUMULO_SERVICE_INSTANCE="${ACCUMULO_SERVICE_INSTANCE}" "${bin}/accumulo-service" "$service" "$control_cmd" "-a" "$host" "${@:4}"
+        debug "ACCUMULO_SERVICE_INSTANCE=\"$ACCUMULO_SERVICE_INSTANCE\" \"$bin/accumulo-service\" \"$service\" \"$control_cmd\" -a \"$host\" \"${*:4}\"" ||
+          ACCUMULO_SERVICE_INSTANCE="$ACCUMULO_SERVICE_INSTANCE" "$bin/accumulo-service" "$service" "$control_cmd" -a "$host" "${@:4}"
       else
-        debugAndRun ACCUMULO_SERVICE_INSTANCE="${ACCUMULO_SERVICE_INSTANCE}" "${bin}/accumulo-service" "$service" "$control_cmd" "-a" "$host"
+        debug "ACCUMULO_SERVICE_INSTANCE=\"$ACCUMULO_SERVICE_INSTANCE\" \"$bin/accumulo-service\" \"$service\" \"$control_cmd\" -a \"$host\"" ||
+          ACCUMULO_SERVICE_INSTANCE="$ACCUMULO_SERVICE_INSTANCE" "$bin/accumulo-service" "$service" "$control_cmd" -a "$host"
       fi
     else
       if [[ $# -gt 3 ]]; then
         EXTRA_ARGS="${*:4}"
-        debugAndRun "$SSH" "$host" "bash -c 'ACCUMULO_SERVICE_INSTANCE=${ACCUMULO_SERVICE_INSTANCE} ${bin}/accumulo-service \"$service\" \"$control_cmd\" \"-a\" \"$host\" $EXTRA_ARGS '"
+        debug "$SSH \"$host\" \"bash -c 'ACCUMULO_SERVICE_INSTANCE=\\\"$ACCUMULO_SERVICE_INSTANCE\\\" \\\"$bin/accumulo-service\\\" \\\"$service\\\" \\\"$control_cmd\\\" -a \\\"$host\\\" $EXTRA_ARGS '\"" ||
+          $SSH "$host" "bash -c 'ACCUMULO_SERVICE_INSTANCE=\"$ACCUMULO_SERVICE_INSTANCE\" \"$bin/accumulo-service\" \"$service\" \"$control_cmd\" -a \"$host\" $EXTRA_ARGS '"
       else
-        debugAndRun "$SSH" "$host" "bash -c 'ACCUMULO_SERVICE_INSTANCE=${ACCUMULO_SERVICE_INSTANCE} ${bin}/accumulo-service \"$service\" \"$control_cmd\" \"-a\" \"$host\"'"
+        debug "$SSH \"$host\" \"bash -c 'ACCUMULO_SERVICE_INSTANCE=\\\"$ACCUMULO_SERVICE_INSTANCE\\\" \\\"$bin/accumulo-service\\\" \\\"$service\\\" \\\"$control_cmd\\\" -a \\\"$host\\\"'\"" ||
+          $SSH "$host" "bash -c 'ACCUMULO_SERVICE_INSTANCE=\"$ACCUMULO_SERVICE_INSTANCE\" \"$bin/accumulo-service\" \"$service\" \"$control_cmd\" -a \"$host\"'"
       fi
     fi
   done
@@ -456,9 +449,8 @@ function stop_tservers() {
   done
 
   echo "Cleaning tablet server entries from zookeeper"
-  if ! isDebug; then
-    ${accumulo_cmd} org.apache.accumulo.server.util.ZooZap -tservers
-  fi
+  debug "$accumulo_cmd" org.apache.accumulo.server.util.ZooZap -tservers ||
+    $accumulo_cmd org.apache.accumulo.server.util.ZooZap -tservers
 }
 
 function kill_all() {
@@ -503,15 +495,14 @@ function kill_all() {
   done
 
   echo "Cleaning all server entries in ZooKeeper"
-  if ! isDebug; then
-    ${accumulo_cmd} org.apache.accumulo.server.util.ZooZap -manager -tservers -compaction-coordinators -compactors -sservers
-  fi
+  debug "$accumulo_cmd" org.apache.accumulo.server.util.ZooZap -manager -tservers -compaction-coordinators -compactors -sservers ||
+    $accumulo_cmd org.apache.accumulo.server.util.ZooZap -manager -tservers -compaction-coordinators -compactors -sservers
 }
 
 function stop_all() {
   echo "Stopping Accumulo cluster..."
-  if ! isDebug; then
-    if ! ${accumulo_cmd} admin stopAll; then
+  if ! debug "$accumulo_cmd" admin stopAll; then
+    if ! $accumulo_cmd admin stopAll; then
       echo "Invalid password or unable to connect to the manager"
       echo "Initiating forced shutdown in 15 seconds (Ctrl-C to abort)"
       sleep 10
@@ -567,9 +558,8 @@ function stop_all() {
   stop_tservers
 
   echo "Cleaning all server entries in ZooKeeper"
-  if ! isDebug; then
-    ${accumulo_cmd} org.apache.accumulo.server.util.ZooZap -manager -tservers -compaction-coordinators -compactors -sservers
-  fi
+  debug "$accumulo_cmd" org.apache.accumulo.server.util.ZooZap -manager -tservers -compaction-coordinators -compactors -sservers ||
+    $accumulo_cmd org.apache.accumulo.server.util.ZooZap -manager -tservers -compaction-coordinators -compactors -sservers
 }
 
 function stop_here() {
@@ -577,20 +567,12 @@ function stop_here() {
   hosts_to_check=("$(hostname -a 2>/dev/null | head -1)" "$(hostname -f)")
 
   if echo "${TSERVER_HOSTS}" | grep -Eq 'localhost|127[.]0[.]0[.]1'; then
-    if ! isDebug; then
-      ${accumulo_cmd} admin stop localhost
-    else
-      debug "Stopping tservers on localhost via admin command"
-    fi
+    debug "Stopping tservers on localhost via admin command" || $accumulo_cmd admin stop localhost
   else
     for host in "${hosts_to_check[@]}"; do
       for tserver in $TSERVER_HOSTS; do
         if echo "$tserver" | grep -q "$host"; then
-          if ! isDebug; then
-            ${accumulo_cmd} admin stop "$host"
-          else
-            debug "Stopping tservers on $host via admin command"
-          fi
+          debug "Stopping tservers on $host via admin command" || $accumulo_cmd admin stop "$host"
         fi
       done
     done
@@ -654,7 +636,7 @@ function main() {
     fi
   done
 
-  debug "debug: ${DEBUG} args: ${program_args[*]}"
+  debug "dry-run: $DEBUG args: ${program_args[*]}"
 
   case "${program_args[0]}" in
     create-config)


### PR DESCRIPTION
Fix the accumulo-cluster script's quote handling by removing the extra layer of indirection using eval and newer bash features to quote variables while printing. That many layers of nested quoting makes it very hard to reason about what the script is actually doing. The trade-off with avoiding eval is that some of the quoting may not be shown correctly.

This change replaces the debugAndRun method and its use of eval with a simpler debug implementation that merely prints the provided command when debug is enabled, and returns true when debug is enabled, or false when it isn't. The return code is then used to execute the command that was printed. For example, in the following command, if debug is enabled, the debug command will print "mycommand" and skip the execution. However, if debug is disabled, then no printing will be done, and instead "mycommand" will be executed.

    debug mycommand || mycommand

To try to print debug statements that with proper quotes suitable for copy and pasting, one must provide a slightly different command on either side of the `||`, so that the one on the left will print the quotes correctly, and the one on the right will execute the command correctly. For example:

    debug "mycommand \"$1\"" || mycommand "$1"

Assume `$1=="foo bar"`. The extra quotes will ensure that this prints `mycommand "foo bar"` instead of `mycommand foo bar` when debug is enabled, because `mycommand "foo bar"` is what would be executed if debug is not enabled.