### PR TITLE
Filter based on columns declared in TabletMetadataCheck

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -54,7 +54,6 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.apache.accumulo.core.client.admin.TabletAvailability;
 import org.apache.accumulo.core.clientImpl.ClientContext;
@@ -351,36 +350,21 @@ public class TabletMetadata {
       COLUMNS_TO_QUALIFIERS = colsToQualifiers.build();
     }
 
-    private static Stream<ByteSequence> resolveFamiliesAsBytes(ColumnType column) {
-      return COLUMNS_TO_FAMILIES.get(column).stream()
-          .map(family -> new ArrayByteSequence(family.copyBytes()));
-    }
-
-    public static Set<ByteSequence> resolveFamilies(ColumnType column) {
-      return resolveFamiliesAsBytes(column).collect(Collectors.toSet());
-    }
-
     public static Set<ByteSequence> resolveFamilies(Set<ColumnType> columns) {
-      return columns.stream().flatMap(ColumnType::resolveFamiliesAsBytes)
-          .collect(Collectors.toSet());
+      return columns.stream()
+          .flatMap(cf -> COLUMNS_TO_FAMILIES.get(cf).stream()
+              .map(family -> new ArrayByteSequence(family.copyBytes())))
+          .collect(Collectors.toUnmodifiableSet());
     }
 
     public static Set<Text> resolveFamiliesAsText(ColumnType column) {
       return COLUMNS_TO_FAMILIES.get(column);
     }
 
-    public static Set<Text> resolveFamiliesAsText(Set<ColumnType> columns) {
-      return columns.stream().flatMap(column -> resolveFamiliesAsText(column).stream())
-          .collect(Collectors.toSet());
-    }
-
     public static ColumnFQ resolveQualifier(ColumnType columnType) {
       return COLUMNS_TO_QUALIFIERS.get(columnType);
     }
 
