### PR TITLE
Made ITs that restart MAC faster

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooCache.java
@@ -533,13 +533,10 @@ public class ZooCache {
     Preconditions.checkState(!closed);
     Predicate<String> pathPredicateToUse;
     if (log.isTraceEnabled()) {
-      pathPredicateToUse = path -> {
-        boolean testResult = pathPredicate.test(path);
-        if (testResult) {
-          log.trace("removing {} from cache", path);
-        }
-        return testResult;
-      };
+      pathPredicateToUse = pathPredicate.and(path -> {
+        log.trace("removing {} from cache", path);
+        return true;
+      });
     } else {
       pathPredicateToUse = pathPredicate;
     }

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterControl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterControl.java
@@ -280,12 +280,10 @@ public class MiniAccumuloClusterControl implements ClusterControl {
           try {
             cluster.stopProcessWithTimeout(managerProcess, 30, TimeUnit.SECONDS);
             try {
-              new ZooZap().zap(cluster.getServerContext().getSiteConfiguration(),
-                  new String[] {"-manager"});
-            } catch (Exception e) {
+              new ZooZap().zap(cluster.getServerContext().getSiteConfiguration(), "-manager");
+            } catch (RuntimeException e) {
               log.error("Error zapping Manager zookeeper lock", e);
             }
-
           } catch (ExecutionException | TimeoutException e) {
             log.warn("Manager did not fully stop after 30 seconds", e);
           } catch (InterruptedException e) {

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterControl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterControl.java
@@ -280,8 +280,6 @@ public class MiniAccumuloClusterControl implements ClusterControl {
           try {
             cluster.stopProcessWithTimeout(managerProcess, 30, TimeUnit.SECONDS);
             try {
-              System.setProperty("accumulo.properties",
-                  "file://" + cluster.getAccumuloPropertiesPath());
               new ZooZap().zap(cluster.getServerContext().getSiteConfiguration(),
                   new String[] {"-manager"});
             } catch (Exception e) {

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
@@ -835,7 +835,6 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
     // is restarted, then the processes will start right away
     // and not wait for the old locks to be cleaned up.
     try {
-      System.setProperty("accumulo.properties", "file://" + getAccumuloPropertiesPath());
       new ZooZap().zap(getServerContext().getSiteConfiguration(), new String[] {"-manager",
           "-compaction-coordinators", "-tservers", "-compactors", "-sservers"});
     } catch (Exception e) {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
@@ -102,7 +102,7 @@ public class ZooZap implements KeywordExecutable {
     }
   }
 
-  public void zap(SiteConfiguration siteConf, String[] args) {
+  public void zap(SiteConfiguration siteConf, String... args) {
     Opts opts = new Opts();
     opts.parseArgs(keyword(), args);
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
@@ -90,6 +90,19 @@ public class ZooZap implements KeywordExecutable {
 
   @Override
   public void execute(String[] args) throws Exception {
+    try {
+      var siteConf = SiteConfiguration.auto();
+      // Login as the server on secure HDFS
+      if (siteConf.getBoolean(Property.INSTANCE_RPC_SASL_ENABLED)) {
+        SecurityUtil.serverLogin(siteConf);
+      }
+      zap(siteConf, args);
+    } finally {
+      SingletonManager.setMode(Mode.CLOSED);
+    }
+  }
+
+  public void zap(SiteConfiguration siteConf, String[] args) {
     Opts opts = new Opts();
     opts.parseArgs(keyword(), args);
 
@@ -98,111 +111,100 @@ public class ZooZap implements KeywordExecutable {
       return;
     }
 
-    try {
-      var siteConf = SiteConfiguration.auto();
-      // Login as the server on secure HDFS
-      if (siteConf.getBoolean(Property.INSTANCE_RPC_SASL_ENABLED)) {
-        SecurityUtil.serverLogin(siteConf);
-      }
+    String volDir = VolumeConfiguration.getVolumeUris(siteConf).iterator().next();
+    Path instanceDir = new Path(volDir, "instance_id");
+    InstanceId iid = VolumeManager.getInstanceIDFromHdfs(instanceDir, new Configuration());
+    ZooReaderWriter zoo = new ZooReaderWriter(siteConf);
 
-      String volDir = VolumeConfiguration.getVolumeUris(siteConf).iterator().next();
-      Path instanceDir = new Path(volDir, "instance_id");
-      InstanceId iid = VolumeManager.getInstanceIDFromHdfs(instanceDir, new Configuration());
-      ZooReaderWriter zoo = new ZooReaderWriter(siteConf);
+    if (opts.zapMaster) {
+      log.warn("The -master option is deprecated. Please use -manager instead.");
+    }
+    if (opts.zapManager || opts.zapMaster) {
+      String managerLockPath = Constants.ZROOT + "/" + iid + Constants.ZMANAGER_LOCK;
 
-      if (opts.zapMaster) {
-        log.warn("The -master option is deprecated. Please use -manager instead.");
-      }
-      if (opts.zapManager || opts.zapMaster) {
-        String managerLockPath = Constants.ZROOT + "/" + iid + Constants.ZMANAGER_LOCK;
-
-        try {
-          zapDirectory(zoo, managerLockPath, opts);
-        } catch (KeeperException | InterruptedException e) {
-          e.printStackTrace();
-        }
-      }
-
-      if (opts.zapTservers) {
-        String tserversPath = Constants.ZROOT + "/" + iid + Constants.ZTSERVERS;
-        try {
-          List<String> children = zoo.getChildren(tserversPath);
-          for (String child : children) {
-            message("Deleting " + tserversPath + "/" + child + " from zookeeper", opts);
-
-            if (opts.zapManager || opts.zapMaster) {
-              zoo.recursiveDelete(tserversPath + "/" + child, NodeMissingPolicy.SKIP);
-            } else {
-              var zLockPath = ServiceLock.path(tserversPath + "/" + child);
-              if (!zoo.getChildren(zLockPath.toString()).isEmpty()) {
-                if (!ServiceLock.deleteLock(zoo, zLockPath, "tserver")) {
-                  message("Did not delete " + tserversPath + "/" + child, opts);
-                }
-              }
-            }
-          }
-        } catch (KeeperException | InterruptedException e) {
-          log.error("{}", e.getMessage(), e);
-        }
-      }
-
-      // Remove the tracers, we don't use them anymore.
-      @SuppressWarnings("deprecation")
-      String path = siteConf.get(Property.TRACE_ZK_PATH);
       try {
-        zapDirectory(zoo, path, opts);
-      } catch (Exception e) {
-        // do nothing if the /tracers node does not exist.
+        zapDirectory(zoo, managerLockPath, opts);
+      } catch (KeeperException | InterruptedException e) {
+        e.printStackTrace();
       }
+    }
 
-      if (opts.zapCoordinators) {
-        final String coordinatorPath = Constants.ZROOT + "/" + iid + Constants.ZCOORDINATOR_LOCK;
-        try {
-          if (zoo.exists(coordinatorPath)) {
-            zapDirectory(zoo, coordinatorPath, opts);
-          }
-        } catch (KeeperException | InterruptedException e) {
-          log.error("Error deleting coordinator from zookeeper, {}", e.getMessage(), e);
-        }
-      }
+    if (opts.zapTservers) {
+      String tserversPath = Constants.ZROOT + "/" + iid + Constants.ZTSERVERS;
+      try {
+        List<String> children = zoo.getChildren(tserversPath);
+        for (String child : children) {
+          message("Deleting " + tserversPath + "/" + child + " from zookeeper", opts);
 
-      if (opts.zapCompactors) {
-        String compactorsBasepath = Constants.ZROOT + "/" + iid + Constants.ZCOMPACTORS;
-        try {
-          if (zoo.exists(compactorsBasepath)) {
-            List<String> queues = zoo.getChildren(compactorsBasepath);
-            for (String queue : queues) {
-              message("Deleting " + compactorsBasepath + "/" + queue + " from zookeeper", opts);
-              zoo.recursiveDelete(compactorsBasepath + "/" + queue, NodeMissingPolicy.SKIP);
-            }
-          }
-        } catch (KeeperException | InterruptedException e) {
-          log.error("Error deleting compactors from zookeeper, {}", e.getMessage(), e);
-        }
-
-      }
-
-      if (opts.zapScanServers) {
-        String sserversPath = Constants.ZROOT + "/" + iid + Constants.ZSSERVERS;
-        try {
-          if (zoo.exists(sserversPath)) {
-            List<String> children = zoo.getChildren(sserversPath);
-            for (String child : children) {
-              message("Deleting " + sserversPath + "/" + child + " from zookeeper", opts);
-
-              var zLockPath = ServiceLock.path(sserversPath + "/" + child);
-              if (!zoo.getChildren(zLockPath.toString()).isEmpty()) {
-                ServiceLock.deleteLock(zoo, zLockPath);
+          if (opts.zapManager || opts.zapMaster) {
+            zoo.recursiveDelete(tserversPath + "/" + child, NodeMissingPolicy.SKIP);
+          } else {
+            var zLockPath = ServiceLock.path(tserversPath + "/" + child);
+            if (!zoo.getChildren(zLockPath.toString()).isEmpty()) {
+              if (!ServiceLock.deleteLock(zoo, zLockPath, "tserver")) {
+                message("Did not delete " + tserversPath + "/" + child, opts);
               }
             }
           }
-        } catch (KeeperException | InterruptedException e) {
-          log.error("{}", e.getMessage(), e);
         }
+      } catch (KeeperException | InterruptedException e) {
+        log.error("{}", e.getMessage(), e);
+      }
+    }
+
+    // Remove the tracers, we don't use them anymore.
+    @SuppressWarnings("deprecation")
+    String path = siteConf.get(Property.TRACE_ZK_PATH);
+    try {
+      zapDirectory(zoo, path, opts);
+    } catch (Exception e) {
+      // do nothing if the /tracers node does not exist.
+    }
+
+    if (opts.zapCoordinators) {
+      final String coordinatorPath = Constants.ZROOT + "/" + iid + Constants.ZCOORDINATOR_LOCK;
+      try {
+        if (zoo.exists(coordinatorPath)) {
+          zapDirectory(zoo, coordinatorPath, opts);
+        }
+      } catch (KeeperException | InterruptedException e) {
+        log.error("Error deleting coordinator from zookeeper, {}", e.getMessage(), e);
+      }
+    }
+
+    if (opts.zapCompactors) {
+      String compactorsBasepath = Constants.ZROOT + "/" + iid + Constants.ZCOMPACTORS;
+      try {
+        if (zoo.exists(compactorsBasepath)) {
+          List<String> queues = zoo.getChildren(compactorsBasepath);
+          for (String queue : queues) {
+            message("Deleting " + compactorsBasepath + "/" + queue + " from zookeeper", opts);
+            zoo.recursiveDelete(compactorsBasepath + "/" + queue, NodeMissingPolicy.SKIP);
+          }
+        }
+      } catch (KeeperException | InterruptedException e) {
+        log.error("Error deleting compactors from zookeeper, {}", e.getMessage(), e);
       }
 
-    } finally {
-      SingletonManager.setMode(Mode.CLOSED);
+    }
+
+    if (opts.zapScanServers) {
+      String sserversPath = Constants.ZROOT + "/" + iid + Constants.ZSSERVERS;
+      try {
+        if (zoo.exists(sserversPath)) {
+          List<String> children = zoo.getChildren(sserversPath);
+          for (String child : children) {
+            message("Deleting " + sserversPath + "/" + child + " from zookeeper", opts);
+
+            var zLockPath = ServiceLock.path(sserversPath + "/" + child);
+            if (!zoo.getChildren(zLockPath.toString()).isEmpty()) {
+              ServiceLock.deleteLock(zoo, zLockPath);
+            }
+          }
+        }
+      } catch (KeeperException | InterruptedException e) {
+        log.error("{}", e.getMessage(), e);
+      }
     }
 
   }


### PR DESCRIPTION
Modified MAC so that it cleaned up lock paths
in ZooKeeper and ZooCache when stopping. Noticed
that in tests that restarted MAC the Manager
process would wait for the previous lock to be
removed on the session timeout. The lock paths
would also be cached in ZooCache and not updated
right away because the Watcher would not fire
when MAC was stopped, a ConnectionLoss error
would be returned when MAC started, and it would
take a while for ZooCache to fix itself.