### PR TITLE
Sets default column size when terminal size is 0

### DIFF
--- a/shell/src/main/java/org/apache/accumulo/shell/commands/HelpCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/HelpCommand.java
@@ -39,7 +39,8 @@ public class HelpCommand extends Command {
   @Override
   public int execute(final String fullCommand, final CommandLine cl, final Shell shellState)
       throws ShellCommandException, IOException {
-    int numColumns = shellState.getTerminal().getWidth();
+    int numColumns =
+        (shellState.getTerminal().getWidth() == 0) ? 80 : shellState.getTerminal().getWidth();
     if (cl.hasOption(noWrapOpt.getOpt())) {
       numColumns = Integer.MAX_VALUE;
     }


### PR DESCRIPTION
Sets a default column size of 80 characters if the terminal width is set to 0. This supports running the help command in a dumb terminal while still throwing an IllegalArgumentException for terminal widths under 40 characters. 

This fixes the current `ShellServerIT.help` and `ShellServerIT.extensions` test failures. 