### PR TITLE
Updated Java distribution for GitHub Actions builds

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -41,7 +41,7 @@ jobs:
     - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
-        distribution: adopt
+        distribution: temurin
         java-version: 17
         cache: 'maven'
     - name: Show the first log message
@@ -72,7 +72,7 @@ jobs:
     - name: Set up JDK ${{ matrix.profile.javaver }}
       uses: actions/setup-java@v4
       with:
-        distribution: adopt
+        distribution: temurin
         java-version: ${{ matrix.profile.javaver }}
         cache: 'maven'
     - name: Override DNS to fix IP address for hostname


### PR DESCRIPTION
Changed the distribution from adopt to temurin as recommended at https://github.com/actions/setup-java#supported-distributions because AdoptOpenJDK has moved to Eclipse Temurin and is not being updated anymore.