### PR TITLE
Fixes bug where failed bulk import status was not cleaned up

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/PrepBulkImport.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/PrepBulkImport.java
@@ -323,5 +323,6 @@ public class PrepBulkImport extends ManagerRepo {
     // unreserve sourceDir/error directories
     Utils.unreserveHdfsDirectory(environment, bulkInfo.sourceDir, fateId);
     Utils.getReadLock(environment, bulkInfo.tableId, fateId).unlock();
+    environment.removeBulkImportStatus(bulkInfo.sourceDir);
   }
 }


### PR DESCRIPTION
The shell and monitor display active bulk imports and this is driven by custom code in the manager that updates this status as the bulk import runs.  When a bulk import fate operation failed it was not clearing this.