### PR TITLE
Modified Upgrader11to12.upgradeZookeeper to be idempotent

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader11to12.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader11to12.java
@@ -134,22 +134,20 @@ public class Upgrader11to12 implements Upgrader {
 
       String zPath = context.getZooKeeperRoot() + Constants.ZNAMESPACES;
       byte[] namespacesData = zrw.getData(zPath);
-      if (namespacesData.length != 0) {
-        throw new IllegalStateException(
-            "Unexpected data found under namespaces node: " + new String(namespacesData, UTF_8));
-      }
-      List<String> namespaceIdList = zrw.getChildren(zPath);
-      Map<String,String> namespaceMap = new HashMap<>();
-      for (String namespaceId : namespaceIdList) {
-        String namespaceNamePath = zPath + "/" + namespaceId + ZNAMESPACE_NAME;
-        namespaceMap.put(namespaceId, new String(zrw.getData(namespaceNamePath), UTF_8));
-      }
-      byte[] mapping = NamespaceMapping.serialize(namespaceMap);
-      zrw.putPersistentData(zPath, mapping, ZooUtil.NodeExistsPolicy.OVERWRITE);
+      if (namespacesData.length == 0) {
+        List<String> namespaceIdList = zrw.getChildren(zPath);
+        Map<String,String> namespaceMap = new HashMap<>();
+        for (String namespaceId : namespaceIdList) {
+          String namespaceNamePath = zPath + "/" + namespaceId + ZNAMESPACE_NAME;
+          namespaceMap.put(namespaceId, new String(zrw.getData(namespaceNamePath), UTF_8));
+        }
+        byte[] mapping = NamespaceMapping.serialize(namespaceMap);
+        zrw.putPersistentData(zPath, mapping, ZooUtil.NodeExistsPolicy.OVERWRITE);
 
-      for (String namespaceId : namespaceIdList) {
-        String namespaceNamePath = zPath + "/" + namespaceId + ZNAMESPACE_NAME;
-        zrw.delete(namespaceNamePath);
+        for (String namespaceId : namespaceIdList) {
+          String namespaceNamePath = zPath + "/" + namespaceId + ZNAMESPACE_NAME;
+          zrw.delete(namespaceNamePath);
+        }
       }
 
       log.info("Removing problems reports from zookeeper");


### PR DESCRIPTION
The namespace modifications that happen in this method can only be run once. On the second invocation this method would throw an IllegalStateException.

Closes #5347