### PR TITLE
Resets compaction queue max size when config changes

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
@@ -296,7 +296,7 @@ public class CompactionCoordinator
 
   protected void startConfigMonitor(ScheduledThreadPoolExecutor schedExecutor) {
     ScheduledFuture<?> future =
-        schedExecutor.scheduleWithFixedDelay(this::cleanUpInternalState, 0, 1, TimeUnit.MINUTES);
+        schedExecutor.scheduleWithFixedDelay(this::checkForConfigChanges, 0, 1, TimeUnit.MINUTES);
     ThreadPools.watchNonCriticalScheduledTask(future);
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
@@ -294,7 +294,7 @@ public class CompactionCoordinator
     ThreadPools.watchNonCriticalScheduledTask(future);
   }
 
-  private void startConfigMonitor(ScheduledThreadPoolExecutor schedExecutor) {
+  protected void startConfigMonitor(ScheduledThreadPoolExecutor schedExecutor) {
     ScheduledFuture<?> future =
         schedExecutor.scheduleWithFixedDelay(this::cleanUpInternalState, 0, 1, TimeUnit.MINUTES);
     ThreadPools.watchNonCriticalScheduledTask(future);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/queue/CompactionJobQueues.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/queue/CompactionJobQueues.java
@@ -193,4 +193,8 @@ public class CompactionJobQueues {
     pq.add(tabletMetadata, jobs,
         currentGenerations.get(DataLevel.of(tabletMetadata.getTableId())).get());
   }
+
+  public void resetMaxSize(long size) {
+    priorityQueues.values().forEach(cjpq -> cjpq.resetMaxSize(size));
+  }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/queue/CompactionJobQueues.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/queue/CompactionJobQueues.java
@@ -48,7 +48,7 @@ public class CompactionJobQueues {
   private final ConcurrentHashMap<CompactorGroupId,CompactionJobPriorityQueue> priorityQueues =
       new ConcurrentHashMap<>();
 
-  private final long queueSize;
+  private volatile long queueSize;
 
   private final Map<DataLevel,AtomicLong> currentGenerations;
 
@@ -195,6 +195,7 @@ public class CompactionJobQueues {
   }
 
   public void resetMaxSize(long size) {
-    priorityQueues.values().forEach(cjpq -> cjpq.resetMaxSize(size));
+    this.queueSize = size;
+    priorityQueues.values().forEach(cjpq -> cjpq.resetMaxSize(this.queueSize));
   }
 }

--- a/server/manager/src/test/java/org/apache/accumulo/manager/compaction/CompactionCoordinatorTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/compaction/CompactionCoordinatorTest.java
@@ -153,6 +153,9 @@ public class CompactionCoordinatorTest {
     }
 
     @Override
+    protected void startConfigMonitor(ScheduledThreadPoolExecutor schedExecutor) {}
+
+    @Override
     public void compactionCompleted(TInfo tinfo, TCredentials credentials,
         String externalCompactionId, TKeyExtent textent, TCompactionStats stats)
         throws ThriftSecurityException {}

--- a/server/manager/src/test/java/org/apache/accumulo/manager/compaction/queue/CompactionJobQueuesTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/compaction/queue/CompactionJobQueuesTest.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -409,5 +410,34 @@ public class CompactionJobQueuesTest {
     assertTrue(future5.isDone());
     assertTrue(future6.isCompletedExceptionally());
     assertTrue(future6.isDone());
+  }
+
+  @Test
+  public void testResetSize() throws Exception {
+    CompactionJobQueues jobQueues = new CompactionJobQueues(1000000);
+
+    var tid = TableId.of("1");
+    var extent1 = new KeyExtent(tid, new Text("z"), new Text("q"));
+
+    var tm1 = TabletMetadata.builder(extent1).build();
+
+    var cg1 = CompactorGroupId.of("CG1");
+    var cg2 = CompactorGroupId.of("CG2");
+
+    jobQueues.add(tm1, List.of(newJob((short) 1, 5, cg1)));
+
+    assertEquals(Set.of(cg1), jobQueues.getQueueIds());
+    assertEquals(1000000, jobQueues.getQueueMaxSize(cg1));
+
+    jobQueues.resetMaxSize(500000);
+
+    assertEquals(Set.of(cg1), jobQueues.getQueueIds());
+    assertEquals(500000, jobQueues.getQueueMaxSize(cg1));
+
+    // create a new queue and ensure it uses the updated max size
+    jobQueues.add(tm1, List.of(newJob((short) 1, 5, cg2)));
+    assertEquals(Set.of(cg1, cg2), jobQueues.getQueueIds());
+    assertEquals(500000, jobQueues.getQueueMaxSize(cg1));
+    assertEquals(500000, jobQueues.getQueueMaxSize(cg2));
   }
 }


### PR DESCRIPTION
Updates the manager to reset the max size on compaction queues when config changes.  In the case where the current data size of the queue exceeds the new configured size the lowest priority jobs are dropped until the size is acceptable.