### PR TITLE
avoids another contentious check in compaction reservation

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
@@ -521,6 +521,11 @@ public interface Ample {
     ConditionalTabletMutator requireFiles(Set<StoredTabletFile> files);
 
     /**
+     * Requires the given set of files are not currently involved in any running compactions.
+     */
+    ConditionalTabletMutator requireNotCompacting(Set<StoredTabletFile> files);
+
+    /**
      * <p>
      * Ample provides the following features on top of the conditional writer to help automate
      * handling of edges cases that arise when using the conditional writer.

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/AsyncConditionalTabletsMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/AsyncConditionalTabletsMutatorImpl.java
@@ -97,5 +97,4 @@ public class AsyncConditionalTabletsMutatorImpl implements Ample.AsyncConditiona
     bufferingMutator.close();
     executor.shutdownNow();
   }
-
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ConditionalTabletMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ConditionalTabletMutatorImpl.java
@@ -64,6 +64,7 @@ import org.apache.accumulo.core.metadata.schema.TabletOperationId;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.metadata.iterators.DisjointCompactionIterator;
 import org.apache.accumulo.server.metadata.iterators.PresentIterator;
 import org.apache.accumulo.server.metadata.iterators.SetEncodingIterator;
 import org.apache.accumulo.server.metadata.iterators.TabletExistsIterator;
@@ -341,6 +342,14 @@ public class ConditionalTabletMutatorImpl extends TabletMutatorBase<Ample.Condit
           .setValue(PresentIterator.VALUE).setIterators(is);
       mutation.addCondition(c);
     }
+    return this;
+  }
+
+  @Override
+  public ConditionalTabletMutator requireNotCompacting(Set<StoredTabletFile> files) {
+    Preconditions.checkState(updatesEnabled, "Cannot make updates after calling mutate.");
+    Condition condition = DisjointCompactionIterator.createCondition(files);
+    mutation.addCondition(condition);
     return this;
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/iterators/ColumnFamilyTransformationIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/iterators/ColumnFamilyTransformationIterator.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.metadata.iterators;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.PartialKey;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.hadoop.io.Text;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Provides the ability to seek to and transform an entire column family in a row into a single
+ * value. This class is intended to be used with conditional mutation iterators that want to check
+ * an entire column family.
+ */
+public abstract class ColumnFamilyTransformationIterator
+    implements SortedKeyValueIterator<Key,Value> {
+
+  protected static final Text EMPTY = new Text();
+  private SortedKeyValueIterator<Key,Value> source;
+
+  private Key startKey = null;
+  private Value topValue = null;
+
+  static Text getTabletRow(Range range) {
+    var row = range.getStartKey().getRow();
+    // expecting this range to cover a single metadata row, so validate the range meets expectations
+    MetadataSchema.TabletsSection.validateRow(row);
+    Preconditions.checkArgument(row.equals(range.getEndKey().getRow()));
+    return row;
+  }
+
+  @Override
+  public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive)
+      throws IOException {
+
+    Text tabletRow = getTabletRow(range);
+    Text family = range.getStartKey().getColumnFamily();
+
+    Preconditions.checkArgument(
+        family.getLength() > 0 && range.getStartKey().getColumnQualifier().getLength() == 0);
+
+    Key startKey = new Key(tabletRow, family);
+    Key endKey = new Key(tabletRow, family).followingKey(PartialKey.ROW_COLFAM);
+
+    Range r = new Range(startKey, true, endKey, false);
+
+    source.seek(r, Set.of(), false);
+
+    topValue = transform(source);
+
+    this.startKey = startKey;
+  }
+
+  /**
+   * An iterator that is limited to a single column family is passed in and should be transformed to
+   * a single Value. Can return null if this iterator should not have a top.
+   */
+  protected abstract Value transform(SortedKeyValueIterator<Key,Value> familyIterator)
+      throws IOException;
+
+  @Override
+  public Key getTopKey() {
+    if (startKey == null) {
+      throw new IllegalStateException("never been seeked");
+    }
+    if (topValue == null) {
+      throw new NoSuchElementException();
+    }
+
+    return startKey;
+  }
+
+  @Override
+  public Value getTopValue() {
+    if (startKey == null) {
+      throw new IllegalStateException("never been seeked");
+    }
+    if (topValue == null) {
+      throw new NoSuchElementException();
+    }
+    return topValue;
+  }
+
+  @Override
+  public SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment env) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean isRunningLowOnMemory() {
+    return source.isRunningLowOnMemory();
+  }
+
+  @Override
+  public boolean hasTop() {
+    if (startKey == null) {
+      throw new IllegalStateException("never been seeked");
+    }
+    return topValue != null;
+  }
+
+  @Override
+  public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options,
+      IteratorEnvironment env) throws IOException {
+    this.source = source;
+  }
+
+  @Override
+  public void next() throws IOException {
+    if (startKey == null) {
+      throw new IllegalStateException("never been seeked");
+    }
+    topValue = null;
+  }
+
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/iterators/DisjointCompactionIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/iterators/DisjointCompactionIterator.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.metadata.iterators;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.data.Condition;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.accumulo.core.metadata.StoredTabletFile;
+import org.apache.accumulo.core.metadata.schema.CompactionMetadata;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ExternalCompactionColumnFamily;
+import org.apache.accumulo.core.util.LazySingletons;
+import org.apache.accumulo.server.metadata.ConditionalTabletMutatorImpl;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.reflect.TypeToken;
+
+/**
+ * An iterator used with conditional updates to tablets to check that for a given set of files none
+ * of them are currently compacting.
+ */
+public class DisjointCompactionIterator extends ColumnFamilyTransformationIterator {
+
+  private Set<StoredTabletFile> filesToCompact;
+
+  private static final String DISJOINT = "disjoint";
+  private static final String OVERLAPS = "overlaps";
+  private static final String FILES_KEY = "files";
+
+  @Override
+  protected Value transform(SortedKeyValueIterator<Key,Value> source) throws IOException {
+    while (source.hasTop()) {
+      Preconditions.checkState(
+          source.getTopKey().getColumnFamily().equals(ExternalCompactionColumnFamily.NAME));
+      var compactionMetadata = CompactionMetadata.fromJson(source.getTopValue().toString());
+      if (!Collections.disjoint(filesToCompact, compactionMetadata.getJobFiles())) {
+        return new Value(OVERLAPS);
+      }
+      source.next();
+    }
+    return new Value(DISJOINT);
+  }
+
+  @Override
+  public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options,
+      IteratorEnvironment env) throws IOException {
+    super.init(source, options, env);
+    filesToCompact = decode(options.get(FILES_KEY));
+  }
+
+  /**
+   * Creates a condition that will only pass if the given files are disjoint with all files
+   * currently compacting for a tablet.
+   */
+  public static Condition createCondition(Set<StoredTabletFile> filesToCompact) {
+    Preconditions.checkArgument(!filesToCompact.isEmpty());
+    IteratorSetting is = new IteratorSetting(ConditionalTabletMutatorImpl.INITIAL_ITERATOR_PRIO,
+        DisjointCompactionIterator.class);
+    is.addOption(FILES_KEY, encode(filesToCompact));
+    return new Condition(ExternalCompactionColumnFamily.NAME, EMPTY).setValue(DISJOINT)
+        .setIterators(is);
+  }
+
+  private static String encode(Set<StoredTabletFile> filesToCompact) {
+    var files =
+        filesToCompact.stream().map(StoredTabletFile::getMetadata).collect(Collectors.toSet());
+    return LazySingletons.GSON.get().toJson(files);
+  }
+
+  private Set<StoredTabletFile> decode(String s) {
+    Type fileSetType = new TypeToken<HashSet<String>>() {}.getType();
+    Set<String> files = LazySingletons.GSON.get().fromJson(s, fileSetType);
+    return files.stream().map(StoredTabletFile::of).collect(Collectors.toSet());
+  }
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/iterators/SetEncodingIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/iterators/SetEncodingIterator.java
@@ -29,20 +29,15 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.function.Function;
 
 import org.apache.accumulo.core.client.IteratorSetting;
