### PR TITLE
Remove zookeeper-jute from minicluster

### DIFF
--- a/minicluster/pom.xml
+++ b/minicluster/pom.xml
@@ -97,10 +97,6 @@
       <artifactId>zookeeper</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.zookeeper</groupId>
-      <artifactId>zookeeper-jute</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>


### PR DESCRIPTION
Use ZooReaderWriter to do ZK updates in MiniAccumuloClusterImpl instead of requiring zookeeper-jute on the classpath (also makes the code shorter and more readable)