### PR TITLE
avoid clearing server in cache when scanner closed and interrupted

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerIterator.java
@@ -124,6 +124,8 @@ public class ScannerIterator implements Iterator<Entry<Key,Value>> {
   }
 
   void close() {
+    // setting this so that some errors can be ignored
+    scanState.closeInitiated = true;
     // run actual close operation in the background so this does not block.
     context.executeCleanupTask(() -> {
       synchronized (scanState) {


### PR DESCRIPTION
When the thread running an accumulo scanner is interrupted it may cause the server the scanner was reading from to be cleared from the cache. This can be disruptive in the case where the server is fine. This change makes a narrow exception to clearing the server from the cache for the case where the scanner was closed and an interrupt was seen.  The reason this is so narrow is to avoid failing to invalidate the cache in the case where there is actually a problem with the server.