### PR TITLE
Validation check for KeyExtents

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/LoadMappingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/LoadMappingIterator.java
@@ -85,7 +85,7 @@ public class LoadMappingIterator
 
     if (lastKeyExtent != null && currentKeyExtent.compareTo(lastKeyExtent) < 0) {
       throw new IllegalStateException(
-          String.format("KeyExtents are not in sorted order: %s comes after %s", lastKeyExtent,
+          String.format("KeyExtents are not in sorted order: %s was seen before %s", lastKeyExtent,
               currentKeyExtent));
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/LoadMappingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/LoadMappingIterator.java
@@ -99,7 +99,7 @@ public class LoadMappingIterator
       }
 
     } catch (JsonSyntaxException | JsonIOException e) {
-      throw new NoSuchElementException("Failed to read next mapping: " + e);
+      throw new NoSuchElementException("Failed to read next mapping" + e);
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/LoadMappingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/LoadMappingIterator.java
@@ -99,7 +99,7 @@ public class LoadMappingIterator
       }
 
     } catch (JsonSyntaxException | JsonIOException e) {
-      throw new NoSuchElementException("Failed to read next mapping" + e);
+      throw new IllegalStateException("Failed to read next mapping", e);
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/LoadMappingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/LoadMappingIterator.java
@@ -99,7 +99,7 @@ public class LoadMappingIterator
       }
 
     } catch (JsonSyntaxException | JsonIOException e) {
-      throw new NoSuchElementException("Failed to read next mapping: " + e.getMessage());
+      throw new NoSuchElementException("Failed to read next mapping: " + e);
     }
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/bulk/LoadMappingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/bulk/LoadMappingIteratorTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.clientImpl.bulk;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.hadoop.io.Text;
+import org.junit.jupiter.api.Test;
+
+public class LoadMappingIteratorTest {
+  private LoadMappingIterator createLoadMappingIter(Map<KeyExtent,String> loadRanges)
+      throws IOException {
+    SortedMap<KeyExtent,Bulk.Files> mapping = new TreeMap<>();
+
+    loadRanges.forEach((extent, files) -> {
+      Bulk.Files testFiles = new Bulk.Files();
+      long c = 0L;
+      for (String f : files.split(" ")) {
+        c++;
+        testFiles.add(new Bulk.FileInfo(f, c, c));
+      }
+
+      mapping.put(extent, testFiles);
+    });
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    BulkSerialize.writeLoadMapping(mapping, "/some/dir", p -> baos);
+    ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+    LoadMappingIterator lmi =
+        BulkSerialize.readLoadMapping("/some/dir", TableId.of("1"), p -> bais);
+    return lmi;
+  }
+
+  KeyExtent nke(String prev, String end) {
+    Text per = prev == null ? null : new Text(prev);
+    Text er = end == null ? null : new Text(end);
+
+    return new KeyExtent(TableId.of("1"), er, per);
+  }
+
+  @Test
+  void testValidOrderedInput() throws IOException {
+    Map<KeyExtent,String> loadRanges = new LinkedHashMap<>();
+    loadRanges.put(nke(null, "c"), "f1 f2");
+    loadRanges.put(nke("c", "g"), "f2 f3");
+    loadRanges.put(nke("g", "r"), "f2 f4");
+    loadRanges.put(nke("r", "w"), "f2 f5");
+    loadRanges.put(nke("w", null), "f2 f6");
+
+    try (LoadMappingIterator iterator = createLoadMappingIter(loadRanges)) {
+      List<KeyExtent> result = new ArrayList<>();
+      while (iterator.hasNext()) {
+        result.add(iterator.next().getKey());
+      }
+      assertEquals(new ArrayList<>(loadRanges.keySet()), result);
+    }
+  }
+
+  @Test
+  void testInvalidOutOfOrderInput() throws IOException {
+    Map<KeyExtent,String> loadRanges = new LinkedHashMap<>();
+    loadRanges.put(nke("c", "g"), "f2 f3");
+    loadRanges.put(nke(null, "c"), "f1 f2"); // Out of order!
+    loadRanges.put(nke("g", "r"), "f2 f4");
+    loadRanges.put(nke("r", "w"), "f2 f5");
+    loadRanges.put(nke("w", null), "f2 f6");
+
+    try (LoadMappingIterator iterator = createLoadMappingIter(loadRanges)) {
+      KeyExtent previous = null;
+      while (iterator.hasNext()) {
+        KeyExtent current = iterator.next().getKey();
+        System.out.println("Comparing " + current + " with previous: " + previous);
+        if (previous != null && current.compareTo(previous) < 0) {
+          throw new IllegalStateException("Input is out of order!");
+        }
+        previous = current;
+      }
+    } catch (IllegalStateException e) {
+      // Catching the exception to verify it gets thrown
+      assertTrue(e.getMessage().contains("KeyExtents are not in sorted order"));
+    }
+  }
+}

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/bulk/LoadMappingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/bulk/LoadMappingIteratorTest.java
@@ -133,7 +133,7 @@ public class LoadMappingIteratorTest {
     try (LoadMappingIterator iterator = createLoadMappingIter(loadRanges)) {
       assertEquals(nke("c", "g"), iterator.next().getKey());
       var e = assertThrows(IllegalStateException.class, iterator::next);
-      String expected = "KeyExtents are not in sorted order: 1;g;c comes after 1;c<";
+      String expected = "KeyExtents are not in sorted order: 1;g;c was seen before 1;c<";
       assertEquals(expected, e.getMessage());
     }
   }

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/bulk/LoadMappingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/bulk/LoadMappingIteratorTest.java
@@ -19,7 +19,8 @@
 package org.apache.accumulo.core.clientImpl.bulk;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -99,14 +100,14 @@ public class LoadMappingIteratorTest {
       while (iterator.hasNext()) {
         KeyExtent current = iterator.next().getKey();
         System.out.println("Comparing " + current + " with previous: " + previous);
-        if (previous != null && current.compareTo(previous) < 0) {
-          throw new IllegalStateException("Input is out of order!");
-        }
+        assertFalse(previous != null && current.compareTo(previous) < 0, "Input is out of order!");
+
         previous = current;
       }
     } catch (IllegalStateException e) {
-      // Catching the exception to verify it gets thrown
-      assertTrue(e.getMessage().contains("KeyExtents are not in sorted order"));
+      assertThrows(IllegalStateException.class, () -> {
+        throw e;
+      }, "Expected an IllegalStateException due to out-of-order KeyExtents");
     }
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/bulk/LoadMappingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/bulk/LoadMappingIteratorTest.java
@@ -49,7 +49,7 @@ import com.google.gson.stream.JsonWriter;
 public class LoadMappingIteratorTest {
   private LoadMappingIterator createLoadMappingIter(Map<KeyExtent,String> loadRanges)
       throws IOException {
-    Map<KeyExtent,Bulk.Files> unorderedMapping = new LinkedHashMap<>();
+    Map<KeyExtent,Bulk.Files> mapping = new LinkedHashMap<>();
 
     loadRanges.forEach((extent, files) -> {
       Bulk.Files testFiles = new Bulk.Files();
@@ -59,13 +59,13 @@ public class LoadMappingIteratorTest {
         testFiles.add(new Bulk.FileInfo(f, c, c));
       }
 
-      unorderedMapping.put(extent, testFiles);
+      mapping.put(extent, testFiles);
     });
 
     // Serialize unordered mapping directly
     byte[] serializedData;
     try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-      writeLoadMappingWithoutSorting(unorderedMapping, "/some/dir", p -> baos);
+      writeLoadMappingWithoutSorting(mapping, "/some/dir", p -> baos);
       serializedData = baos.toByteArray();
     }
     ByteArrayInputStream bais = new ByteArrayInputStream(serializedData);

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/bulk/LoadMappingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/bulk/LoadMappingIteratorTest.java
@@ -129,8 +129,9 @@ public class LoadMappingIteratorTest {
 
     try (LoadMappingIterator iterator = createLoadMappingIter(loadRanges)) {
       assertEquals(nke("c", "g"), iterator.next().getKey());
-      assertThrows(IllegalStateException.class, iterator::next,
-          "Expected an IllegalStateException due to out-of-order KeyExtents");
+      var e = assertThrows(IllegalStateException.class, iterator::next);
+      String expected = "KeyExtents are not in sorted order: 1;g;c comes after 1;c<";
+      assertEquals(expected, e.getMessage());
     }
   }
 }


### PR DESCRIPTION
Closes [issue #5045 ](https://github.com/apache/accumulo/issues/5045)

Added a validation check in `LoadMappingIterator`, to ensure that KeyExtents are sorted.  