### PR TITLE
Executes conditional mutations in a thread pool

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -770,11 +770,11 @@ public enum Property {
   TSERV_CONDITIONAL_UPDATE_THREADS_ROOT("tserver.conditionalupdate.threads.root", "16",
       PropertyType.COUNT, "Numbers of threads for executing conditional updates on the root table.",
       "4.0.0"),
-  TSERV_CONDITIONAL_UPDATE_THREADS_META("tserver.conditionalupdate.threads.meta", "16",
-      PropertyType.COUNT, "Numbers of threads for executing conditional updates on the metadata table.",
-      "4.0.0"),
-  TSERV_CONDITIONAL_UPDATE_THREADS_USER("tserver.conditionalupdate.threads.user", "16",
-      PropertyType.COUNT, "Numbers of threads for executing conditional updates on the user table.",
+  TSERV_CONDITIONAL_UPDATE_THREADS_META("tserver.conditionalupdate.threads.meta", "64",
+      PropertyType.COUNT,
+      "Numbers of threads for executing conditional updates on the metadata table.", "4.0.0"),
+  TSERV_CONDITIONAL_UPDATE_THREADS_USER("tserver.conditionalupdate.threads.user", "64",
+      PropertyType.COUNT, "Numbers of threads for executing conditional updates on user tables.",
       "4.0.0"),
 
   // accumulo garbage collector properties

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -767,6 +767,15 @@ public enum Property {
       "Resource group name for this TabletServer. Resource groups can be defined to dedicate resources "
           + " to specific tables (e.g. balancing tablets for table(s) within a group, see TableLoadBalancer).",
       "4.0.0"),
+  TSERV_CONDITIONAL_UPDATE_THREADS_ROOT("tserver.conditionalupdate.threads.root", "16",
+      PropertyType.COUNT, "Numbers of threads for executing conditional updates on the root table.",
+      "4.0.0"),
+  TSERV_CONDITIONAL_UPDATE_THREADS_META("tserver.conditionalupdate.threads.meta", "16",
+      PropertyType.COUNT, "Numbers of threads for executing conditional updates on the root table.",
+      "4.0.0"),
+  TSERV_CONDITIONAL_UPDATE_THREADS_USER("tserver.conditionalupdate.threads.user", "16",
+      PropertyType.COUNT, "Numbers of threads for executing conditional updates on the root table.",
+      "4.0.0"),
 
   // accumulo garbage collector properties
   GC_PREFIX("gc.", null, PropertyType.PREFIX,

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -771,7 +771,7 @@ public enum Property {
       PropertyType.COUNT, "Numbers of threads for executing conditional updates on the root table.",
       "4.0.0"),
   TSERV_CONDITIONAL_UPDATE_THREADS_META("tserver.conditionalupdate.threads.meta", "16",
-      PropertyType.COUNT, "Numbers of threads for executing conditional updates on the root table.",
+      PropertyType.COUNT, "Numbers of threads for executing conditional updates on the metadata table.",
       "4.0.0"),
   TSERV_CONDITIONAL_UPDATE_THREADS_USER("tserver.conditionalupdate.threads.user", "16",
       PropertyType.COUNT, "Numbers of threads for executing conditional updates on the root table.",

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -774,7 +774,7 @@ public enum Property {
       PropertyType.COUNT, "Numbers of threads for executing conditional updates on the metadata table.",
       "4.0.0"),
   TSERV_CONDITIONAL_UPDATE_THREADS_USER("tserver.conditionalupdate.threads.user", "16",
-      PropertyType.COUNT, "Numbers of threads for executing conditional updates on the root table.",
+      PropertyType.COUNT, "Numbers of threads for executing conditional updates on the user table.",
       "4.0.0"),
 
   // accumulo garbage collector properties

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPoolNames.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPoolNames.java
@@ -62,6 +62,9 @@ public enum ThreadPoolNames {
   TSERVER_TABLET_MIGRATION_POOL("accumulo.pool.tserver.tablet.migration"),
   TSERVER_WAL_CREATOR_POOL("accumulo.pool.tserver.wal.creator"),
   TSERVER_WAL_SORT_CONCURRENT_POOL("accumulo.pool.tserver.wal.sort.concurrent"),
+  TSERVER_CONDITIONAL_UPDATE_ROOT_POOL("accumulo.pool.tserver.conditionalupdate.root"),
+  TSERVER_CONDITIONAL_UPDATE_META_POOL("accumulo.pool.tserver.conditionalupdate.meta"),
+  TSERVER_CONDITIONAL_UPDATE_USER_POOL("accumulo.pool.tserver.conditionalupdate.user"),
   UTILITY_CHECK_FILE_TASKS("accumulo.pool.util.check.file.tasks"),
   UTILITY_VERIFY_TABLET_ASSIGNMENTS("accumulo.pool.util.check.tablet.servers");
 

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
@@ -28,6 +28,9 @@ import static org.apache.accumulo.core.util.threads.ThreadPoolNames.MANAGER_FATE
 import static org.apache.accumulo.core.util.threads.ThreadPoolNames.MANAGER_STATUS_POOL;
 import static org.apache.accumulo.core.util.threads.ThreadPoolNames.SCHED_FUTURE_CHECKER_POOL;
 import static org.apache.accumulo.core.util.threads.ThreadPoolNames.TSERVER_ASSIGNMENT_POOL;
+import static org.apache.accumulo.core.util.threads.ThreadPoolNames.TSERVER_CONDITIONAL_UPDATE_META_POOL;
+import static org.apache.accumulo.core.util.threads.ThreadPoolNames.TSERVER_CONDITIONAL_UPDATE_ROOT_POOL;
+import static org.apache.accumulo.core.util.threads.ThreadPoolNames.TSERVER_CONDITIONAL_UPDATE_USER_POOL;
 import static org.apache.accumulo.core.util.threads.ThreadPoolNames.TSERVER_MIGRATIONS_POOL;
 import static org.apache.accumulo.core.util.threads.ThreadPoolNames.TSERVER_MINOR_COMPACTOR_POOL;
 import static org.apache.accumulo.core.util.threads.ThreadPoolNames.TSERVER_SUMMARY_PARTITION_POOL;
@@ -339,6 +342,27 @@ public class ThreadPools {
       case TSERV_SUMMARY_PARTITION_THREADS:
         builder = getPoolBuilder(TSERVER_SUMMARY_PARTITION_POOL).numCoreThreads(conf.getCount(p))
             .withTimeOut(60L, MILLISECONDS);
+        if (emitThreadPoolMetrics) {
+          builder.enableThreadPoolMetrics();
+        }
+        return builder.build();
+      case TSERV_CONDITIONAL_UPDATE_THREADS_ROOT:
+        builder = getPoolBuilder(TSERVER_CONDITIONAL_UPDATE_ROOT_POOL)
+            .numCoreThreads(conf.getCount(p)).withTimeOut(60L, MILLISECONDS);
+        if (emitThreadPoolMetrics) {
+          builder.enableThreadPoolMetrics();
+        }
+        return builder.build();
+      case TSERV_CONDITIONAL_UPDATE_THREADS_META:
+        builder = getPoolBuilder(TSERVER_CONDITIONAL_UPDATE_META_POOL)
+            .numCoreThreads(conf.getCount(p)).withTimeOut(60L, MILLISECONDS);
+        if (emitThreadPoolMetrics) {
+          builder.enableThreadPoolMetrics();
+        }
+        return builder.build();
+      case TSERV_CONDITIONAL_UPDATE_THREADS_USER:
+        builder = getPoolBuilder(TSERVER_CONDITIONAL_UPDATE_USER_POOL)
+            .numCoreThreads(conf.getCount(p)).withTimeOut(60L, MILLISECONDS);
         if (emitThreadPoolMetrics) {
           builder.enableThreadPoolMetrics();
         }


### PR DESCRIPTION
Conditional mutations currently execute in the thrift thread pool which can grow unbounded in size.  Having an unbounded number of conditional mutations executing concurrently could degrade a tablet servers health in some cases.  This change adds threads pools for executing conditional updates.  This will help limit the CPU and memory used by executing conditional mutations.  Conditional mutations can also contain data as part of the mutation that needs to be checked, if this is large that could still cause memory issues.  This change more limits the memory used by reading current tablet data to check the condition.  Limiting the memory used by conditional mutations waiting to execute is something that would need to somehow be controlled by thrift.  So this change protects memory and CPU resources for conditional mutations that are executing but does not protect memory for ones that are waiting to execute.  To protect memory for those waiting to execute would need to end the current practice of letting the thrift thread pool grow unbounded, but that is a long existing problem.