### PR TITLE
Fixed LogSorter from changes due to incorrect merge

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -394,7 +394,7 @@ public class ScanServer extends AbstractServer
       try {
         // Attempt to process all existing log sorting work and start a background
         // thread to look for log sorting work in the future
-        logSorter.startWatchingForRecoveryLogs();
+        logSorter.startWatchingForRecoveryLogs(threadPoolSize);
       } catch (Exception ex) {
         LOG.error("Error starting LogSorter");
         throw new RuntimeException(ex);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -586,7 +586,7 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
       try {
         // Attempt to process all existing log sorting work and start a background
         // thread to look for log sorting work in the future
-        logSorter.startWatchingForRecoveryLogs();
+        logSorter.startWatchingForRecoveryLogs(threadPoolSize);
       } catch (Exception ex) {
         log.error("Error starting LogSorter");
         throw new RuntimeException(ex);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
@@ -313,8 +313,8 @@ public class LogSorter {
    * thread to look for log sorting work in the future that will be processed by the
    * ThreadPoolExecutor
    */
-  public void startWatchingForRecoveryLogs() throws KeeperException, InterruptedException {
-    int threadPoolSize = this.conf.getCount(Property.TSERV_WAL_SORT_MAX_CONCURRENT);
+  public void startWatchingForRecoveryLogs(int threadPoolSize)
+      throws KeeperException, InterruptedException {
     ThreadPoolExecutor threadPool =
         ThreadPools.getServerThreadPools().getPoolBuilder(TSERVER_WAL_SORT_CONCURRENT_POOL)
             .numCoreThreads(threadPoolSize).enableThreadPoolMetrics().build();


### PR DESCRIPTION
The merge of #5193 from 2.1 to main reverted some changes in main to LogSorter causing RecoveryIT to fail.