### PR TITLE
Better handling for runtime exception in Tablet.commit 

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
@@ -469,6 +469,7 @@ public class TabletClientHandler implements TabletClientService.Iface {
         }
       } catch (Exception e) {
         TraceUtil.setException(span2, e, true);
+        log.error("Error logging mutations sent from {}", TServerUtils.clientAddress.get(), e);
         throw e;
       } finally {
         span2.end();
@@ -496,6 +497,10 @@ public class TabletClientHandler implements TabletClientService.Iface {
         us.commitTimes.addStat(t2 - t1);
 
         updateAvgCommitTime(t2 - t1, sendables.size());
+      } catch (Exception e) {
+        TraceUtil.setException(span3, e, true);
+        log.error("Error committing mutations sent from {}", TServerUtils.clientAddress.get(), e);
+        throw e;
       } finally {
         span3.end();
       }
@@ -675,6 +680,7 @@ public class TabletClientHandler implements TabletClientService.Iface {
           session.commit(mutations);
         } catch (Exception e) {
           TraceUtil.setException(span3, e, true);
+          log.error("Error committing mutations sent from {}", TServerUtils.clientAddress.get(), e);
           throw e;
         } finally {
           span3.end();
@@ -831,6 +837,7 @@ public class TabletClientHandler implements TabletClientService.Iface {
       updateAvgCommitTime(t2 - t1, sendables.size());
     } catch (Exception e) {
       TraceUtil.setException(span3, e, true);
+      log.error("Error committing mutations sent from {}", TServerUtils.clientAddress.get(), e);
       throw e;
     } finally {
       span3.end();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -880,10 +880,17 @@ public class Tablet extends TabletBase {
     try {
       getTabletMemory().mutate(commitSession, mutations, totalCount);
       getTabletMemory().updateMemoryUsageStats();
+synchronized (this) {
+       getTabletMemory().updateMemoryUsageStats();
+        if (isCloseComplete()) {
+          throw new IllegalStateException(
+              "Tablet " + extent + " closed with outstanding messages to the logger");
+        }
       numEntries += totalCount;
       numEntriesInMemory += totalCount;
       ingestCount += totalCount;
       ingestBytes += totalBytes;
+      }
     } finally {
       synchronized (this) {
         if (isCloseComplete()) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -879,26 +879,19 @@ public class Tablet extends TabletBase {
 
     try {
       getTabletMemory().mutate(commitSession, mutations, totalCount);
-      getTabletMemory().updateMemoryUsageStats();
-synchronized (this) {
-       getTabletMemory().updateMemoryUsageStats();
+      synchronized (this) {
+        getTabletMemory().updateMemoryUsageStats();
         if (isCloseComplete()) {
           throw new IllegalStateException(
               "Tablet " + extent + " closed with outstanding messages to the logger");
         }
-      numEntries += totalCount;
-      numEntriesInMemory += totalCount;
-      ingestCount += totalCount;
-      ingestBytes += totalBytes;
+        numEntries += totalCount;
+        numEntriesInMemory += totalCount;
+        ingestCount += totalCount;
+        ingestBytes += totalBytes;
       }
     } finally {
-      synchronized (this) {
-        if (isCloseComplete()) {
-          throw new IllegalStateException(
-              "Tablet " + extent + " closed with outstanding messages to the logger");
-        }
-        decrementWritesInProgress(commitSession);
-      }
+      decrementWritesInProgress(commitSession);
     }
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -879,21 +879,18 @@ public class Tablet extends TabletBase {
 
     try {
       getTabletMemory().mutate(commitSession, mutations, totalCount);
+      getTabletMemory().updateMemoryUsageStats();
+      numEntries += totalCount;
+      numEntriesInMemory += totalCount;
+      ingestCount += totalCount;
+      ingestBytes += totalBytes;
     } finally {
       synchronized (this) {
         if (isCloseComplete()) {
           throw new IllegalStateException(
               "Tablet " + extent + " closed with outstanding messages to the logger");
         }
-        // decrement here in case an exception is thrown below
         decrementWritesInProgress(commitSession);
-
-        getTabletMemory().updateMemoryUsageStats();
-
-        numEntries += totalCount;
-        numEntriesInMemory += totalCount;
-        ingestCount += totalCount;
-        ingestBytes += totalBytes;
       }
     }
   }


### PR DESCRIPTION
Wrapped call to getTabletMemory().mutate() in try/finally so that a RuntimeException does not short circuit the code in the method that decrements the writes. Added logging in TabletClientHandler to note which client was causing the failure.

Closes #5208