-import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Condition;
 import org.apache.accumulo.core.data.Key;
-import org.apache.accumulo.core.data.PartialKey;
-import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.server.metadata.ConditionalTabletMutatorImpl;
 import org.apache.hadoop.io.Text;
@@ -61,44 +56,17 @@ import com.google.common.base.Preconditions;
  * will be concatenated with a null byte separator.</li>
  * </ul>
  */
-public class SetEncodingIterator implements SortedKeyValueIterator<Key,Value> {
+public class SetEncodingIterator extends ColumnFamilyTransformationIterator {
 
   public static final String CONCAT_VALUE = "concat.value";
   private static final String VALUE_SEPARATOR = "\u0000";
   private static final byte[] VALUE_SEPARATOR_BYTES = VALUE_SEPARATOR.getBytes(UTF_8);
   private static final int VALUE_SEPARATOR_BYTES_LENGTH = VALUE_SEPARATOR_BYTES.length;
 
-  private SortedKeyValueIterator<Key,Value> source;
-
-  private Key startKey = null;
-  private Value topValue = null;
   private boolean concat = false;
 
-  static Text getTabletRow(Range range) {
-    var row = range.getStartKey().getRow();
-    // expecting this range to cover a single metadata row, so validate the range meets expectations
-    MetadataSchema.TabletsSection.validateRow(row);
-    Preconditions.checkArgument(row.equals(range.getEndKey().getRow()));
-    return row;
-  }
-
   @Override
-  public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive)
-      throws IOException {
-
-    Text tabletRow = getTabletRow(range);
-    Text family = range.getStartKey().getColumnFamily();
-
-    Preconditions.checkArgument(
-        family.getLength() > 0 && range.getStartKey().getColumnQualifier().getLength() == 0);
-
-    startKey = new Key(tabletRow, family);
-    Key endKey = new Key(tabletRow, family).followingKey(PartialKey.ROW_COLFAM);
-
-    Range r = new Range(startKey, true, endKey, false);
-
-    source.seek(r, Set.of(), false);
-
+  protected Value transform(SortedKeyValueIterator<Key,Value> source) throws IOException {
     try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
         DataOutputStream dos = new DataOutputStream(baos)) {
 
@@ -122,70 +90,20 @@ public class SetEncodingIterator implements SortedKeyValueIterator<Key,Value> {
       // The length is written last so that buffering can be avoided in this iterator.
       dos.writeInt(count);
 
-      topValue = new Value(baos.toByteArray());
+      return new Value(baos.toByteArray());
     }
-
-  }
-
-  @Override
-  public Key getTopKey() {
-    if (startKey == null) {
-      throw new IllegalStateException("never been seeked");
-    }
-    if (topValue == null) {
-      throw new NoSuchElementException();
-    }
-
-    return startKey;
-  }
-
-  @Override
-  public Value getTopValue() {
-    if (startKey == null) {
-      throw new IllegalStateException("never been seeked");
-    }
-    if (topValue == null) {
-      throw new NoSuchElementException();
-    }
-    return topValue;
-  }
-
-  @Override
-  public SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment env) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public boolean isRunningLowOnMemory() {
-    return source.isRunningLowOnMemory();
-  }
-
-  @Override
-  public boolean hasTop() {
-    if (startKey == null) {
-      throw new IllegalStateException("never been seeked");
-    }
-    return topValue != null;
   }
 
   @Override
   public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options,
       IteratorEnvironment env) throws IOException {
+    super.init(source, options, env);
     String concat = options.get(CONCAT_VALUE);
     if (concat == null || !(concat.equalsIgnoreCase("true") || concat.equalsIgnoreCase("false"))) {
       throw new IllegalArgumentException(
           CONCAT_VALUE + " option must be supplied with a value of 'true' or 'false'");
     }
-    this.source = source;
     this.concat = Boolean.parseBoolean(concat);
-  }
-
-  @Override
-  public void next() throws IOException {
-    if (startKey == null) {
-      throw new IllegalStateException("never been seeked");
-    }
-    topValue = null;
   }
 
   /**
@@ -231,8 +149,6 @@ public class SetEncodingIterator implements SortedKeyValueIterator<Key,Value> {
     System.arraycopy(val, 0, bytesToWrite, key.length + VALUE_SEPARATOR_BYTES_LENGTH, val.length);
     return bytesToWrite;
   }
-
-  private static final Text EMPTY = new Text();
 
   /*
    * Create a condition that will check the column qualifier values of the rows in the tablets

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
@@ -557,14 +557,14 @@ public class CompactionCoordinator
 
         // any data that is read from the tablet to make a decision about if it can compact or not
         // must be checked for changes in the conditional mutation.
-        var tabletMutator =
-            tabletsMutator.mutateTablet(extent).requireAbsentOperation().requireFiles(jobFiles);
+        var tabletMutator = tabletsMutator.mutateTablet(extent).requireAbsentOperation()
+            .requireFiles(jobFiles).requireNotCompacting(jobFiles);
         if (metaJob.getJob().getKind() == CompactionKind.SYSTEM) {
           // For system compactions the user compaction requested column is examined when deciding
           // if a compaction can start so need to check for changes to this column.
-          tabletMutator.requireSame(tabletMetadata, SELECTED, ECOMP, USER_COMPACTION_REQUESTED);
+          tabletMutator.requireSame(tabletMetadata, SELECTED, USER_COMPACTION_REQUESTED);
         } else {
-          tabletMutator.requireSame(tabletMetadata, SELECTED, ECOMP);
+          tabletMutator.requireSame(tabletMetadata, SELECTED);
         }
 
         if (metaJob.getJob().getKind() == CompactionKind.SYSTEM) {


### PR DESCRIPTION
When reserving a set of files for compaction the conditional mutation would require the current set of compactions it read in a tablet to be the same when adding a compaction.  On a busy tablet that has lots of compactions starting and stopping this set is rapidly changing and this would cause the conditional mutation to fail and retry.

To avoid this the conditional mutation was improved to check that the set of files being added for compaction to the tablet do not exist in any current compactions.  This check will no longer fail for changes to compactions on unrelated files.