### PR TITLE
Improvements to ExternalCompaction ITs

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionTestUtils.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionTestUtils.java
@@ -99,6 +99,12 @@ public class ExternalCompactionTestUtils {
         .filter(state -> state.getExtent().tableId().equals(tid));
   }
 
+  public static long getFinalStateForTableCount(AccumuloCluster cluster, TableId tid) {
+    try (var finalStatesForTable = getFinalStatesForTable(cluster, tid)) {
+      return finalStatesForTable.count();
+    }
+  }
+
   public static void compact(final AccumuloClient client, String table1, int modulus,
       String expectedQueue, boolean wait)
       throws AccumuloSecurityException, TableNotFoundException, AccumuloException {


### PR DESCRIPTION
In #5283 I made sure the Scanner that was used to construct a Stream returned by Amples `getExternalCompactionFinalStates()` got closed. I did not touch the test code when that PR was merged into 2.1. This PR improves the usages of that method in the test code by closing the Stream and therefore the resources used in that method. I added a helper method to get the count of these states to make some of the test code cleaner too.