### PR TITLE
Convert compaction duration to mills

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/RunningCompactionInfo.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/RunningCompactionInfo.java
@@ -75,7 +75,7 @@ public class RunningCompactionInfo {
     if (lastEntry != null) {
       last = lastEntry.getValue();
       updateMillis = lastEntry.getKey();
-      duration = last.getCompactionAgeNanos();
+      duration = NANOSECONDS.toMillis(last.getCompactionAgeNanos());
     } else {
       log.debug("No updates found for {}", ecid);
       lastUpdate = 1;
@@ -84,7 +84,7 @@ public class RunningCompactionInfo {
       duration = 0;
       return;
     }
-    long durationMinutes = NANOSECONDS.toMinutes(duration);
+    long durationMinutes = MILLISECONDS.toMinutes(duration);
     if (durationMinutes > 15) {
       log.warn("Compaction {} has been running for {} minutes", ecid, durationMinutes);
     }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/ec.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/ec.js
@@ -80,7 +80,6 @@ $(document).ready(function () {
     "columnDefs": [{
         "targets": "duration",
         "render": function (data, type, row) {
-          data = data / 1_000_000; // convert from nanos to millis
           if (type === 'display') data = timeDuration(data);
           return data;
         }

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionProgressIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionProgressIT.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test.compaction;
 
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.accumulo.core.util.UtilWaitThread.sleepUninterruptibly;
 import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.QUEUE1;
 import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.compact;
@@ -183,7 +183,7 @@ public class ExternalCompactionProgressIT extends AccumuloClusterHarness {
           .getCompactions().values().iterator().next();
       RunningCompactionInfo updatedCompactionInfo = new RunningCompactionInfo(updatedCompaction);
 
-      final Duration reportedCompactionDuration = Duration.ofNanos(updatedCompactionInfo.duration);
+      final Duration reportedCompactionDuration = Duration.ofMillis(updatedCompactionInfo.duration);
       final Duration measuredCompactionDuration =
           Duration.ofNanos(System.nanoTime() - compactionStartTime);
       final Duration coordinatorAge = Duration.ofNanos(System.nanoTime() - coordinatorRestartTime);
@@ -432,7 +432,7 @@ public class ExternalCompactionProgressIT extends AccumuloClusterHarness {
         RunningCompactionInfo rci = new RunningCompactionInfo(ec);
         RunningCompactionInfo previousRci = runningMap.put(ecid, rci);
         log.debug("ECID {} has been running for {} seconds", ecid,
-            NANOSECONDS.toSeconds(rci.duration));
+            MILLISECONDS.toSeconds(rci.duration));
         if (previousRci == null) {
           log.debug("New ECID {} with inputFiles: {}", ecid, rci.numFiles);
         } else {


### PR DESCRIPTION
Converts the compaction duration from nanos to mills in RunningCompactionInfo.

This removes the need to handle the data conversion in the monitor and ec-admin utility.

Closes #5204 