### PR TITLE
Close scanner in AmpleImpl.getExternalCompactionFinalStates()

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
@@ -320,7 +320,7 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
 
     scanner.setRange(ExternalCompactionSection.getRange());
     int pLen = ExternalCompactionSection.getRowPrefix().length();
-    return scanner.stream()
+    return scanner.stream().onClose(scanner::close)
         .map(e -> ExternalCompactionFinalState.fromJson(
             ExternalCompactionId.of(e.getKey().getRowData().toString().substring(pLen)),
             e.getValue().toString()));

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionFinalizer.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionFinalizer.java
@@ -214,9 +214,8 @@ public class CompactionFinalizer {
   }
 
   private void notifyTservers() {
-    try {
-      Iterator<ExternalCompactionFinalState> finalStates =
-          context.getAmple().getExternalCompactionFinalStates().iterator();
+    try (var finalStatesStream = context.getAmple().getExternalCompactionFinalStates()) {
+      Iterator<ExternalCompactionFinalState> finalStates = finalStatesStream.iterator();
       while (finalStates.hasNext()) {
         ExternalCompactionFinalState state = finalStates.next();
         LOG.debug("Found external compaction in final state: {}, queueing for tserver notification",


### PR DESCRIPTION
`AmpleImple.getExternalCompactionFinalStates()` creates a `Scanner` and returns a `Stream` off of that `Scanner`. This PR adds an `onClose()` to the stream that will close the `Scanner`.

I changed things so that the `Stream` returned by this method is explicitly closed in a try-with-resources block.

There were other spots that use this method but they were in the testing code so I left those alone. I'll probably clean those up too in 3.1 and main once this is merged up.