### PR TITLE
Adds some missing FATE functionality

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
@@ -210,6 +210,7 @@ public class Fate<T> {
 
     @Override
     public void run() {
+      runningTxRunners.add(this);
       try {
         while (keepRunning.get() && !stop.get()) {
           FateTxStore<T> txStore = null;
@@ -442,9 +443,7 @@ public class Fate<T> {
         // If the pool grew, then ensure that there is a TransactionRunner for each thread
         for (int i = 0; i < needed; i++) {
           try {
-            var txRunner = new TransactionRunner();
-            runningTxRunners.add(txRunner);
-            pool.execute(txRunner);
+            pool.execute(new TransactionRunner());
           } catch (RejectedExecutionException e) {
             // RejectedExecutionException could be shutting down
             if (pool.isShutdown()) {

--- a/test/src/main/java/org/apache/accumulo/test/fate/FastFate.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FastFate.java
@@ -27,9 +27,12 @@ import org.apache.accumulo.core.fate.FateStore;
 import org.apache.accumulo.core.fate.Repo;
 
 /**
- * A FATE which performs the dead reservation cleanup with a much shorter delay between
+ * A FATE which performs the dead reservation cleanup and the check on the pool size with a much
+ * shorter delay between for faster testing.
  */
 public class FastFate<T> extends Fate<T> {
+  private static final Duration DEAD_RES_CLEANUP_DELAY = Duration.ofSeconds(15);
+  private static final Duration POOL_WATCHER_DELAY = Duration.ofSeconds(5);
 
   public FastFate(T environment, FateStore<T> store, boolean runDeadResCleaner,
       Function<Repo<T>,String> toLogStrFunc, AccumuloConfiguration conf) {
@@ -38,6 +41,11 @@ public class FastFate<T> extends Fate<T> {
 
   @Override
   public Duration getDeadResCleanupDelay() {
-    return Duration.ofSeconds(15);
+    return DEAD_RES_CLEANUP_DELAY;
+  }
+
+  @Override
+  public Duration getPoolWatcherDelay() {
+    return POOL_WATCHER_DELAY;
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/fate/FatePoolResizeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FatePoolResizeIT.java
@@ -72,6 +72,7 @@ public abstract class FatePoolResizeIT extends SharedMiniClusterBase
       assertEquals(newNumThreads, fate.getTxRunnersActive());
     } finally {
       fate.shutdown(1, TimeUnit.MINUTES);
+      assertEquals(0, fate.getTxRunnersActive());
     }
   }
 
@@ -114,6 +115,7 @@ public abstract class FatePoolResizeIT extends SharedMiniClusterBase
       assertEquals(newNumThreads, fate.getTxRunnersActive());
     } finally {
       fate.shutdown(1, TimeUnit.MINUTES);
+      assertEquals(0, fate.getTxRunnersActive());
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/fate/FatePoolResizeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FatePoolResizeIT.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test.fate;
+
+import static org.apache.accumulo.test.fate.FateStoreUtil.TEST_FATE_OP;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.accumulo.core.conf.ConfigurationCopy;
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.fate.Fate;
+import org.apache.accumulo.core.fate.FateId;
+import org.apache.accumulo.core.fate.FateStore;
+import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.harness.SharedMiniClusterBase;
+import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.test.util.Wait;
+import org.junit.jupiter.api.Test;
+
+public abstract class FatePoolResizeIT extends SharedMiniClusterBase
+    implements FateTestRunner<FatePoolResizeIT.PoolResizeTestEnv> {
+
+  @Test
+  public void testIncreaseSize() throws Exception {
+    executeTest(this::testIncreaseSize);
+  }
+
+  protected void testIncreaseSize(FateStore<PoolResizeTestEnv> store, ServerContext sctx)
+      throws Exception {
+    final int numThreads = 10;
+    final int newNumThreads = 20;
+    final ConfigurationCopy config = initConfig(numThreads);
+    final var env = new PoolResizeTestEnv();
+    final Fate<PoolResizeTestEnv> fate = new FastFate<>(env, store, false, r -> r + "", config);
+    try {
+      // create a tx for all future threads. For now, only some of the txns will be workable
+      for (int i = 0; i < newNumThreads; i++) {
+        var fateId = fate.startTransaction();
+        fate.seedTransaction(TEST_FATE_OP, fateId, new PoolResizeTestRepo(), true, "testing");
+      }
+      // wait for all available threads to be working on a tx
+      Wait.waitFor(() -> env.numWorkers.get() == numThreads);
+      assertEquals(numThreads, fate.getTxRunnersActive());
+      config.set(Property.MANAGER_FATE_THREADPOOL_SIZE, String.valueOf(newNumThreads));
+      // wait for new config to be detected, new runners to be created, and for these runners to
+      // pick up the rest of the available txns
+      Wait.waitFor(() -> env.numWorkers.get() == newNumThreads);
+      assertEquals(newNumThreads, fate.getTxRunnersActive());
+      // finish work
+      env.isReadyLatch.countDown();
+      Wait.waitFor(() -> env.numWorkers.get() == 0);
+      // workers should still be running since we haven't shutdown, just not working on anything
+      assertEquals(newNumThreads, fate.getTxRunnersActive());
+    } finally {
+      fate.shutdown(1, TimeUnit.MINUTES);
+    }
+  }
+
+  @Test
+  public void testDecreaseSize() throws Exception {
+    executeTest(this::testDecreaseSize);
+  }
+
+  protected void testDecreaseSize(FateStore<PoolResizeTestEnv> store, ServerContext sctx)
+      throws Exception {
+    final int numThreads = 20;
+    final int newNumThreads = 10;
+    final ConfigurationCopy config = initConfig(numThreads);
+    final var env = new PoolResizeTestEnv();
+    final Fate<PoolResizeTestEnv> fate = new FastFate<>(env, store, false, r -> r + "", config);
+    try {
+      // create a tx for each thread
+      for (int i = 0; i < numThreads; i++) {
+        var fateId = fate.startTransaction();
+        fate.seedTransaction(TEST_FATE_OP, fateId, new PoolResizeTestRepo(), true, "testing");
+      }
+      // wait for all threads to be working on a tx
+      Wait.waitFor(() -> env.numWorkers.get() == numThreads);
+      assertEquals(numThreads, fate.getTxRunnersActive());
+      config.set(Property.MANAGER_FATE_THREADPOOL_SIZE, String.valueOf(newNumThreads));
+      // ensure another execution of the pool watcher task occurs after we change the size
+      Thread.sleep(fate.getPoolWatcherDelay().toMillis() * 2);
+      // at this point, FATE should detect that there are more transaction runners running than
+      // configured. None can be safely stopped yet, (still in progress - haven't passed isReady).
+      // We ensure none have been unexpectedly stopped, then we allow isReady to pass and the txns
+      // to complete
+      assertEquals(numThreads, env.numWorkers.get());
+      env.isReadyLatch.countDown();
+      // wait for the pool size to be decreased to the expected value
+      Wait.waitFor(() -> fate.getTxRunnersActive() == newNumThreads);
+      // wait for all threads to have completed their tx
+      Wait.waitFor(() -> env.numWorkers.get() == 0);
+      // wait a bit longer to ensure no more workers than expected were stopped
+      Thread.sleep(5_000);
+      assertEquals(newNumThreads, fate.getTxRunnersActive());
+    } finally {
+      fate.shutdown(1, TimeUnit.MINUTES);
+    }
+  }
+
+  private ConfigurationCopy initConfig(int numThreads) {
+    ConfigurationCopy config = new ConfigurationCopy();
+    config.set(Property.GENERAL_THREADPOOL_SIZE, "2");
+    config.set(Property.MANAGER_FATE_THREADPOOL_SIZE, String.valueOf(numThreads));
+    config.set(Property.MANAGER_FATE_IDLE_CHECK_INTERVAL, "60m");
+    return config;
+  }
+
+  public static class PoolResizeTestRepo implements Repo<PoolResizeTestEnv> {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public long isReady(FateId fateId, PoolResizeTestEnv environment) throws Exception {
+      environment.numWorkers.incrementAndGet();
+      environment.isReadyLatch.await();
+      return 0;
+    }
+
+    @Override
+    public String getName() {
+      return this.getClass().getSimpleName();
+    }
+
+    @Override
+    public Repo<PoolResizeTestEnv> call(FateId fateId, PoolResizeTestEnv environment)
+        throws Exception {
+      environment.numWorkers.decrementAndGet();
+      return null;
+    }
+
+    @Override
+    public void undo(FateId fateId, PoolResizeTestEnv environment) throws Exception {
+
+    }
+
+    @Override
+    public String getReturn() {
+      return null;
+    }
+  }
+
+  public static class PoolResizeTestEnv extends TestEnv {
+    private final AtomicInteger numWorkers = new AtomicInteger(0);
+    private final CountDownLatch isReadyLatch = new CountDownLatch(1);
+  }
+}

--- a/test/src/main/java/org/apache/accumulo/test/fate/meta/MetaFatePoolResizeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/meta/MetaFatePoolResizeIT.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test.fate.meta;
+
+import static org.apache.accumulo.core.fate.AbstractFateStore.createDummyLockID;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+
+import java.io.File;
+
+import org.apache.accumulo.core.fate.AbstractFateStore;
+import org.apache.accumulo.core.fate.zookeeper.MetaFateStore;
+import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.test.fate.FatePoolResizeIT;
+import org.apache.accumulo.test.fate.FateStoreUtil;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.io.TempDir;
+
+public class MetaFatePoolResizeIT extends FatePoolResizeIT {
+  @TempDir
+  private static File tempDir;
+
+  @BeforeAll
+  public static void setup() throws Exception {
+    FateStoreUtil.MetaFateZKSetup.setup(tempDir);
+  }
+
+  @AfterAll
+  public static void teardown() throws Exception {
+    FateStoreUtil.MetaFateZKSetup.teardown();
+  }
+
+  @Override
+  public void executeTest(FateTestExecutor<PoolResizeTestEnv> testMethod, int maxDeferred,
+      AbstractFateStore.FateIdGenerator fateIdGenerator) throws Exception {
+    String zkRoot = FateStoreUtil.MetaFateZKSetup.getZkRoot();
+    var zk = FateStoreUtil.MetaFateZKSetup.getZk();
+    String fatePath = FateStoreUtil.MetaFateZKSetup.getZkFatePath();
+    ServerContext sctx = createMock(ServerContext.class);
+    expect(sctx.getZooKeeperRoot()).andReturn(zkRoot).anyTimes();
+    expect(sctx.getZooSession()).andReturn(zk).anyTimes();
+    replay(sctx);
+
+    testMethod.execute(
+        new MetaFateStore<>(fatePath, zk, createDummyLockID(), null, maxDeferred, fateIdGenerator),
+        sctx);
+  }
+}

--- a/test/src/main/java/org/apache/accumulo/test/fate/meta/MetaFatePoolResizeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/meta/MetaFatePoolResizeIT.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test.fate.meta;
 
-import static org.apache.accumulo.core.fate.AbstractFateStore.createDummyLockID;
+import static org.apache.accumulo.test.fate.TestLock.createDummyLockID;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;

--- a/test/src/main/java/org/apache/accumulo/test/fate/user/UserFatePoolResizeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/user/UserFatePoolResizeIT.java
@@ -18,8 +18,8 @@
  */
 package org.apache.accumulo.test.fate.user;
 
-import static org.apache.accumulo.core.fate.AbstractFateStore.createDummyLockID;
 import static org.apache.accumulo.test.fate.FateStoreUtil.createFateTable;
+import static org.apache.accumulo.test.fate.TestLock.createDummyLockID;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.clientImpl.ClientContext;

--- a/test/src/main/java/org/apache/accumulo/test/fate/user/UserFatePoolResizeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/user/UserFatePoolResizeIT.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test.fate.user;
+
+import static org.apache.accumulo.core.fate.AbstractFateStore.createDummyLockID;
+import static org.apache.accumulo.test.fate.FateStoreUtil.createFateTable;
+
+import org.apache.accumulo.core.client.Accumulo;
+import org.apache.accumulo.core.clientImpl.ClientContext;
+import org.apache.accumulo.core.fate.AbstractFateStore;
+import org.apache.accumulo.core.fate.user.UserFateStore;
+import org.apache.accumulo.harness.SharedMiniClusterBase;
+import org.apache.accumulo.test.fate.FatePoolResizeIT;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+public class UserFatePoolResizeIT extends FatePoolResizeIT {
+
+  private String table;
+
+  @BeforeAll
+  public static void setup() throws Exception {
+    SharedMiniClusterBase.startMiniCluster();
+  }
+
+  @AfterAll
+  public static void teardown() {
+    SharedMiniClusterBase.stopMiniCluster();
+  }
+
+  @Override
+  public void executeTest(FateTestExecutor<PoolResizeTestEnv> testMethod, int maxDeferred,
+      AbstractFateStore.FateIdGenerator fateIdGenerator) throws Exception {
+    table = getUniqueNames(1)[0];
+    try (ClientContext client =
+        (ClientContext) Accumulo.newClient().from(getClientProps()).build()) {
+      createFateTable(client, table);
+      testMethod.execute(new UserFateStore<>(client, table, createDummyLockID(), null, maxDeferred,
+          fateIdGenerator), getCluster().getServerContext());
+    }
+  }
+}


### PR DESCRIPTION
Adds some missing FATE functionality

- Previously, if a user configured fewer FATE threads to work on transactions (via MANAGER_FATE_THREADPOOL_SIZE property), the pool size would not actually be decreased. These changes safely stop excess workers in the case where the property value is decreased.
- Added test FatePoolResizeIT (tests both META and USER transactions: MetaFatePoolResizeIT and UserFatePoolResizeIT) to ensure the pool size is correctly increased and decreased with configuration changes.
- Fate.shutdown() was not waiting on termination of the fate pool watcher when needed. Added the missing wait.

Another potential solution to this problem is disallowing decreasing the pool size, but I'm not sure if that's the way we want to go about this.

Confirmation/changes to the thread safety of the new code would be appreciated. I would also be curious if someone had a better idea of how we can go about stopping the transaction runners. Currently just try to stop a random one each second.

This is another prereq for #5130.
This also addresses the test mentioned in #5171.