### PR TITLE
Convert several ITs to use SharedMiniClusterBase

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/AdminCheckIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/AdminCheckIT.java
@@ -40,22 +40,35 @@ import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.admin.CompactionConfig;
+import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.cli.ServerUtilOpts;
 import org.apache.accumulo.server.util.Admin;
 import org.apache.accumulo.server.util.checkCommand.CheckRunner;
-import org.apache.accumulo.test.functional.ConfigurableMacBase;
 import org.apache.accumulo.test.functional.ReadWriteIT;
 import org.apache.accumulo.test.functional.SlowIterator;
 import org.easymock.EasyMock;
 import org.easymock.IAnswer;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import com.beust.jcommander.JCommander;
 import com.google.common.collect.Sets;
 
-public class AdminCheckIT extends ConfigurableMacBase {
+public class AdminCheckIT extends SharedMiniClusterBase {
+
+  @BeforeAll
+  public static void setup() throws Exception {
+    SharedMiniClusterBase.startMiniCluster();
+  }
+
+  @AfterAll
+  public static void teardown() {
+    SharedMiniClusterBase.stopMiniCluster();
+  }
+
   private static final PrintStream ORIGINAL_OUT = System.out;
 
   @AfterEach
@@ -308,7 +321,7 @@ public class AdminCheckIT extends ConfigurableMacBase {
     String table = getUniqueNames(1)[0];
     Admin.CheckCommand.Check tableLocksCheck = Admin.CheckCommand.Check.TABLE_LOCKS;
 
-    try (AccumuloClient client = Accumulo.newClient().from(getClientProperties()).build()) {
+    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
       client.tableOperations().create(table);
 
       ReadWriteIT.ingest(client, 10, 10, 10, 0, table);
@@ -400,7 +413,7 @@ public class AdminCheckIT extends ConfigurableMacBase {
     // Tests the USER_FILES check in the case where it should pass
     Admin.CheckCommand.Check userFilesCheck = Admin.CheckCommand.Check.USER_FILES;
 
-    try (AccumuloClient client = Accumulo.newClient().from(getClientProperties()).build()) {
+    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
       // create a table, insert some data, and flush so there's a file to check
       String table = getUniqueNames(1)[0];
       client.tableOperations().create(table);
@@ -447,7 +460,7 @@ public class AdminCheckIT extends ConfigurableMacBase {
       Admin.CheckCommand dummyCheckCommand = new DummyCheckCommand(checksPass);
       cl.addCommand("check", dummyCheckCommand);
       cl.parse(args);
-      Admin.executeCheckCommand(getServerContext(), dummyCheckCommand, opts);
+      Admin.executeCheckCommand(getCluster().getServerContext(), dummyCheckCommand, opts);
       return null;
     });
     EasyMock.replay(admin);

--- a/test/src/main/java/org/apache/accumulo/test/MultiTableBatchWriterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MultiTableBatchWriterIT.java
@@ -41,14 +41,26 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.harness.AccumuloClusterHarness;
+import org.apache.accumulo.harness.SharedMiniClusterBase;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Maps;
 
-public class MultiTableBatchWriterIT extends AccumuloClusterHarness {
+public class MultiTableBatchWriterIT extends SharedMiniClusterBase {
+
+  @BeforeAll
+  public static void setup() throws Exception {
+    SharedMiniClusterBase.startMiniCluster();
+  }
+
+  @AfterAll
+  public static void teardown() {
+    SharedMiniClusterBase.stopMiniCluster();
+  }
 
   private AccumuloClient accumuloClient;
   private MultiTableBatchWriter mtbw;

--- a/test/src/main/java/org/apache/accumulo/test/OrIteratorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/OrIteratorIT.java
@@ -46,11 +46,24 @@ import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.OrIterator;
-import org.apache.accumulo.harness.AccumuloClusterHarness;
+import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.hadoop.io.Text;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class OrIteratorIT extends AccumuloClusterHarness {
+public class OrIteratorIT extends SharedMiniClusterBase {
+
+  @BeforeAll
+  public static void setup() throws Exception {
+    SharedMiniClusterBase.startMiniCluster();
+  }
+
+  @AfterAll
+  public static void teardown() {
+    SharedMiniClusterBase.stopMiniCluster();
+  }
+
   private static final String EMPTY = "";
 
   @Override

--- a/test/src/main/java/org/apache/accumulo/test/SampleIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/SampleIT.java
@@ -66,14 +66,26 @@ import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iterators.WrappingIterator;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.harness.AccumuloClusterHarness;
+import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.test.util.FileMetadataUtil;
 import org.apache.hadoop.io.Text;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Iterables;
 
-public class SampleIT extends AccumuloClusterHarness {
+public class SampleIT extends SharedMiniClusterBase {
+
+  @BeforeAll
+  public static void setup() throws Exception {
+    SharedMiniClusterBase.startMiniCluster();
+  }
+
+  @AfterAll
+  public static void teardown() {
+    SharedMiniClusterBase.stopMiniCluster();
+  }
 
   private static final Map<String,String> OPTIONS_1 =
       Map.of("hasher", "murmur3_32", "modulus", "1009");
@@ -162,8 +174,9 @@ public class SampleIT extends AccumuloClusterHarness {
         // Fence off the data to a Range that is a subset of the original data
         Range fenced = new Range(new Text(String.format("r_%06d", 2999)), false,
             new Text(String.format("r_%06d", 6000)), true);
-        FileMetadataUtil.splitFilesIntoRanges(getServerContext(), tableName, Set.of(fenced));
-        assertEquals(1, countFiles(getServerContext(), tableName));
+        FileMetadataUtil.splitFilesIntoRanges(getCluster().getServerContext(), tableName,
+            Set.of(fenced));
+        assertEquals(1, countFiles(getCluster().getServerContext(), tableName));
 
         // Build the map of expected values to be seen by filtering out keys not in the fenced range
         TreeMap<Key,Value> fenceExpected =
@@ -222,8 +235,9 @@ public class SampleIT extends AccumuloClusterHarness {
 
         // Split files into ranged files if provided
         if (!fileRanges.isEmpty()) {
-          FileMetadataUtil.splitFilesIntoRanges(getServerContext(), tableName, fileRanges);
-          assertEquals(fileRanges.size(), countFiles(getServerContext(), tableName));
+          FileMetadataUtil.splitFilesIntoRanges(getCluster().getServerContext(), tableName,
+              fileRanges);
+          assertEquals(fileRanges.size(), countFiles(getCluster().getServerContext(), tableName));
         }
 
         Scanner oScanner = newOfflineScanner(client, tableName, clone, SC1);
@@ -430,8 +444,9 @@ public class SampleIT extends AccumuloClusterHarness {
 
         // Split files into ranged files if provided
         if (!fileRanges.isEmpty()) {
-          FileMetadataUtil.splitFilesIntoRanges(getServerContext(), tableName, fileRanges);
-          assertEquals(fileRanges.size(), countFiles(getServerContext(), tableName));
+          FileMetadataUtil.splitFilesIntoRanges(getCluster().getServerContext(), tableName,
+              fileRanges);
+          assertEquals(fileRanges.size(), countFiles(getCluster().getServerContext(), tableName));
         }
 
         oScanner = newOfflineScanner(client, tableName, clone, null);
@@ -524,8 +539,9 @@ public class SampleIT extends AccumuloClusterHarness {
 
         // Split files into ranged files if provided
         if (!fileRanges.isEmpty()) {
-          FileMetadataUtil.splitFilesIntoRanges(getServerContext(), tableName, fileRanges);
-          assertEquals(fileRanges.size(), countFiles(getServerContext(), tableName));
+          FileMetadataUtil.splitFilesIntoRanges(getCluster().getServerContext(), tableName,
+              fileRanges);
+          assertEquals(fileRanges.size(), countFiles(getCluster().getServerContext(), tableName));
         }
 
         Scanner oScanner = newOfflineScanner(client, tableName, clone, SC1);

--- a/test/src/main/java/org/apache/accumulo/test/functional/CloneTestIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CloneTestIT.java
@@ -62,15 +62,27 @@ import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.harness.AccumuloClusterHarness;
+import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class CloneTestIT extends AccumuloClusterHarness {
+public class CloneTestIT extends SharedMiniClusterBase {
+
+  @BeforeAll
+  public static void setup() throws Exception {
+    SharedMiniClusterBase.startMiniCluster();
+  }
+
+  @AfterAll
+  public static void teardown() {
+    SharedMiniClusterBase.stopMiniCluster();
+  }
 
   @Override
   protected Duration defaultTimeout() {
@@ -161,7 +173,7 @@ public class CloneTestIT extends AccumuloClusterHarness {
 
         if (cf.equals(DataFileColumnFamily.NAME)) {
           Path p = StoredTabletFile.of(cq).getPath();
-          FileSystem fs = cluster.getFileSystem();
+          FileSystem fs = getCluster().getFileSystem();
           assertTrue(fs.exists(p), "File does not exist: " + p);
         } else if (cf.equals(ServerColumnFamily.DIRECTORY_COLUMN.getColumnFamily())) {
           assertEquals(ServerColumnFamily.DIRECTORY_COLUMN.getColumnQualifier(), cq,

--- a/test/src/main/java/org/apache/accumulo/test/functional/MetadataIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MetadataIT.java
@@ -59,22 +59,28 @@ import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.TablePermission;
-import org.apache.accumulo.harness.AccumuloClusterHarness;
-import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
-import org.apache.hadoop.conf.Configuration;
+import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.hadoop.io.Text;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class MetadataIT extends AccumuloClusterHarness {
+public class MetadataIT extends SharedMiniClusterBase {
+
+  @BeforeAll
+  public static void setup() throws Exception {
+    SharedMiniClusterBase.startMiniClusterWithConfig(
+        (cfg, coreSite) -> cfg.getClusterServerConfiguration().setNumDefaultTabletServers(1));
+  }
+
+  @AfterAll
+  public static void teardown() {
+    SharedMiniClusterBase.stopMiniCluster();
+  }
 
   @Override
   protected Duration defaultTimeout() {
     return Duration.ofMinutes(2);
-  }
-
-  @Override
-  public void configureMiniCluster(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
-    cfg.getClusterServerConfiguration().setNumDefaultTabletServers(1);
   }
 
   @Test

--- a/test/src/main/java/org/apache/accumulo/test/functional/SessionDurabilityIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SessionDurabilityIT.java
@@ -38,32 +38,40 @@ import org.apache.accumulo.core.data.Condition;
 import org.apache.accumulo.core.data.ConditionalMutation;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.minicluster.ServerType;
-import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.miniclusterImpl.ProcessReference;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.RawLocalFileSystem;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Iterators;
 
-public class SessionDurabilityIT extends ConfigurableMacBase {
+public class SessionDurabilityIT extends SharedMiniClusterBase {
+
+  @BeforeAll
+  public static void setup() throws Exception {
+    SharedMiniClusterBase.startMiniClusterWithConfig((cfg, coreSite) -> {
+      cfg.getClusterServerConfiguration().setNumDefaultTabletServers(1);
+      coreSite.set("fs.file.impl", RawLocalFileSystem.class.getName());
+      cfg.setProperty(Property.INSTANCE_ZK_TIMEOUT, "15s");
+    });
+  }
+
+  @AfterAll
+  public static void teardown() {
+    SharedMiniClusterBase.stopMiniCluster();
+  }
 
   @Override
   protected Duration defaultTimeout() {
     return Duration.ofMinutes(3);
   }
 
-  @Override
-  public void configure(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
-    cfg.getClusterServerConfiguration().setNumDefaultTabletServers(1);
-    hadoopCoreSite.set("fs.file.impl", RawLocalFileSystem.class.getName());
-    cfg.setProperty(Property.INSTANCE_ZK_TIMEOUT, "15s");
-  }
-
   @Test
   public void nondurableTableHasDurableWrites() throws Exception {
-    try (AccumuloClient c = Accumulo.newClient().from(getClientProperties()).build()) {
+    try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
       String tableName = getUniqueNames(1)[0];
       // table default has no durability
       c.tableOperations().create(tableName, new NewTableConfiguration()
@@ -81,7 +89,7 @@ public class SessionDurabilityIT extends ConfigurableMacBase {
 
   @Test
   public void durableTableLosesNonDurableWrites() throws Exception {
-    try (AccumuloClient c = Accumulo.newClient().from(getClientProperties()).build()) {
+    try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
       String tableName = getUniqueNames(1)[0];
       // table default is durable writes
       c.tableOperations().create(tableName, new NewTableConfiguration()
@@ -113,7 +121,7 @@ public class SessionDurabilityIT extends ConfigurableMacBase {
 
   @Test
   public void testConditionDurability() throws Exception {
-    try (AccumuloClient c = Accumulo.newClient().from(getClientProperties()).build()) {
+    try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
       String tableName = getUniqueNames(1)[0];
       // table default is durable writes
       c.tableOperations().create(tableName, new NewTableConfiguration()
@@ -132,7 +140,7 @@ public class SessionDurabilityIT extends ConfigurableMacBase {
 
   @Test
   public void testConditionDurability2() throws Exception {
-    try (AccumuloClient c = Accumulo.newClient().from(getClientProperties()).build()) {
+    try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
       String tableName = getUniqueNames(1)[0];
       // table default is durable writes
       c.tableOperations().create(tableName, new NewTableConfiguration()
@@ -161,10 +169,10 @@ public class SessionDurabilityIT extends ConfigurableMacBase {
   }
 
   private void restartTServer() throws Exception {
-    for (ProcessReference proc : cluster.getProcesses().get(ServerType.TABLET_SERVER)) {
-      cluster.killProcess(ServerType.TABLET_SERVER, proc);
+    for (ProcessReference proc : getCluster().getProcesses().get(ServerType.TABLET_SERVER)) {
+      getCluster().killProcess(ServerType.TABLET_SERVER, proc);
     }
-    cluster.start();
+    getCluster().start();
   }
 
 }


### PR DESCRIPTION
This change migrates several ITs to using SharedMiniClusterBase so that a single cluster is stood up and reused for all the tests in the test class. This has the benefit of speeding up the tests because the entire cluster does not need to be torn down and recreated for each test.

There are likely more tests that could be changed as well but some would take some more significant refactoring to do so. The updates to these tests sped up the build by about 15 minutes on my VM. 