### PR TITLE
Gets the correct filesystem when writing an rfile

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/rfile/FSConfArgs.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/rfile/FSConfArgs.java
@@ -22,15 +22,23 @@ import java.io.IOException;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 
 class FSConfArgs {
 
   FileSystem fs;
   Configuration conf;
 
+  FileSystem getFileSystem(Path path) throws IOException {
+    if (fs == null) {
+      return path.getFileSystem(getConf());
+    }
+    return fs;
+  }
+
   FileSystem getFileSystem() throws IOException {
     if (fs == null) {
-      fs = FileSystem.get(getConf());
+      return FileSystem.get(getConf());
     }
     return fs;
   }

--- a/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileScannerBuilder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileScannerBuilder.java
@@ -56,8 +56,8 @@ class RFileScannerBuilder implements RFile.InputArguments, RFile.ScannerFSOption
       if (sources == null) {
         sources = new RFileSource[paths.length];
         for (int i = 0; i < paths.length; i++) {
-          sources[i] = new RFileSource(getFileSystem().open(paths[i]),
-              getFileSystem().getFileStatus(paths[i]).getLen());
+          sources[i] = new RFileSource(getFileSystem(paths[i]).open(paths[i]),
+              getFileSystem(paths[i]).getFileStatus(paths[i]).getLen());
         }
       } else {
         for (int i = 0; i < sources.length; i++) {

--- a/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileWriterBuilder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileWriterBuilder.java
@@ -119,7 +119,7 @@ class RFileWriterBuilder implements RFile.OutputArguments, RFile.WriterFSOptions
           visCacheSize);
     } else {
       return new RFileWriter(fileops.newWriterBuilder()
-          .forFile(out.path.toString(), out.getFileSystem(), out.getConf(), cs)
+          .forFile(out.path.toString(), out.getFileSystem(out.path), out.getConf(), cs)
           .withTableConfiguration(acuconf).withStartDisabled().build(), visCacheSize);
     }
   }

--- a/core/src/test/java/org/apache/accumulo/core/client/rfile/RFileClientTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/rfile/RFileClientTest.java
@@ -858,10 +858,19 @@ public class RFileClientTest {
     assertTrue(Arrays.stream(exception.getStackTrace())
         .noneMatch(ste -> ste.getClassName().contains(localFsClass)));
 
+    var exception2 = assertThrows(RuntimeException.class, () -> {
+      var scanner = RFile.newScanner().from(fileUri).build();
+      scanner.iterator();
+    });
+    assertTrue(Arrays.stream(exception2.getCause().getStackTrace())
+        .anyMatch(ste -> ste.getClassName().contains(DistributedFileSystem.class.getName())));
+    assertTrue(Arrays.stream(exception2.getCause().getStackTrace())
+        .noneMatch(ste -> ste.getClassName().contains(localFsClass)));
+
     // verify the assumptions this test is making about the local filesystem being the default.
-    var exception2 = assertThrows(IllegalArgumentException.class,
+    var exception3 = assertThrows(IllegalArgumentException.class,
         () -> FileSystem.get(new Configuration()).open(new Path(fileUri)));
-    assertTrue(Arrays.stream(exception2.getStackTrace())
+    assertTrue(Arrays.stream(exception3.getStackTrace())
         .anyMatch(ste -> ste.getClassName().contains(localFsClass)));
   }
 }


### PR DESCRIPTION
Modified the rfile client code to get the filesystem based on the path being written or read.  This covers the case of having multiple filesystems defined in hadoop config.