### PR TITLE
Fixed FileNormalizationIT after #5237

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/CompactionMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/CompactionMetadata.java
@@ -113,7 +113,7 @@ public class CompactionMetadata {
     GSonData jData = new GSonData();
     jData.inputs =
         jobFiles.stream().map(stf -> new TabletFileCqMetadataGson(stf)).collect(toList());
-    jData.tmp = new TabletFileCqMetadataGson(compactTmpName);
+    jData.tmp = new TabletFileCqMetadataGson(compactTmpName.insert());
     jData.compactor = compactorId;
     jData.kind = kind.name();
     jData.groupId = cgid.toString();

--- a/core/src/main/java/org/apache/accumulo/core/metadata/StoredTabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/StoredTabletFile.java
@@ -236,7 +236,7 @@ public class StoredTabletFile extends AbstractTabletFile<StoredTabletFile> {
    * returned as an empty byte array
    **/
 
-  private static byte[] encodeRow(final Key key) {
+  protected static byte[] encodeRow(final Key key) {
     final Text row = key != null ? key.getRow() : null;
     if (row != null) {
       try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -252,7 +252,7 @@ public class StoredTabletFile extends AbstractTabletFile<StoredTabletFile> {
     return new byte[0];
   }
 
-  private static Text decodeRow(byte[] serialized) {
+  protected static Text decodeRow(byte[] serialized) {
     // Empty byte array means null row
     if (serialized.length == 0) {
       return null;
@@ -292,26 +292,26 @@ public class StoredTabletFile extends AbstractTabletFile<StoredTabletFile> {
   }
 
   static class TabletFileCqMetadataGson {
-    private String path;
-    private byte[] startRow;
-    private byte[] endRow;
+    protected String metadataEntry;
+    protected String path;
+    protected byte[] startRow;
+    protected byte[] endRow;
 
     TabletFileCqMetadataGson() {}
 
-    TabletFileCqMetadataGson(AbstractTabletFile<?> atf) {
-      path = Objects.requireNonNull(atf.path.toString());
-      startRow = encodeRow(atf.range.getStartKey());
-      endRow = encodeRow(atf.range.getEndKey());
+    TabletFileCqMetadataGson(StoredTabletFile stf) {
+      metadataEntry = Objects.requireNonNull(stf.getMetadata());
+      path = Objects.requireNonNull(stf.getMetadataPath());
+      startRow = encodeRow(stf.range.getStartKey());
+      endRow = encodeRow(stf.range.getEndKey());
     }
 
     ReferencedTabletFile toReferencedTabletFile() {
-      return new ReferencedTabletFile(new Path(URI.create(path)),
-          new Range(decodeRow(startRow), true, decodeRow(endRow), false));
+      return new StoredTabletFile(metadataEntry).getTabletFile();
     }
 
     StoredTabletFile toStoredTabletFile() {
-      return StoredTabletFile.of(new Path(URI.create(path)),
-          new Range(decodeRow(startRow), true, decodeRow(endRow), false));
+      return new StoredTabletFile(metadataEntry);
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/StoredTabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/StoredTabletFile.java
@@ -236,7 +236,7 @@ public class StoredTabletFile extends AbstractTabletFile<StoredTabletFile> {
    * returned as an empty byte array
    **/
 
-  protected static byte[] encodeRow(final Key key) {
+  static byte[] encodeRow(final Key key) {
     final Text row = key != null ? key.getRow() : null;
     if (row != null) {
       try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -252,7 +252,7 @@ public class StoredTabletFile extends AbstractTabletFile<StoredTabletFile> {
     return new byte[0];
   }
 
-  protected static Text decodeRow(byte[] serialized) {
+  static Text decodeRow(byte[] serialized) {
     // Empty byte array means null row
     if (serialized.length == 0) {
       return null;


### PR DESCRIPTION
The changes in #5237 to make the external compaction json metadata entry easier to use ended up breaking FileNormalizationIT. #5237 removed the metadata entry string which ended up escaping the double quotes in the string for the json and replaced it with an object that contains the path, start, and end row. The problem with this is that the metadata entry retains any misnormalization of the file name (e.g. double slashes in the path) and that path alone does not. This fixes the issue by putting the metadata entry into the new object that is serialized to json so that the json for the external compaction files now contains the metadata entry, normalized path, start and end row.