### PR TITLE
Remove niceMocks

### DIFF
--- a/core/src/test/java/org/apache/accumulo/core/data/constraints/VisibilityConstraintTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/constraints/VisibilityConstraintTest.java
@@ -20,9 +20,9 @@ package org.apache.accumulo.core.data.constraints;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -32,16 +32,16 @@ import java.util.List;
 import org.apache.accumulo.core.data.ArrayByteSequence;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.constraints.Constraint.Environment;
-import org.apache.accumulo.core.security.AuthorizationContainer;
 import org.apache.accumulo.core.security.ColumnVisibility;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class VisibilityConstraintTest {
 
-  VisibilityConstraint vc;
-  Environment env;
-  Mutation mutation;
+  private VisibilityConstraint vc;
+  private Environment env;
+  private Mutation mutation;
 
   static final ColumnVisibility good = new ColumnVisibility("good|bad");
   static final ColumnVisibility bad = new ColumnVisibility("good&bad");
@@ -57,15 +57,16 @@ public class VisibilityConstraintTest {
     vc = new VisibilityConstraint();
     mutation = new Mutation("r");
 
-    ArrayByteSequence bs = new ArrayByteSequence("good".getBytes(UTF_8));
-
-    AuthorizationContainer ac = createNiceMock(AuthorizationContainer.class);
-    expect(ac.contains(bs)).andReturn(true);
-    replay(ac);
-
     env = createMock(Environment.class);
-    expect(env.getAuthorizationsContainer()).andReturn(ac);
+    expect(env.getAuthorizationsContainer())
+        .andReturn(new ArrayByteSequence("good".getBytes(UTF_8))::equals).anyTimes();
+
     replay(env);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    verify(env);
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/file/streams/RateLimitedInputStreamTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/streams/RateLimitedInputStreamTest.java
@@ -36,7 +36,7 @@ public class RateLimitedInputStreamTest {
     // Create variables for tracking behaviors of mock object
     AtomicLong rateLimiterPermitsAcquired = new AtomicLong();
     // Construct mock object
-    RateLimiter rateLimiter = EasyMock.niceMock(RateLimiter.class);
+    RateLimiter rateLimiter = EasyMock.createMock(RateLimiter.class);
     // Stub Mock Method
     rateLimiter.acquire(EasyMock.anyLong());
     EasyMock.expectLastCall()

--- a/core/src/test/java/org/apache/accumulo/core/file/streams/RateLimitedOutputStreamTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/streams/RateLimitedOutputStreamTest.java
@@ -38,7 +38,7 @@ public class RateLimitedOutputStreamTest {
     // Create variables for tracking behaviors of mock object
     AtomicLong rateLimiterPermitsAcquired = new AtomicLong();
     // Construct mock object
-    RateLimiter rateLimiter = EasyMock.niceMock(RateLimiter.class);
+    RateLimiter rateLimiter = EasyMock.createMock(RateLimiter.class);
     // Stub Mock Method
     rateLimiter.acquire(EasyMock.anyLong());
     EasyMock.expectLastCall()

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ActiveAssignmentRunnable.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ActiveAssignmentRunnable.java
@@ -39,12 +39,9 @@ public class ActiveAssignmentRunnable implements Runnable {
 
   public ActiveAssignmentRunnable(ConcurrentHashMap<KeyExtent,RunnableStartedAt> activeAssignments,
       KeyExtent extent, Runnable delegate) {
-    requireNonNull(activeAssignments);
-    requireNonNull(extent);
-    requireNonNull(delegate);
-    this.activeAssignments = activeAssignments;
-    this.extent = extent;
-    this.delegate = delegate;
+    this.activeAssignments = requireNonNull(activeAssignments);
+    this.extent = requireNonNull(extent);
+    this.delegate = requireNonNull(delegate);
   }
 
   @Override

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
@@ -398,8 +398,8 @@ public class TabletServerResourceManager {
 
     // We can use the same map for both metadata and normal assignments since the keyspace (extent)
     // is guaranteed to be unique. Schedule the task once, the task will reschedule itself.
-    ThreadPools.watchCriticalScheduledTask(context.getScheduledExecutor().schedule(
-        new AssignmentWatcher(acuConf, context, activeAssignments), 5000, TimeUnit.MILLISECONDS));
+    ThreadPools.watchCriticalScheduledTask(context.getScheduledExecutor()
+        .schedule(new AssignmentWatcher(context, activeAssignments), 5000, TimeUnit.MILLISECONDS));
   }
 
   public int getOpenFiles() {
@@ -417,16 +417,14 @@ public class TabletServerResourceManager {
     private static long longAssignments = 0;
 
     private final Map<KeyExtent,RunnableStartedAt> activeAssignments;
-    private final AccumuloConfiguration conf;
     private final ServerContext context;
 
     public static long getLongAssignments() {
       return longAssignments;
     }
 
-    public AssignmentWatcher(AccumuloConfiguration conf, ServerContext context,
+    public AssignmentWatcher(ServerContext context,
         Map<KeyExtent,RunnableStartedAt> activeAssignments) {
-      this.conf = conf;
       this.context = context;
       this.activeAssignments = activeAssignments;
     }
@@ -434,7 +432,7 @@ public class TabletServerResourceManager {
     @Override
     public void run() {
       final long millisBeforeWarning =
-          this.conf.getTimeInMillis(Property.TSERV_ASSIGNMENT_DURATION_WARNING);
+          context.getConfiguration().getTimeInMillis(Property.TSERV_ASSIGNMENT_DURATION_WARNING);
       try {
         long now = System.currentTimeMillis();
         KeyExtent extent;

--- a/shell/src/test/java/org/apache/accumulo/shell/format/DeleterFormatterTest.java
+++ b/shell/src/test/java/org/apache/accumulo/shell/format/DeleterFormatterTest.java
@@ -21,7 +21,6 @@ package org.apache.accumulo.shell.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
@@ -85,12 +84,17 @@ public class DeleterFormatterTest {
   }
 
   @BeforeEach
-  public void setUp() throws IOException {
+  public void setUp() throws Exception {
     input = new SettableInputStream();
     baos = new ByteArrayOutputStream();
 
-    writer = createNiceMock(BatchWriter.class);
-    shellState = createNiceMock(Shell.class);
+    writer = createMock(BatchWriter.class);
+    writer.addMutation(anyObject());
+    expectLastCall().anyTimes();
+    writer.close();
+    expectLastCall().anyTimes();
+
+    shellState = createMock(Shell.class);
 
     terminal = new DumbTerminal(input, baos);
     terminal.setSize(new Size(80, 24));
@@ -197,7 +201,7 @@ public class DeleterFormatterTest {
   @Test
   public void testMutationException() throws MutationsRejectedException {
     MutationsRejectedException mre = createMock(MutationsRejectedException.class);
-    BatchWriter exceptionWriter = createNiceMock(BatchWriter.class);
+    BatchWriter exceptionWriter = createMock(BatchWriter.class);
     exceptionWriter.close();
     expectLastCall().andThrow(mre);
     exceptionWriter.addMutation(anyObject(Mutation.class));


### PR DESCRIPTION
* Remove the use of mock objects created using EasyMock.niceMock to improve the rigor of our test coverage a little, and the reliability of those affected tests

Trivial changes in related non-test code:

* make use of return value from Objects.requireNonNull
* avoid passing redundant AccumuloConfiguration object when ServerContext suffices