### PR TITLE
simplifies concurrency in ZooSession and ZooCache

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/zookeeper/ZooSession.java
+++ b/core/src/main/java/org/apache/accumulo/core/zookeeper/ZooSession.java
@@ -28,10 +28,9 @@ import java.net.UnknownHostException;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
@@ -54,6 +53,8 @@ import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
 
 /**
  * A ZooKeeper client facade that maintains a ZooKeeper delegate instance. If the delegate instance
@@ -115,10 +116,20 @@ public class ZooSession implements AutoCloseable {
     zoo.addAuthInfo("digest", ("accumulo:" + requireNonNull(secret)).getBytes(UTF_8));
   }
 
-  private final AtomicBoolean closed = new AtomicBoolean();
-  private final AtomicLong connectCounter;
+  private static class ZookeeperAndCounter {
+    final ZooKeeper zookeeper;
+    final long connectionCount;
+
+    private ZookeeperAndCounter(ZooKeeper zookeeper, long connectionCount) {
+      Preconditions.checkArgument(connectionCount >= 0);
+      this.zookeeper = Objects.requireNonNull(zookeeper);
+      this.connectionCount = connectionCount;
+    }
+  }
+
+  private boolean closed = false;
   private final String connectString;
-  private final AtomicReference<ZooKeeper> delegate = new AtomicReference<>();
+  private final AtomicReference<ZookeeperAndCounter> delegate = new AtomicReference<>();
   private final String instanceSecret;
   private final String sessionName;
   private final int timeout;
@@ -155,24 +166,32 @@ public class ZooSession implements AutoCloseable {
     // information for logging which instance of ZooSession this is
     this.sessionName =
         String.format("%s[%s_%s]", getClass().getSimpleName(), clientName, UUID.randomUUID());
-    this.connectCounter = new AtomicLong(); // incremented when we need to create a new delegate
     this.zrw = new ZooReaderWriter(this);
   }
 
   private ZooKeeper verifyConnected() {
-    if (closed.get()) {
-      throw new IllegalStateException(sessionName + " was closed");
+    var zkac = delegate.get();
+    if (zkac != null && zkac.zookeeper.getState().isAlive()) {
+      return zkac.zookeeper;
+    } else {
+      return reconnect().zookeeper;
     }
-    return delegate.updateAndGet(zk -> (zk != null && zk.getState().isAlive()) ? zk : reconnect());
   }
 
-  private synchronized ZooKeeper reconnect() {
-    ZooKeeper zk;
-    if ((zk = delegate.get()) != null && zk.getState().isAlive()) {
-      return zk;
+  private synchronized ZookeeperAndCounter reconnect() {
+    if (closed) {
+      throw new IllegalStateException(sessionName + " was closed");
     }
-    zk = null;
-    var reconnectName = String.format("%s#%s", sessionName, connectCounter.getAndIncrement());
+
+    ZookeeperAndCounter zkac;
+    if ((zkac = delegate.get()) != null && zkac.zookeeper.getState().isAlive()) {
+      return zkac;
+    }
+
+    final long nextCounter = (zkac == null ? 0 : zkac.connectionCount) + 1;
+    zkac = null;
+
+    var reconnectName = String.format("%s#%s", sessionName, nextCounter);
     log.debug("{} (re-)connecting to {} with timeout {}{}", reconnectName, connectString, timeout,
         instanceSecret == null ? "" : " with auth");
     final int TIME_BETWEEN_CONNECT_CHECKS_MS = 100;
@@ -181,6 +200,8 @@ public class ZooSession implements AutoCloseable {
     long sleepTime = 100;
 
     long startTime = System.nanoTime();
+
+    ZooKeeper zk = null;
 
     while (tryAgain) {
       try {
@@ -236,7 +257,10 @@ public class ZooSession implements AutoCloseable {
         }
       }
     }
-    return zk;
+
+    zkac = new ZookeeperAndCounter(zk, nextCounter);
+    delegate.set(zkac);
+    return zkac;
   }
 
   public void addAuthInfo(String scheme, byte[] auth) {
@@ -294,27 +318,28 @@ public class ZooSession implements AutoCloseable {
     verifyConnected().sync(path, cb, ctx);
   }
 
-  public void addPersistentRecursiveWatchers(Set<String> paths, Watcher watcher)
+  public long addPersistentRecursiveWatchers(Set<String> paths, Watcher watcher)
       throws KeeperException, InterruptedException {
+    ZookeeperAndCounter localZkac = reconnect();
 
-    ZooKeeper localZK = verifyConnected();
     Set<String> remainingPaths = new HashSet<>(paths);
     while (true) {
       try {
         Iterator<String> remainingPathsIter = remainingPaths.iterator();
         while (remainingPathsIter.hasNext()) {
           String path = remainingPathsIter.next();
-          localZK.addWatch(path, watcher, AddWatchMode.PERSISTENT_RECURSIVE);
+          localZkac.zookeeper.addWatch(path, watcher, AddWatchMode.PERSISTENT_RECURSIVE);
           remainingPathsIter.remove();
         }
-        break;
+
+        return localZkac.connectionCount;
       } catch (KeeperException e) {
         log.error("Error setting persistent watcher in ZooKeeper, retrying...", e);
-        ZooKeeper currentZK = verifyConnected();
+        ZookeeperAndCounter currentZkac = reconnect();
         // If ZooKeeper object is different, then reset the localZK variable
         // and start over.
-        if (localZK != currentZK) {
-          localZK = currentZK;
+        if (localZkac != currentZkac) {
+          localZkac = currentZkac;
           remainingPaths = new HashSet<>(paths);
         }
       }
@@ -322,9 +347,13 @@ public class ZooSession implements AutoCloseable {
   }
 
   @Override
-  public void close() {
-    if (closed.compareAndSet(false, true)) {
-      closeZk(delegate.getAndSet(null));
+  public synchronized void close() {
+    if (!closed) {
+      var zkac = delegate.getAndSet(null);
+      if (zkac != null) {
+        closeZk(zkac.zookeeper);
+      }
+      closed = true;
     }
   }
 
@@ -348,7 +377,13 @@ public class ZooSession implements AutoCloseable {
    * @return connection counter
    */
   public long getConnectionCounter() {
-    return connectCounter.get();
+    var zkac = delegate.get();
+    if (delegate.get() == null) {
+      // If null then this is closed or in the process of opening. If closed reconnect will throw an
+      // exception. If in the process of opening, then reconnect will wait for that to finish.
+      return reconnect().connectionCount;
+    }
+    return zkac.connectionCount;
   }
 
 }

