### PR TITLE
Use new REST API for tables page

### DIFF
--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/Endpoints.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/Endpoints.java
@@ -44,6 +44,7 @@ import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.admin.TabletInformation;
 import org.apache.accumulo.core.client.admin.servers.ServerId;
 import org.apache.accumulo.core.compaction.thrift.TExternalCompaction;
+import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.metrics.flatbuffers.FMetric;
 import org.apache.accumulo.core.process.thrift.MetricResponse;
 import org.apache.accumulo.monitor.Monitor;
@@ -313,31 +314,33 @@ public class Endpoints {
   @GET
   @Path("tables")
   @Produces(MediaType.APPLICATION_JSON)
-  @Description("Returns a map of table name to table details")
-  public Map<String,TableSummary> getTables() {
+  @Description("Returns a map of TableId to table details")
+  public Map<TableId,TableSummary> getTables() {
     return monitor.getInformationFetcher().getSummary().getTables();
   }
 
   @GET
-  @Path("tables/{name}")
+  @Path("tables/{tableId}")
   @Produces(MediaType.APPLICATION_JSON)
-  @Description("Returns table details for the supplied table name")
-  public TableSummary getTable(@PathParam("name") String tableName) {
-    TableSummary ts = monitor.getInformationFetcher().getSummary().getTables().get(tableName);
+  @Description("Returns table details for the supplied TableId")
+  public TableSummary getTable(@PathParam("tableId") String tableId) {
+    TableSummary ts =
+        monitor.getInformationFetcher().getSummary().getTables().get(TableId.of(tableId));
     if (ts == null) {
-      throw new NotFoundException(tableName + " not found");
+      throw new NotFoundException(tableId + " not found");
     }
     return ts;
   }
 
   @GET
-  @Path("tables/{name}/tablets")
+  @Path("tables/{tableId}/tablets")
   @Produces(MediaType.APPLICATION_JSON)
   @Description("Returns tablet details for the supplied table name")
-  public List<TabletInformation> getTablets(@PathParam("name") String tableName) {
-    List<TabletInformation> ti = monitor.getInformationFetcher().getSummary().getTablets(tableName);
+  public List<TabletInformation> getTablets(@PathParam("tableId") String tableId) {
+    List<TabletInformation> ti =
+        monitor.getInformationFetcher().getSummary().getTablets(TableId.of(tableId));
     if (ti == null) {
-      throw new NotFoundException(tableName + " not found");
+      throw new NotFoundException(tableId + " not found");
     }
     return ti;
   }

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/view/WebViews.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/view/WebViews.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.monitor.view;
 
 import static org.apache.accumulo.monitor.util.ParameterValidator.ALPHA_NUM_REGEX_BLANK_OK;
+import static org.apache.accumulo.monitor.util.ParameterValidator.ALPHA_NUM_REGEX_TABLE_ID;
 import static org.apache.accumulo.monitor.util.ParameterValidator.HOSTNAME_PORT_REGEX;
 
 import java.io.IOException;
@@ -42,6 +43,7 @@ import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.monitor.Monitor;
 import org.glassfish.jersey.server.mvc.Template;
 import org.slf4j.Logger;
@@ -277,24 +279,24 @@ public class WebViews {
   /**
    * Returns participating tservers template
    *
-   * @param tableID Table ID for participating tservers
+   * @param tableId Table ID for participating tservers
    * @return Participating tservers model
    */
   @GET
-  @Path("tables/{tableID}")
+  @Path("tables/{tableId}")
   @Template(name = "/default.ftl")
-  public Map<String,Object> getTables(@PathParam("tableID") @NotNull String tableID)
+  public Map<String,Object> getTables(
+      @PathParam("tableId") @NotNull @Pattern(regexp = ALPHA_NUM_REGEX_TABLE_ID) String tableId)
       throws TableNotFoundException {
-    // TODO: switched to use tablename as param. switch back to tableID
-    // String tableName = monitor.getContext().getTableName(TableId.of(tableID));
+    String tableName = monitor.getContext().getTableName(TableId.of(tableId));
 
     Map<String,Object> model = getModel();
     model.put("title", "Table Status");
 
     model.put("template", "table.ftl");
     model.put("js", "table.js");
-    model.put("tableID", tableID);
-    model.put("table", tableID);
+    model.put("tableId", tableId);
+    model.put("table", tableName);
 
     return model;
   }

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/view/WebViews.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/view/WebViews.java
@@ -19,7 +19,6 @@
 package org.apache.accumulo.monitor.view;
 
 import static org.apache.accumulo.monitor.util.ParameterValidator.ALPHA_NUM_REGEX_BLANK_OK;
-import static org.apache.accumulo.monitor.util.ParameterValidator.ALPHA_NUM_REGEX_TABLE_ID;
 import static org.apache.accumulo.monitor.util.ParameterValidator.HOSTNAME_PORT_REGEX;
 
 import java.io.IOException;
@@ -43,7 +42,6 @@ import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
-import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.monitor.Monitor;
 import org.glassfish.jersey.server.mvc.Template;
 import org.slf4j.Logger;
@@ -285,11 +283,10 @@ public class WebViews {
   @GET
   @Path("tables/{tableID}")
   @Template(name = "/default.ftl")
-  public Map<String,Object> getTables(
-      @PathParam("tableID") @NotNull @Pattern(regexp = ALPHA_NUM_REGEX_TABLE_ID) String tableID)
+  public Map<String,Object> getTables(@PathParam("tableID") @NotNull String tableID)
       throws TableNotFoundException {
-
-    String tableName = monitor.getContext().getTableName(TableId.of(tableID));
+    // TODO: switched to use tablename as param. switch back to tableID
+    // String tableName = monitor.getContext().getTableName(TableId.of(tableID));
 
     Map<String,Object> model = getModel();
     model.put("title", "Table Status");
@@ -297,7 +294,7 @@ public class WebViews {
     model.put("template", "table.ftl");
     model.put("js", "table.js");
     model.put("tableID", tableID);
-    model.put("table", tableName);
+    model.put("table", tableID);
 
     return model;
   }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
@@ -25,7 +25,7 @@
 // Suffixes for quantity
 var QUANTITY_SUFFIX = ['', 'K', 'M', 'B', 'T', 'e15', 'e18', 'e21'];
 // Suffixes for size
-var SIZE_SUFFIX = ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z'];
+var SIZE_SUFFIX = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB'];
 
 /**
  * Initializes Auto Refresh to false if it is not set,
@@ -103,14 +103,14 @@ function bigNumber(big, suffixes, base) {
 }
 
 /**
- * Converts a number to a size with suffix
+ * Converts a size in bytes to a human-readable string with appropriate units.
  *
- * @param {number} size Number to convert
- * @return {string} Number with suffix added
+ * @param {number} size - The size in bytes to be converted.
+ * @returns {string} The human-readable string representation of the size.
  */
 function bigNumberForSize(size) {
-  if (size === null) {
-    size = 0;
+  if (size === 0) {
+    return '0B';
   }
   return bigNumber(size, SIZE_SUFFIX, 1024);
 }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/table.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/table.js
@@ -38,8 +38,8 @@ function refresh() {
 /**
  * Makes the REST call to fetch tablet details and render them.
  */
-function initTabletsTable(tableID) {
-  var tabletsUrl = '/rest-v2/tables/' + tableID + '/tablets';
+function initTabletsTable(tableId) {
+  var tabletsUrl = '/rest-v2/tables/' + tableId + '/tablets';
   console.debug('Fetching tablets info from: ' + tabletsUrl);
 
   tabletsTable = $('#tabletsList').DataTable({
@@ -83,10 +83,10 @@ function initTabletsTable(tableID) {
 /**
  * Initialize the table
  * 
- * @param {String} tableID the accumulo table ID
+ * @param {String} tableId the accumulo table ID
  */
-function initTableServerTable(tableID) {
-  const url = '/rest-v2/tables/' + tableID;
+function initTableServerTable(tableId) {
+  const url = '/rest-v2/tables/' + tableId;
   console.debug('REST url used to fetch summary data: ' + url);
 
   tableServersTable = $('#participatingTServers').DataTable({
@@ -163,5 +163,5 @@ function initTableServerTable(tableID) {
   });
 
   refreshTable();
-  initTabletsTable(tableID);
+  initTabletsTable(tableId);
 }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/table.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/table.js
@@ -173,23 +173,23 @@ function initTableServerTable(tableId) {
       },
       {
         "data": "totalAssignedTablets",
-        "title": "Assigned Count"
+        "title": "Assigned Tablet Count"
       },
       {
         "data": "totalAssignedToDeadServerTablets",
-        "title": "AssignedToDeadServerTablets"
+        "title": "Tablets Assigned to Dead Servers Count"
       },
       {
         "data": "totalHostedTablets",
-        "title": "HostedTablets"
+        "title": "Hosted Tablet Count"
       },
       {
         "data": "totalSuspendedTablets",
-        "title": "SuspendedTablets"
+        "title": "Suspended Tablet Count"
       },
       {
         "data": "totalUnassignedTablets",
-        "title": "UnassignedTablets"
+        "title": "Unassigned Tablet Count"
       }
     ]
   });

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/table.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/table.js
@@ -47,6 +47,26 @@ function initTabletsTable(tableId) {
       "url": tabletsUrl,
       "dataSrc": ""
     },
+    "stateSave": true,
+    "columnDefs": [{
+        "targets": "big-num",
+        "render": function (data, type) {
+          if (type === 'display') {
+            data = bigNumberForQuantity(data);
+          }
+          return data;
+        }
+      },
+      {
+        "targets": "big-size",
+        "render": function (data, type) {
+          if (type === 'display') {
+            data = bigNumberForSize(data);
+          }
+          return data;
+        }
+      }
+    ],
     "columns": [{
         "data": "tabletId",
         "title": "Tablet ID"
@@ -75,8 +95,7 @@ function initTabletsTable(tableId) {
         "data": "location",
         "title": "Location"
       }
-    ],
-    "stateSave": true
+    ]
   });
 }
 
@@ -97,6 +116,29 @@ function initTableServerTable(tableId) {
         return [json];
       }
     },
+    "stateSave": true,
+    "searching": false,
+    "paging": false,
+    "info": false,
+    "columnDefs": [{
+        "targets": "big-num",
+        "render": function (data, type) {
+          if (type === 'display') {
+            data = bigNumberForQuantity(data);
+          }
+          return data;
+        }
+      },
+      {
+        "targets": "big-size",
+        "render": function (data, type) {
+          if (type === 'display') {
+            data = bigNumberForSize(data);
+          }
+          return data;
+        }
+      }
+    ],
     "columns": [{
         "data": "totalEntries",
         "title": "Entry Count"
@@ -149,17 +191,7 @@ function initTableServerTable(tableId) {
         "data": "totalUnassignedTablets",
         "title": "UnassignedTablets"
       }
-    ],
-    "stateSave": true,
-    "columnDefs": [{
-      "targets": "big-num",
-      "render": function (data, type) {
-        if (type === 'display') {
-          data = bigNumberForQuantity(data);
-        }
-        return data;
-      }
-    }]
+    ]
   });
 
   refreshTable();

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/table.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/table.ftl
@@ -23,7 +23,7 @@
          * Creates participating Tservers initial table, passes the tableID from the template
          */
         $(function () {
-          initTableServerTable('${tableID}');
+          initTableServerTable('${table}');
         });
       </script>
       <div class="row">
@@ -37,18 +37,40 @@
             <caption><span class="table-caption">${table}</span></caption>
             <thead>
               <tr>
-                <th>Server&nbsp;</th>
-                <th class="big-num">Hosted<br />Tablets&nbsp;</th>
-                <th class="duration">Last&nbsp;Contact&nbsp;</th>
-                <th class="big-num" title="Key/value pairs over each instance, table or tablet.">Entries&nbsp;</th>
-                <th class="big-num" title="The number of Key/Value pairs inserted. (Note that deletes are considered inserted)">Ingest&nbsp;</th>
-                <th class="big-num" title="The number of key/value pairs returned to clients. (Not the number of scans)">Query&nbsp;</th>
-                <th class="duration" title="The amount of time live ingest operations (mutations, batch writes) have been waiting for the tserver to free up memory.">Hold&nbsp;Time&nbsp;</th>
-                <th title="Information about the scans threads. Shows how many threads are running and, in parentheses, how much work is queued for the threads.">Scans&nbsp;</th>
-                <th title="The action of flushing memory to disk. Multiple tablets can be compacted simultaneously, but sometimes they must wait for resources to be available. The number of tablets waiting for compaction is in parentheses.">Minor&nbsp;Compactions&nbsp;</th>
-                <th class="percent" title="The recent index cache hit rate.">Index Cache<br />Hit Rate&nbsp;</th>
-                <th class="percent" title="The recent data cache hit rate.">Data Cache<br />Hit Rate&nbsp;</th>
-                <th class="big-num" title="The Unix one minute load average. The average number of processes in the run queue over a one minute interval.">OS&nbsp;Load&nbsp;</th>
+                <th>Entry Count</th>
+                <th>Size on disk</th>
+                <th>File Count</th>
+                <th>WAL Count</th>
+                <th>Total Tablet Count</th>
+                <th>Always Hosted Count</th>
+                <th>On Demand Count</th>
+                <th>Never Hosted Count</th>
+                <th>Assigned Count</th>
+                <th>Assigned To Dead Server Tablets</th>
+                <th>Hosted Tablets</th>
+                <th>Suspended Tablets</th>
+                <th>Unassigned Tablets</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </div>
+      <br><br>
+      <!-- Section for tablets details DataTable -->
+      <div class="row">
+        <div class="col-xs-12">
+          <caption><span class="table-caption">Tablet Details</span></caption>
+          <table id="tabletsList" class="table caption-top table-bordered table-striped table-condensed">
+            <thead>
+              <tr>
+                <th>Tablet ID</th>
+                <th>Estimated Size</th>
+                <th>Estimated Entries</th>
+                <th>Availability</th>
+                <th>Files</th>
+                <th>WALs</th>
+                <th>Location</th>
               </tr>
             </thead>
             <tbody></tbody>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/table.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/table.ftl
@@ -37,19 +37,19 @@
             <caption><span class="table-caption">${table}</span></caption>
             <thead>
               <tr>
-                <th>Entry Count</th>
-                <th>Size on disk</th>
-                <th>File Count</th>
-                <th>WAL Count</th>
-                <th>Total Tablet Count</th>
-                <th>Always Hosted Count</th>
-                <th>On Demand Count</th>
-                <th>Never Hosted Count</th>
-                <th>Assigned Count</th>
-                <th>Assigned To Dead Server Tablets</th>
-                <th>Hosted Tablets</th>
-                <th>Suspended Tablets</th>
-                <th>Unassigned Tablets</th>
+                <th class="big-num">Entry Count</th>
+                <th class="big-size">Size on disk</th>
+                <th class="big-num">File Count</th>
+                <th class="big-num">WAL Count</th>
+                <th class="big-num">Total Tablet Count</th>
+                <th class="big-num">Always Hosted Count</th>
+                <th class="big-num">On Demand Count</th>
+                <th class="big-num">Never Hosted Count</th>
+                <th class="big-num">Assigned Count</th>
+                <th class="big-num">Assigned To Dead Server Tablets</th>
+                <th class="big-num">Hosted Tablets</th>
+                <th class="big-num">Suspended Tablets</th>
+                <th class="big-num">Unassigned Tablets</th>
               </tr>
             </thead>
             <tbody></tbody>
@@ -65,11 +65,11 @@
             <thead>
               <tr>
                 <th>Tablet ID</th>
-                <th>Estimated Size</th>
-                <th>Estimated Entries</th>
+                <th class="big-size">Estimated Size</th>
+                <th class="big-num">Estimated Entries</th>
                 <th>Availability</th>
-                <th>Files</th>
-                <th>WALs</th>
+                <th class="big-num">Files</th>
+                <th class="big-num">WALs</th>
                 <th>Location</th>
               </tr>
             </thead>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/table.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/table.ftl
@@ -28,13 +28,13 @@
       </script>
       <div class="row">
         <div class="col-xs-12">
-          <h3>${title}</h3>
+          <h3>Table Details: ${title} <small class="text-muted">(ID: ${tableId})</small></h3>
         </div>
       </div>
       <div class="row">
         <div class="col-xs-12">
           <table id="participatingTServers" class="table caption-top table-bordered table-striped table-condensed">
-            <caption><span class="table-caption">${table}</span></caption>
+            <caption><span class="table-caption">Table Summary for: ${table} <small>(ID: ${tableId})</small></span></caption>
             <thead>
               <tr>
                 <th class="big-num">Entry Count</th>
@@ -61,7 +61,7 @@
       <div class="row">
         <div class="col-xs-12">
           <table id="tabletsList" class="table caption-top table-bordered table-striped table-condensed">
-            <caption><span class="table-caption">Tablet Details</span></caption>
+            <caption><span class="table-caption">Tablet Details for: ${table} <small>(ID: ${tableId})</small></span></caption>
             <thead>
               <tr>
                 <th>Tablet ID</th>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/table.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/table.ftl
@@ -28,13 +28,13 @@
       </script>
       <div class="row">
         <div class="col-xs-12">
-          <h3>Table Details: ${title} <small class="text-muted">(ID: ${tableId})</small></h3>
+          <h3>Details for table ${table} <small>(ID: ${tableId})</small></h3>
         </div>
       </div>
       <div class="row">
         <div class="col-xs-12">
           <table id="participatingTServers" class="table caption-top table-bordered table-striped table-condensed">
-            <caption><span class="table-caption">Table Summary for: ${table} <small>(ID: ${tableId})</small></span></caption>
+            <caption><span class="table-caption">Table Summary</span></caption>
             <thead>
               <tr>
                 <th class="big-num">Entry Count</th>
@@ -61,7 +61,7 @@
       <div class="row">
         <div class="col-xs-12">
           <table id="tabletsList" class="table caption-top table-bordered table-striped table-condensed">
-            <caption><span class="table-caption">Tablet Details for: ${table} <small>(ID: ${tableId})</small></span></caption>
+            <caption><span class="table-caption">Tablet Details</span></caption>
             <thead>
               <tr>
                 <th>Tablet ID</th>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/table.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/table.ftl
@@ -20,10 +20,10 @@
 -->
       <script>
         /**
-         * Creates participating Tservers initial table, passes the tableID from the template
+         * Creates participating Tservers initial table, passes the tableId from the template
          */
         $(function () {
-          initTableServerTable('${table}');
+          initTableServerTable('${tableId}');
         });
       </script>
       <div class="row">
@@ -60,8 +60,8 @@
       <!-- Section for tablets details DataTable -->
       <div class="row">
         <div class="col-xs-12">
-          <caption><span class="table-caption">Tablet Details</span></caption>
           <table id="tabletsList" class="table caption-top table-bordered table-striped table-condensed">
+            <caption><span class="table-caption">Tablet Details</span></caption>
             <thead>
               <tr>
                 <th>Tablet ID</th>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/tables.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/tables.ftl
@@ -40,11 +40,20 @@
             "stateSave": true,
             "columnDefs": [
               {
-                "type": "num",
                 "targets": "big-num",
-                "render": function (data, type, row) {
-                  if (type === 'display')
+                "render": function (data, type) {
+                  if (type === 'display') {
                     data = bigNumberForQuantity(data);
+                  }
+                  return data;
+                }
+              },
+              {
+                "targets": "big-size",
+                "render": function (data, type) {
+                  if (type === 'display') {
+                    data = bigNumberForSize(data);
+                  }
                   return data;
                 }
               }
@@ -101,7 +110,7 @@
               <th title="Table Name">Table&nbsp;Name</th>
               <th title="Tables are broken down into ranges of rows called tablets." class="big-num">Tablets</th>
               <th title="Key/value pairs over each instance, table or tablet." class="big-num">Entries</th>
-              <th title="Total size on disk." class="big-num">Size on Disk</th>
+              <th title="Total size on disk." class="big-size">Size on Disk</th>
               <th title="Total number of files." class="big-num">Files</th>
               <th title="Total number of WALs." class="big-num">WALs</th>
               <th title="Number of tablets that are always hosted." class="big-num">Always Available</th>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/tables.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/tables.ftl
@@ -32,7 +32,7 @@
               "url": "/rest-v2/tables",
               "dataSrc": function (json) {
                 return Object.keys(json).map(function (key) {
-                  json[key].tablename = key;
+                  json[key].tableId = key;
                   return json[key];
                 });
               }
@@ -51,11 +51,11 @@
             ],
             "columns": [
               {
-                "data": "tablename",
+                "data": "tableName",
                 "type": "html",
                 "render": function (data, type, row, meta) {
                   if (type === 'display') {
-                    data = '<a href="/tables/' + row.tablename + '">' + row.tablename + '</a>';
+                    data = '<a href="/tables/' + row.tableId + '">' + row.tableName + '</a>';
                   }
                   return data;
                 }


### PR DESCRIPTION
This PR populates the individual table pages with the info returned by `/rest-v2/tables/<tablename>` and `/rest-v2/tables/<tablename>/tablets`.