### PR TITLE
Adds property for jline to prefer using stdout vs stderr

### DIFF
--- a/assemble/conf/accumulo-env.sh
+++ b/assemble/conf/accumulo-env.sh
@@ -77,6 +77,7 @@ JAVA_OPTS=(
   '-XX:OnOutOfMemoryError=kill -9 %p'
   '-XX:-OmitStackTraceInFastThrow'
   '-Djava.net.preferIPv4Stack=true'
+  '-Dorg.jline.terminal.output=out'
   "-Daccumulo.native.lib.path=${lib}/native"
   "${accumulo_initial_opts[@]}"
 )

--- a/assemble/conf/accumulo-env.sh
+++ b/assemble/conf/accumulo-env.sh
@@ -77,7 +77,6 @@ JAVA_OPTS=(
   '-XX:OnOutOfMemoryError=kill -9 %p'
   '-XX:-OmitStackTraceInFastThrow'
   '-Djava.net.preferIPv4Stack=true'
-  '-Dorg.jline.terminal.output=out'
   "-Daccumulo.native.lib.path=${lib}/native"
   "${accumulo_initial_opts[@]}"
 )

--- a/shell/src/main/java/org/apache/accumulo/shell/Shell.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/Shell.java
@@ -175,6 +175,7 @@ import org.jline.reader.impl.LineReaderImpl;
 import org.jline.terminal.Attributes;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
+import org.jline.terminal.TerminalBuilder.SystemOutput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -300,7 +301,8 @@ public class Shell extends ShellOptions implements KeywordExecutable {
    */
   public boolean config(String... args) throws IOException {
     if (this.terminal == null) {
-      this.terminal = TerminalBuilder.builder().jansi(false).build();
+      this.terminal =
+          TerminalBuilder.builder().jansi(false).systemOutput(SystemOutput.SysOut).build();
     }
     if (this.reader == null) {
       this.reader = LineReaderBuilder.builder().terminal(this.terminal).build();


### PR DESCRIPTION
When the shell is being used with an execute command and pipe `./accumulo shell -e '<command>' | grep "<>"`,
 jline does not write the output on stdout and instead writes it to stderr.

This causes frustration when attempting to script actions using the accumulo shell.

Without Property Set:
```
$ ./accumulo shell -e 'scan -t accumulo.root -np' | grep localhost 
2024-12-31T05:15:59,532 [shell.Shell] INFO : Loading configuration from /workspace/fluo-uno/install/accumulo-2.1.3/conf/accumulo-client.properties
!0;~ file:hdfs://localhost:8020/accumulo/tables/!0/table_info/0_1.rf []	0,0
!0;~ loc:10000501ae30004 []	localhost:9997
!0;~ srv:dir []	table_info
!0;~ srv:flush []	4
!0;~ srv:lock []	tservers/localhost:9997/zlock#d923681f-93ab-498f-b32e-0abf799b8354#0000000000$10000501ae30004
!0;~ srv:time []	L0
!0;~ ~tab:~pr []	\x00
!0< loc:10000501ae30004 []	localhost:9997
!0< srv:dir []	default_tablet
!0< srv:flush []	4
!0< srv:lock []	tservers/localhost:9997/zlock#d923681f-93ab-498f-b32e-0abf799b8354#0000000000$10000501ae30004
!0< srv:time []	L0
!0< ~tab:~pr []	\x01~
```

With Property Set:
```
$ ./accumulo shell -e 'scan -t accumulo.root -np' | grep localhost 
!0;~ file:hdfs://localhost:8020/accumulo/tables/!0/table_info/0_1.rf []	0,0
!0;~ loc:10000501ae30004 []	localhost:9997
!0;~ srv:lock []	tservers/localhost:9997/zlock#d923681f-93ab-498f-b32e-0abf799b8354#0000000000$10000501ae30004
!0< loc:10000501ae30004 []	localhost:9997
!0< srv:lock []	tservers/localhost:9997/zlock#d923681f-93ab-498f-b32e-0abf799b8354#0000000000$10000501ae30004
```

What made this odd was that the shell writes to stdout if not using a  pipe `|` as redirecting the output to a file works
`/accumulo shell -e '<command>'  > output.txt`

Related Jline Code: 

https://github.com/jline/jline3/blob/c75301facc8716b59c1d57d3e3c5943358022560/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java#L541 

https://github.com/jline/jline3/blob/c75301facc8716b59c1d57d3e3c5943358022560/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java#L588
