### PR TITLE
Remove tserver lock entries per group

### DIFF
--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -381,10 +381,12 @@ function control_services() {
 
   local count
   local hosts
+  local zap_group
   if [[ $ARG_ALL == 1 || $ARG_TSERVER == 1 ]]; then
     tserver_groups=$TSERVER_GROUPS
     if [[ -n $ARG_TSERVER_GROUP ]]; then
       tserver_groups=$ARG_TSERVER_GROUP
+      zap_group=$ARG_TSERVER_GROUP
     fi
     for group in $tserver_groups; do
       echo "${cmd}ing tablet servers for group $group"
@@ -467,10 +469,17 @@ function control_services() {
     done
   fi
 
-  if [[ $ARG_LOCAL == 0 && $ARG_ALL == 1 && ($operation == "stop" || $operation == "kill") ]]; then
-    if ! isDebug; then
-      echo "Cleaning all server entries in ZooKeeper"
-      $accumulo_cmd org.apache.accumulo.server.util.ZooZap -manager -tservers -compactors -sservers
+  if [[ $ARG_LOCAL == 0 && ($operation == "stop" || $operation == "kill") ]]; then
+    if [[ $ARG_TSERVER == 1 ]]; then
+      if ! isDebug; then
+        echo "Cleaning all tserver entries in ZooKeeper"
+        $accumulo_cmd org.apache.accumulo.server.util.ZooZap -tservers -group "$zap_group"
+      fi
+    elif [[ $ARG_ALL == 1 ]]; then
+      if ! isDebug; then
+        echo "Cleaning all server entries in ZooKeeper"
+        $accumulo_cmd org.apache.accumulo.server.util.ZooZap -manager -tservers -compactors -sservers
+      fi
     fi
   fi
 


### PR DESCRIPTION
Removes all tserver lock entries when a group of tservers is stopped or killed.

Requires #5174 to be merged in beforehand.

Closes #5178 
 