### PR TITLE
Filter columns in CompactionReservationCheck

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/iterators/TabletMetadataCheckIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/iterators/TabletMetadataCheckIterator.java
@@ -102,7 +102,7 @@ public class TabletMetadataCheckIterator implements SortedKeyValueIterator<Key,V
 
     if (source.hasTop()) {
       var tabletMetadata = TabletMetadata.convertRow(new IteratorAdapter(source),
-          EnumSet.allOf(TabletMetadata.ColumnType.class), false, false);
+          EnumSet.copyOf(colsToRead), false, false);
 
       // TODO checking the prev end row here is redundant w/ other checks that ample currently
       // does.. however we could try to make all checks eventually use this class

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionReservationCheck.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionReservationCheck.java
@@ -18,6 +18,13 @@
  */
 package org.apache.accumulo.manager.compaction.coordinator;
 
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.ECOMP;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.FILES;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.OPID;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.PREV_ROW;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.SELECTED;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.USER_COMPACTION_REQUESTED;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -28,6 +35,7 @@ import java.util.stream.Collectors;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.accumulo.core.metadata.schema.TabletMetadataCheck;
 import org.apache.accumulo.core.spi.compaction.CompactionKind;
 import org.apache.accumulo.core.util.time.SteadyTime;
@@ -152,5 +160,10 @@ public class CompactionReservationCheck implements TabletMetadataCheck {
     }
 
     return true;
+  }
+
+  @Override
+  public Set<ColumnType> columnsToRead() {
+    return Set.of(PREV_ROW, OPID, SELECTED, FILES, ECOMP, USER_COMPACTION_REQUESTED);
   }
 }


### PR DESCRIPTION
Only load required columns for check to avoid reading unnecessary data into memory

Closes #5254