### PR TITLE
uses consistent zk host addr in MAC

### DIFF
--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
@@ -261,7 +261,7 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
       zooCfg.setProperty("tickTime", "2000");
       zooCfg.setProperty("initLimit", "10");
       zooCfg.setProperty("syncLimit", "5");
-      zooCfg.setProperty("clientPortAddress", "127.0.0.1");
+      zooCfg.setProperty("clientPortAddress", MiniAccumuloConfigImpl.DEFAULT_ZOOKEEPER_HOST);
       zooCfg.setProperty("clientPort", config.getZooKeeperPort() + "");
       zooCfg.setProperty("maxClientCnxns", "1000");
       zooCfg.setProperty("dataDir", config.getZooKeeperDir().getAbsolutePath());
@@ -549,7 +549,8 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
           // sleep a little bit to let zookeeper come up before calling init, seems to work better
           long startTime = System.currentTimeMillis();
           while (true) {
-            try (Socket s = new Socket("localhost", config.getZooKeeperPort())) {
+            try (Socket s = new Socket(MiniAccumuloConfigImpl.DEFAULT_ZOOKEEPER_HOST,
+                config.getZooKeeperPort())) {
               s.setReuseAddress(true);
               s.getOutputStream().write("ruok\n".getBytes(UTF_8));
               s.getOutputStream().flush();

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
@@ -215,7 +215,7 @@ public class MiniAccumuloConfigImpl {
             zooKeeperPort = PortUtils.getRandomFreePort();
           }
 
-          zkHost = "localhost:" + zooKeeperPort;
+          zkHost = "127.0.0.1:" + zooKeeperPort;
         }
         siteConfig.put(Property.INSTANCE_ZK_HOST.getKey(), zkHost);
       }

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
@@ -68,6 +68,7 @@ public class MiniAccumuloConfigImpl {
 
   private static final Logger log = LoggerFactory.getLogger(MiniAccumuloConfigImpl.class);
   private static final String DEFAULT_INSTANCE_SECRET = "DONTTELL";
+  static final String DEFAULT_ZOOKEEPER_HOST = "127.0.0.1";
 
   private File dir = null;
   private String rootPassword = null;
@@ -215,7 +216,7 @@ public class MiniAccumuloConfigImpl {
             zooKeeperPort = PortUtils.getRandomFreePort();
           }
 
-          zkHost = "127.0.0.1:" + zooKeeperPort;
+          zkHost = DEFAULT_ZOOKEEPER_HOST + ":" + zooKeeperPort;
         }
         siteConfig.put(Property.INSTANCE_ZK_HOST.getKey(), zkHost);
       }


### PR DESCRIPTION
Was seeing slow ITs related to recent changes that cause more ZK clients to be created.  ZK client creation was slow.  The cause was ZOOKEEPER-3100 and MiniAccumulo setting 127.0.0.1 in ZK server config and using localhost for ZK in accumulo config. This caused the ZK server to listen on 127.0.0.1 and the ZK client to sometimes attempt to use the IPV6 addr for localhost which failed and retried possibly adding seconds to each ZK connection attempt.

This changes updates accumulo config created by mini accumulo to use 127.0.0.1 for zookeeper.