### PR TITLE
Use new jquery api in monitor

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/bulkImport.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/bulkImport.js
@@ -38,7 +38,7 @@ function refresh() {
 /**
  * Initializes the bulk import DataTables
  */
-$(document).ready(function () {
+$(function () {
 
   const url = '/rest/bulkImports';
   console.debug('REST url used to fetch data for the DataTables in bulkImport.js: ' + url);

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/compactions.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/compactions.js
@@ -22,7 +22,7 @@ var compactionsList;
 /**
  * Creates active compactions table
  */
-$(document).ready(function () {
+$(function () {
   // Create a table for compactions list
   compactionsList = $('#compactionsList').DataTable({
     "ajax": {

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/ec.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/ec.js
@@ -27,7 +27,7 @@ var runningTableData;
 /**
  * Creates active compactions table
  */
-$(document).ready(function () {
+$(function () {
   if (sessionStorage.ecDetailsJSON === undefined) {
     sessionStorage.ecDetailsJSON = JSON.stringify([]);
   }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/gc.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/gc.js
@@ -22,7 +22,7 @@ var gcTable;
 /**
  * Creates active compactions table
  */
-$(document).ready(function () {
+$(function () {
   // Create a table for compactions list
   gcTable = $('#gcActivity').DataTable({
     "ajax": {

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/manager.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/manager.js
@@ -90,7 +90,7 @@ function refreshManagerTables() {
 /**
  * Creates initial tables
  */
-$(document).ready(function () {
+$(function () {
 
   // Generates the manager table
   managerStatusTable = $('#managerStatus').DataTable({

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
@@ -122,7 +122,7 @@ function updateServerNotifications(statusData) {
 /**
  * Creates the initial sidebar
  */
-$(document).ready(function () {
+$(function () {
   refreshSidebar();
 });
 

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/overview.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/overview.js
@@ -21,7 +21,7 @@
 /**
  * Creates overview initial table
  */
-$(document).ready(function () {
+$(function () {
   refreshOverview();
 });
 

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/scans.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/scans.js
@@ -23,7 +23,7 @@ var scansList;
 /**
  * Creates scans initial table
  */
-$(document).ready(function () {
+$(function () {
   // Create a table for scans list
   scansList = $('#scansList').DataTable({
     "ajax": {

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/systemAlert.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/systemAlert.js
@@ -154,7 +154,7 @@ function updateSystemAlerts() {
   updateManagerAlerts();
 }
 
-$(document).ready(function () {
+$(function () {
 
   // dismiss the alert when clicked
   $('#systemAlertCloseButton').click(function () {

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/tservers.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/tservers.js
@@ -129,7 +129,7 @@ function clearDeadTServers(server) {
 /**
  * Creates initial tables
  */
-$(document).ready(function () {
+$(function () {
 
   refreshRecoveryList();
 

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/default.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/default.ftl
@@ -49,7 +49,7 @@
       /**
        * Sets up autorefresh on initial load
        */
-      $(document).ready(function() {
+      $(function() {
         setupAutoRefresh();
       });
     </script>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/server.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/server.ftl
@@ -19,7 +19,7 @@
 
 -->
       <script>
-        $(document).ready(function () {
+        $(function () {
           // initialize DataTables
           initServerTables('${server}');
         });

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/table.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/table.ftl
@@ -22,7 +22,7 @@
         /**
          * Creates participating Tservers initial table, passes the tableID from the template
          */
-        $(document).ready(function () {
+        $(function () {
           initTableServerTable('${tableID}');
         });
       </script>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/tables.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/tables.ftl
@@ -25,7 +25,7 @@
          *   - uses ajax call for data source and saves sort state in session
          *   - defines custom number formats
          */
-        $(document).ready(function () {
+        $(function () {
 
           tableList = $('#tableList').DataTable({
             "ajax": {


### PR DESCRIPTION
The use of jquerys `$( document ).ready( handler )` is deprecated and [their docs](https://api.jquery.com/ready/) suggest a new syntax to "Specify a function to execute when the DOM is fully loaded." This PR converts our usages to that new syntax.