### PR TITLE
removes compaction metrics that is no longer useful

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metrics/Metric.java
+++ b/core/src/main/java/org/apache/accumulo/core/metrics/Metric.java
@@ -54,8 +54,6 @@ public enum Metric {
       MetricDocSection.COMPACTION),
   COMPACTOR_JOB_PRIORITY_QUEUES("accumulo.compaction.queue.count", MetricType.GAUGE,
       "Number of priority queues for compaction jobs.", MetricDocSection.COMPACTION),
-  COMPACTOR_JOB_PRIORITY_QUEUE_MAX_SIZE("accumulo.compaction.queue.max.size", MetricType.GAUGE,
-      "The maximum size in bytes of all jobs.", MetricDocSection.COMPACTION),
   COMPACTOR_JOB_PRIORITY_QUEUE_JOBS_DEQUEUED("accumulo.compaction.queue.jobs.dequeued",
       MetricType.GAUGE, "Count of dequeued jobs.", MetricDocSection.COMPACTION),
   COMPACTOR_JOB_PRIORITY_QUEUE_JOBS_QUEUED("accumulo.compaction.queue.jobs.queued",

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
@@ -194,7 +194,6 @@ public class CompactionCoordinator
   private final Manager manager;
 
   private final LoadingCache<String,Integer> compactorCounts;
-  private final long jobQueueInitialSize;
 
   private volatile long coordinatorStartTime;
 
@@ -208,10 +207,10 @@ public class CompactionCoordinator
     this.security = security;
     this.manager = Objects.requireNonNull(manager);
 
-    this.jobQueueInitialSize =
+    long jobQueueMaxSize =
         ctx.getConfiguration().getAsBytes(Property.MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_SIZE);
 
-    this.jobQueues = new CompactionJobQueues(jobQueueInitialSize);
+    this.jobQueues = new CompactionJobQueues(jobQueueMaxSize);
 
     this.queueMetrics = new QueueMetrics(jobQueues);
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/QueueMetrics.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/QueueMetrics.java
@@ -28,7 +28,6 @@ import static org.apache.accumulo.core.metrics.Metric.COMPACTOR_JOB_PRIORITY_QUE
 import static org.apache.accumulo.core.metrics.Metric.COMPACTOR_JOB_PRIORITY_QUEUE_JOBS_QUEUED;
 import static org.apache.accumulo.core.metrics.Metric.COMPACTOR_JOB_PRIORITY_QUEUE_JOBS_REJECTED;
 import static org.apache.accumulo.core.metrics.Metric.COMPACTOR_JOB_PRIORITY_QUEUE_JOBS_SIZE;
-import static org.apache.accumulo.core.metrics.Metric.COMPACTOR_JOB_PRIORITY_QUEUE_MAX_SIZE;
 import static org.apache.accumulo.core.metrics.MetricsUtil.formatString;
 
 import java.util.HashMap;
@@ -58,7 +57,6 @@ import io.micrometer.core.instrument.Timer;
 public class QueueMetrics implements MetricsProducer {
 
   private static class QueueMeters {
-    private final Gauge length;
     private final Gauge jobsQueued;
     private final Gauge jobsQueuedSize;
     private final Gauge jobsDequeued;
@@ -72,11 +70,6 @@ public class QueueMetrics implements MetricsProducer {
     public QueueMeters(MeterRegistry meterRegistry, CompactorGroupId cgid,
         CompactionJobPriorityQueue queue) {
       var queueId = formatString(cgid.canonical());
-
-      length =
-          Gauge.builder(COMPACTOR_JOB_PRIORITY_QUEUE_MAX_SIZE.getName(), queue, q -> q.getMaxSize())
-              .description(COMPACTOR_JOB_PRIORITY_QUEUE_MAX_SIZE.getDescription())
-              .tags(List.of(Tag.of("queue.id", queueId))).register(meterRegistry);
 
       jobsQueued = Gauge
           .builder(COMPACTOR_JOB_PRIORITY_QUEUE_JOBS_QUEUED.getName(), queue,
@@ -133,7 +126,6 @@ public class QueueMetrics implements MetricsProducer {
     }
 
     private void removeMeters(MeterRegistry registry) {
-      registry.remove(length);
       registry.remove(jobsQueued);
       registry.remove(jobsDequeued);
       registry.remove(jobsRejected);

--- a/test/src/main/java/org/apache/accumulo/test/compaction/CompactionPriorityQueueMetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/CompactionPriorityQueueMetricsIT.java
@@ -23,7 +23,6 @@ import static org.apache.accumulo.core.metrics.Metric.COMPACTOR_JOB_PRIORITY_QUE
 import static org.apache.accumulo.core.metrics.Metric.COMPACTOR_JOB_PRIORITY_QUEUE_JOBS_QUEUED;
 import static org.apache.accumulo.core.metrics.Metric.COMPACTOR_JOB_PRIORITY_QUEUE_JOBS_REJECTED;
 import static org.apache.accumulo.core.metrics.Metric.COMPACTOR_JOB_PRIORITY_QUEUE_JOBS_SIZE;
-import static org.apache.accumulo.core.metrics.Metric.COMPACTOR_JOB_PRIORITY_QUEUE_MAX_SIZE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -364,7 +363,6 @@ public class CompactionPriorityQueueMetricsIT extends SharedMiniClusterBase {
     // Set lowest priority to the lowest possible system compaction priority
     long lowestPriority = Short.MIN_VALUE;
     long rejectedCount = 0L;
-    int queueSize = 0;
 
     boolean sawQueues = false;
     // An empty queue means that the last known value is the most recent.
@@ -376,9 +374,6 @@ public class CompactionPriorityQueueMetricsIT extends SharedMiniClusterBase {
       } else if (metric.getName().contains(COMPACTOR_JOB_PRIORITY_QUEUE_JOBS_PRIORITY.getName())
           && metric.getTags().containsValue(QUEUE1_METRIC_LABEL)) {
         lowestPriority = Math.max(lowestPriority, Long.parseLong(metric.getValue()));
-      } else if (metric.getName().contains(COMPACTOR_JOB_PRIORITY_QUEUE_MAX_SIZE.getName())
-          && metric.getTags().containsValue(QUEUE1_METRIC_LABEL)) {
-        queueSize = Integer.parseInt(metric.getValue());
       } else if (metric.getName().contains(COMPACTOR_JOB_PRIORITY_QUEUES.getName())) {
         sawQueues = true;
       } else {
@@ -402,9 +397,6 @@ public class CompactionPriorityQueueMetricsIT extends SharedMiniClusterBase {
 
     // Multiple Queues have been created
     assertTrue(sawQueues);
-
-    // Queue size matches the intended queue size
-    assertEquals(QUEUE1_SIZE, queueSize);
 
     // Start Compactors
     getCluster().getConfig().getClusterServerConfiguration().addCompactorResourceGroup(QUEUE1, 1);

--- a/test/src/main/java/org/apache/accumulo/test/metrics/MetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/metrics/MetricsIT.java
@@ -144,15 +144,14 @@ public class MetricsIT extends ConfigurableMacBase implements MetricsProducer {
 
     List<String> statsDMetrics;
 
-    final int compactionPriorityQueueLengthBit = 0;
-    final int compactionPriorityQueueQueuedBit = 1;
-    final int compactionPriorityQueueDequeuedBit = 2;
-    final int compactionPriorityQueueRejectedBit = 3;
-    final int compactionPriorityQueuePriorityBit = 4;
-    final int compactionPriorityQueueSizeBit = 5;
+    final int compactionPriorityQueueQueuedBit = 0;
+    final int compactionPriorityQueueDequeuedBit = 1;
+    final int compactionPriorityQueueRejectedBit = 2;
+    final int compactionPriorityQueuePriorityBit = 3;
+    final int compactionPriorityQueueSizeBit = 4;
 
-    final BitSet trueSet = new BitSet(6);
-    trueSet.set(0, 5, true);
+    final BitSet trueSet = new BitSet(5);
+    trueSet.set(0, 4, true);
 
     final BitSet queueMetricsSeen = new BitSet(5);
 
@@ -188,9 +187,6 @@ public class MetricsIT extends ConfigurableMacBase implements MetricsProducer {
               seenMetrics.add(metric);
               expectedMetrics.remove(metric);
               switch (metric) {
-                case COMPACTOR_JOB_PRIORITY_QUEUE_MAX_SIZE:
-                  queueMetricsSeen.set(compactionPriorityQueueLengthBit, true);
-                  break;
                 case COMPACTOR_JOB_PRIORITY_QUEUE_JOBS_QUEUED:
                   queueMetricsSeen.set(compactionPriorityQueueQueuedBit, true);
                   break;


### PR DESCRIPTION
Because of recent changes a compaction metric was always reporting the value of a configuration property.  Removed this mertic and also renamed and moved a variable from instance level to local level.