### PR TITLE
Fix Fate pool watcher bug

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
@@ -250,7 +250,7 @@ public class Fate<T> {
       // resize the pool if the property changed
       ThreadPools.resizePool(pool, conf, Property.MANAGER_FATE_THREADPOOL_SIZE);
       // If the pool grew, then ensure that there is a TransactionRunner for each thread
-      int needed = conf.getCount(Property.MANAGER_FATE_THREADPOOL_SIZE) - pool.getQueue().size();
+      int needed = conf.getCount(Property.MANAGER_FATE_THREADPOOL_SIZE) - pool.getActiveCount();
       if (needed > 0) {
         for (int i = 0; i < needed; i++) {
           try {


### PR DESCRIPTION
Was incorrectly calculating the number of TransactionRunners to execute.
`getQueue().size()` is the number of tasks that have been submitted to the pool that currently don't have a thread available to work on them. This should instead be the number of tasks that are currently running. Before this was submitting new TransactionRunners unnecessarily
Noticed when working on #5130