### PR TITLE
Discussion: Support adding in an accumulo-access expression to a column visibility

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -87,10 +87,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.accumulo</groupId>
-      <artifactId>accumulo-access</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.accumulo</groupId>
       <artifactId>accumulo-start</artifactId>
     </dependency>
     <dependency>
@@ -278,8 +274,6 @@
                 <allow>javax[.]security[.]auth[.]DestroyFailedException</allow>
                 <!-- allow questionable Hadoop exceptions for mapreduce -->
                 <allow>org[.]apache[.]hadoop[.]mapred[.](FileAlreadyExistsException|InvalidJobConfException)</allow>
-                <!-- allow the following types from the visibility API -->
-                <allow>org[.]apache[.]accumulo[.]access[.].*</allow>
               </allows>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,6 @@
     <surefire.reuseForks>true</surefire.reuseForks>
     <unitTestMemSize>-Xmx1G</unitTestMemSize>
     <!-- dependency and plugin versions managed with properties -->
-    <version.accumulo-access>1.0.0-SNAPSHOT</version.accumulo-access>
     <version.auto-service>1.1.1</version.auto-service>
     <version.bouncycastle>1.78.1</version.bouncycastle>
     <version.curator>5.5.0</version.curator>
@@ -328,11 +327,6 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>4.13.2</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.accumulo</groupId>
-        <artifactId>accumulo-access</artifactId>
-        <version>${version.accumulo-access}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.accumulo</groupId>


### PR DESCRIPTION
Includes changes from #5217 

This PR adds a new dependency to 2.1.4 which I'm not sure we want to do. 
Using this PR to evaluate ColumnVisibility  usages in 2.1 to think through performance concerns.

Merging this requires conversation about if we want to do this in 2.1 vs maybe doing a 2.2 release to use as a stepping stone.