### PR TITLE
Fix issue with ZooPropEditor setting classloader context property

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/classloader/ClassLoaderUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/classloader/ClassLoaderUtil.java
@@ -69,7 +69,7 @@ public class ClassLoaderUtil {
   }
 
   // for testing
-  static synchronized void resetContextFactoryForTests() {
+  public static synchronized void resetContextFactoryForTests() {
     FACTORY = null;
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/SystemPropUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/SystemPropUtil.java
@@ -37,7 +37,8 @@ public class SystemPropUtil {
   public static void setSystemProperty(ServerContext context, String property, String value)
       throws IllegalArgumentException {
     final SystemPropKey key = SystemPropKey.of(context);
-    context.getPropStore().putAll(key, Map.of(validateSystemProperty(key, property, value), value));
+    context.getPropStore().putAll(key,
+        Map.of(validateSystemProperty(context, key, property, value), value));
   }
 
   public static void modifyProperties(ServerContext context, long version,
@@ -46,7 +47,7 @@ public class SystemPropUtil {
     final Map<String,
         String> checkedProperties = properties.entrySet().stream()
             .collect(Collectors.toMap(
-                entry -> validateSystemProperty(key, entry.getKey(), entry.getValue()),
+                entry -> validateSystemProperty(context, key, entry.getKey(), entry.getValue()),
                 Map.Entry::getValue));
     context.getPropStore().replaceAll(key, version, checkedProperties);
   }
@@ -66,8 +67,8 @@ public class SystemPropUtil {
     context.getPropStore().removeProperties(SystemPropKey.of(context), List.of(property));
   }
 
-  private static String validateSystemProperty(SystemPropKey key, String property,
-      final String value) throws IllegalArgumentException {
+  private static String validateSystemProperty(ServerContext context, SystemPropKey key,
+      String property, final String value) throws IllegalArgumentException {
     // Retrieve the replacement name for this property, if there is one.
     // Do this before we check if the name is a valid zookeeper name.
     final var original = property;
@@ -88,7 +89,7 @@ public class SystemPropUtil {
       throw iae;
     }
     if (Property.isValidTablePropertyKey(property)) {
-      PropUtil.validateProperties(key, Map.of(property, value));
+      PropUtil.validateProperties(context, key, Map.of(property, value));
     }
 
     // Find the property taking prefix into account

--- a/server/base/src/test/java/org/apache/accumulo/server/util/PropUtilTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/PropUtilTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.util;
+
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Map;
+
+import org.apache.accumulo.core.classloader.ClassLoaderUtil;
+import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.InstanceId;
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.spi.common.ContextClassLoaderFactory;
+import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.conf.store.TablePropKey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class PropUtilTest {
+
+  private static final String TEST_CONTEXT_NAME = "TestContext";
+  private static final String INVALID_TEST_CONTEXT_NAME = "InvalidTestContext";
+
+  public static class TestContextClassLoaderFactory implements ContextClassLoaderFactory {
+
+    @Override
+    public ClassLoader getClassLoader(String contextName) {
+      if (contextName.equals(TEST_CONTEXT_NAME)) {
+        return this.getClass().getClassLoader();
+      }
+      return null;
+    }
+
+  }
+
+  @BeforeEach
+  public void before() {
+    ClassLoaderUtil.resetContextFactoryForTests();
+  }
+
+  @Test
+  public void testSetClasspathContextFails() {
+    ServerContext ctx = createMock(ServerContext.class);
+    AccumuloConfiguration conf = createMock(AccumuloConfiguration.class);
+    InstanceId iid = createMock(InstanceId.class);
+    TableId tid = createMock(TableId.class);
+    TablePropKey tkey = TablePropKey.of(iid, tid);
+
+    expect(ctx.getConfiguration()).andReturn(conf).once();
+    expect(conf.get(Property.GENERAL_CONTEXT_CLASSLOADER_FACTORY))
+        .andReturn(TestContextClassLoaderFactory.class.getName());
+
+    replay(ctx, conf, iid, tid);
+    IllegalArgumentException e =
+        assertThrows(IllegalArgumentException.class, () -> PropUtil.validateProperties(ctx, tkey,
+            Map.of(Property.TABLE_CLASSLOADER_CONTEXT.getKey(), INVALID_TEST_CONTEXT_NAME)));
+    assertEquals("Unable to resolve classloader for context: " + INVALID_TEST_CONTEXT_NAME,
+        e.getMessage());
+    verify(ctx, conf, iid, tid);
+  }
+
+  @Test
+  public void testSetClasspathContext() {
+    ServerContext ctx = createMock(ServerContext.class);
+    AccumuloConfiguration conf = createMock(AccumuloConfiguration.class);
+    InstanceId iid = createMock(InstanceId.class);
+    TableId tid = createMock(TableId.class);
+    TablePropKey tkey = TablePropKey.of(iid, tid);
+
+    expect(ctx.getConfiguration()).andReturn(conf).once();
+    expect(conf.get(Property.GENERAL_CONTEXT_CLASSLOADER_FACTORY))
+        .andReturn(TestContextClassLoaderFactory.class.getName());
+
+    replay(ctx, conf, iid, tid);
+    PropUtil.validateProperties(ctx, tkey,
+        Map.of(Property.TABLE_CLASSLOADER_CONTEXT.getKey(), TEST_CONTEXT_NAME));
+    verify(ctx, conf, iid, tid);
+  }
+
+}


### PR DESCRIPTION
The root cause of the issue is that ClassLoaderUtil.initContextFactory was not being called which caused an NPE to be thrown which returned false from ClassLoaderUtil.isValidContext.

Closes #5198