### PR TITLE
Used data size instead of entry size of compaction queue

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -465,7 +465,6 @@ public enum Property {
       "The number of threads used to seed fate split task, the actual split work is done by fate"
           + " threads.",
       "4.0.0"),
-  // TODO need to add a metric for data size of the queue so this metric can be tuned
   MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_SIZE("manager.compaction.major.service.queue.size",
       "1M", PropertyType.MEMORY,
       "The data size of each resource groups compaction job priority queue.  The memory size of "

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -465,14 +465,13 @@ public enum Property {
       "The number of threads used to seed fate split task, the actual split work is done by fate"
           + " threads.",
       "4.0.0"),
-
-  MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_INITIAL_SIZE(
-      "manager.compaction.major.service.queue.initial.size", "10000", PropertyType.COUNT,
-      "The initial size of each resource groups compaction job priority queue.", "4.0.0"),
-  MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_SIZE_FACTOR(
-      "manager.compaction.major.service.queue.size.factor", "3.0", PropertyType.FRACTION,
-      "The dynamic resizing of the compaction job priority queue is based on"
-          + " the number of compactors for the group multiplied by this factor.",
+  // TODO need to add a metric for data size of the queue so this metric can be tuned
+  MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_SIZE("manager.compaction.major.service.queue.size",
+      "1M", PropertyType.MEMORY,
+      "The data size of each resource groups compaction job priority queue.  The memory size of "
+          + "each compaction job is estimated and the sum of these sizes per resource group will not "
+          + "exceed this setting. When the size is exceeded the lowest priority jobs are dropped as "
+          + "needed.",
       "4.0.0"),
   SPLIT_PREFIX("split.", null, PropertyType.PREFIX,
       "System wide properties related to splitting tablets.", "3.1.0"),
@@ -1460,7 +1459,7 @@ public enum Property {
       RPC_MAX_MESSAGE_SIZE,
 
       // compaction coordiantor properties
-      MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_INITIAL_SIZE,
+      MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_SIZE,
 
       // block cache options
       GENERAL_CACHE_MANAGER_IMPL, TSERV_DATACACHE_SIZE, TSERV_INDEXCACHE_SIZE,

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
@@ -188,8 +188,8 @@ public class MiniAccumuloConfigImpl {
 
       mergeProp(Property.COMPACTOR_PORTSEARCH.getKey(), "true");
 
-      mergeProp(Property.MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_INITIAL_SIZE.getKey(),
-          Property.MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_INITIAL_SIZE.getDefaultValue());
+      mergeProp(Property.MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_SIZE.getKey(),
+          Property.MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_SIZE.getDefaultValue());
       mergeProp(Property.COMPACTION_SERVICE_DEFAULT_PLANNER.getKey(),
           Property.COMPACTION_SERVICE_DEFAULT_PLANNER.getDefaultValue());
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/queue/SizeTrackingTreeMap.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/queue/SizeTrackingTreeMap.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.manager.compaction.queue;
+
+import java.util.AbstractMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * This class wraps a treemap and tracks the data size of everything added and removed from the
+ * treemap.
+ */
+class SizeTrackingTreeMap<K,V> {
+
+  private static class ValueWrapper<V2> {
+    final V2 val;
+    final long computedSize;
+
+    private ValueWrapper(V2 val, long computedSize) {
+      this.val = val;
+      this.computedSize = computedSize;
+    }
+  }
+
+  private final TreeMap<K,ValueWrapper<V>> map = new TreeMap<>();
+  private long dataSize = 0;
+  private Weigher<V> weigher;
+
+  private Map.Entry<K,V> unwrap(Map.Entry<K,ValueWrapper<V>> wrapperEntry) {
+    if (wrapperEntry == null) {
+      return null;
+    }
+    return new AbstractMap.SimpleImmutableEntry<>(wrapperEntry.getKey(),
+        wrapperEntry.getValue().val);
+  }
+
+  private void incrementDataSize(ValueWrapper<V> val) {
+    Preconditions.checkState(dataSize >= 0);
+    dataSize += val.computedSize;
+  }
+
+  private void decrementDataSize(Map.Entry<K,ValueWrapper<V>> entry) {
+    if (entry != null) {
+      decrementDataSize(entry.getValue());
+    }
+  }
+
+  private void decrementDataSize(ValueWrapper<V> val) {
+    if (val != null) {
+      Preconditions.checkState(dataSize >= val.computedSize);
+      dataSize -= val.computedSize;
+    }
+  }
+
+  interface Weigher<V2> {
+    long weigh(V2 val);
+  }
+
+  public SizeTrackingTreeMap(Weigher<V> weigher) {
+    this.weigher = weigher;
+  }
+
+  public boolean isEmpty() {
+    return map.isEmpty();
+  }
+
+  public long dataSize() {
+    return dataSize;
+  }
+
+  public int entrySize() {
+    return map.size();
+  }
+
+  public K lastKey() {
+    return map.lastKey();
+  }
+
+  public Map.Entry<K,V> firstEntry() {
+    return unwrap(map.firstEntry());
+  }
+
+  public void remove(K key) {
+    var prev = map.remove(key);
+    decrementDataSize(prev);
+  }
+
+  public Map.Entry<K,V> pollFirstEntry() {
+    var first = map.pollFirstEntry();
+    decrementDataSize(first);
+    return unwrap(first);
+  }
+
+  public Map.Entry<K,V> pollLastEntry() {
+    var last = map.pollLastEntry();
+    decrementDataSize(last);
+    return unwrap(last);
+  }
+
+  public void put(K key, V val) {
+    var wrapped = new ValueWrapper<>(val, weigher.weigh(val));
+    var prev = map.put(key, wrapped);
+    decrementDataSize(prev);
+    incrementDataSize(wrapped);
+  }
+
+  public void clear() {
+    map.clear();
+    dataSize = 0;
+  }
+}

--- a/server/manager/src/test/java/org/apache/accumulo/manager/compaction/queue/CompactionJobPriorityQueueTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/compaction/queue/CompactionJobPriorityQueueTest.java
@@ -74,7 +74,7 @@ public class CompactionJobPriorityQueueTest {
 
     EasyMock.replay(tm, cj1, cj2);
 
-    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, 2);
+    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, 2, mj -> 1);
     assertEquals(1, queue.add(tm, List.of(cj1), 1L));
 
     MetaJob job = queue.peek();
@@ -129,7 +129,7 @@ public class CompactionJobPriorityQueueTest {
 
     EasyMock.replay(tm, cj1, cj2);
 
-    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, 2);
+    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, 2, mj -> 1);
     assertEquals(2, queue.add(tm, List.of(cj1, cj2), 1L));
 
     EasyMock.verify(tm, cj1, cj2);
@@ -186,7 +186,7 @@ public class CompactionJobPriorityQueueTest {
 
     EasyMock.replay(tm, cj1, cj2, cj3);
 
-    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, 2);
+    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, 2, mj -> 1);
     assertEquals(2, queue.add(tm, List.of(cj1, cj2, cj3), 1L));
 
     EasyMock.verify(tm, cj1, cj2, cj3);
@@ -247,7 +247,7 @@ public class CompactionJobPriorityQueueTest {
 
     TreeSet<CompactionJob> expected = new TreeSet<>(CompactionJobPrioritizer.JOB_COMPARATOR);
 
-    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, 100);
+    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, 1000, mj -> 10);
 
     // create and add 1000 jobs
     for (int x = 0; x < 1000; x++) {
@@ -256,7 +256,7 @@ public class CompactionJobPriorityQueueTest {
       expected.add(pair.getSecond());
     }
 
-    assertEquals(100, queue.getMaxSize());
+    assertEquals(1000, queue.getMaxSize());
     assertEquals(100, queue.getQueuedJobs());
     assertEquals(900, queue.getRejectedJobs());
     // There should be 1000 total job ages even though 900 were rejected
@@ -268,7 +268,7 @@ public class CompactionJobPriorityQueueTest {
     assertTrue(stats.getMaxAge().toMillis() > 0);
     assertTrue(stats.getAvgAge().toMillis() > 0);
 
-    // iterate over the expected set and make sure that they next job in the queue
+    // iterate over the expected set and make sure that the next job in the queue
     // matches
     int matchesSeen = 0;
     for (CompactionJob expectedJob : expected) {
@@ -312,7 +312,7 @@ public class CompactionJobPriorityQueueTest {
    */
   @Test
   public void testAsyncCancelCleanup() {
-    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, 100);
+    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, 100, mj -> 1);
 
     List<CompletableFuture<MetaJob>> futures = new ArrayList<>();
 
@@ -342,7 +342,7 @@ public class CompactionJobPriorityQueueTest {
 
   @Test
   public void testChangeMaxSize() {
-    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, 100);
+    CompactionJobPriorityQueue queue = new CompactionJobPriorityQueue(GROUP, 100, mj -> 1);
     assertEquals(100, queue.getMaxSize());
     queue.setMaxSize(50);
     assertEquals(50, queue.getMaxSize());
@@ -351,5 +351,4 @@ public class CompactionJobPriorityQueueTest {
     // Make sure previous value was not changed after invalid setting
     assertEquals(50, queue.getMaxSize());
   }
-
 }

--- a/server/manager/src/test/java/org/apache/accumulo/manager/compaction/queue/CompactionJobQueuesTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/compaction/queue/CompactionJobQueuesTest.java
@@ -81,7 +81,7 @@ public class CompactionJobQueuesTest {
     var cg2 = CompactorGroupId.of("CG2");
     var cg3 = CompactorGroupId.of("CG3");
 
-    CompactionJobQueues jobQueues = new CompactionJobQueues(100);
+    CompactionJobQueues jobQueues = new CompactionJobQueues(1000000);
 
     jobQueues.beginFullScan(DataLevel.USER);
 
@@ -247,7 +247,7 @@ public class CompactionJobQueuesTest {
 
     var cg1 = CompactorGroupId.of("CG1");
 
-    CompactionJobQueues jobQueues = new CompactionJobQueues(100);
+    CompactionJobQueues jobQueues = new CompactionJobQueues(1000000);
 
     jobQueues.add(tm1, List.of(newJob((short) 1, 5, cg1)));
     jobQueues.add(tm2, List.of(newJob((short) 2, 6, cg1)));
@@ -283,7 +283,7 @@ public class CompactionJobQueuesTest {
 
     final int numToAdd = 100_000;
 
-    CompactionJobQueues jobQueues = new CompactionJobQueues(numToAdd + 1);
+    CompactionJobQueues jobQueues = new CompactionJobQueues(10000000);
     CompactorGroupId[] groups =
         Stream.of("G1", "G2", "G3").map(CompactorGroupId::of).toArray(CompactorGroupId[]::new);
 
@@ -342,7 +342,7 @@ public class CompactionJobQueuesTest {
 
   @Test
   public void testGetAsync() throws Exception {
-    CompactionJobQueues jobQueues = new CompactionJobQueues(100);
+    CompactionJobQueues jobQueues = new CompactionJobQueues(1000000);
 
     var tid = TableId.of("1");
     var extent1 = new KeyExtent(tid, new Text("z"), new Text("q"));

--- a/server/manager/src/test/java/org/apache/accumulo/manager/compaction/queue/SizeTrackingTreeMapTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/compaction/queue/SizeTrackingTreeMapTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.manager.compaction.queue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.TreeMap;
+
+import org.junit.jupiter.api.Test;
+
+public class SizeTrackingTreeMapTest {
+  @Test
+  public void testSizeTracking() {
+    List<String> computeSizeCalls = new ArrayList<>();
+    var stmap = new SizeTrackingTreeMap<Integer,String>(val -> {
+      computeSizeCalls.add(val);
+      return val.length();
+    });
+
+    TreeMap<Integer,String> expected = new TreeMap<>();
+
+    check(expected, stmap);
+    assertEquals(List.of(), computeSizeCalls);
+
+    stmap.put(3, "1234567890");
+    expected.put(3, "1234567890");
+    check(expected, stmap);
+    assertEquals(List.of("1234567890"), computeSizeCalls);
+
+    stmap.put(4, "12345");
+    expected.put(4, "12345");
+    check(expected, stmap);
+    assertEquals(List.of("1234567890", "12345"), computeSizeCalls);
+
+    // remove a key that does not exist
+    stmap.remove(2);
+    expected.remove(2);
+    check(expected, stmap);
+    assertEquals(List.of("1234567890", "12345"), computeSizeCalls);
+
+    // remove a key that does exist
+    stmap.remove(3);
+    expected.remove(3);
+    check(expected, stmap);
+    assertEquals(List.of("1234567890", "12345"), computeSizeCalls);
+
+    // update an existing key, should decrement the old size and increment the new size
+    stmap.put(4, "123");
+    expected.put(4, "123");
+    check(expected, stmap);
+    assertEquals(List.of("1234567890", "12345", "123"), computeSizeCalls);
+
+    stmap.put(7, "123456789012345");
+    expected.put(7, "123456789012345");
+    check(expected, stmap);
+    assertEquals(List.of("1234567890", "12345", "123", "123456789012345"), computeSizeCalls);
+
+    stmap.put(11, "1234567");
+    expected.put(11, "1234567");
+    check(expected, stmap);
+    assertEquals(List.of("1234567890", "12345", "123", "123456789012345", "1234567"),
+        computeSizeCalls);
+
+    assertEquals(expected.pollFirstEntry(), stmap.pollFirstEntry());
+    check(expected, stmap);
+    assertEquals(List.of("1234567890", "12345", "123", "123456789012345", "1234567"),
+        computeSizeCalls);
+
+    assertEquals(expected.pollLastEntry(), stmap.pollLastEntry());
+    check(expected, stmap);
+    assertEquals(List.of("1234567890", "12345", "123", "123456789012345", "1234567"),
+        computeSizeCalls);
+
+    expected.clear();
+    stmap.clear();
+    check(expected, stmap);
+    assertEquals(List.of("1234567890", "12345", "123", "123456789012345", "1234567"),
+        computeSizeCalls);
+  }
+
+  private void check(TreeMap<Integer,String> expected, SizeTrackingTreeMap<Integer,String> stmap) {
+    long expectedDataSize = expected.values().stream().mapToLong(String::length).sum();
+    assertEquals(expectedDataSize, stmap.dataSize());
+    assertEquals(expected.size(), stmap.entrySize());
+    assertEquals(expected.isEmpty(), stmap.isEmpty());
+    assertEquals(expected.firstEntry(), stmap.firstEntry());
+    if (expected.isEmpty()) {
+      assertThrows(NoSuchElementException.class, stmap::lastKey);
+    } else {
+      assertEquals(expected.lastKey(), stmap.lastKey());
+    }
+  }
+}

--- a/test/src/main/java/org/apache/accumulo/test/compaction/CompactionPriorityQueueMetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/CompactionPriorityQueueMetricsIT.java
@@ -109,7 +109,7 @@ public class CompactionPriorityQueueMetricsIT extends SharedMiniClusterBase {
   public static final String QUEUE1 = "METRICSQ1";
   public static final String QUEUE1_METRIC_LABEL = MetricsUtil.formatString(QUEUE1);
   public static final String QUEUE1_SERVICE = "Q1";
-  public static final int QUEUE1_SIZE = 10*1024;
+  public static final int QUEUE1_SIZE = 10 * 1024;
 
   // Metrics collector Thread
   final LinkedBlockingQueue<TestStatsDSink.Metric> queueMetrics = new LinkedBlockingQueue<>();

--- a/test/src/main/java/org/apache/accumulo/test/compaction/CompactionPriorityQueueMetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/CompactionPriorityQueueMetricsIT.java
@@ -109,7 +109,7 @@ public class CompactionPriorityQueueMetricsIT extends SharedMiniClusterBase {
   public static final String QUEUE1 = "METRICSQ1";
   public static final String QUEUE1_METRIC_LABEL = MetricsUtil.formatString(QUEUE1);
   public static final String QUEUE1_SERVICE = "Q1";
-  public static final int QUEUE1_SIZE = 6;
+  public static final int QUEUE1_SIZE = 10*1024;
 
   // Metrics collector Thread
   final LinkedBlockingQueue<TestStatsDSink.Metric> queueMetrics = new LinkedBlockingQueue<>();
@@ -202,7 +202,7 @@ public class CompactionPriorityQueueMetricsIT extends SharedMiniClusterBase {
           Property.COMPACTION_SERVICE_PREFIX.getKey() + QUEUE1_SERVICE + ".planner.opts.groups",
           "[{'group':'" + QUEUE1 + "'}]");
 
-      cfg.setProperty(Property.MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_SIZE, "6");
+      cfg.setProperty(Property.MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_SIZE, "10K");
       cfg.getClusterServerConfiguration().addCompactorResourceGroup(QUEUE1, 0);
 
       // This test waits for dead compactors to be absent in zookeeper. The following setting will

--- a/test/src/main/java/org/apache/accumulo/test/compaction/CompactionPriorityQueueMetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/CompactionPriorityQueueMetricsIT.java
@@ -202,7 +202,7 @@ public class CompactionPriorityQueueMetricsIT extends SharedMiniClusterBase {
           Property.COMPACTION_SERVICE_PREFIX.getKey() + QUEUE1_SERVICE + ".planner.opts.groups",
           "[{'group':'" + QUEUE1 + "'}]");
 
-      cfg.setProperty(Property.MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_INITIAL_SIZE, "6");
+      cfg.setProperty(Property.MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_SIZE, "6");
       cfg.getClusterServerConfiguration().addCompactorResourceGroup(QUEUE1, 0);
 
       // This test waits for dead compactors to be absent in zookeeper. The following setting will


### PR DESCRIPTION
Modified the compaction queue limit to use the data size of the compaction jobs instead of the number of compaction jobs for limiting the number of compaction jobs buffered.

fixes #5186