### PR TITLE
improves bulk import error message

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
@@ -263,8 +263,8 @@ public class Fate<T> {
       // as a warning. They're a normal, handled failure condition.
       if (e instanceof AcceptableException) {
         var tableOpEx = (AcceptableThriftTableOperationException) e;
-        log.debug(msg + " for {}({}) {}", tableOpEx.getTableName(), tableOpEx.getTableId(),
-            tableOpEx.getDescription());
+        log.info("{} for table:{}({}) saw acceptable exception: {}", msg, tableOpEx.getTableName(),
+            tableOpEx.getTableId(), tableOpEx.getDescription());
       } else {
         log.warn(msg, e);
       }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/PrepBulkImport.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/PrepBulkImport.java
@@ -203,9 +203,9 @@ public class PrepBulkImport extends ManagerRepo {
     if (maxFilesPerTablet > 0 && currRange.getValue().getSize() > maxFilesPerTablet) {
       throw new AcceptableThriftTableOperationException(tableId, null, TableOperation.BULK_IMPORT,
           TableOperationExceptionType.OTHER,
-          "Attempted to import " + currRange.getValue().getSize()
-              + " files into a single tablet which exceeds the configured max of "
-              + maxFilesPerTablet);
+          "Attempted to import " + currRange.getValue().getSize() + " files into tablets in range "
+              + currRange.getKey() + " which exceeds the configured max files per tablet of "
+              + maxFilesPerTablet + " from " + Property.TABLE_BULK_MAX_TABLET_FILES.getKey());
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
@@ -428,6 +428,8 @@ public class BulkNewIT extends SharedMiniClusterBase {
       newTableConf.setProperties(props);
       client.tableOperations().create(tableName, newTableConf);
 
+      var tableId = ((ClientContext) client).getTableId(tableName);
+
       String dir = getDir("/testBulkFileMFP-");
 
       for (int i = 4; i < 8; i++) {
@@ -450,6 +452,9 @@ public class BulkNewIT extends SharedMiniClusterBase {
       // message should contain the limit of 5 and the number of files attempted to import 6
       assertTrue(msg.contains(" 5"), msg);
       assertTrue(msg.contains(" 6"), msg);
+      // error should include range information
+      assertTrue(msg.contains(tableId + "<<"), msg);
+      assertTrue(msg.contains(" " + Property.TABLE_BULK_MAX_TABLET_FILES.getKey()), msg);
 
       // ensure no data was added to table
       verifyData(client, tableName, 40, 79, false);
@@ -476,6 +481,8 @@ public class BulkNewIT extends SharedMiniClusterBase {
       // message should contain the limit of 5 and the number of files attempted to import 7
       assertTrue(msg.contains(" 5"), msg);
       assertTrue(msg.contains(" 7"), msg);
+      assertTrue(msg.contains(tableId + ";0100<"), msg);
+      assertTrue(msg.contains(" " + Property.TABLE_BULK_MAX_TABLET_FILES.getKey()), msg);
       verifyData(client, tableName, 40, 79, false);
 
       // try the middle tablet
@@ -496,6 +503,8 @@ public class BulkNewIT extends SharedMiniClusterBase {
       // message should contain the limit of 5 and the number of files attempted to import 6
       assertTrue(msg.contains(" 5"), msg);
       assertTrue(msg.contains(" 6"), msg);
+      assertTrue(msg.contains(tableId + ";0200;0100"), msg);
+      assertTrue(msg.contains(" " + Property.TABLE_BULK_MAX_TABLET_FILES.getKey()), msg);
       verifyData(client, tableName, 40, 79, false);
 
       // try the last tablet
@@ -516,6 +525,8 @@ public class BulkNewIT extends SharedMiniClusterBase {
       // message should contain the limit of 5 and the number of files attempted to import 7
       assertTrue(msg.contains(" 5"), msg);
       assertTrue(msg.contains(" 7"), msg);
+      assertTrue(msg.contains(tableId + "<;0200"), msg);
+      assertTrue(msg.contains(" " + Property.TABLE_BULK_MAX_TABLET_FILES.getKey()), msg);
       verifyData(client, tableName, 40, 79, false);
 
       // test an import that has more files than the limit, but not in a single tablet so it should


### PR DESCRIPTION
For the case when a bulk import exceeds the configured files per tablet limit improves the error message to include range info and the relevant property name.