### PR TITLE
Rename TxName to fateOp for clarity (#5230)

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/AdminUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/AdminUtil.java
@@ -353,7 +353,7 @@ public class AdminUtil<T> {
         fateIds.forEach(fateId -> {
 
           ReadOnlyFateTxStore<T> txStore = store.read(fateId);
-          // tx name will not be set if the tx is not seeded with work (it is NEW)
+          // fate op will not be set if the tx is not seeded with work (it is NEW)
           Fate.FateOperation fateOp = txStore.getTransactionInfo(Fate.TxInfo.FATE_OP) == null ? null
               : ((Fate.FateOperation) txStore.getTransactionInfo(Fate.TxInfo.FATE_OP));
 

--- a/core/src/main/java/org/apache/accumulo/core/fate/AdminUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/AdminUtil.java
@@ -65,20 +65,20 @@ public class AdminUtil<T> {
     private final FateId fateId;
     private final FateInstanceType instanceType;
     private final TStatus status;
-    private final Fate.FateOperation txName;
+    private final Fate.FateOperation fateOp;
     private final List<String> hlocks;
     private final List<String> wlocks;
     private final String top;
     private final long timeCreated;
 
     private TransactionStatus(FateId fateId, FateInstanceType instanceType, TStatus status,
-        Fate.FateOperation txName, List<String> hlocks, List<String> wlocks, String top,
+        Fate.FateOperation fateOp, List<String> hlocks, List<String> wlocks, String top,
         Long timeCreated) {
 
       this.fateId = fateId;
       this.instanceType = instanceType;
       this.status = status;
-      this.txName = txName;
+      this.fateOp = fateOp;
       this.hlocks = Collections.unmodifiableList(hlocks);
       this.wlocks = Collections.unmodifiableList(wlocks);
       this.top = top;
@@ -105,8 +105,8 @@ public class AdminUtil<T> {
     /**
      * @return The name of the transaction running.
      */
-    public Fate.FateOperation getTxName() {
-      return txName;
+    public Fate.FateOperation getFateOp() {
+      return fateOp;
     }
 
     /**
@@ -354,8 +354,8 @@ public class AdminUtil<T> {
 
           ReadOnlyFateTxStore<T> txStore = store.read(fateId);
           // tx name will not be set if the tx is not seeded with work (it is NEW)
-          Fate.FateOperation txName = txStore.getTransactionInfo(Fate.TxInfo.TX_NAME) == null ? null
-              : ((Fate.FateOperation) txStore.getTransactionInfo(Fate.TxInfo.TX_NAME));
+          Fate.FateOperation fateOp = txStore.getTransactionInfo(Fate.TxInfo.FATE_OP) == null ? null
+              : ((Fate.FateOperation) txStore.getTransactionInfo(Fate.TxInfo.FATE_OP));
 
           List<String> hlocks = heldLocks.remove(fateId);
 
@@ -381,7 +381,7 @@ public class AdminUtil<T> {
 
           if (includeByStatus(status, statusFilter) && includeByFateId(fateId, fateIdFilter)
               && includeByInstanceType(fateId.getType(), typesFilter)) {
-            statuses.add(new TransactionStatus(fateId, type, status, txName, hlocks, wlocks, top,
+            statuses.add(new TransactionStatus(fateId, type, status, fateOp, hlocks, wlocks, top,
                 timeCreated));
           }
         });
@@ -418,7 +418,7 @@ public class AdminUtil<T> {
     for (TransactionStatus txStatus : fateStatus.getTransactions()) {
       fmt.format(
           "%-15s fateId: %s  status: %-18s locked: %-15s locking: %-15s op: %-15s created: %s%n",
-          txStatus.getTxName(), txStatus.getFateId(), txStatus.getStatus(), txStatus.getHeldLocks(),
+          txStatus.getFateOp(), txStatus.getFateId(), txStatus.getStatus(), txStatus.getHeldLocks(),
           txStatus.getWaitingLocks(), txStatus.getTop(), txStatus.getTimeCreatedFormatted());
     }
     fmt.format(" %s transactions", fateStatus.getTransactions().size());

--- a/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
@@ -96,7 +96,7 @@ public class Fate<T> {
   private final ConcurrentLinkedQueue<Integer> idleCountHistory = new ConcurrentLinkedQueue<>();
 
   public enum TxInfo {
-    TX_NAME, AUTO_CLEAN, EXCEPTION, TX_AGEOFF, RETURN_VALUE
+    FATE_OP, AUTO_CLEAN, EXCEPTION, TX_AGEOFF, RETURN_VALUE
   }
 
   public enum FateOperation {
@@ -538,17 +538,17 @@ public class Fate<T> {
     return store.create();
   }
 
-  public void seedTransaction(FateOperation txName, FateKey fateKey, Repo<T> repo,
+  public void seedTransaction(FateOperation fateOp, FateKey fateKey, Repo<T> repo,
       boolean autoCleanUp) {
-    store.seedTransaction(txName, fateKey, repo, autoCleanUp);
+    store.seedTransaction(fateOp, fateKey, repo, autoCleanUp);
   }
 
   // start work in the transaction.. it is safe to call this
   // multiple times for a transaction... but it will only seed once
-  public void seedTransaction(FateOperation txName, FateId fateId, Repo<T> repo,
+  public void seedTransaction(FateOperation fateOp, FateId fateId, Repo<T> repo,
       boolean autoCleanUp, String goalMessage) {
     log.info("Seeding {} {}", fateId, goalMessage);
-    store.seedTransaction(txName, fateId, repo, autoCleanUp);
+    store.seedTransaction(fateOp, fateId, repo, autoCleanUp);
   }
 
   // check on the transaction

--- a/core/src/main/java/org/apache/accumulo/core/fate/FateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/FateStore.java
@@ -66,7 +66,7 @@ public interface FateStore<T> extends ReadOnlyFateStore<T> {
    *         empty optional otherwise. If there was a failure this could return an empty optional
    *         when it actually succeeded.
    */
-  Optional<FateId> seedTransaction(Fate.FateOperation txName, FateKey fateKey, Repo<T> repo,
+  Optional<FateId> seedTransaction(Fate.FateOperation fateOp, FateKey fateKey, Repo<T> repo,
       boolean autoCleanUp);
 
   /**
@@ -84,7 +84,7 @@ public interface FateStore<T> extends ReadOnlyFateStore<T> {
    *         failures. When there are no failures returns true if seeded and false otherwise. If
    *         there was a failure this could return false when it actually succeeded.
    */
-  boolean seedTransaction(Fate.FateOperation txName, FateId fateId, Repo<T> repo,
+  boolean seedTransaction(Fate.FateOperation fateOp, FateId fateId, Repo<T> repo,
       boolean autoCleanUp);
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/fate/FateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/FateStore.java
@@ -54,7 +54,7 @@ public interface FateStore<T> extends ReadOnlyFateStore<T> {
    * fateKey. If seeded, sets the following data for the fateId in the store.
    *
    * <ul>
-   * <li>Set the tx name</li>
+   * <li>Set the fate op</li>
    * <li>Set the status to SUBMITTED</li>
    * <li>Set the fate key</li>
    * <li>Sets autocleanup only if true</li>
@@ -74,7 +74,7 @@ public interface FateStore<T> extends ReadOnlyFateStore<T> {
    * unreserved. If seeded, sets the following data for the fateId in the store.
    *
    * <ul>
-   * <li>Set the tx name</li>
+   * <li>Set the fate op</li>
    * <li>Set the status to SUBMITTED</li>
    * <li>Sets autocleanup only if true</li>
    * <li>Sets the creation time</li>

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/FateMutator.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/FateMutator.java
@@ -75,7 +75,7 @@ public interface FateMutator<T> {
    */
   FateMutator<T> putUnreserveTx(FateStore.FateReservation reservation);
 
-  FateMutator<T> putName(byte[] data);
+  FateMutator<T> putFateOp(byte[] data);
 
   FateMutator<T> putAutoClean(byte[] data);
 

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/FateMutatorImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/FateMutatorImpl.java
@@ -129,7 +129,7 @@ public class FateMutatorImpl<T> implements FateMutator<T> {
   }
 
   @Override
-  public FateMutator<T> putName(byte[] data) {
+  public FateMutator<T> putFateOp(byte[] data) {
     TxInfoColumnFamily.FATE_OP_COLUMN.put(mutation, new Value(data));
     return this;
   }

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/FateMutatorImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/FateMutatorImpl.java
@@ -130,7 +130,7 @@ public class FateMutatorImpl<T> implements FateMutator<T> {
 
   @Override
   public FateMutator<T> putName(byte[] data) {
-    TxInfoColumnFamily.TX_NAME_COLUMN.put(mutation, new Value(data));
+    TxInfoColumnFamily.FATE_OP_COLUMN.put(mutation, new Value(data));
     return this;
   }
 
@@ -161,7 +161,7 @@ public class FateMutatorImpl<T> implements FateMutator<T> {
   @Override
   public FateMutator<T> putTxInfo(TxInfo txInfo, byte[] data) {
     switch (txInfo) {
-      case TX_NAME:
+      case FATE_OP:
         putName(data);
         break;
       case AUTO_CLEAN:

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/FateMutatorImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/FateMutatorImpl.java
@@ -162,7 +162,7 @@ public class FateMutatorImpl<T> implements FateMutator<T> {
   public FateMutator<T> putTxInfo(TxInfo txInfo, byte[] data) {
     switch (txInfo) {
       case FATE_OP:
-        putName(data);
+        putFateOp(data);
         break;
       case AUTO_CLEAN:
         putAutoClean(data);

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/UserFateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/UserFateStore.java
@@ -133,12 +133,12 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
   }
 
   @Override
-  public Optional<FateId> seedTransaction(Fate.FateOperation txName, FateKey fateKey, Repo<T> repo,
+  public Optional<FateId> seedTransaction(Fate.FateOperation fateOp, FateKey fateKey, Repo<T> repo,
       boolean autoCleanUp) {
     final var fateId = fateIdGenerator.fromTypeAndKey(type(), fateKey);
     Supplier<FateMutator<T>> mutatorFactory = () -> newMutator(fateId).requireAbsent()
         .putKey(fateKey).putCreateTime(System.currentTimeMillis());
-    if (seedTransaction(mutatorFactory, fateKey + " " + fateId, txName, repo, autoCleanUp)) {
+    if (seedTransaction(mutatorFactory, fateKey + " " + fateId, fateOp, repo, autoCleanUp)) {
       return Optional.of(fateId);
     } else {
       return Optional.empty();
@@ -146,20 +146,20 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
   }
 
   @Override
-  public boolean seedTransaction(Fate.FateOperation txName, FateId fateId, Repo<T> repo,
+  public boolean seedTransaction(Fate.FateOperation fateOp, FateId fateId, Repo<T> repo,
       boolean autoCleanUp) {
     Supplier<FateMutator<T>> mutatorFactory =
         () -> newMutator(fateId).requireStatus(TStatus.NEW).requireUnreserved().requireAbsentKey();
-    return seedTransaction(mutatorFactory, fateId.canonical(), txName, repo, autoCleanUp);
+    return seedTransaction(mutatorFactory, fateId.canonical(), fateOp, repo, autoCleanUp);
   }
 
   private boolean seedTransaction(Supplier<FateMutator<T>> mutatorFactory, String logId,
-      Fate.FateOperation txName, Repo<T> repo, boolean autoCleanUp) {
+      Fate.FateOperation fateOp, Repo<T> repo, boolean autoCleanUp) {
     int maxAttempts = 5;
     for (int attempt = 0; attempt < maxAttempts; attempt++) {
       var mutator = mutatorFactory.get();
       mutator =
-          mutator.putName(serializeTxInfo(txName)).putRepo(1, repo).putStatus(TStatus.SUBMITTED);
+          mutator.putName(serializeTxInfo(fateOp)).putRepo(1, repo).putStatus(TStatus.SUBMITTED);
       if (autoCleanUp) {
         mutator = mutator.putAutoClean(serializeTxInfo(autoCleanUp));
       }
@@ -420,8 +420,8 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
 
         final ColumnFQ cq;
         switch (txInfo) {
-          case TX_NAME:
-            cq = TxInfoColumnFamily.TX_NAME_COLUMN;
+          case FATE_OP:
+            cq = TxInfoColumnFamily.FATE_OP_COLUMN;
             break;
           case AUTO_CLEAN:
             cq = TxInfoColumnFamily.AUTO_CLEAN_COLUMN;

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/UserFateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/UserFateStore.java
@@ -159,7 +159,7 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
     for (int attempt = 0; attempt < maxAttempts; attempt++) {
       var mutator = mutatorFactory.get();
       mutator =
-          mutator.putName(serializeTxInfo(fateOp)).putRepo(1, repo).putStatus(TStatus.SUBMITTED);
+          mutator.putFateOp(serializeTxInfo(fateOp)).putRepo(1, repo).putStatus(TStatus.SUBMITTED);
       if (autoCleanUp) {
         mutator = mutator.putAutoClean(serializeTxInfo(autoCleanUp));
       }

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/schema/FateSchema.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/schema/FateSchema.java
@@ -44,7 +44,7 @@ public class FateSchema {
     public static final String STR_NAME = "txinfo";
     public static final Text NAME = new Text(STR_NAME);
 
-    public static final String FATE_OP = "fateOp";
+    public static final String FATE_OP = "fateop";
     public static final ColumnFQ FATE_OP_COLUMN = new ColumnFQ(NAME, new Text(FATE_OP));
 
     public static final String AUTO_CLEAN = "autoclean";

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/schema/FateSchema.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/schema/FateSchema.java
@@ -44,8 +44,8 @@ public class FateSchema {
     public static final String STR_NAME = "txinfo";
     public static final Text NAME = new Text(STR_NAME);
 
-    public static final String TX_NAME = "txname";
-    public static final ColumnFQ TX_NAME_COLUMN = new ColumnFQ(NAME, new Text(TX_NAME));
+    public static final String FATE_OP = "fateOp";
+    public static final ColumnFQ FATE_OP_COLUMN = new ColumnFQ(NAME, new Text(FATE_OP));
 
     public static final String AUTO_CLEAN = "autoclean";
     public static final ColumnFQ AUTO_CLEAN_COLUMN = new ColumnFQ(NAME, new Text(AUTO_CLEAN));

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/MetaFateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/MetaFateStore.java
@@ -181,11 +181,11 @@ public class MetaFateStore<T> extends AbstractFateStore<T> {
   }
 
   @Override
-  public Optional<FateId> seedTransaction(Fate.FateOperation txName, FateKey fateKey, Repo<T> repo,
+  public Optional<FateId> seedTransaction(Fate.FateOperation fateOp, FateKey fateKey, Repo<T> repo,
       boolean autoCleanUp) {
     return createAndReserve(fateKey).map(txStore -> {
       try {
-        seedTransaction(txName, repo, autoCleanUp, txStore);
+        seedTransaction(fateOp, repo, autoCleanUp, txStore);
         return txStore.getID();
       } finally {
         txStore.unreserve(Duration.ZERO);
@@ -194,12 +194,12 @@ public class MetaFateStore<T> extends AbstractFateStore<T> {
   }
 
   @Override
-  public boolean seedTransaction(Fate.FateOperation txName, FateId fateId, Repo<T> repo,
+  public boolean seedTransaction(Fate.FateOperation fateOp, FateId fateId, Repo<T> repo,
       boolean autoCleanUp) {
     return tryReserve(fateId).map(txStore -> {
       try {
         if (txStore.getStatus() == NEW) {
-          seedTransaction(txName, repo, autoCleanUp, txStore);
+          seedTransaction(fateOp, repo, autoCleanUp, txStore);
           return true;
         }
         return false;
@@ -209,7 +209,7 @@ public class MetaFateStore<T> extends AbstractFateStore<T> {
     }).orElse(false);
   }
 
-  private void seedTransaction(Fate.FateOperation txName, Repo<T> repo, boolean autoCleanUp,
+  private void seedTransaction(Fate.FateOperation fateOp, Repo<T> repo, boolean autoCleanUp,
       FateTxStore<T> txStore) {
     if (txStore.top() == null) {
       try {
@@ -223,7 +223,7 @@ public class MetaFateStore<T> extends AbstractFateStore<T> {
     if (autoCleanUp) {
       txStore.setTransactionInfo(TxInfo.AUTO_CLEAN, autoCleanUp);
     }
-    txStore.setTransactionInfo(TxInfo.TX_NAME, txName);
+    txStore.setTransactionInfo(TxInfo.FATE_OP, fateOp);
     txStore.setStatus(SUBMITTED);
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/logging/FateLogger.java
+++ b/core/src/main/java/org/apache/accumulo/core/logging/FateLogger.java
@@ -150,9 +150,9 @@ public class FateLogger {
       }
 
       @Override
-      public Optional<FateId> seedTransaction(Fate.FateOperation txName, FateKey fateKey,
+      public Optional<FateId> seedTransaction(Fate.FateOperation fateOp, FateKey fateKey,
           Repo<T> repo, boolean autoCleanUp) {
-        var optional = store.seedTransaction(txName, fateKey, repo, autoCleanUp);
+        var optional = store.seedTransaction(fateOp, fateKey, repo, autoCleanUp);
         if (storeLog.isTraceEnabled()) {
           optional.ifPresentOrElse(fateId -> {
             storeLog.trace("{} seeded {} {} {}", fateId, fateKey, toLogString.apply(repo),
@@ -166,9 +166,9 @@ public class FateLogger {
       }
 
       @Override
-      public boolean seedTransaction(Fate.FateOperation txName, FateId fateId, Repo<T> repo,
+      public boolean seedTransaction(Fate.FateOperation fateOp, FateId fateId, Repo<T> repo,
           boolean autoCleanUp) {
-        boolean seeded = store.seedTransaction(txName, fateId, repo, autoCleanUp);
+        boolean seeded = store.seedTransaction(fateOp, fateId, repo, autoCleanUp);
         if (storeLog.isTraceEnabled()) {
           storeLog.trace("{} {} {} {}", fateId, seeded ? "seeded" : "unable to seed",
               toLogString.apply(repo), autoCleanUp);

--- a/core/src/test/java/org/apache/accumulo/core/fate/TestStore.java
+++ b/core/src/test/java/org/apache/accumulo/core/fate/TestStore.java
@@ -53,13 +53,13 @@ public class TestStore implements FateStore<String> {
   }
 
   @Override
-  public Optional<FateId> seedTransaction(Fate.FateOperation txName, FateKey fateKey,
+  public Optional<FateId> seedTransaction(Fate.FateOperation fateOp, FateKey fateKey,
       Repo<String> repo, boolean autoCleanUp) {
     return Optional.empty();
   }
 
   @Override
-  public boolean seedTransaction(Fate.FateOperation txName, FateId fateId, Repo<String> repo,
+  public boolean seedTransaction(Fate.FateOperation fateOp, FateId fateId, Repo<String> repo,
       boolean autoCleanUp) {
     return false;
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/fateCommand/FateSummaryReport.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/fateCommand/FateSummaryReport.java
@@ -88,7 +88,7 @@ public class FateSummaryReport {
     }
     String top = txnStatus.getTop();
     stepCounts.merge(Objects.requireNonNullElse(top, "?"), 1, Integer::sum);
-    Fate.FateOperation runningRepo = txnStatus.getTxName();
+    Fate.FateOperation runningRepo = txnStatus.getFateOp();
 
     cmdCounts.merge(runningRepo == null ? "?" : runningRepo.name(), 1, Integer::sum);
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/fateCommand/FateTxnDetails.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/fateCommand/FateTxnDetails.java
@@ -33,7 +33,7 @@ public class FateTxnDetails implements Comparable<FateTxnDetails> {
 
   private long running;
   private String status = "?";
-  private String txName = "?";
+  private String fateOp = "?";
   private String step = "?";
   private String fateId = "?";
   private List<String> locksHeld = List.of();
@@ -73,8 +73,8 @@ public class FateTxnDetails implements Comparable<FateTxnDetails> {
     if (txnStatus.getTop() != null) {
       step = txnStatus.getTop();
     }
-    if (txnStatus.getTxName() != null) {
-      txName = txnStatus.getTxName().name();
+    if (txnStatus.getFateOp() != null) {
+      fateOp = txnStatus.getFateOp().name();
     }
     if (txnStatus.getFateId() != null) {
       fateId = txnStatus.getFateId().canonical();
@@ -103,8 +103,8 @@ public class FateTxnDetails implements Comparable<FateTxnDetails> {
     return running;
   }
 
-  public String getTxName() {
-    return txName;
+  public String getFateOp() {
+    return fateOp;
   }
 
   public String getStep() {
@@ -167,7 +167,7 @@ public class FateTxnDetails implements Comparable<FateTxnDetails> {
     String hms = String.format("%d:%02d:%02d", elapsed.toHours(), elapsed.toMinutesPart(),
         elapsed.toSecondsPart());
 
-    return hms + "\t" + fateId + "\t" + status + "\t" + txName + "\t" + step + "\theld:"
+    return hms + "\t" + fateId + "\t" + status + "\t" + fateOp + "\t" + step + "\theld:"
         + locksHeld.toString() + "\twaiting:" + locksWaiting.toString();
   }
 

--- a/server/base/src/test/java/org/apache/accumulo/server/util/fateCommand/SummaryReportTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/fateCommand/SummaryReportTest.java
@@ -73,7 +73,7 @@ class SummaryReportTest {
     expect(status1.getTimeCreated()).andReturn(now - TimeUnit.DAYS.toMillis(1)).anyTimes();
     expect(status1.getStatus()).andReturn(ReadOnlyFateStore.TStatus.IN_PROGRESS).anyTimes();
     expect(status1.getTop()).andReturn(null).anyTimes();
-    expect(status1.getTxName()).andReturn(null).anyTimes();
+    expect(status1.getFateOp()).andReturn(null).anyTimes();
     expect(status1.getFateId()).andReturn(FateId.from("FATE:USER:" + UUID.randomUUID())).anyTimes();
     expect(status1.getHeldLocks()).andReturn(List.of()).anyTimes();
     expect(status1.getWaitingLocks()).andReturn(List.of()).anyTimes();

--- a/server/base/src/test/java/org/apache/accumulo/server/util/fateCommand/TxnDetailsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/fateCommand/TxnDetailsTest.java
@@ -58,7 +58,7 @@ class TxnDetailsTest {
     expect(status1.getTimeCreated()).andReturn(now - TimeUnit.DAYS.toMillis(1)).anyTimes();
     expect(status1.getStatus()).andReturn(ReadOnlyFateStore.TStatus.IN_PROGRESS).anyTimes();
     expect(status1.getTop()).andReturn("step1").anyTimes();
-    expect(status1.getTxName()).andReturn(Fate.FateOperation.TABLE_CREATE).anyTimes();
+    expect(status1.getFateOp()).andReturn(Fate.FateOperation.TABLE_CREATE).anyTimes();
     expect(status1.getFateId()).andReturn(FateId.from("FATE:USER:" + uuid1)).anyTimes();
     expect(status1.getHeldLocks()).andReturn(List.of()).anyTimes();
     expect(status1.getWaitingLocks()).andReturn(List.of()).anyTimes();
@@ -67,7 +67,7 @@ class TxnDetailsTest {
     expect(status2.getTimeCreated()).andReturn(now - TimeUnit.DAYS.toMillis(7)).anyTimes();
     expect(status2.getStatus()).andReturn(ReadOnlyFateStore.TStatus.IN_PROGRESS).anyTimes();
     expect(status2.getTop()).andReturn("step2").anyTimes();
-    expect(status2.getTxName()).andReturn(Fate.FateOperation.TABLE_DELETE).anyTimes();
+    expect(status2.getFateOp()).andReturn(Fate.FateOperation.TABLE_DELETE).anyTimes();
     expect(status2.getFateId()).andReturn(FateId.from("FATE:USER:" + uuid2)).anyTimes();
     expect(status2.getHeldLocks()).andReturn(List.of()).anyTimes();
     expect(status2.getWaitingLocks()).andReturn(List.of()).anyTimes();
@@ -101,7 +101,7 @@ class TxnDetailsTest {
     expect(status1.getTimeCreated()).andReturn(now - TimeUnit.DAYS.toMillis(1)).anyTimes();
     expect(status1.getStatus()).andReturn(ReadOnlyFateStore.TStatus.IN_PROGRESS).anyTimes();
     expect(status1.getTop()).andReturn("step1").anyTimes();
-    expect(status1.getTxName()).andReturn(Fate.FateOperation.TABLE_COMPACT).anyTimes();
+    expect(status1.getFateOp()).andReturn(Fate.FateOperation.TABLE_COMPACT).anyTimes();
     expect(status1.getFateId()).andReturn(FateId.from("FATE:USER:" + UUID.randomUUID())).anyTimes();
     // incomplete lock info (W unknown ns id, no table))
     expect(status1.getHeldLocks()).andReturn(List.of("R:1", "R:2", "W:a")).anyTimes();

--- a/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/FateMetricValues.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/FateMetricValues.java
@@ -102,7 +102,7 @@ public abstract class FateMetricValues {
 
       // incr count for op type for for in_progress transactions.
       if (ReadOnlyFateStore.TStatus.IN_PROGRESS.equals(tx.getStatus())) {
-        Fate.FateOperation opType = tx.getTxName();
+        Fate.FateOperation opType = tx.getFateOp();
         String opTypeStr = opType == null ? "UNKNOWN" : opType.name();
         opTypeCounters.merge(opTypeStr, 1L, Long::sum);
       }

--- a/test/src/main/java/org/apache/accumulo/test/fate/FateExecutionOrderIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FateExecutionOrderIT.java
@@ -227,7 +227,7 @@ public abstract class FateExecutionOrderIT extends SharedMiniClusterBase
       var txStore = store.reserve(fateIds[i]);
       try {
         txStore.push(new FirstOp());
-        txStore.setTransactionInfo(TxInfo.TX_NAME, "TEST_" + i);
+        txStore.setTransactionInfo(TxInfo.FATE_OP, "TEST_" + i);
         txStore.setStatus(SUBMITTED);
       } finally {
         txStore.unreserve(Duration.ZERO);
@@ -359,7 +359,7 @@ public abstract class FateExecutionOrderIT extends SharedMiniClusterBase
       var txStore = store.reserve(fateIds[i]);
       try {
         txStore.push(new FirstNonInterleavingOp());
-        txStore.setTransactionInfo(TxInfo.TX_NAME, "TEST_" + i);
+        txStore.setTransactionInfo(TxInfo.FATE_OP, "TEST_" + i);
         txStore.setStatus(SUBMITTED);
       } finally {
         txStore.unreserve(Duration.ZERO);

--- a/test/src/main/java/org/apache/accumulo/test/fate/FateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FateIT.java
@@ -532,14 +532,14 @@ public abstract class FateIT extends SharedMiniClusterBase implements FateTestRu
     assertDoesNotThrow(() -> txStore.push(repo));
     assertDoesNotThrow(() -> txStore.setStatus(ReadOnlyFateStore.TStatus.SUCCESSFUL));
     assertDoesNotThrow(txStore::pop);
-    assertDoesNotThrow(() -> txStore.setTransactionInfo(Fate.TxInfo.TX_NAME, "name"));
+    assertDoesNotThrow(() -> txStore.setTransactionInfo(Fate.TxInfo.FATE_OP, "name"));
     assertDoesNotThrow(txStore::delete);
 
     // test that all write ops result in an exception since the tx has been deleted
     assertThrows(Exception.class, () -> txStore.push(repo));
     assertThrows(Exception.class, () -> txStore.setStatus(ReadOnlyFateStore.TStatus.SUCCESSFUL));
     assertThrows(Exception.class, txStore::pop);
-    assertThrows(Exception.class, () -> txStore.setTransactionInfo(Fate.TxInfo.TX_NAME, "name"));
+    assertThrows(Exception.class, () -> txStore.setTransactionInfo(Fate.TxInfo.FATE_OP, "name"));
     assertThrows(Exception.class, txStore::delete);
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/fate/FateOpsCommandsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FateOpsCommandsIT.java
@@ -466,7 +466,7 @@ public abstract class FateOpsCommandsIT extends ConfigurableMacBase
       // Validate transaction name and transaction step from summary command
 
       for (FateTxnDetails d : report.getFateDetails()) {
-        assertEquals("TABLE_COMPACT", d.getTxName());
+        assertEquals("TABLE_COMPACT", d.getFateOp());
         assertEquals("CompactionDriver", d.getStep());
         fateIdsStarted.add(d.getFateId());
       }
@@ -743,7 +743,7 @@ public abstract class FateOpsCommandsIT extends ConfigurableMacBase
         List.of(ReadOnlyFateStore.TStatus.NEW, ReadOnlyFateStore.TStatus.UNKNOWN,
             ReadOnlyFateStore.TStatus.NEW));
     // None of them should have a name since none of them were seeded with work
-    assertEquals(status.getTransactions().stream().map(AdminUtil.TransactionStatus::getTxName)
+    assertEquals(status.getTransactions().stream().map(AdminUtil.TransactionStatus::getFateOp)
         .collect(Collectors.toList()), Arrays.asList(null, null, null));
     // None of them should have a Repo since none of them were seeded with work
     assertEquals(status.getTransactions().stream().map(AdminUtil.TransactionStatus::getTop)
@@ -832,7 +832,7 @@ public abstract class FateOpsCommandsIT extends ConfigurableMacBase
       assertTrue(fateIdsStarted.contains(d.getFateId()));
       assertEquals("NEW", d.getStatus());
       assertEquals("?", d.getStep());
-      assertEquals("?", d.getTxName());
+      assertEquals("?", d.getFateOp());
       assertNotEquals(0, d.getRunning());
       assertEquals("[]", d.getLocksHeld().toString());
       assertEquals("[]", d.getLocksWaiting().toString());

--- a/test/src/main/java/org/apache/accumulo/test/fate/FateStoreIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FateStoreIT.java
@@ -101,8 +101,8 @@ public abstract class FateStoreIT extends SharedMiniClusterBase implements FateT
     assertEquals(TStatus.SUBMITTED, txStore.getStatus());
 
     // Set a name to test setTransactionInfo()
-    txStore.setTransactionInfo(TxInfo.TX_NAME, "name");
-    assertEquals("name", txStore.getTransactionInfo(TxInfo.TX_NAME));
+    txStore.setTransactionInfo(TxInfo.FATE_OP, "name");
+    assertEquals("name", txStore.getTransactionInfo(TxInfo.FATE_OP));
 
     // Try setting a second test op to test getStack()
     // when listing or popping TestOperation2 should be first
@@ -652,7 +652,7 @@ public abstract class FateStoreIT extends SharedMiniClusterBase implements FateT
     assertTrue(store.tryReserve(fateId).isEmpty());
     assertEquals(TStatus.UNKNOWN, txStore.getStatus());
     assertNull(txStore.top());
-    assertNull(txStore.getTransactionInfo(TxInfo.TX_NAME));
+    assertNull(txStore.getTransactionInfo(TxInfo.FATE_OP));
     assertEquals(0, txStore.timeCreated());
     assertEquals(Optional.empty(), txStore.getKey());
     assertEquals(fateId, txStore.getID());

--- a/test/src/main/java/org/apache/accumulo/test/functional/FateConcurrencyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FateConcurrencyIT.java
@@ -421,10 +421,10 @@ public class FateConcurrencyIT extends AccumuloClusterHarness {
     log.trace("Fate id: {}, status: {}", tx.getFateId(), tx.getStatus());
 
     String top = tx.getTop();
-    Fate.FateOperation txName = tx.getTxName();
+    Fate.FateOperation fateOp = tx.getFateOp();
 
-    return top != null && txName != null && top.contains("CompactionDriver")
-        && txName == Fate.FateOperation.TABLE_COMPACT;
+    return top != null && fateOp != null && top.contains("CompactionDriver")
+        && fateOp == Fate.FateOperation.TABLE_COMPACT;
   }
 
   /**


### PR DESCRIPTION
Replaced occurrences of TxName, txName, and similar references with fateOp.

Changes
    Renamed `txName` → `fateOp` where applicable
    Updated related method names

Fixes #5230 