### PR TITLE
Use a FileHandler when loading properties

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/SiteConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/SiteConfiguration.java
@@ -39,6 +39,7 @@ import org.apache.commons.configuration2.CompositeConfiguration;
 import org.apache.commons.configuration2.MapConfiguration;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.commons.configuration2.io.FileHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -222,8 +223,9 @@ public class SiteConfiguration extends AccumuloConfiguration {
   private static AbstractConfiguration getPropsFileConfig(URL accumuloPropsLocation) {
     var config = new PropertiesConfiguration();
     if (accumuloPropsLocation != null) {
+      var fileHandler = new FileHandler(config);
       try (var reader = new InputStreamReader(accumuloPropsLocation.openStream(), UTF_8)) {
-        config.read(reader);
+        fileHandler.load(reader);
       } catch (ConfigurationException | IOException e) {
         throw new IllegalArgumentException(e);
       }

--- a/start/src/main/java/org/apache/accumulo/start/classloader/AccumuloClassLoader.java
+++ b/start/src/main/java/org/apache/accumulo/start/classloader/AccumuloClassLoader.java
@@ -34,6 +34,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.io.FileHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -90,8 +91,9 @@ public class AccumuloClassLoader {
     }
     try {
       var config = new PropertiesConfiguration();
+      var fileHandler = new FileHandler(config);
       try (var reader = new InputStreamReader(accumuloConfigUrl.openStream(), UTF_8)) {
-        config.read(reader);
+        fileHandler.load(reader);
       }
       String value = config.getString(propertyName);
       if (value != null) {


### PR DESCRIPTION
Fixes error when using `include` or `includeOptional` property directives in accumulo.properties
```
Caused by: org.apache.commons.configuration2.ex.ConfigurationException: Load operation not properly initialized! Do not call read(InputStream) directly, but use a FileHandler to load a configuration.
	at org.apache.commons.configuration2.PropertiesConfiguration.loadIncludeFile(PropertiesConfiguration.java:1395)
	at org.apache.commons.configuration2.PropertiesConfiguration.propertyLoaded(PropertiesConfiguration.java:1479)
	at org.apache.commons.configuration2.PropertiesConfigurationLayout.load(PropertiesConfigurationLayout.java:444)
	at org.apache.commons.configuration2.PropertiesConfiguration.read(PropertiesConfiguration.java:1500)
	at org.apache.accumulo.start.classloader.AccumuloClassLoader.getAccumuloProperty(AccumuloClassLoader.java:94)
```

Discovered when testing #5231, fixes #5234