### PR TITLE
fixes creating same table name in different namespaces

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
@@ -80,7 +80,7 @@ public class Utils {
             final byte[] nId =
                 context.getZooReader().getData(zTablePath + Constants.ZTABLE_NAMESPACE);
             if (destNamespaceId.canonical().equals(new String(nId, UTF_8))
-                && !tableId.equals(TableId.of(tid))) {
+                && !tableId.canonical().equals(tid)) {
               throw new AcceptableThriftTableOperationException(tid, tableName, operation,
                   TableOperationExceptionType.EXISTS, null);
             }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
@@ -23,8 +23,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Base64;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.locks.Lock;
@@ -32,9 +30,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 
 import org.apache.accumulo.core.Constants;
-import org.apache.accumulo.core.client.NamespaceNotFoundException;
 import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
-import org.apache.accumulo.core.clientImpl.Namespace;
 import org.apache.accumulo.core.clientImpl.Namespaces;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
@@ -58,8 +54,6 @@ import org.apache.zookeeper.KeeperException.NoNodeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Preconditions;
-
 public class Utils {
   private static final byte[] ZERO_BYTE = {'0'};
   private static final Logger log = LoggerFactory.getLogger(Utils.class);
@@ -68,10 +62,11 @@ public class Utils {
    * Checks that a table name is only used by the specified table id or not used at all.
    */
   public static void checkTableNameDoesNotExist(ServerContext context, String tableName,
-      TableId tableId, TableOperation operation) throws AcceptableThriftTableOperationException {
+      NamespaceId destNamespaceId, TableId tableId, TableOperation operation)
+      throws AcceptableThriftTableOperationException {
 
-    final Map<NamespaceId,String> namespaces = new HashMap<>();
-    final boolean namespaceInTableName = tableName.contains(".");
+    var newTableName = TableNameUtil.qualify(tableName).getSecond();
+
     try {
       for (String tid : context.getZooReader()
           .getChildren(context.getZooKeeperRoot() + Constants.ZTABLES)) {
@@ -79,36 +74,17 @@ public class Utils {
         final String zTablePath = context.getZooKeeperRoot() + Constants.ZTABLES + "/" + tid;
         try {
           final byte[] tname = context.getZooReader().getData(zTablePath + Constants.ZTABLE_NAME);
-          Preconditions.checkState(tname != null, "Malformed table entry in ZooKeeper at %s",
-              zTablePath);
 
-          String namespaceName = Namespace.DEFAULT.name();
-          if (namespaceInTableName) {
+          if (newTableName.equals(new String(tname, UTF_8))) {
+            // only make RPCs to get the namespace when the table names are equal
             final byte[] nId =
                 context.getZooReader().getData(zTablePath + Constants.ZTABLE_NAMESPACE);
-            if (nId != null) {
-              final NamespaceId namespaceId = NamespaceId.of(new String(nId, UTF_8));
-              if (!namespaceId.equals(Namespace.DEFAULT.id())) {
-                namespaceName = namespaces.get(namespaceId);
-                if (namespaceName == null) {
-                  try {
-                    namespaceName = Namespaces.getNamespaceName(context, namespaceId);
-                    namespaces.put(namespaceId, namespaceName);
-                  } catch (NamespaceNotFoundException e) {
-                    throw new AcceptableThriftTableOperationException(null, tableName,
-                        TableOperation.CREATE, TableOperationExceptionType.OTHER,
-                        "Table (" + tableId.canonical() + ") contains reference to namespace ("
-                            + namespaceId + ") that doesn't exist");
-                  }
-                }
-              }
+            if (destNamespaceId.canonical().equals(new String(nId, UTF_8))
+                && !tableId.equals(TableId.of(tid))) {
+              throw new AcceptableThriftTableOperationException(tid, tableName, operation,
+                  TableOperationExceptionType.EXISTS, null);
             }
-          }
 
-          if (tableName.equals(TableNameUtil.qualified(new String(tname, UTF_8), namespaceName))
-              && !tableId.equals(TableId.of(tid))) {
-            throw new AcceptableThriftTableOperationException(tid, tableName, operation,
-                TableOperationExceptionType.EXISTS, null);
           }
         } catch (NoNodeException nne) {
           log.trace("skipping tableId {}, either being created or has been deleted.", tid, nne);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneTable.java
@@ -42,7 +42,7 @@ public class CloneTable extends ManagerRepo {
     cloneInfo.tableName = tableName;
     cloneInfo.propertiesToExclude = propertiesToExclude;
     cloneInfo.propertiesToSet = propertiesToSet;
-    cloneInfo.srcNamespaceId = namespaceId;
+    cloneInfo.srcNamespaceId = namespaceId; // TODO this seems like the dest table id
     cloneInfo.keepOffline = keepOffline;
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneTable.java
@@ -42,7 +42,7 @@ public class CloneTable extends ManagerRepo {
     cloneInfo.tableName = tableName;
     cloneInfo.propertiesToExclude = propertiesToExclude;
     cloneInfo.propertiesToSet = propertiesToSet;
-    cloneInfo.srcNamespaceId = namespaceId; // TODO this seems like the dest table id
+    cloneInfo.srcNamespaceId = namespaceId;
     cloneInfo.keepOffline = keepOffline;
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneZookeeper.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneZookeeper.java
@@ -60,7 +60,7 @@ class CloneZookeeper extends ManagerRepo {
       // write tableName & tableId to zookeeper
 
       Utils.checkTableNameDoesNotExist(environment.getContext(), cloneInfo.tableName,
-          cloneInfo.tableId, TableOperation.CLONE);
+          cloneInfo.namespaceId, cloneInfo.tableId, TableOperation.CLONE);
 
       environment.getTableManager().cloneTable(cloneInfo.srcTableId, cloneInfo.tableId,
           cloneInfo.tableName, cloneInfo.namespaceId, cloneInfo.propertiesToSet,

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/PopulateZookeeper.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/PopulateZookeeper.java
@@ -28,10 +28,13 @@ import org.apache.accumulo.manager.tableOps.TableInfo;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.accumulo.server.conf.store.TablePropKey;
 import org.apache.accumulo.server.util.PropUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class PopulateZookeeper extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;
+  private static final Logger log = LoggerFactory.getLogger(PopulateZookeeper.class);
 
   private final TableInfo tableInfo;
 
@@ -53,7 +56,7 @@ class PopulateZookeeper extends ManagerRepo {
     try {
       // write tableName & tableId to zookeeper
       Utils.checkTableNameDoesNotExist(manager.getContext(), tableInfo.getTableName(),
-          tableInfo.getTableId(), TableOperation.CREATE);
+          tableInfo.getNamespaceId(), tableInfo.getTableId(), TableOperation.CREATE);
 
       manager.getTableManager().addTable(tableInfo.getTableId(), tableInfo.getNamespaceId(),
           tableInfo.getTableName());

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/rename/RenameTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/rename/RenameTable.java
@@ -76,7 +76,7 @@ public class RenameTable extends ManagerRepo {
 
     Utils.getTableNameLock().lock();
     try {
-      Utils.checkTableNameDoesNotExist(manager.getContext(), newTableName, tableId,
+      Utils.checkTableNameDoesNotExist(manager.getContext(), newTableName, namespaceId, tableId,
           TableOperation.RENAME);
 
       final String newName = qualifiedNewTableName.getSecond();

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportPopulateZookeeper.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportPopulateZookeeper.java
@@ -75,8 +75,8 @@ class ImportPopulateZookeeper extends ManagerRepo {
     Utils.getTableNameLock().lock();
     try {
       // write tableName & tableId to zookeeper
-      Utils.checkTableNameDoesNotExist(env.getContext(), tableInfo.tableName, tableInfo.tableId,
-          TableOperation.CREATE);
+      Utils.checkTableNameDoesNotExist(env.getContext(), tableInfo.tableName, tableInfo.namespaceId,
+          tableInfo.tableId, TableOperation.CREATE);
 
       String namespace = TableNameUtil.qualify(tableInfo.tableName).getFirst();
       NamespaceId namespaceId = Namespaces.getNamespaceId(env.getContext(), namespace);

--- a/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
@@ -258,6 +258,7 @@ public class TableOperationsIT extends AccumuloClusterHarness {
 
     assertTrue(accumuloClient.tableOperations().list().containsAll(tables));
     assertTrue(accumuloClient.tableOperations().list().containsAll(clones));
+    assertFalse(accumuloClient.tableOperations().list().contains("test1.table"));
 
     // Read and write data to tables w/ the same name in different namespaces to ensure no wires are
     // crossed.
@@ -280,6 +281,13 @@ public class TableOperationsIT extends AccumuloClusterHarness {
     for (var table : Sets.union(tables, clones)) {
       assertThrows(TableExistsException.class,
           () -> accumuloClient.tableOperations().create(table));
+    }
+
+    for (var srcTable : List.of("metadata", "test1.table2")) {
+      for (var destTable : Sets.union(tables, clones)) {
+        assertThrows(TableExistsException.class, () -> accumuloClient.tableOperations()
+            .clone(srcTable, destTable, CloneConfiguration.empty()));
+      }
     }
 
     // TODO test export/import w/ diff table names

--- a/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
@@ -277,6 +277,11 @@ public class TableOperationsIT extends AccumuloClusterHarness {
       }
     }
 
+    for (var table : Sets.union(tables, clones)) {
+      assertThrows(TableExistsException.class,
+          () -> accumuloClient.tableOperations().create(table));
+    }
+
     // TODO test export/import w/ diff table names
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
@@ -289,8 +289,6 @@ public class TableOperationsIT extends AccumuloClusterHarness {
             .clone(srcTable, destTable, CloneConfiguration.empty()));
       }
     }
-
-    // TODO test export/import w/ diff table names
   }
 
   @Test


### PR DESCRIPTION
When trying to create a table with the name `metadata` it failed because `accumulo.metadata` existed.  The code doing the check for existing tables was not properly checking namespaces.  Fixed the check and added some test for the same table name in different namespaces.