### PR TITLE
Disables HTML escaping in LoadPlan json encoding.

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/data/LoadPlan.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/LoadPlan.java
@@ -279,7 +279,8 @@ public class LoadPlan {
 
   }
 
-  private static final Gson gson = new GsonBuilder().disableJdkUnsafe().serializeNulls().create();
+  private static final Gson gson =
+      new GsonBuilder().disableHtmlEscaping().disableJdkUnsafe().serializeNulls().create();
 
   /**
    * Serializes the load plan to json that looks like the following. The values of startRow and

--- a/core/src/test/java/org/apache/accumulo/core/data/LoadPlanTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/LoadPlanTest.java
@@ -119,7 +119,7 @@ public class LoadPlanTest {
     builder.loadFileTo("f1.rf", RangeType.TABLE, null, "003");
     builder.loadFileTo("f2.rf", RangeType.FILE, "004", "007");
     builder.loadFileTo("f1.rf", RangeType.TABLE, "005", "006");
-    builder.loadFileTo("f3.rf", RangeType.TABLE, "008", null);
+    builder.loadFileTo("f3.rf", RangeType.TABLE, new byte[] {0, 1, 2, 3, 4, 5, 6}, null);
     String json = builder.build().toJson();
 
     String b64003 = Base64.getUrlEncoder().encodeToString("003".getBytes(UTF_8));
@@ -127,13 +127,13 @@ public class LoadPlanTest {
     String b64005 = Base64.getUrlEncoder().encodeToString("005".getBytes(UTF_8));
     String b64006 = Base64.getUrlEncoder().encodeToString("006".getBytes(UTF_8));
     String b64007 = Base64.getUrlEncoder().encodeToString("007".getBytes(UTF_8));
-    String b64008 = Base64.getUrlEncoder().encodeToString("008".getBytes(UTF_8));
+    String b64binary = Base64.getUrlEncoder().encodeToString(new byte[] {0, 1, 2, 3, 4, 5, 6});
 
     String expected = "{'destinations':[{'fileName':'f1.rf','startRow':null,'endRow':'" + b64003
         + "','rangeType':'TABLE'},{'fileName':'f2.rf','startRow':'" + b64004 + "','endRow':'"
         + b64007 + "','rangeType':'FILE'},{'fileName':'f1.rf','startRow':'" + b64005
         + "','endRow':'" + b64006 + "','rangeType':'TABLE'},{'fileName':'f3.rf','startRow':'"
-        + b64008 + "','endRow':null,'rangeType':'TABLE'}]}";
+        + b64binary + "','endRow':null,'rangeType':'TABLE'}]}";
 
     assertEquals(expected.replace("'", "\""), json);
   }


### PR DESCRIPTION
The encoding in LoadPlan was using GSon default settings which encoded some HTML chars like `=` as unicode escape sequences.  This did not cause any problems because GSon would reverse this encoding.  However it was not documented in the javadoc for LoadPlan and it seems unnecessary.

Disabled the HTML escaping so the code aligns w/ the javadoc.  Also updated the unit test to produce `=` in the base64 and see how that behaves in the json.  This allows the test to better detect changes in the way the code persist data.