--- a/core/src/test/java/org/apache/accumulo/core/zookeeper/ZooCacheTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/zookeeper/ZooCacheTest.java
@@ -60,8 +60,8 @@ public class ZooCacheTest {
     }
 
     @Override
-    protected void setupWatchers() {
-      clear();
+    protected boolean setupWatchers() {
+      return false;
     }
 
     public void executeWatcher(WatchedEvent event) {
@@ -95,7 +95,7 @@ public class ZooCacheTest {
   @SuppressWarnings("unchecked")
   public void testOverlappingPaths() throws Exception {
     expect(zk.getConnectionCounter()).andReturn(2L).times(2);
-    zk.addPersistentRecursiveWatchers(isA(Set.class), isA(Watcher.class));
+    expect(zk.addPersistentRecursiveWatchers(isA(Set.class), isA(Watcher.class))).andReturn(3L);
     replay(zk);
     assertThrows(IllegalArgumentException.class,
         () -> new ZooCache(zk, Set.of(root, root + "/localhost:9995")));
@@ -121,7 +121,7 @@ public class ZooCacheTest {
   @SuppressWarnings("unchecked")
   public void testUnwatchedPaths() throws Exception {
     expect(zk.getConnectionCounter()).andReturn(2L).anyTimes();
-    zk.addPersistentRecursiveWatchers(isA(Set.class), isA(Watcher.class));
+    expect(zk.addPersistentRecursiveWatchers(isA(Set.class), isA(Watcher.class))).andReturn(3L);
     replay(zk);
     ZooCache cache = new ZooCache(zk, Set.of(root));
     assertThrows(IllegalStateException.class, () -> cache.get("/some/unknown/path"));


### PR DESCRIPTION
Made a few changes to how ZooCache and ZooSession handle concurrency in order to make it easier to reason about the code.

ZooCache and ZooSession had code that used Atomics to do computations in addition to synchronized blocks.  This adds complexity w/o an apparent benefit.  Stopped doing the computations in both places and moved all computations in to the synchronized block.

ZooSession has a counter that was used by ZooCache to know when zookeeper changed.  ZooSession updated this counter independently from updating the zookeeper reference and ZooCache read the refrence and counter at different times.  Reorganized the code so that read and write of the counter and zookeeper are done at the same times by ZooSession and ZooCache.

ZooSession.close() could run conucurrently with the code that created new ZooKeeper objects in ZooSession.  Made the close method synchronized and tweaked how the closed variable is checked.