-    public static Set<ColumnFQ> resolveQualifiers(Set<ColumnType> columns) {
-      return columns.stream().map(ColumnType::resolveQualifier).collect(Collectors.toSet());
-    }
   }
 
   public static class Location {

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadataCheck.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadataCheck.java
@@ -71,8 +71,8 @@ public interface TabletMetadataCheck {
       this.families = columns.equals(ALL_COLUMNS) ? Set.of() : ColumnType.resolveFamilies(columns);
     }
 
-    public Set<ColumnType> getColumns() {
-      return columns;
+    public EnumSet<ColumnType> getColumns() {
+      return EnumSet.copyOf(columns);
     }
 
     public Set<ByteSequence> getFamilies() {

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
@@ -318,7 +318,9 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
     public Options fetch(ColumnType... colsToFetch) {
       Preconditions.checkArgument(colsToFetch.length > 0);
 
-      Map<Boolean,Set<ColumnType>> groups = Set.of(colsToFetch).stream()
+      var columns = Set.of(colsToFetch);
+      fetchedCols.addAll(columns);
+      Map<Boolean,Set<ColumnType>> groups = columns.stream()
           .collect(Collectors.partitioningBy(FETCH_QUALIFIERS::contains, Collectors.toSet()));
       qualifiers.addAll(ColumnType.resolveQualifiers(groups.get(true)));
       families.addAll(ColumnType.resolveFamiliesAsText(groups.get(false)));

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataCheckTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataCheckTest.java
@@ -27,6 +27,7 @@ import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.EnumSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -50,7 +51,7 @@ public class TabletMetadataCheckTest {
     assertTrue(TabletMetadataCheck.ALL_RESOLVED_COLUMNS.getFamilies().isEmpty());
 
     // Add some column types and verify resolved families is not empty and is correct
-    var expectedColumnTypes = Set.of(PREV_ROW, SELECTED, FILES, ECOMP, SCANS, DIR);
+    var expectedColumnTypes = EnumSet.of(PREV_ROW, SELECTED, FILES, ECOMP, SCANS, DIR);
     var expectedFamilies = Set
         .of(ServerColumnFamily.NAME, TabletColumnFamily.NAME, DataFileColumnFamily.NAME,
             ScanFileColumnFamily.NAME, ExternalCompactionColumnFamily.NAME)

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataCheckTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataCheckTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.metadata.schema;
+
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.DIR;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.ECOMP;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.FILES;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.PREV_ROW;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.SCANS;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.SELECTED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.accumulo.core.data.ArrayByteSequence;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ExternalCompactionColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ScanFileColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
+import org.apache.accumulo.core.metadata.schema.TabletMetadataCheck.ResolvedColumns;
+import org.junit.jupiter.api.Test;
+
+public class TabletMetadataCheckTest {
+
+  @Test
+  public void testResolvedColumns() {
+    // check columns is empty set when all columns is used
+    var resolved1 = new ResolvedColumns(TabletMetadataCheck.ALL_COLUMNS);
+    assertTrue(resolved1.getFamilies().isEmpty());
+    assertTrue(TabletMetadataCheck.ALL_RESOLVED_COLUMNS.getFamilies().isEmpty());
+
+    // Add some column types and verify resolved families is not empty and is correct
+    var expectedColumnTypes = Set.of(PREV_ROW, SELECTED, FILES, ECOMP, SCANS, DIR);
+    var expectedFamilies = Set
+        .of(ServerColumnFamily.NAME, TabletColumnFamily.NAME, DataFileColumnFamily.NAME,
+            ScanFileColumnFamily.NAME, ExternalCompactionColumnFamily.NAME)
+        .stream().map(family -> new ArrayByteSequence(family.copyBytes()))
+        .collect(Collectors.toSet());
+    var resolved2 = new ResolvedColumns(expectedColumnTypes);
+    assertEquals(expectedColumnTypes, resolved2.getColumns());
+    assertEquals(ColumnType.resolveFamilies(resolved2.getColumns()), resolved2.getFamilies());
+    assertEquals(expectedFamilies, resolved2.getFamilies());
+  }
+
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/iterators/TabletMetadataCheckIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/iterators/TabletMetadataCheckIterator.java
@@ -23,7 +23,6 @@ import static org.apache.accumulo.server.metadata.iterators.ColumnFamilyTransfor
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.EnumSet;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -102,7 +101,7 @@ public class TabletMetadataCheckIterator implements SortedKeyValueIterator<Key,V
 
     if (source.hasTop()) {
       var tabletMetadata = TabletMetadata.convertRow(new IteratorAdapter(source),
-          EnumSet.copyOf(colsToRead.getColumns()), false, false);
+          colsToRead.getColumns(), false, false);
 
       // TODO checking the prev end row here is redundant w/ other checks that ample currently
       // does.. however we could try to make all checks eventually use this class

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/iterators/TabletMetadataCheckIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/iterators/TabletMetadataCheckIterator.java
@@ -97,7 +97,8 @@ public class TabletMetadataCheckIterator implements SortedKeyValueIterator<Key,V
 
     var colsToRead = check.columnsToRead();
 
-    source.seek(new Range(tabletRow), colsToRead.getFamilies(), true);
+    source.seek(new Range(tabletRow), colsToRead.getFamilies(),
+        !colsToRead.getFamilies().isEmpty());
 
     if (source.hasTop()) {
       var tabletMetadata = TabletMetadata.convertRow(new IteratorAdapter(source),

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/iterators/TabletMetadataCheckIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/iterators/TabletMetadataCheckIterator.java
@@ -27,7 +27,6 @@ import java.util.EnumSet;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.Set;
 
 import org.apache.accumulo.core.classloader.ClassLoaderUtil;
 import org.apache.accumulo.core.client.IteratorSetting;
@@ -98,11 +97,11 @@ public class TabletMetadataCheckIterator implements SortedKeyValueIterator<Key,V
 
     var colsToRead = check.columnsToRead();
 
-    source.seek(new Range(tabletRow), Set.of(), false);
+    source.seek(new Range(tabletRow), colsToRead.getFamilies(), true);
 
     if (source.hasTop()) {
       var tabletMetadata = TabletMetadata.convertRow(new IteratorAdapter(source),
-          EnumSet.copyOf(colsToRead), false, false);
+          EnumSet.copyOf(colsToRead.getColumns()), false, false);
 
       // TODO checking the prev end row here is redundant w/ other checks that ample currently
       // does.. however we could try to make all checks eventually use this class

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionReservationCheck.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionReservationCheck.java
@@ -35,7 +35,6 @@ import java.util.stream.Collectors;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
-import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.accumulo.core.metadata.schema.TabletMetadataCheck;
 import org.apache.accumulo.core.spi.compaction.CompactionKind;
 import org.apache.accumulo.core.util.time.SteadyTime;
@@ -50,6 +49,11 @@ import com.google.common.base.Preconditions;
 public class CompactionReservationCheck implements TabletMetadataCheck {
 
   private static final Logger log = LoggerFactory.getLogger(CompactionReservationCheck.class);
+
+  // Cache the ResolvedColumns statically so we do not need to recreate the set of
+  // columns and families for each mutation
+  private static final ResolvedColumns RESOLVED_COLUMNS = new ResolvedColumns(
+      Set.of(PREV_ROW, OPID, SELECTED, FILES, ECOMP, USER_COMPACTION_REQUESTED));
 
   private CompactionKind kind;
   private List<String> jobFilesStr;
@@ -163,7 +167,7 @@ public class CompactionReservationCheck implements TabletMetadataCheck {
   }
 
   @Override
-  public Set<ColumnType> columnsToRead() {
-    return Set.of(PREV_ROW, OPID, SELECTED, FILES, ECOMP, USER_COMPACTION_REQUESTED);
+  public ResolvedColumns columnsToRead() {
+    return RESOLVED_COLUMNS;
   }
 }

--- a/server/manager/src/test/java/org/apache/accumulo/manager/compaction/CompactionReservationCheckTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/compaction/CompactionReservationCheckTest.java
@@ -32,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 import java.time.Duration;
+import java.util.EnumSet;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -233,7 +234,7 @@ public class CompactionReservationCheckTest {
     var resolved2 = new CompactionReservationCheck(CompactionKind.SYSTEM, Set.of(), null, false,
         SteadyTime.from(Duration.ZERO), 100L).columnsToRead();
     var expectedColumnTypes =
-        Set.of(PREV_ROW, OPID, SELECTED, FILES, ECOMP, USER_COMPACTION_REQUESTED);
+        EnumSet.of(PREV_ROW, OPID, SELECTED, FILES, ECOMP, USER_COMPACTION_REQUESTED);
     var expectedFamilies = Set
         .of(ServerColumnFamily.NAME, TabletColumnFamily.NAME, DataFileColumnFamily.NAME,
             ExternalCompactionColumnFamily.NAME, UserCompactionRequestedColumnFamily.NAME)

--- a/server/manager/src/test/java/org/apache/accumulo/manager/compaction/CompactionReservationCheckTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/compaction/CompactionReservationCheckTest.java
@@ -19,10 +19,14 @@
 package org.apache.accumulo.manager.compaction;
 
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.ECOMP;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.FILES;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.OPID;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.PREV_ROW;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.SELECTED;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.USER_COMPACTION_REQUESTED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -31,7 +35,9 @@ import java.time.Duration;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
+import org.apache.accumulo.core.data.ArrayByteSequence;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.fate.FateId;
@@ -41,8 +47,14 @@ import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.CompactionMetadata;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ExternalCompactionColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.UserCompactionRequestedColumnFamily;
 import org.apache.accumulo.core.metadata.schema.SelectedFiles;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.accumulo.core.metadata.schema.TabletOperationId;
 import org.apache.accumulo.core.metadata.schema.TabletOperationType;
 import org.apache.accumulo.core.spi.compaction.CompactionKind;
@@ -212,6 +224,27 @@ public class CompactionReservationCheckTest {
         () -> canReserveSystem(null, CompactionKind.SYSTEM, Set.of(file1, file2), false, time));
     assertThrows(NullPointerException.class,
         () -> canReserveUser(null, CompactionKind.USER, Set.of(file1, file2), fateId1, time));
+  }
+
+  @Test
+  public void testResolvedColumns() throws Exception {
+    var resolved1 = new CompactionReservationCheck(CompactionKind.SYSTEM, Set.of(), null, false,
+        SteadyTime.from(Duration.ZERO), 100L).columnsToRead();
+    var resolved2 = new CompactionReservationCheck(CompactionKind.SYSTEM, Set.of(), null, false,
+        SteadyTime.from(Duration.ZERO), 100L).columnsToRead();
+    var expectedColumnTypes =
+        Set.of(PREV_ROW, OPID, SELECTED, FILES, ECOMP, USER_COMPACTION_REQUESTED);
+    var expectedFamilies = Set
+        .of(ServerColumnFamily.NAME, TabletColumnFamily.NAME, DataFileColumnFamily.NAME,
+            ExternalCompactionColumnFamily.NAME, UserCompactionRequestedColumnFamily.NAME)
+        .stream().map(family -> new ArrayByteSequence(family.copyBytes()))
+        .collect(Collectors.toSet());
+
+    // Verify same object is re-used across instances
+    assertSame(resolved1, resolved2);
+    assertEquals(expectedColumnTypes, resolved1.getColumns());
+    assertEquals(ColumnType.resolveFamilies(expectedColumnTypes), resolved1.getFamilies());
+    assertEquals(expectedFamilies, resolved1.getFamilies());
   }
 
   private boolean canReserveSystem(TabletMetadata tabletMetadata, CompactionKind kind,


### PR DESCRIPTION
Adds filtering to TabletMetadataCheckIterator that will use matching families for the provided columns in order to reduce the amount of data that is fetched. A ResolvedColumns instance is returned by each TabletMetadataCheck instance that contains the set of columns and set of matching families to read.

CompactionReservationCheck caches the ResolvedColumns instance statically to avoid having to recreate the set of columns and familes for each scan.

This closes #5254