### PR TITLE
Improve Ample logging for rejected conditional mutations

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import org.apache.accumulo.core.client.ConditionalWriter;
 import org.apache.accumulo.core.client.admin.TabletAvailability;
@@ -623,6 +624,16 @@ public interface Ample {
      *        let the rejected status carry forward in this case.
      */
     void submit(RejectionHandler rejectionHandler);
+
+    /**
+     * Overloaded version of {@link #submit(RejectionHandler)} that takes a short description of the
+     * operation to assist with debugging.
+     *
+     * @param rejectionHandler The rejection handler
+     * @param description A short description of the operation (e.g., "bulk import", "compaction")
+     */
+    void submit(RejectionHandler rejectionHandler, Supplier<String> description);
+
   }
 
   /**

--- a/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
@@ -350,12 +350,10 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
     // Do not add any code here, it may interfere with the finally block removing extents from
     // hostingRequestInProgress
     try (var mutator = manager.getContext().getAmple().conditionallyMutateTablets()) {
-      inProgress.forEach(ke -> {
-        mutator.mutateTablet(ke).requireAbsentOperation()
-            .requireTabletAvailability(TabletAvailability.ONDEMAND).requireAbsentLocation()
-            .setHostingRequested().submit(TabletMetadata::getHostingRequested);
-
-      });
+      inProgress.forEach(ke -> mutator.mutateTablet(ke).requireAbsentOperation()
+          .requireTabletAvailability(TabletAvailability.ONDEMAND).requireAbsentLocation()
+          .setHostingRequested()
+          .submit(TabletMetadata::getHostingRequested, () -> "host ondemand"));
 
       List<Range> ranges = new ArrayList<>();
 
@@ -1094,7 +1092,7 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
               "replaceVolume conditional mutation rejection check {} logsRemoved:{} filesRemoved:{}",
               tm.getExtent(), logsRemoved, filesRemoved);
           return logsRemoved && filesRemoved;
-        });
+        }, () -> "replace volume");
       }
 
       tabletsMutator.process().forEach((extent, result) -> {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
@@ -635,8 +635,9 @@ public class CompactionCoordinator
             }
 
             tabletMutator.putExternalCompaction(externalCompactionId, ecm);
-            tabletMutator
-                .submit(tm -> tm.getExternalCompactions().containsKey(externalCompactionId));
+            tabletMutator.submit(
+                tm -> tm.getExternalCompactions().containsKey(externalCompactionId),
+                () -> "compaction reservation");
 
             var result = tabletsMutator.process().get(extent);
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/CommitCompaction.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/CommitCompaction.java
@@ -130,7 +130,7 @@ public class CommitCompaction extends ManagerRepo {
 
         tabletMutator.submit(
             tabletMetadata -> !tabletMetadata.getExternalCompactions().containsKey(ecid),
-            () -> "commit compaction");
+            () -> "commit compaction "+ecid);
 
         if (LOG.isDebugEnabled()) {
           LOG.debug("Compaction completed {} added {} removed {}", tablet.getExtent(), newDatafile,

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/CommitCompaction.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/CommitCompaction.java
@@ -128,8 +128,9 @@ public class CommitCompaction extends ManagerRepo {
         // make the needed updates to the tablet
         updateTabletForCompaction(commitData.stats, ecid, tablet, newDatafile, ecm, tabletMutator);
 
-        tabletMutator
-            .submit(tabletMetadata -> !tabletMetadata.getExternalCompactions().containsKey(ecid));
+        tabletMutator.submit(
+            tabletMetadata -> !tabletMetadata.getExternalCompactions().containsKey(ecid),
+            () -> "commit compaction");
 
         if (LOG.isDebugEnabled()) {
           LOG.debug("Compaction completed {} added {} removed {}", tablet.getExtent(), newDatafile,

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/CommitCompaction.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/CommitCompaction.java
@@ -130,7 +130,7 @@ public class CommitCompaction extends ManagerRepo {
 
         tabletMutator.submit(
             tabletMetadata -> !tabletMetadata.getExternalCompactions().containsKey(ecid),
-            () -> "commit compaction "+ecid);
+            () -> "commit compaction " + ecid);
 
         if (LOG.isDebugEnabled()) {
           LOG.debug("Compaction completed {} added {} removed {}", tablet.getExtent(), newDatafile,

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/availability/SetTabletAvailability.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/availability/SetTabletAvailability.java
@@ -136,7 +136,8 @@ public class SetTabletAvailability extends ManagerRepo {
             tabletExtent);
         mutator.mutateTablet(tabletExtent).requireAbsentOperation()
             .putTabletAvailability(tabletAvailability)
-            .submit(tabletMeta -> tabletMeta.getTabletAvailability() == tabletAvailability);
+            .submit(tabletMeta -> tabletMeta.getTabletAvailability() == tabletAvailability,
+                () -> "set tablet availability");
       }
     }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/CleanUpBulkImport.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/CleanUpBulkImport.java
@@ -111,7 +111,7 @@ public class CleanUpBulkImport extends ManagerRepo {
                 tabletsMutator.mutateTablet(tablet.getExtent()).requireAbsentOperation();
             tablet.getLoaded().entrySet().stream().filter(entry -> entry.getValue().equals(fateId))
                 .map(Map.Entry::getKey).forEach(tabletMutator::deleteBulkFile);
-            tabletMutator.submit(tm -> false, () -> "remove bulk load entries");
+            tabletMutator.submit(tm -> false, () -> "remove bulk load entries "+fateId);
           }
         }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/CleanUpBulkImport.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/CleanUpBulkImport.java
@@ -111,7 +111,7 @@ public class CleanUpBulkImport extends ManagerRepo {
                 tabletsMutator.mutateTablet(tablet.getExtent()).requireAbsentOperation();
             tablet.getLoaded().entrySet().stream().filter(entry -> entry.getValue().equals(fateId))
                 .map(Map.Entry::getKey).forEach(tabletMutator::deleteBulkFile);
-            tabletMutator.submit(tm -> false, () -> "remove bulk load entries "+fateId);
+            tabletMutator.submit(tm -> false, () -> "remove bulk load entries " + fateId);
           }
         }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/CleanUpBulkImport.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/CleanUpBulkImport.java
@@ -111,7 +111,7 @@ public class CleanUpBulkImport extends ManagerRepo {
                 tabletsMutator.mutateTablet(tablet.getExtent()).requireAbsentOperation();
             tablet.getLoaded().entrySet().stream().filter(entry -> entry.getValue().equals(fateId))
                 .map(Map.Entry::getKey).forEach(tabletMutator::deleteBulkFile);
-            tabletMutator.submit(tm -> false);
+            tabletMutator.submit(tm -> false, () -> "remove bulk load entries");
           }
         }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
@@ -251,7 +251,7 @@ class LoadFiles extends ManagerRepo {
         Preconditions.checkState(
             loadingFiles.put(tablet.getExtent(), List.copyOf(filesToLoad.keySet())) == null);
 
-        tabletMutator.submit(tm -> false, () -> "bulk load files");
+        tabletMutator.submit(tm -> false, () -> "bulk load files "+fateId);
       }
     }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
@@ -251,7 +251,7 @@ class LoadFiles extends ManagerRepo {
         Preconditions.checkState(
             loadingFiles.put(tablet.getExtent(), List.copyOf(filesToLoad.keySet())) == null);
 
-        tabletMutator.submit(tm -> false);
+        tabletMutator.submit(tm -> false, () -> "bulk load files");
       }
     }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
@@ -251,7 +251,7 @@ class LoadFiles extends ManagerRepo {
         Preconditions.checkState(
             loadingFiles.put(tablet.getExtent(), List.copyOf(filesToLoad.keySet())) == null);
 
-        tabletMutator.submit(tm -> false, () -> "bulk load files "+fateId);
+        tabletMutator.submit(tm -> false, () -> "bulk load files " + fateId);
       }
     }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriver.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriver.java
@@ -211,7 +211,8 @@ public class CompactionDriver extends ManagerRepo {
           // this tablet has no files try to mark it as done
           tabletsMutator.mutateTablet(tablet.getExtent()).requireAbsentOperation()
               .requireSame(tablet, FILES, COMPACTED).putCompacted(fateId)
-              .submit(tabletMetadata -> tabletMetadata.getCompacted().contains(fateId));
+              .submit(tabletMetadata -> tabletMetadata.getCompacted().contains(fateId),
+                  () -> "no files, attempting to mark as compacted");
           noFiles++;
         } else if (tablet.getSelectedFiles() == null && tablet.getExternalCompactions().isEmpty()) {
           // there are no selected files
@@ -242,7 +243,8 @@ public class CompactionDriver extends ManagerRepo {
             // no files were selected so mark the tablet as compacted
             tabletsMutator.mutateTablet(tablet.getExtent()).requireAbsentOperation()
                 .requireSame(tablet, FILES, SELECTED, ECOMP, COMPACTED).putCompacted(fateId)
-                .submit(tabletMetadata -> tabletMetadata.getCompacted().contains(fateId));
+                .submit(tabletMetadata -> tabletMetadata.getCompacted().contains(fateId),
+                    () -> "no files, attempting to mark as compacted");
 
             noneSelected++;
           } else {
@@ -260,9 +262,11 @@ public class CompactionDriver extends ManagerRepo {
 
             selectionsSubmitted.put(tablet.getExtent(), filesToCompact);
 
-            mutator.submit(tabletMetadata -> tabletMetadata.getSelectedFiles() != null
-                && tabletMetadata.getSelectedFiles().getFateId().equals(fateId)
-                || tabletMetadata.getCompacted().contains(fateId));
+            mutator.submit(
+                tabletMetadata -> tabletMetadata.getSelectedFiles() != null
+                    && tabletMetadata.getSelectedFiles().getFateId().equals(fateId)
+                    || tabletMetadata.getCompacted().contains(fateId),
+                () -> "selecting files for compaction");
 
             if (minSelected == null || tablet.getExtent().compareTo(minSelected) < 0) {
               minSelected = tablet.getExtent();
@@ -298,7 +302,8 @@ public class CompactionDriver extends ManagerRepo {
             var mutator = tabletsMutator.mutateTablet(tablet.getExtent()).requireAbsentOperation()
                 .requireSame(tablet, ECOMP, USER_COMPACTION_REQUESTED)
                 .putUserCompactionRequested(fateId);
-            mutator.submit(tm -> tm.getUserCompactionsRequested().contains(fateId));
+            mutator.submit(tm -> tm.getUserCompactionsRequested().contains(fateId),
+                () -> "marking as needing a user requested compaction");
             userCompactionRequested++;
           } else {
             // Marker was already added and we are waiting
@@ -400,7 +405,7 @@ public class CompactionDriver extends ManagerRepo {
               mutator.deleteUserCompactionRequested(fateId);
             }
 
-            mutator.submit(needsNoUpdate::test);
+            mutator.submit(needsNoUpdate::test, () -> "cleanup metadata for failed compaction");
           }
         }
       }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriver.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriver.java
@@ -212,7 +212,7 @@ public class CompactionDriver extends ManagerRepo {
           tabletsMutator.mutateTablet(tablet.getExtent()).requireAbsentOperation()
               .requireSame(tablet, FILES, COMPACTED).putCompacted(fateId)
               .submit(tabletMetadata -> tabletMetadata.getCompacted().contains(fateId),
-                  () -> "no files, attempting to mark as compacted");
+                  () -> "no files, attempting to mark as compacted. " + fateId);
           noFiles++;
         } else if (tablet.getSelectedFiles() == null && tablet.getExternalCompactions().isEmpty()) {
           // there are no selected files
@@ -244,7 +244,7 @@ public class CompactionDriver extends ManagerRepo {
             tabletsMutator.mutateTablet(tablet.getExtent()).requireAbsentOperation()
                 .requireSame(tablet, FILES, SELECTED, ECOMP, COMPACTED).putCompacted(fateId)
                 .submit(tabletMetadata -> tabletMetadata.getCompacted().contains(fateId),
-                    () -> "no files, attempting to mark as compacted");
+                    () -> "no files, attempting to mark as compacted. " + fateId);
 
             noneSelected++;
           } else {
@@ -266,7 +266,7 @@ public class CompactionDriver extends ManagerRepo {
                 tabletMetadata -> tabletMetadata.getSelectedFiles() != null
                     && tabletMetadata.getSelectedFiles().getFateId().equals(fateId)
                     || tabletMetadata.getCompacted().contains(fateId),
-                () -> "selecting files for compaction");
+                () -> "selecting files for compaction. " + fateId);
 
             if (minSelected == null || tablet.getExtent().compareTo(minSelected) < 0) {
               minSelected = tablet.getExtent();
@@ -303,7 +303,7 @@ public class CompactionDriver extends ManagerRepo {
                 .requireSame(tablet, ECOMP, USER_COMPACTION_REQUESTED)
                 .putUserCompactionRequested(fateId);
             mutator.submit(tm -> tm.getUserCompactionsRequested().contains(fateId),
-                () -> "marking as needing a user requested compaction");
+                () -> "marking as needing a user requested compaction. " + fateId);
             userCompactionRequested++;
           } else {
             // Marker was already added and we are waiting
@@ -405,7 +405,8 @@ public class CompactionDriver extends ManagerRepo {
               mutator.deleteUserCompactionRequested(fateId);
             }
 
-            mutator.submit(needsNoUpdate::test, () -> "cleanup metadata for failed compaction");
+            mutator.submit(needsNoUpdate::test,
+                () -> "cleanup metadata for failed compaction. " + fateId);
           }
         }
       }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/ReserveTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/ReserveTablets.java
@@ -96,7 +96,7 @@ public class ReserveTablets extends ManagerRepo {
           // must wait for the tablet to have no location before proceeding to actually delete. See
           // the documentation about the opid column in the MetadataSchema class for more details.
           conditionalMutator.mutateTablet(tabletMeta.getExtent()).requireAbsentOperation()
-              .putOperation(opid).submit(tm -> opid.equals(tm.getOperationId()));
+              .putOperation(opid).submit(tm -> opid.equals(tm.getOperationId()), () -> "put opid");
           submitted++;
         }
       }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/ReserveTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/ReserveTablets.java
@@ -96,7 +96,7 @@ public class ReserveTablets extends ManagerRepo {
           // must wait for the tablet to have no location before proceeding to actually delete. See
           // the documentation about the opid column in the MetadataSchema class for more details.
           conditionalMutator.mutateTablet(tabletMeta.getExtent()).requireAbsentOperation()
-              .putOperation(opid).submit(tm -> opid.equals(tm.getOperationId()), () -> "put opid");
+              .putOperation(opid).submit(tm -> opid.equals(tm.getOperationId()), () -> "put opid "+opid);
           submitted++;
         }
       }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/ReserveTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/ReserveTablets.java
@@ -96,7 +96,8 @@ public class ReserveTablets extends ManagerRepo {
           // must wait for the tablet to have no location before proceeding to actually delete. See
           // the documentation about the opid column in the MetadataSchema class for more details.
           conditionalMutator.mutateTablet(tabletMeta.getExtent()).requireAbsentOperation()
-              .putOperation(opid).submit(tm -> opid.equals(tm.getOperationId()), () -> "put opid "+opid);
+              .putOperation(opid)
+              .submit(tm -> opid.equals(tm.getOperationId()), () -> "put opid " + opid);
           submitted++;
         }
       }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/DeleteRows.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/DeleteRows.java
@@ -178,16 +178,21 @@ public class DeleteRows extends ManagerRepo {
           }
         }
 
-        filesToDelete.forEach(file -> log.debug("{} deleting file {} for {}", fateId, file,
-            tabletMetadata.getExtent()));
-        filesToAddMap.forEach((file, dfv) -> log.debug("{} adding file {} {} for {}", fateId, file,
-            dfv, tabletMetadata.getExtent()));
+        filesToDelete.forEach(file -> {
+          log.debug("{} deleting file {} for {}", fateId, file, tabletMetadata.getExtent());
+          tabletMutator.deleteFile(file);
+        });
 
-        filesToDelete.forEach(tabletMutator::deleteFile);
-        filesToAddMap.forEach(tabletMutator::putFile);
+        filesToAddMap.forEach((file, dfv) -> {
+          log.debug("{} adding file {} {} for {}", fateId, file, dfv, tabletMetadata.getExtent());
+          tabletMutator.putFile(file, dfv);
+        });
 
-        tabletMutator.submit(tm -> tm.getFiles().containsAll(filesToAddMap.keySet())
-            && Collections.disjoint(tm.getFiles(), filesToDelete));
+        tabletMutator
+            .submit(
+                tm -> tm.getFiles().containsAll(filesToAddMap.keySet())
+                    && Collections.disjoint(tm.getFiles(), filesToDelete),
+                () -> "delete tablet files");
       }
 
       var results = tabletsMutator.process();

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/DeleteRows.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/DeleteRows.java
@@ -188,11 +188,10 @@ public class DeleteRows extends ManagerRepo {
           tabletMutator.putFile(file, dfv);
         });
 
-        tabletMutator
-            .submit(
-                tm -> tm.getFiles().containsAll(filesToAddMap.keySet())
-                    && Collections.disjoint(tm.getFiles(), filesToDelete),
-                () -> "delete tablet files (as part of merge or deleterow operation) "+fateId);
+        tabletMutator.submit(
+            tm -> tm.getFiles().containsAll(filesToAddMap.keySet())
+                && Collections.disjoint(tm.getFiles(), filesToDelete),
+            () -> "delete tablet files (as part of merge or deleterow operation) " + fateId);
       }
 
       var results = tabletsMutator.process();

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/DeleteRows.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/DeleteRows.java
@@ -192,7 +192,7 @@ public class DeleteRows extends ManagerRepo {
             .submit(
                 tm -> tm.getFiles().containsAll(filesToAddMap.keySet())
                     && Collections.disjoint(tm.getFiles(), filesToDelete),
-                () -> "delete tablet files");
+                () -> "delete tablet files (as part of merge or deleterow operation) "+fateId);
       }
 
       var results = tabletsMutator.process();

--- a/test/src/main/java/org/apache/accumulo/test/functional/AmpleConditionalWriterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/AmpleConditionalWriterIT.java
@@ -173,7 +173,8 @@ public class AmpleConditionalWriterIT extends AccumuloClusterHarness {
       // test require absent with a future location set
       try (var ctmi = new ConditionalTabletsMutatorImpl(context)) {
         ctmi.mutateTablet(e1).requireAbsentOperation().requireAbsentLocation()
-            .putLocation(Location.future(ts2)).submit(tm -> false);
+            .putLocation(Location.future(ts2)).submit(tm -> false,
+                () -> "Testing that requireAbsentLocation() fails when a future location is set");
         assertEquals(Status.REJECTED, ctmi.process().get(e1).getStatus());
       }
       assertEquals(Location.future(ts1), context.getAmple().readTablet(e1).getLocation());
@@ -196,7 +197,8 @@ public class AmpleConditionalWriterIT extends AccumuloClusterHarness {
       try (var ctmi = new ConditionalTabletsMutatorImpl(context)) {
         ctmi.mutateTablet(e1).requireAbsentOperation().requireAbsentLocation()
             .putLocation(Location.future(ts2)).submit(tm -> false);
-        assertEquals(Status.REJECTED, ctmi.process().get(e1).getStatus());
+        assertEquals(Status.REJECTED, ctmi.process().get(e1).getStatus(),
+            () -> "Testing that requireAbsentLocation() fails when a current location is set");
       }
       assertEquals(Location.current(ts1), context.getAmple().readTablet(e1).getLocation());
 


### PR DESCRIPTION
Addresses #5202

Adds an overloaded `submit` method to accept a description for the conditional mutation. This description gets logged if the mutation is rejected.

Used this new overloaded submit method in AmpleConditionalWriterIT to make sure it works. I am not too sure where other good spots to use this are but will continue to look into it.