### PR TITLE
Remove redundant interfaces for thrift services

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/trace/TraceUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/trace/TraceUtil.java
@@ -21,7 +21,9 @@ package org.apache.accumulo.core.trace;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Proxy;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 
 import org.apache.accumulo.core.Constants;
@@ -214,8 +216,19 @@ public class TraceUtil {
   private static <T> T wrapRpc(final InvocationHandler handler, final T instance) {
     @SuppressWarnings("unchecked")
     T proxiedInstance = (T) Proxy.newProxyInstance(instance.getClass().getClassLoader(),
-        instance.getClass().getInterfaces(), handler);
+        getInterfaces(instance.getClass()).toArray(new Class<?>[0]), handler);
     return proxiedInstance;
+  }
+
+  private static Set<Class<?>> getInterfaces(Class<?> clazz) {
+    var set = new HashSet<Class<?>>();
+    if (clazz != null) {
+      set.addAll(getInterfaces(clazz.getSuperclass()));
+      for (Class<?> interfaze : clazz.getInterfaces()) {
+        set.add(interfaze);
+      }
+    }
+    return set;
   }
 
 }

--- a/test/src/main/java/org/apache/accumulo/test/SelfStoppingScanServer.java
+++ b/test/src/main/java/org/apache/accumulo/test/SelfStoppingScanServer.java
@@ -22,18 +22,15 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.accumulo.core.cli.ConfigOpts;
 import org.apache.accumulo.core.clientImpl.thrift.TInfo;
-import org.apache.accumulo.core.tabletscan.thrift.TabletScanClientService;
 import org.apache.accumulo.core.tabletserver.thrift.NoSuchScanIDException;
 import org.apache.accumulo.tserver.ScanServer;
-import org.apache.accumulo.tserver.TabletHostingServer;
 import org.apache.thrift.TException;
 
 /**
  * ScanServer implementation that will stop itself after the the 3rd scan batch scan
  *
  */
-public class SelfStoppingScanServer extends ScanServer
-    implements TabletScanClientService.Iface, TabletHostingServer {
+public class SelfStoppingScanServer extends ScanServer {
 
   private final AtomicInteger scanCount = new AtomicInteger(0);
 

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalDoNothingCompactor.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalDoNothingCompactor.java
@@ -28,7 +28,6 @@ import java.util.concurrent.atomic.LongAdder;
 
 import org.apache.accumulo.compactor.Compactor;
 import org.apache.accumulo.core.cli.ConfigOpts;
-import org.apache.accumulo.core.compaction.thrift.CompactorService.Iface;
 import org.apache.accumulo.core.compaction.thrift.TCompactionState;
 import org.apache.accumulo.core.compaction.thrift.TCompactionStatusUpdate;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
@@ -45,7 +44,7 @@ import org.apache.accumulo.server.tablets.TabletNameGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ExternalDoNothingCompactor extends Compactor implements Iface {
+public class ExternalDoNothingCompactor extends Compactor {
 
   private static final Logger LOG = LoggerFactory.getLogger(ExternalDoNothingCompactor.class);
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/MemoryConsumingCompactor.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MemoryConsumingCompactor.java
@@ -37,7 +37,7 @@ import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class MemoryConsumingCompactor extends Compactor implements CompactorService.Iface {
+public class MemoryConsumingCompactor extends Compactor {
 
   private static final Logger LOG = LoggerFactory.getLogger(MemoryConsumingCompactor.class);
 


### PR DESCRIPTION
Update Proxy/reflection code to gather all the thrift interfaces from the proxied instances, so you don't need to declare them all explicitly on each subclass.