### PR TITLE
Only create Threadpools when calling ZooInfoViewer or ZooPropEditor

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/conf/util/ZooInfoViewer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/util/ZooInfoViewer.java
@@ -115,11 +115,8 @@ public class ZooInfoViewer implements KeywordExecutable {
     log.info("print properties: {}", opts.printProps);
     log.info("print instances: {}", opts.printInstanceIds);
 
-    try {
-      ServerContext context = getContext(opts);
+    try (ServerContext context = getContext(opts)) {
       generateReport(context.getInstanceID(), opts, context.getZooReader());
-    } catch (Exception e) {
-      throw new RuntimeException(e);
     }
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/util/ZooInfoViewer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/util/ZooInfoViewer.java
@@ -106,7 +106,6 @@ public class ZooInfoViewer implements KeywordExecutable {
 
   @Override
   public void execute(String[] args) throws Exception {
-    nullWatcher = new NullWatcher(new ReadyMonitor(ZooInfoViewer.class.getSimpleName(), 20_000L));
 
     ZooInfoViewer.Opts opts = new ZooInfoViewer.Opts();
     opts.parseArgs(ZooInfoViewer.class.getName(), args);
@@ -127,6 +126,7 @@ public class ZooInfoViewer implements KeywordExecutable {
 
   void generateReport(final InstanceId iid, final ZooInfoViewer.Opts opts,
       final ZooReader zooReader) throws Exception {
+    nullWatcher = new NullWatcher(new ReadyMonitor(ZooInfoViewer.class.getSimpleName(), 20_000L));
 
     OutputStream outStream;
 

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/util/ZooInfoViewer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/util/ZooInfoViewer.java
@@ -85,8 +85,7 @@ public class ZooInfoViewer implements KeywordExecutable {
       DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneId.from(ZoneOffset.UTC));
   private static final Logger log = LoggerFactory.getLogger(ZooInfoViewer.class);
 
-  private final NullWatcher nullWatcher =
-      new NullWatcher(new ReadyMonitor(ZooInfoViewer.class.getSimpleName(), 20_000L));
+  private NullWatcher nullWatcher;
 
   private static final String INDENT = "  ";
 
@@ -107,6 +106,7 @@ public class ZooInfoViewer implements KeywordExecutable {
 
   @Override
   public void execute(String[] args) throws Exception {
+    nullWatcher = new NullWatcher(new ReadyMonitor(ZooInfoViewer.class.getSimpleName(), 20_000L));
 
     ZooInfoViewer.Opts opts = new ZooInfoViewer.Opts();
     opts.parseArgs(ZooInfoViewer.class.getName(), args);

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/util/ZooPropEditor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/util/ZooPropEditor.java
@@ -61,8 +61,7 @@ import com.google.auto.service.AutoService;
 public class ZooPropEditor implements KeywordExecutable {
 
   private static final Logger LOG = LoggerFactory.getLogger(ZooPropEditor.class);
-  private final NullWatcher nullWatcher =
-      new NullWatcher(new ReadyMonitor(ZooInfoViewer.class.getSimpleName(), 20_000L));
+  private NullWatcher nullWatcher;
 
   /**
    * No-op constructor - provided so ServiceLoader autoload does not consume resources.
@@ -82,6 +81,8 @@ public class ZooPropEditor implements KeywordExecutable {
 
   @Override
   public void execute(String[] args) throws Exception {
+    nullWatcher = new NullWatcher(new ReadyMonitor(ZooInfoViewer.class.getSimpleName(), 20_000L));
+
     ZooPropEditor.Opts opts = new ZooPropEditor.Opts();
     opts.parseArgs(ZooPropEditor.class.getName(), args);
 

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/util/ZooInfoViewerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/util/ZooInfoViewerTest.java
@@ -157,6 +157,7 @@ public class ZooInfoViewerTest {
     ServerContext context =
         MockServerContext.getWithZK(InstanceId.of(instanceName), instanceName, 20_000);
     expect(context.getZooReader()).andReturn(zooReader).once();
+    context.close();
 
     replay(context);
 
@@ -311,6 +312,7 @@ public class ZooInfoViewerTest {
 
     ServerContext context = MockServerContext.getMockContextWithPropStore(iid, zrw, propStore);
     expect(context.getZooReader()).andReturn(zooReader).once();
+    context.close();
 
     replay(context);
 


### PR DESCRIPTION
Before this change, the `accumulo.pool.scheduled.future.checker` thread would be created when all KeywordExecutable classes are loaded in.
https://github.com/apache/accumulo/blob/a320bbe87bf6c01031044c7681c05d89579809e2/start/src/main/java/org/apache/accumulo/start/Main.java#L231 

By moving the nullWatchers to the execute method, the threads are only created when the classes are executed.


