### PR TITLE
Allow providing a chroot to ZK suppliers

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
@@ -224,7 +224,8 @@ public class ClientContext implements AccumuloClient {
 
     this.zooSession = memoize(() -> {
       var zk = info
-          .getZooKeeperSupplier(getClass().getSimpleName() + "(" + info.getPrincipal() + ")").get();
+          .getZooKeeperSupplier(getClass().getSimpleName() + "(" + info.getPrincipal() + ")", "")
+          .get();
       zooKeeperOpened.set(true);
       return zk;
     });
@@ -1100,7 +1101,7 @@ public class ClientContext implements AccumuloClient {
       // so, it can't rely on being able to continue to use the same client's ZooCache,
       // because that client could be closed, and its ZooSession also closed
       // this needs to be fixed; TODO https://github.com/apache/accumulo/issues/2301
-      var zk = info.getZooKeeperSupplier(ZookeeperLockChecker.class.getSimpleName()).get();
+      var zk = info.getZooKeeperSupplier(ZookeeperLockChecker.class.getSimpleName(), "").get();
       this.zkLockChecker =
           new ZookeeperLockChecker(new ZooCache(zk), getZooKeeperRoot() + Constants.ZTSERVERS);
     }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientInfo.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientInfo.java
@@ -50,7 +50,7 @@ public interface ClientInfo {
   /**
    * @return a Supplier for creating new ZooKeeper client instances based on the configuration
    */
-  Supplier<ZooSession> getZooKeeperSupplier(String clientName);
+  Supplier<ZooSession> getZooKeeperSupplier(String clientName, String rootPath);
 
   /**
    * @return Zookeeper connection information for Accumulo instance

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerInfo.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerInfo.java
@@ -24,6 +24,7 @@ import static java.util.Objects.requireNonNull;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Properties;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.function.ToIntFunction;
@@ -57,7 +58,8 @@ public class ServerInfo implements ClientInfo {
   static ServerInfo fromServerConfig(SiteConfiguration siteConfig) {
     final Function<ServerInfo,String> instanceNameFromZk = si -> {
       try (var zk =
-          si.getZooKeeperSupplier(ServerInfo.class.getSimpleName() + ".getInstanceId()").get()) {
+          si.getZooKeeperSupplier(ServerInfo.class.getSimpleName() + ".getInstanceName()", "")
+              .get()) {
         return ZooUtil.getInstanceName(zk, si.getInstanceId());
       }
     };
@@ -109,7 +111,7 @@ public class ServerInfo implements ClientInfo {
   private final Supplier<InstanceId> instanceId;
   private final Supplier<String> instanceName;
   private final Supplier<Credentials> credentials;
-  private final Function<String,ZooSession> zooSessionForName;
+  private final BiFunction<String,String,ZooSession> zooSessionForName;
 
   // set up everything to be lazily loaded with memoized suppliers, so if nothing is used, the cost
   // is low; to support different scenarios, plug in the functionality to retrieve certain items
@@ -139,7 +141,7 @@ public class ServerInfo implements ClientInfo {
     this.credentials =
         memoize(() -> SystemCredentials.get(getInstanceId(), getSiteConfiguration()));
 
-    this.zooSessionForName = name -> new ZooSession(name, getZooKeepers(),
+    this.zooSessionForName = (name, rootPath) -> new ZooSession(name, getZooKeepers() + rootPath,
         getZooKeepersSessionTimeOut(), getSiteConfiguration().get(Property.INSTANCE_SECRET));
 
     // from here on, set up the suppliers based on what was passed in, to support different cases
@@ -163,8 +165,8 @@ public class ServerInfo implements ClientInfo {
   }
 
   @Override
-  public Supplier<ZooSession> getZooKeeperSupplier(String clientName) {
-    return () -> zooSessionForName.apply(clientName);
+  public Supplier<ZooSession> getZooKeeperSupplier(String clientName, String rootPath) {
+    return () -> zooSessionForName.apply(requireNonNull(clientName), requireNonNull(rootPath));
   }
 
   @Override


### PR DESCRIPTION
* Add support to ClientInfo (and implementations) for providing a chroot path to the ZooKeeper (ZooSession) supplier
* Fix typo in two ZooSession client names to lookup the instanceId or instanceName from the other (the client names were the reverse of the operation being performed, creating a little confusion in the logs)