### PR TITLE
Log iteration to result count in BulkImport code

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/BulkImport.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/BulkImport.java
@@ -338,10 +338,7 @@ public class BulkImport implements ImportDestinationArguments, ImportMappingOpti
 
     List<KeyExtent> result = new ArrayList<>();
     Text row = new Text();
-    long iterationCount = 0;
     while (true) {
-      iterationCount++;
-
       row = nextRowFunction.apply(row);
       if (row == null) {
         break;
@@ -356,8 +353,6 @@ public class BulkImport implements ImportDestinationArguments, ImportMappingOpti
       }
     }
 
-    log.debug("performed {} iterations to identify {} overlapping tablets", iterationCount,
-        result.size());
     return result;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/BulkImport.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/BulkImport.java
@@ -338,7 +338,10 @@ public class BulkImport implements ImportDestinationArguments, ImportMappingOpti
 
     List<KeyExtent> result = new ArrayList<>();
     Text row = new Text();
+    long iterationCount = 0;
     while (true) {
+      iterationCount++;
+
       row = nextRowFunction.apply(row);
       if (row == null) {
         break;
@@ -353,6 +356,8 @@ public class BulkImport implements ImportDestinationArguments, ImportMappingOpti
       }
     }
 
+    log.debug("performed {} iterations to identify {} overlapping tablets", iterationCount,
+        result.size());
     return result;
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
@@ -368,7 +368,7 @@ class LoadFiles extends ManagerRepo {
     log.trace("{}: Completed Finding Overlapping Tablets", fmtTid);
 
     if (importTimingStats.callCount > 0) {
-      log.info(
+      log.debug(
           "Bulk import stats for {} (tid = {}): processed {} tablets in {} calls which took {}ms ({} nanos). Skipped {} iterations which took {}ms ({} nanos) or {}% of the processing time.",
           bulkInfo.sourceDir, FateTxId.formatTid(tid), importTimingStats.tabletCount,
           importTimingStats.callCount, totalProcessingTime.toMillis(),


### PR DESCRIPTION
Related to #5201. Logs the number of iterations performed to produce the resulting returned value (overlapping tablets). This will make it more evident if this code is doing a lot of scanning relative to the number of values we are looking for.