### PR TITLE
Checks for corruption earlier and always report errors

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
@@ -370,7 +370,7 @@ public class TabletClientHandler implements TabletClientService.Iface {
       us.unhandledException = e;
       us.currentTablet = null;
 
-      // rethrowing it will cause logging from thrift, so not adding logging here
+      // Rethrowing it will cause logging from thrift, so not adding logging here.
       throw e;
     } finally {
       if (reserved) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
@@ -267,8 +267,8 @@ public class TabletClientHandler implements TabletClientService.Iface {
     if (us.currentTablet != null && us.currentTablet.getExtent().equals(keyExtent)) {
       return;
     }
-    if (us.currentTablet == null
-        && (us.failures.containsKey(keyExtent) || us.authFailures.containsKey(keyExtent))) {
+    if (us.currentTablet == null && (us.failures.containsKey(keyExtent)
+        || us.authFailures.containsKey(keyExtent) || us.unhandledException != null)) {
       // if there were previous failures, then do not accept additional writes
       return;
     }
@@ -339,6 +339,11 @@ public class TabletClientHandler implements TabletClientService.Iface {
         List<Mutation> mutations = us.queuedMutations.get(us.currentTablet);
         for (TMutation tmutation : tmutations) {
           Mutation mutation = new ServerMutation(tmutation);
+          // Deserialize the mutation in an attempt to check for data corruption that happened on
+          // the network. This will avoid writing a corrupt mutation to the write ahead log and
+          // failing after its written to the write ahead log when it is deserialized to update the
+          // in memory map.
+          mutation.getUpdates();
           mutations.add(mutation);
           additionalMutationSize += mutation.numBytes();
         }
@@ -358,6 +363,15 @@ public class TabletClientHandler implements TabletClientService.Iface {
           }
         }
       }
+    } catch (RuntimeException e) {
+      // This method is a thrift oneway method so an exception from it will not make it back to the
+      // client. Need to record the exception and set the session such that any future updates to
+      // the session are ignored.
+      us.unhandledException = e;
+      us.currentTablet = null;
+
+      // rethrowing it will cause logging from thrift, so not adding logging here
+      throw e;
     } finally {
       if (reserved) {
         server.sessionManager.unreserveSession(us);
@@ -536,6 +550,13 @@ public class TabletClientHandler implements TabletClientService.Iface {
     }
 
     try {
+      if (us.unhandledException != null) {
+        // Something unexpected happened during this write session, so throw an exception here to
+        // cause a TApplicationException on the client side.
+        throw new IllegalStateException("Write session " + updateID + " saw an unexpected exception",
+                us.unhandledException);
+      }
+
       // clients may or may not see data from an update session while
       // it is in progress, however when the update session is closed
       // want to ensure that reads wait for the write to finish

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
@@ -553,8 +553,8 @@ public class TabletClientHandler implements TabletClientService.Iface {
       if (us.unhandledException != null) {
         // Something unexpected happened during this write session, so throw an exception here to
         // cause a TApplicationException on the client side.
-        throw new IllegalStateException("Write session " + updateID + " saw an unexpected exception",
-                us.unhandledException);
+        throw new IllegalStateException(
+            "Write session " + updateID + " saw an unexpected exception", us.unhandledException);
       }
 
       // clients may or may not see data from an update session while

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
@@ -551,6 +551,13 @@ public class TabletClientHandler implements TabletClientService.Iface {
 
     try {
       if (us.unhandledException != null) {
+        // Since flush() is not being called, any memory added to the global queued mutations
+        // counter will not be decremented. So do that here before throwing an exception.
+        server.updateTotalQueuedMutationSize(-us.queuedMutationSize);
+        us.queuedMutationSize = 0;
+        // make this memory available for GC
+        us.queuedMutations.clear();
+
         // Something unexpected happened during this write session, so throw an exception here to
         // cause a TApplicationException on the client side.
         throw new IllegalStateException(

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/UpdateSession.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/UpdateSession.java
@@ -50,6 +50,7 @@ public class UpdateSession extends Session {
   public long flushTime = 0;
   public long queuedMutationSize = 0;
   public final Durability durability;
+  public Exception unhandledException = null;
 
   public UpdateSession(TservConstraintEnv env, TCredentials credentials, Durability durability) {
     super(credentials);

--- a/test/src/main/java/org/apache/accumulo/test/CorruptMutationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/CorruptMutationIT.java
@@ -18,7 +18,9 @@
  */
 package org.apache.accumulo.test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import java.util.Set;

--- a/test/src/main/java/org/apache/accumulo/test/CorruptMutationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/CorruptMutationIT.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.accumulo.core.client.Accumulo;
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.clientImpl.ClientContext;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.core.dataImpl.thrift.TMutation;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.rpc.ThriftUtil;
+import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
+import org.apache.accumulo.core.tabletserver.thrift.TDurability;
+import org.apache.accumulo.core.tabletserver.thrift.TabletClientService;
+import org.apache.accumulo.core.trace.TraceUtil;
+import org.apache.accumulo.core.trace.thrift.TInfo;
+import org.apache.accumulo.harness.AccumuloClusterHarness;
+import org.apache.thrift.TApplicationException;
+import org.apache.thrift.TServiceClient;
+import org.junit.jupiter.api.Test;
+
+public class CorruptMutationIT extends AccumuloClusterHarness {
+  @Test
+  public void testCorruptMutation() throws Exception {
+    
+    String table = getUniqueNames(1)[0];
+    try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
+      c.tableOperations().create(table);
+      try (BatchWriter writer = c.createBatchWriter(table)) {
+        Mutation m = new Mutation("1");
+        m.put("f1", "q1", new Value("v1"));
+        writer.addMutation(m);
+      }
+
+      var ctx = (ClientContext) c;
+      var tableId = ctx.getTableId(table);
+      var extent = new KeyExtent(tableId, null, null);
+      var tabletMetadata = ctx.getAmple().readTablet(extent, TabletMetadata.ColumnType.LOCATION);
+      var location = tabletMetadata.getLocation();
+      assertNotNull(location);
+      assertEquals(TabletMetadata.LocationType.CURRENT, location.getType());
+
+      TabletClientService.Iface client =
+          ThriftUtil.getClient(ThriftClientTypes.TABLET_SERVER, location.getHostAndPort(), ctx);
+      // Make the same RPC calls made by the BatchWriter, but pass a corrupt serialized mutation in
+      // this try block.
+      try {
+        TInfo tinfo = TraceUtil.traceInfo();
+
+        long sessionId = client.startUpdate(tinfo, ctx.rpcCreds(), TDurability.DEFAULT);
+        Mutation m = new Mutation("abc");
+        m.put("x", "y", "z");
+
+        // Serialize the mutation
+        TMutation tMutation = m.toThrift();
+
+        // Simulate data corruption in the serialized mutation
+        tMutation.entries = -42;
+
+        // The server side will see an error here, however since this is a thrift oneway method no
+        // exception is expected here.
+        client.applyUpdates(tinfo, sessionId, extent.toThrift(), List.of(tMutation));
+
+        // Since client.applyUpdates experienced an error, should see an error when closing the
+        // session.
+        assertThrows(TApplicationException.class, () -> client.closeUpdate(tinfo, sessionId));
+      } finally {
+        ThriftUtil.returnClient((TServiceClient) client, ctx);
+      }
+
+      // The failed mutation should not have left the tablet in a bad state. Do some follow-on
+      // actions to ensure the tablet is still functional.
+      try (BatchWriter writer = c.createBatchWriter(table)) {
+        Mutation m = new Mutation("2");
+        m.put("f1", "q1", new Value("v2"));
+        writer.addMutation(m);
+      }
+
+      try (Scanner scanner = c.createScanner(table)) {
+        var valuesSeen =
+            scanner.stream().map(e -> e.getValue().toString()).collect(Collectors.toSet());
+        assertEquals(Set.of("v1", "v2"), valuesSeen);
+      }
+
+      c.tableOperations().flush(table, null, null, true);
+
+      try (Scanner scanner = c.createScanner(table)) {
+        var valuesSeen =
+            scanner.stream().map(e -> e.getValue().toString()).collect(Collectors.toSet());
+        assertEquals(Set.of("v1", "v2"), valuesSeen);
+      }
+    }
+  }
+}

--- a/test/src/main/java/org/apache/accumulo/test/CorruptMutationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/CorruptMutationIT.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.Test;
 public class CorruptMutationIT extends AccumuloClusterHarness {
   @Test
   public void testCorruptMutation() throws Exception {
-    
+
     String table = getUniqueNames(1)[0];
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
       c.tableOperations().create(table);

--- a/test/src/main/java/org/apache/accumulo/test/CorruptMutationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/CorruptMutationIT.java
@@ -18,7 +18,11 @@
  */
 package org.apache.accumulo.test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Set;


### PR DESCRIPTION
Was looking into an issue were a mutation was corrupted on the network. This caused the mutation to be written to the write ahead log and then a failure occurred in the tablet server which left the tablet in an inconsistent state.  Modifed the tablet server code to deserialize mutations as early as possible (it used to deserialize after writing to the walog, now it does it before).

Wrote an IT to recreate this problem and found another bug.  Writing data to Accumulo does the following.

 1. Make a startUpdate RPC to create an update session
 2. Make one or more applyUpdates RPCs to add data to the session.  These RPCs are thrift oneway calls, so nothing is reported back.
 3. Call closeUpdate on the session to see what happened with all of the applyUpdates RPCs done in step 2.

If an unexpected exception happened in step 2 above then it would not be reported back to the client.  These changes fix and test that as part of testing the corrupt mutation. After these changes if there was an error in step 2, then step 3 now throws an exception.