### PR TITLE
remove call to method that does not exist in monitor

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
@@ -151,5 +151,4 @@ function refreshSideBarNotifications() {
   const statusData = sessionStorage?.status ? JSON.parse(sessionStorage.status) : undefined;
 
   updateServerNotifications(statusData);
-  updateDebugDropdownNotification(statusData);
 }


### PR DESCRIPTION
The method being called here `updateDebugDropdownNotification()` was removed in #5118. There was a warning in the browser dev console saying `updateDebugDropdownNotification()` was not defined. 