### PR TITLE
Fix compactor.queue to compactor.group

### DIFF
--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -535,7 +535,7 @@ function control_services() {
       hosts="COMPACTOR_HOSTS_$group"
       for compactor in ${!hosts}; do
         if canRunOnHost "$compactor"; then
-          execute_command "$operation" "$compactor" compactor "$group" "-o" "compactor.queue=$group"
+          execute_command "$operation" "$compactor" compactor "$group" "-o" "compactor.group=$group"
         fi
       done
     done


### PR DESCRIPTION
Switches the property override back to `compactor.group` so the compactors join the correct queue.

`compactor.queue` was replaced with `compactor.group` in 4.0