### PR TITLE
Defers server invalidation in tablet location cache

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletLocatorImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletLocatorImpl.java
@@ -86,6 +86,7 @@ public class TabletLocatorImpl extends TabletLocator {
   protected Text lastTabletRow;
 
   private final TreeSet<KeyExtent> badExtents = new TreeSet<>();
+  private final HashSet<String> badServers = new HashSet<>();
   private final ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock();
   private final Lock rLock = rwLock.readLock();
   private final Lock wLock = rwLock.writeLock();
@@ -446,16 +447,10 @@ public class TabletLocatorImpl extends TabletLocator {
 
   @Override
   public void invalidateCache(ClientContext context, String server) {
-    int invalidatedCount = 0;
 
     wLock.lock();
     try {
-      for (TabletLocation cacheEntry : metaCache.values()) {
-        if (cacheEntry.tablet_location.equals(server)) {
-          badExtents.add(cacheEntry.tablet_extent);
-          invalidatedCount++;
-        }
-      }
+      badServers.add(server);
     } finally {
       wLock.unlock();
     }
@@ -463,10 +458,8 @@ public class TabletLocatorImpl extends TabletLocator {
     lockChecker.invalidateCache(server);
 
     if (log.isTraceEnabled()) {
-      log.trace("invalidated {} cache entries  table={} server={}", invalidatedCount, tableId,
-          server);
+      log.trace("queued invalidation for table={} server={}", tableId, server);
     }
-
   }
 
   @Override
@@ -725,7 +718,7 @@ public class TabletLocatorImpl extends TabletLocator {
   private void processInvalidated(ClientContext context, LockCheckerSession lcSession)
       throws AccumuloSecurityException, AccumuloException, TableNotFoundException {
 
-    if (badExtents.isEmpty()) {
+    if (badExtents.isEmpty() && badServers.isEmpty()) {
       return;
     }
 
@@ -734,7 +727,7 @@ public class TabletLocatorImpl extends TabletLocator {
       if (!writeLockHeld) {
         rLock.unlock();
         wLock.lock();
-        if (badExtents.isEmpty()) {
+        if (badExtents.isEmpty() && badServers.isEmpty()) {
           return;
         }
       }
@@ -744,6 +737,26 @@ public class TabletLocatorImpl extends TabletLocator {
       for (KeyExtent be : badExtents) {
         lookups.add(be.toMetaRange());
         removeOverlapping(metaCache, be);
+      }
+
+      if (!badServers.isEmpty()) {
+        int removedCount = 0;
+        var locationIterator = metaCache.values().iterator();
+        while (locationIterator.hasNext()) {
+          TabletLocation cacheEntry = locationIterator.next();
+          if (badServers.contains(cacheEntry.tablet_location)) {
+            locationIterator.remove();
+            lookups.add(cacheEntry.tablet_extent.toMetaRange());
+            removedCount++;
+          }
+        }
+
+        if (log.isTraceEnabled()) {
+          log.trace("Invalidated {} cache entries for table {} related to servers {}", removedCount,
+              tableId, badServers);
+        }
+
+        badServers.clear();
       }
 
       lookups = Range.mergeOverlapping(lookups);


### PR DESCRIPTION
When many accumulo client threads all decided to invalidate some servers at the same time in the tablet location cache each threads would scan though all metadata looking for those servers.

This change adds servers to a set for deferred processing when invalidated.  This has two advantages.  First for multiple threads adding servers at around the same time it can lower the number of scans done over all the cached tablet locations.  Second the amount of work done to invalidate servers is lowered.  The code used to find cache entries for a server, add the extent for that cache entry to badExtents, and then later look for everything in badExtents and remove it.  This change removes all of that work and directly removes entries from the cache and avoids adding anything to badExtents.