### PR TITLE
Fix bugs in accumulo scripts

### DIFF
--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -184,14 +184,14 @@ isDebug() {
 }
 
 debug() {
-  isDebug && echo "${@@P}"
+  isDebug && echo "$1"
 }
 
 debugAndRun() {
-  debug "$@"
+  # Use $* to convert all args as a single argument
+  debug "$*"
   if ! isDebug; then
-    # shellcheck disable=SC2294
-    eval "${@@P}"
+    eval "$(printf "%q " "$@")"
   fi
 }
 
@@ -304,7 +304,8 @@ function execute_command() {
   if [[ $ARG_LOCAL == 1 ]]; then
     debugAndRun ACCUMULO_CLUSTER_ARG="${servers_per_host}" "${bin}/accumulo-service" "$service" "$control_cmd" "-o" "general.process.bind.addr=$host" "$@"
   else
-    debugAndRun "$SSH" "$host" "bash -c 'ACCUMULO_CLUSTER_ARG=${servers_per_host} ${bin}/accumulo-service \"$service\" \"$control_cmd\" \"-o\" \"general.process.bind.addr=$host\" ${*@Q}'"
+    SSH=("${INITAL_SSH[@]}" "$host" "bash -c 'ACCUMULO_CLUSTER_ARG=${servers_per_host} ${bin}/accumulo-service \"$service\" \"$control_cmd\" \"-o\" \"general.process.bind.addr=$host\" $(printf "\"%q\" " "${@}")'")
+    debugAndRun "${SSH[@]}"
   fi
 }
 
@@ -473,8 +474,7 @@ function main() {
   conf="${ACCUMULO_CONF_DIR:-${basedir}/conf}"
 
   accumulo_cmd="${bin}/accumulo"
-  SSH='ssh -qnf -o ConnectTimeout=2'
-
+  INITAL_SSH=('ssh' '-qnf' '-o' 'ConnectTimeout=2')
   cmd="$1"
   shift
   parse_args "$@"

--- a/assemble/bin/accumulo-service
+++ b/assemble/bin/accumulo-service
@@ -98,7 +98,7 @@ function start_service() {
       pid=$(cat "$pid_file")
       if kill -0 "$pid" 2>/dev/null; then
         echo "$HOST : ${service_name} already running (${pid})"
-        exit 0
+        continue
       fi
     fi
     echo "Starting $service_name on $HOST"
@@ -114,16 +114,15 @@ function start_service() {
     nohup "${bin}/accumulo" "$service_type" "$@" "${PROPERTY_OVERRIDES[@]}" >"$outfile" 2>"$errfile" </dev/null &
     echo "$!" >"${pid_file}"
 
-  done
-
-  # Check the max open files limit and selectively warn
-  max_files_open=$(ulimit -n)
-  if [[ -n $max_files_open ]]; then
-    max_files_recommended=32768
-    if ((max_files_open < max_files_recommended)); then
-      echo "WARN : Max open files on $HOST is $max_files_open, recommend $max_files_recommended" >&2
+    # Check the max open files limit and selectively warn
+    max_files_open=$(ulimit -n)
+    if [[ -n $max_files_open ]]; then
+      max_files_recommended=32768
+      if ((max_files_open < max_files_recommended)); then
+        echo "WARN : Max open files on $HOST is $max_files_open, recommend $max_files_recommended" >&2
+      fi
     fi
-  fi
+  done
 }
 
 function control_process() {


### PR DESCRIPTION
Fixes a bug in accumulo-cluster where the eval statement was treating the ssh command as a separate arg string
instead of a single command string with contents

Fixes an bug in accumulo-service where if a single running service of the desired type was encountered, the script would exit

Also removes the dependency on bash 4.4. 

these changes make the ssh command look like the following:

dry-run output: 
`ssh -qnf -o ConnectTimeout=2 localhost bash -c 'ACCUMULO_CLUSTER_ARG=2 /workspace/fluo-uno/install/accumulo-4.0.0-SNAPSHOT/bin/accumulo-service "tserver" "start" "-o" "general.process.bind.addr=localhost" "-o" "tserver.group=default" '`

`set -v` output when running the actual command:
`ssh -qnf -o ConnectTimeout=2 localhost bash\ -c\ \'ACCUMULO_CLUSTER_ARG=2\ /workspace/fluo-uno/install/accumulo-4.0.0-SNAPSHOT/bin/accumulo-service\ \"tserver\"\ \"start\"\ \"-o\"\ \"general.process.bind.addr=localhost\"\ \"-o\"\ \"tserver.group=default\"\ \'`
