### PR TITLE
Applied fix from #5260 in other locations

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/trace/TraceUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/trace/TraceUtil.java
@@ -21,15 +21,14 @@ package org.apache.accumulo.core.trace;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Proxy;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.Callable;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.clientImpl.thrift.TInfo;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.util.ClassUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -216,19 +215,8 @@ public class TraceUtil {
   private static <T> T wrapRpc(final InvocationHandler handler, final T instance) {
     @SuppressWarnings("unchecked")
     T proxiedInstance = (T) Proxy.newProxyInstance(instance.getClass().getClassLoader(),
-        getInterfaces(instance.getClass()).toArray(new Class<?>[0]), handler);
+        ClassUtil.getInterfaces(instance.getClass()).toArray(new Class<?>[0]), handler);
     return proxiedInstance;
-  }
-
-  private static Set<Class<?>> getInterfaces(Class<?> clazz) {
-    var set = new HashSet<Class<?>>();
-    if (clazz != null) {
-      set.addAll(getInterfaces(clazz.getSuperclass()));
-      for (Class<?> interfaze : clazz.getInterfaces()) {
-        set.add(interfaze);
-      }
-    }
-    return set;
   }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/util/ClassUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/ClassUtil.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.util;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class ClassUtil {
+
+  /**
+   * Utility method to return the set of all interfaces implemented by the supplied class and it's
+   * parents.
+   *
+   * @param clazz Class object to check
+   * @return Set of interface classes implemented by input argument
+   */
+  public static Set<Class<?>> getInterfaces(Class<?> clazz) {
+    var set = new HashSet<Class<?>>();
+    if (clazz != null) {
+      set.addAll(getInterfaces(clazz.getSuperclass()));
+      for (Class<?> interfaze : clazz.getInterfaces()) {
+        set.add(interfaze);
+      }
+    }
+    return set;
+  }
+
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/HighlyAvailableServiceWrapper.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/HighlyAvailableServiceWrapper.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.server.rpc;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 
+import org.apache.accumulo.core.util.ClassUtil;
 import org.apache.accumulo.server.HighlyAvailableService;
 
 /**
@@ -42,7 +43,7 @@ public class HighlyAvailableServiceWrapper {
 
     @SuppressWarnings("unchecked")
     I proxiedInstance = (I) Proxy.newProxyInstance(instance.getClass().getClassLoader(),
-        instance.getClass().getInterfaces(), handler);
+        ClassUtil.getInterfaces(instance.getClass()).toArray(new Class<?>[0]), handler);
     return proxiedInstance;
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/TCredentialsUpdatingWrapper.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/TCredentialsUpdatingWrapper.java
@@ -22,6 +22,7 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.util.ClassUtil;
 
 /**
  * Utility method to ensure that the instance of TCredentials which is passed to the implementation
@@ -37,7 +38,7 @@ public class TCredentialsUpdatingWrapper {
 
     @SuppressWarnings("unchecked")
     T proxiedInstance = (T) Proxy.newProxyInstance(originalClass.getClassLoader(),
-        originalClass.getInterfaces(), handler);
+        ClassUtil.getInterfaces(instance.getClass()).toArray(new Class<?>[0]), handler);
 
     return proxiedInstance;
   }


### PR DESCRIPTION
The issue fixed in #5260 was that a class that was implementing a Thrift interface had to declare it, even if it was declared in a parent class. #5260 fixed the logic in one place and then removed the interface declarations from the subclasses. It appears that there are other locations in the code where the same problem exists. This commit moves the fix to a utility class and updates the places where this was being done to use the utility method.