### PR TITLE
Fixes accumulo-cluster message format for tserver operations

### DIFF
--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -471,8 +471,8 @@ function control_services() {
           fi
         fi
       done
+      echo "done"
     done
-    echo "done"
   fi
 
   local manager


### PR DESCRIPTION
Moves the "done" message up to the end of each tserver group operation instead of being at the end.

Changes `accumulo-cluster start` output to having separate lines for each tserver group instead of a continuous line for all groups.  

Old output:
```
$ ./bin/accumulo-cluster start
Executing start on tablet servers for group default ....Executing start on tablet servers for group special ....done
```
New output:
```
 ./bin/accumulo-cluster start
Executing start on tablet servers for group default ....done
Executing start on tablet servers for group special ....done
```
