### PR TITLE
Track state of upgrade to eliminate re-running upgrade code

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/Constants.java
+++ b/core/src/main/java/org/apache/accumulo/core/Constants.java
@@ -84,7 +84,7 @@ public class Constants {
   public static final String ZHDFS_RESERVATIONS = "/hdfs_reservations";
   public static final String ZRECOVERY = "/recovery";
 
-  public static final String ZUPGRADE_STATUS = "/upgrade_status";
+  public static final String ZUPGRADE_PROGRESS = "/upgrade_progress";
 
   /**
    * Base znode for storing secret keys that back delegation tokens

--- a/core/src/main/java/org/apache/accumulo/core/Constants.java
+++ b/core/src/main/java/org/apache/accumulo/core/Constants.java
@@ -84,6 +84,8 @@ public class Constants {
   public static final String ZHDFS_RESERVATIONS = "/hdfs_reservations";
   public static final String ZRECOVERY = "/recovery";
 
+  public static final String ZUPGRADE_STATUS = "/upgrade_status";
+
   /**
    * Base znode for storing secret keys that back delegation tokens
    */

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -1264,6 +1264,9 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener, 
     } catch (KeeperException | InterruptedException e) {
       throw new IllegalStateException("Exception getting manager lock", e);
     }
+    // Setting the Manager state to HAVE_LOCK has the side-effect of
+    // starting the upgrade process if necessary.
+    setManagerState(ManagerState.HAVE_LOCK);
 
     MetricsInfo metricsInfo = getContext().getMetricsInfo();
 
@@ -1619,7 +1622,6 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener, 
       sleepUninterruptibly(TIME_TO_WAIT_BETWEEN_LOCK_CHECKS, MILLISECONDS);
     }
 
-    setManagerState(ManagerState.HAVE_LOCK);
     return sld;
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/PreUpgradeValidation.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/PreUpgradeValidation.java
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.accumulo.core.zookeeper.ZooSession;
 import org.apache.accumulo.core.zookeeper.ZooSession.ZKUtil;
-import org.apache.accumulo.manager.EventCoordinator;
 import org.apache.accumulo.server.AccumuloDataVersion;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.zookeeper.KeeperException;
@@ -48,10 +47,11 @@ public class PreUpgradeValidation {
 
   private final static Logger log = LoggerFactory.getLogger(PreUpgradeValidation.class);
 
-  public void validate(final ServerContext context, final EventCoordinator eventCoordinator) {
-    int cv = AccumuloDataVersion.getCurrentVersion(context);
-    if (cv == AccumuloDataVersion.get()) {
-      log.debug("already at current data version: {}, skipping validation", cv);
+  public void validate(final ServerContext context) {
+    int storedVersion = AccumuloDataVersion.getCurrentVersion(context);
+    int currentVersion = AccumuloDataVersion.get();
+    if (storedVersion == currentVersion) {
+      log.debug("already at current data version: {}, skipping validation", currentVersion);
       return;
     }
     validateACLs(context);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeCoordinator.java
@@ -44,6 +44,7 @@ import org.apache.accumulo.core.fate.ZooStore;
 import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.core.volume.Volume;
 import org.apache.accumulo.manager.EventCoordinator;
+import org.apache.accumulo.manager.upgrade.UpgradeProgressTracker.ComponentVersions;
 import org.apache.accumulo.server.AccumuloDataVersion;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.ServerDirs;
@@ -173,13 +174,22 @@ public class UpgradeCoordinator {
       if (currentVersion < AccumuloDataVersion.get()) {
         abortIfFateTransactions(context);
 
+        final ComponentVersions tracker = UpgradeProgressTracker.get(context);
+
         for (int v = currentVersion; v < AccumuloDataVersion.get(); v++) {
+          if (tracker.getZooKeeperVersion() >= currentVersion) {
+            log.info(
+                "ZooKeeper has already been upgraded to version {}, moving on to next upgrader",
+                currentVersion);
+            continue;
+          }
           log.info("Upgrading Zookeeper - current version {} as step towards target version {}", v,
               AccumuloDataVersion.get());
           var upgrader = upgraders.get(v);
           Objects.requireNonNull(upgrader,
               "upgrade ZooKeeper: failed to find upgrader for version " + currentVersion);
           upgrader.upgradeZookeeper(context);
+          tracker.updateZooKeeperVersion(context, v);
         }
       }
 
@@ -205,17 +215,31 @@ public class UpgradeCoordinator {
           .numMaxThreads(Integer.MAX_VALUE).withTimeOut(60L, SECONDS)
           .withQueue(new SynchronousQueue<>()).build().submit(() -> {
             try {
+              ComponentVersions tracker = UpgradeProgressTracker.get(context);
               for (int v = currentVersion; v < AccumuloDataVersion.get(); v++) {
+                if (tracker.getRootVersion() >= currentVersion) {
+                  log.info(
+                      "Root table has already been upgraded to version {}, moving on to next upgrader",
+                      currentVersion);
+                  continue;
+                }
                 log.info("Upgrading Root - current version {} as step towards target version {}", v,
                     AccumuloDataVersion.get());
                 var upgrader = upgraders.get(v);
                 Objects.requireNonNull(upgrader,
                     "upgrade root: failed to find root upgrader for version " + currentVersion);
                 upgraders.get(v).upgradeRoot(context);
+                tracker.updateRootVersion(context, v);
               }
               setStatus(UpgradeStatus.UPGRADED_ROOT, eventCoordinator);
 
               for (int v = currentVersion; v < AccumuloDataVersion.get(); v++) {
+                if (tracker.getMetadataVersion() >= currentVersion) {
+                  log.info(
+                      "Metadata table has already been upgraded to version {}, moving on to next upgrader",
+                      currentVersion);
+                  continue;
+                }
                 log.info(
                     "Upgrading Metadata - current version {} as step towards target version {}", v,
                     AccumuloDataVersion.get());
@@ -223,6 +247,7 @@ public class UpgradeCoordinator {
                 Objects.requireNonNull(upgrader,
                     "upgrade metadata: failed to find upgrader for version " + currentVersion);
                 upgraders.get(v).upgradeMetadata(context);
+                tracker.updateMetadataVersion(context, v);
               }
               setStatus(UpgradeStatus.UPGRADED_METADATA, eventCoordinator);
 
@@ -234,6 +259,7 @@ public class UpgradeCoordinator {
                   currentVersion);
               log.info("Upgrade complete");
               setStatus(UpgradeStatus.COMPLETE, eventCoordinator);
+              UpgradeProgressTracker.upgradeComplete(context);
             } catch (Exception e) {
               handleFailure(e);
             }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeProgress.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeProgress.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.manager.upgrade;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
+/**
+ * Track upgrade progress for each component. The version stored is the most recent version for
+ * which an upgrade has been completed.
+ */
+public class UpgradeProgress {
+
+  int zooKeeperVersion;
+  int rootVersion;
+  int metadataVersion;
+  int upgradeTargetVersion;
+
+  public UpgradeProgress() {}
+
+  public UpgradeProgress(int currentVersion, int targetVersion) {
+    zooKeeperVersion = currentVersion;
+    rootVersion = currentVersion;
+    metadataVersion = currentVersion;
+    upgradeTargetVersion = targetVersion;
+  }
+
+  public int getZooKeeperVersion() {
+    return zooKeeperVersion;
+  }
+
+  public int getRootVersion() {
+    return rootVersion;
+  }
+
+  public int getMetadataVersion() {
+    return metadataVersion;
+  }
+
+  public int getUpgradeTargetVersion() {
+    return upgradeTargetVersion;
+  }
+
+  public byte[] toJsonBytes() {
+    return GSON.get().toJson(this).getBytes(UTF_8);
+  }
+
+  public static UpgradeProgress fromJsonBytes(byte[] jsonData) {
+    return GSON.get().fromJson(new String(jsonData, UTF_8), UpgradeProgress.class);
+  }
+
+}

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeProgress.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeProgress.java
@@ -27,10 +27,10 @@ import static org.apache.accumulo.core.util.LazySingletons.GSON;
  */
 public class UpgradeProgress {
 
-  int zooKeeperVersion;
-  int rootVersion;
-  int metadataVersion;
-  int upgradeTargetVersion;
+  private int zooKeeperVersion;
+  private int rootVersion;
+  private int metadataVersion;
+  private int upgradeTargetVersion;
 
   public UpgradeProgress() {}
 
@@ -41,12 +41,24 @@ public class UpgradeProgress {
     upgradeTargetVersion = targetVersion;
   }
 
+  public void setZooKeeperVersion(int version) {
+    zooKeeperVersion = version;
+  }
+
   public int getZooKeeperVersion() {
     return zooKeeperVersion;
   }
 
+  public void setRootVersion(int version) {
+    rootVersion = version;
+  }
+
   public int getRootVersion() {
     return rootVersion;
+  }
+
+  public void setMetadataVersion(int version) {
+    metadataVersion = version;
   }
 
   public int getMetadataVersion() {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeProgressTracker.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeProgressTracker.java
@@ -66,9 +66,9 @@ public class UpgradeProgressTracker {
         var stat = new Stat();
         var oldProgressBytes = zk.getData(getZPath(), null, stat);
         var oldProgress = UpgradeProgress.fromJsonBytes(oldProgressBytes);
-        checkState(AccumuloDataVersion.get() == oldProgress.upgradeTargetVersion,
+        checkState(AccumuloDataVersion.get() == oldProgress.getUpgradeTargetVersion(),
             "Upgrade was already started with a different version of software (%s), expecting %s",
-            oldProgress.upgradeTargetVersion, AccumuloDataVersion.get());
+            oldProgress.getUpgradeTargetVersion(), AccumuloDataVersion.get());
         progress = oldProgress;
         znodeVersion = stat.getVersion();
       }
@@ -93,7 +93,7 @@ public class UpgradeProgressTracker {
     checkArgument(progress.getMetadataVersion() == progress.getRootVersion(),
         "Root (%s) and Metadata (%s) versions expected to be equal when upgrading ZooKeeper",
         progress.getRootVersion(), progress.getMetadataVersion());
-    progress.zooKeeperVersion = newVersion;
+    progress.setZooKeeperVersion(newVersion);
     storeProgress();
   }
 
@@ -110,7 +110,7 @@ public class UpgradeProgressTracker {
     checkArgument(newVersion > progress.getMetadataVersion(),
         "New Root version (%s) must be greater than current Metadata version (%s)", newVersion,
         progress.getMetadataVersion());
-    progress.rootVersion = newVersion;
+    progress.setRootVersion(newVersion);
     storeProgress();
   }
 
@@ -127,7 +127,7 @@ public class UpgradeProgressTracker {
     checkArgument(newVersion <= progress.getRootVersion(),
         "New Metadata version (%s) expected to be <= Root version (%s)", newVersion,
         progress.getRootVersion());
-    progress.metadataVersion = newVersion;
+    progress.setMetadataVersion(newVersion);
     storeProgress();
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeProgressTracker.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeProgressTracker.java
@@ -18,30 +18,46 @@
  */
 package org.apache.accumulo.manager.upgrade;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
 import static org.apache.accumulo.core.util.LazySingletons.GSON;
-
-import java.util.Objects;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
-import org.apache.accumulo.core.fate.zookeeper.ZooUtil.NodeExistsPolicy;
+import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil.NodeMissingPolicy;
+import org.apache.accumulo.core.zookeeper.ZooSession;
 import org.apache.accumulo.server.AccumuloDataVersion;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
-
-import com.google.common.base.Preconditions;
+import org.apache.zookeeper.data.Stat;
 
 /**
  * Methods in this class are public **only** for UpgradeProgressTrackerIT
  */
 public class UpgradeProgressTracker {
 
-  public static class ComponentVersions {
+  /**
+   * Track upgrade progress for each component. The version stored is the most recent version for
+   * which an upgrade has been completed.
+   */
+  public static class UpgradeProgress {
+
     private int zooKeeperVersion;
     private int rootVersion;
     private int metadataVersion;
+    private volatile transient int znodeVersion;
+
+    public UpgradeProgress() {}
+
+    public UpgradeProgress(int currentVersion) {
+      zooKeeperVersion = currentVersion;
+      rootVersion = currentVersion;
+      metadataVersion = currentVersion;
+    }
 
     public int getZooKeeperVersion() {
       return zooKeeperVersion;
@@ -49,17 +65,17 @@ public class UpgradeProgressTracker {
 
     public synchronized void updateZooKeeperVersion(ServerContext context, int newVersion)
         throws KeeperException, InterruptedException {
-      Objects.requireNonNull(context, "ServerContext must be supplied");
-      Preconditions.checkArgument(newVersion <= AccumuloDataVersion.get(),
+      requireNonNull(context, "ServerContext must be supplied");
+      checkArgument(newVersion <= AccumuloDataVersion.get(),
           "New version (%s) cannot be larger than current data version (%s)", newVersion,
           AccumuloDataVersion.get());
-      Preconditions.checkArgument(newVersion > zooKeeperVersion,
+      checkArgument(newVersion > zooKeeperVersion,
           "New ZooKeeper version (%s) must be greater than current version (%s)", newVersion,
           zooKeeperVersion);
-      Preconditions.checkArgument(newVersion > rootVersion,
+      checkArgument(newVersion > rootVersion,
           "New ZooKeeper version (%s) expected to be greater than the root version (%s)",
           newVersion, rootVersion);
-      Preconditions.checkArgument(metadataVersion == rootVersion,
+      checkArgument(metadataVersion == rootVersion,
           "Root (%s) and Metadata (%s) versions expected to be equal when upgrading ZooKeeper",
           rootVersion, metadataVersion);
       zooKeeperVersion = newVersion;
@@ -72,17 +88,17 @@ public class UpgradeProgressTracker {
 
     public synchronized void updateRootVersion(ServerContext context, int newVersion)
         throws KeeperException, InterruptedException {
-      Objects.requireNonNull(context, "ServerContext must be supplied");
-      Preconditions.checkArgument(newVersion <= AccumuloDataVersion.get(),
+      requireNonNull(context, "ServerContext must be supplied");
+      checkArgument(newVersion <= AccumuloDataVersion.get(),
           "New version (%s) cannot be larger than current data version (%s)", newVersion,
           AccumuloDataVersion.get());
-      Preconditions.checkArgument(newVersion > rootVersion,
+      checkArgument(newVersion > rootVersion,
           "New Root version (%s) must be greater than current Root version (%s)", newVersion,
           rootVersion);
-      Preconditions.checkArgument(newVersion <= zooKeeperVersion,
+      checkArgument(newVersion <= zooKeeperVersion,
           "New Root version (%s) expected to be <= ZooKeeper version (%s)", newVersion,
           zooKeeperVersion);
-      Preconditions.checkArgument(newVersion > metadataVersion,
+      checkArgument(newVersion > metadataVersion,
           "New Root version (%s) must be greater than current Metadata version (%s)", newVersion,
           metadataVersion);
       rootVersion = newVersion;
@@ -95,17 +111,17 @@ public class UpgradeProgressTracker {
 
     public synchronized void updateMetadataVersion(ServerContext context, int newVersion)
         throws KeeperException, InterruptedException {
-      Objects.requireNonNull(context, "ServerContext must be supplied");
-      Preconditions.checkArgument(newVersion <= AccumuloDataVersion.get(),
+      requireNonNull(context, "ServerContext must be supplied");
+      checkArgument(newVersion <= AccumuloDataVersion.get(),
           "New version (%s) cannot be larger than current data version (%s)", newVersion,
           AccumuloDataVersion.get());
-      Preconditions.checkArgument(newVersion > metadataVersion,
+      checkArgument(newVersion > metadataVersion,
           "New Metadata version (%s) must be greater than current version (%s)", newVersion,
           metadataVersion);
-      Preconditions.checkArgument(newVersion <= zooKeeperVersion,
+      checkArgument(newVersion <= zooKeeperVersion,
           "New Metadata version (%s) expected to be <= ZooKeeper version (%s)", newVersion,
           zooKeeperVersion);
-      Preconditions.checkArgument(newVersion <= rootVersion,
+      checkArgument(newVersion <= rootVersion,
           "New Metadata version (%s) expected to be <= Root version (%s)", newVersion, rootVersion);
       metadataVersion = newVersion;
       put(context, this);
@@ -113,49 +129,69 @@ public class UpgradeProgressTracker {
   }
 
   private static String getZPath(ServerContext context) {
-    return context.getZooKeeperRoot() + Constants.ZUPGRADE_STATUS;
+    return context.getZooKeeperRoot() + Constants.ZUPGRADE_PROGRESS;
   }
 
-  private static synchronized void put(ServerContext context, ComponentVersions cv)
+  private static void put(ServerContext context, UpgradeProgress cv)
       throws KeeperException, InterruptedException {
-    Objects.requireNonNull(context, "ServerContext must be supplied");
-    Objects.requireNonNull(cv, "ComponentVersions object  must be supplied");
+    requireNonNull(context, "ServerContext must be supplied");
+    requireNonNull(cv, "ComponentVersions object  must be supplied");
     final String zpath = getZPath(context);
-    final ZooReaderWriter zrw = context.getZooSession().asReaderWriter();
-    zrw.sync(zpath);
-    if (!zrw.exists(zpath)) {
-      zrw.mkdirs(zpath);
+    final ZooSession zs = context.getZooSession();
+    Stat stat = zs.exists(zpath, null);
+    if (stat == null) {
+      zs.create(zpath, GSON.get().toJson(cv).getBytes(UTF_8), ZooUtil.PUBLIC,
+          CreateMode.PERSISTENT);
+      cv.znodeVersion = zs.exists(zpath, null).getVersion();
+    } else {
+      try {
+        zs.setData(zpath, GSON.get().toJson(cv).getBytes(UTF_8), cv.znodeVersion);
+      } catch (KeeperException e) {
+        if (e.code() == KeeperException.Code.BADVERSION) {
+          throw new IllegalStateException(
+              "Upgrade progress information was updated by another process or thread.");
+        }
+        throw e;
+      }
     }
-    zrw.putPersistentData(zpath, GSON.get().toJson(cv).getBytes(UTF_8), NodeExistsPolicy.OVERWRITE);
   }
 
-  public static synchronized ComponentVersions get(ServerContext context)
+  public static UpgradeProgress get(ServerContext context)
       throws KeeperException, InterruptedException {
     final String zpath = getZPath(context);
     final int currentVersion = AccumuloDataVersion.getCurrentVersion(context);
     final ZooReaderWriter zrw = context.getZooSession().asReaderWriter();
-    zrw.sync(zpath);
     if (!zrw.exists(zpath)) {
-      ComponentVersions cv = new ComponentVersions();
-      cv.zooKeeperVersion = currentVersion;
-      cv.rootVersion = currentVersion;
-      cv.metadataVersion = currentVersion;
-      put(context, cv);
-      return cv;
-    } else {
-      byte[] jsonData = zrw.getData(zpath);
-      return GSON.get().fromJson(new String(jsonData, UTF_8), ComponentVersions.class);
+      try {
+        UpgradeProgress cv = new UpgradeProgress(currentVersion);
+        put(context, cv);
+        return cv;
+      } catch (IllegalStateException ise) {
+        if (ise.getMessage()
+            .equals("Upgrade progress information was updated by another process or thread.")) {
+          // there was a race condition, let this fall through and return the stored information
+          // instead
+        } else {
+          throw ise;
+        }
+      }
     }
+    Stat stat = new Stat();
+    byte[] jsonData = zrw.getData(zpath, stat);
+    UpgradeProgress progress =
+        GSON.get().fromJson(new String(jsonData, UTF_8), UpgradeProgress.class);
+    progress.znodeVersion = stat.getVersion();
+    return progress;
   }
 
   public static synchronized void upgradeComplete(ServerContext context)
       throws KeeperException, InterruptedException {
     // This should be updated prior to deleting the tracking data in zookeeper.
-    Preconditions
-        .checkState(AccumuloDataVersion.getCurrentVersion(context) == AccumuloDataVersion.get());
+    checkState(AccumuloDataVersion.getCurrentVersion(context) == AccumuloDataVersion.get(),
+        "Upgrade completed, but current version (%s) is not equal to the software version (%s)",
+        AccumuloDataVersion.getCurrentVersion(context), AccumuloDataVersion.get());
     final String zpath = getZPath(context);
     final ZooReaderWriter zrw = context.getZooSession().asReaderWriter();
-    zrw.sync(zpath);
     zrw.recursiveDelete(zpath, NodeMissingPolicy.SKIP);
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeProgressTracker.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeProgressTracker.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.manager.upgrade;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
+import java.util.Objects;
+
+import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
+import org.apache.accumulo.core.fate.zookeeper.ZooUtil.NodeExistsPolicy;
+import org.apache.accumulo.core.fate.zookeeper.ZooUtil.NodeMissingPolicy;
+import org.apache.accumulo.server.AccumuloDataVersion;
+import org.apache.accumulo.server.ServerContext;
+import org.apache.zookeeper.KeeperException;
+
+import com.google.common.base.Preconditions;
+
+public class UpgradeProgressTracker {
+
+  public static class ComponentVersions {
+    private int zooKeeperVersion;
+    private int rootVersion;
+    private int metadataVersion;
+
+    int getZooKeeperVersion() {
+      return zooKeeperVersion;
+    }
+
+    synchronized void updateZooKeeperVersion(ServerContext context, int newVersion)
+        throws KeeperException, InterruptedException {
+      Objects.requireNonNull(context, "ServerContext must be supplied");
+      Preconditions.checkArgument(newVersion > zooKeeperVersion,
+          "new version must be greater than current version");
+      zooKeeperVersion = newVersion;
+      put(context, this);
+    }
+
+    int getRootVersion() {
+      return rootVersion;
+    }
+
+    synchronized void updateRootVersion(ServerContext context, int newVersion)
+        throws KeeperException, InterruptedException {
+      Objects.requireNonNull(context, "ServerContext must be supplied");
+      Preconditions.checkArgument(newVersion > rootVersion,
+          "new version must be greater than current version");
+      rootVersion = newVersion;
+      put(context, this);
+    }
+
+    int getMetadataVersion() {
+      return metadataVersion;
+    }
+
+    synchronized void updateMetadataVersion(ServerContext context, int newVersion)
+        throws KeeperException, InterruptedException {
+      Objects.requireNonNull(context, "ServerContext must be supplied");
+      Preconditions.checkArgument(newVersion > metadataVersion,
+          "new version must be greater than current version");
+      metadataVersion = newVersion;
+      put(context, this);
+    }
+  }
+
+  private static String getZPath(ServerContext context) {
+    return context.getZooKeeperRoot() + Constants.ZUPGRADE_STATUS;
+  }
+
+  private static synchronized void put(ServerContext context, ComponentVersions cv)
+      throws KeeperException, InterruptedException {
+    final String zpath = getZPath(context);
+    final ZooReaderWriter zrw = context.getZooSession().asReaderWriter();
+    zrw.sync(zpath);
+    if (!zrw.exists(zpath)) {
+      zrw.mkdirs(zpath);
+    }
+    zrw.putPersistentData(zpath, GSON.get().toJson(cv).getBytes(UTF_8), NodeExistsPolicy.OVERWRITE);
+  }
+
+  static synchronized ComponentVersions get(ServerContext context)
+      throws KeeperException, InterruptedException {
+    final String zpath = getZPath(context);
+    final int currentVersion = AccumuloDataVersion.getCurrentVersion(context);
+    final ZooReaderWriter zrw = context.getZooSession().asReaderWriter();
+    zrw.sync(zpath);
+    if (!zrw.exists(zpath)) {
+      ComponentVersions cv = new ComponentVersions();
+      cv.zooKeeperVersion = currentVersion;
+      cv.rootVersion = currentVersion;
+      cv.metadataVersion = currentVersion;
+      put(context, cv);
+      return cv;
+    } else {
+      byte[] jsonData = zrw.getData(zpath);
+      return GSON.get().fromJson(new String(jsonData, UTF_8), ComponentVersions.class);
+    }
+  }
+
+  static synchronized void upgradeComplete(ServerContext context)
+      throws KeeperException, InterruptedException {
+    final String zpath = getZPath(context);
+    final ZooReaderWriter zrw = context.getZooSession().asReaderWriter();
+    zrw.sync(zpath);
+    if (!zrw.exists(zpath)) {
+      zrw.recursiveDelete(zpath, NodeMissingPolicy.SKIP);
+    }
+  }
+
+}

--- a/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/UpgradeProgressTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/UpgradeProgressTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.manager.upgrade;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class UpgradeProgressTest {
+
+  @Test
+  void testInitialize() {
+    var progress = new UpgradeProgress(42, 1042);
+    assertEquals(42, progress.getZooKeeperVersion());
+    assertEquals(42, progress.getRootVersion());
+    assertEquals(42, progress.getMetadataVersion());
+
+    var progress2 = new UpgradeProgress();
+    assertEquals(0, progress2.getZooKeeperVersion());
+    assertEquals(0, progress2.getRootVersion());
+    assertEquals(0, progress2.getMetadataVersion());
+  }
+
+  @Test
+  void testToFromJson() {
+    var progress = new UpgradeProgress();
+    progress.zooKeeperVersion = 5001;
+    progress.rootVersion = 5002;
+    progress.metadataVersion = 5003;
+    progress.upgradeTargetVersion = 5004;
+
+    // serialize and deserialize
+    byte[] jsonBytes = progress.toJsonBytes();
+    var progress2 = UpgradeProgress.fromJsonBytes(jsonBytes);
+    assertEquals(5001, progress2.getZooKeeperVersion());
+    assertEquals(5002, progress2.getRootVersion());
+    assertEquals(5003, progress2.getMetadataVersion());
+    assertEquals(5004, progress2.getUpgradeTargetVersion());
+
+    // show original is unchanged
+    assertEquals(5001, progress.getZooKeeperVersion());
+    assertEquals(5002, progress.getRootVersion());
+    assertEquals(5003, progress.getMetadataVersion());
+    assertEquals(5004, progress.getUpgradeTargetVersion());
+
+    // test deserialization with a test json string, so we know the deserialization/serialization is
+    // actually using json, and not some other reversible format
+    var json =
+        "{\"zooKeeperVersion\":7001,\"rootVersion\":7002,\"metadataVersion\":7003,\"upgradeTargetVersion\":7004}";
+    var progress3 = UpgradeProgress.fromJsonBytes(json.getBytes(UTF_8));
+    assertEquals(7001, progress3.getZooKeeperVersion());
+    assertEquals(7002, progress3.getRootVersion());
+    assertEquals(7003, progress3.getMetadataVersion());
+    assertEquals(7004, progress3.getUpgradeTargetVersion());
+  }
+
+}

--- a/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/UpgradeProgressTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/UpgradeProgressTest.java
@@ -40,11 +40,9 @@ class UpgradeProgressTest {
 
   @Test
   void testToFromJson() {
-    var progress = new UpgradeProgress();
-    progress.zooKeeperVersion = 5001;
-    progress.rootVersion = 5002;
-    progress.metadataVersion = 5003;
-    progress.upgradeTargetVersion = 5004;
+    var progress = new UpgradeProgress(5001, 5004);
+    progress.setRootVersion(5002);
+    progress.setMetadataVersion(5003);
 
     // serialize and deserialize
     byte[] jsonBytes = progress.toJsonBytes();

--- a/test/src/main/java/org/apache/accumulo/test/upgrade/UpgradeProgressTrackerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/upgrade/UpgradeProgressTrackerIT.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test.upgrade;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+import static org.apache.accumulo.harness.AccumuloITBase.ZOOKEEPER_TESTING_SERVER;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.reset;
+import static org.easymock.EasyMock.verify;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.File;
+import java.util.UUID;
+
+import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.fate.zookeeper.ZooUtil.NodeMissingPolicy;
+import org.apache.accumulo.core.volume.Volume;
+import org.apache.accumulo.core.volume.VolumeImpl;
+import org.apache.accumulo.core.zookeeper.ZooSession;
+import org.apache.accumulo.manager.upgrade.UpgradeProgressTracker;
+import org.apache.accumulo.manager.upgrade.UpgradeProgressTracker.ComponentVersions;
+import org.apache.accumulo.server.AccumuloDataVersion;
+import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.ServerDirs;
+import org.apache.accumulo.server.fs.VolumeManager;
+import org.apache.accumulo.server.fs.VolumeManagerImpl;
+import org.apache.accumulo.test.zookeeper.ZooKeeperTestingServer;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.zookeeper.KeeperException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@Tag(ZOOKEEPER_TESTING_SERVER)
+public class UpgradeProgressTrackerIT {
+
+  @TempDir
+  private static File tempDir;
+
+  private static final String zRoot = "/accumulo/" + UUID.randomUUID().toString();
+
+  private static ZooKeeperTestingServer testZk = null;
+  private static ZooSession zk = null;
+  private static Volume volume;
+
+  @BeforeAll
+  public static void setup() throws Exception {
+    testZk = new ZooKeeperTestingServer(tempDir);
+    zk = testZk.newClient();
+    zk.asReaderWriter().mkdirs(zRoot);
+    volume = new VolumeImpl(new Path(tempDir.toURI()), new Configuration());
+  }
+
+  @AfterAll
+  public static void teardown() throws Exception {
+    try {
+      zk.close();
+    } finally {
+      testZk.close();
+    }
+  }
+
+  private ServerContext ctx = createMock(ServerContext.class);
+  private ServerDirs sd = createMock(ServerDirs.class);
+  private VolumeManager vm = createMock(VolumeManagerImpl.class);
+
+  @BeforeEach
+  public void beforeTest() {
+    reset(ctx, sd, vm);
+    expect(ctx.getZooKeeperRoot()).andReturn(zRoot).anyTimes();
+    expect(ctx.getZooSession()).andReturn(zk).anyTimes();
+    expect(ctx.getServerDirs()).andReturn(sd).anyTimes();
+    expect(ctx.getVolumeManager()).andReturn(vm).anyTimes();
+    expect(vm.getFirst()).andReturn(volume).anyTimes();
+  }
+
+  @AfterEach
+  public void afterTest() throws KeeperException, InterruptedException {
+    verify(ctx, sd, vm);
+    zk.asReaderWriter().recursiveDelete(zRoot + Constants.ZUPGRADE_STATUS, NodeMissingPolicy.SKIP);
+  }
+
+  @Test
+  public void testGetInitial() throws KeeperException, InterruptedException {
+    expect(sd.getAccumuloPersistentVersion(volume)).andReturn(AccumuloDataVersion.get()).anyTimes();
+    replay(ctx, sd, vm);
+    ComponentVersions cv = UpgradeProgressTracker.get(ctx);
+    assertNotNull(cv);
+    assertEquals(AccumuloDataVersion.get(), cv.getZooKeeperVersion());
+    assertEquals(AccumuloDataVersion.get(), cv.getRootVersion());
+    assertEquals(AccumuloDataVersion.get(), cv.getMetadataVersion());
+    byte[] serialized = zk.asReader().getData(zRoot + Constants.ZUPGRADE_STATUS);
+    assertArrayEquals(GSON.get().toJson(cv).getBytes(UTF_8), serialized);
+  }
+
+  @Test
+  public void testUpdates() throws KeeperException, InterruptedException {
+    expect(sd.getAccumuloPersistentVersion(volume)).andReturn(AccumuloDataVersion.get() - 1)
+        .anyTimes();
+    replay(ctx, sd, vm);
+    final ComponentVersions cv = UpgradeProgressTracker.get(ctx);
+    assertNotNull(cv);
+    assertEquals(AccumuloDataVersion.get() - 1, cv.getZooKeeperVersion());
+    assertEquals(AccumuloDataVersion.get() - 1, cv.getRootVersion());
+    assertEquals(AccumuloDataVersion.get() - 1, cv.getMetadataVersion());
+    byte[] serialized = zk.asReader().getData(zRoot + Constants.ZUPGRADE_STATUS);
+    assertArrayEquals(GSON.get().toJson(cv).getBytes(UTF_8), serialized);
+
+    // Test updating out of order
+    assertThrows(IllegalArgumentException.class,
+        () -> cv.updateMetadataVersion(ctx, AccumuloDataVersion.get()));
+    assertThrows(IllegalArgumentException.class,
+        () -> cv.updateRootVersion(ctx, AccumuloDataVersion.get()));
+    serialized = zk.asReader().getData(zRoot + Constants.ZUPGRADE_STATUS);
+    assertArrayEquals(GSON.get().toJson(cv).getBytes(UTF_8), serialized);
+
+    cv.updateZooKeeperVersion(ctx, AccumuloDataVersion.get());
+    ComponentVersions cv2 = UpgradeProgressTracker.get(ctx);
+    assertNotNull(cv2);
+    assertEquals(AccumuloDataVersion.get(), cv2.getZooKeeperVersion());
+    assertEquals(AccumuloDataVersion.get() - 1, cv2.getRootVersion());
+    assertEquals(AccumuloDataVersion.get() - 1, cv2.getMetadataVersion());
+    serialized = zk.asReader().getData(zRoot + Constants.ZUPGRADE_STATUS);
+    assertArrayEquals(GSON.get().toJson(cv2).getBytes(UTF_8), serialized);
+
+    cv2.updateRootVersion(ctx, AccumuloDataVersion.get());
+    cv2 = UpgradeProgressTracker.get(ctx);
+    assertNotNull(cv2);
+    assertEquals(AccumuloDataVersion.get(), cv2.getZooKeeperVersion());
+    assertEquals(AccumuloDataVersion.get(), cv2.getRootVersion());
+    assertEquals(AccumuloDataVersion.get() - 1, cv2.getMetadataVersion());
+    serialized = zk.asReader().getData(zRoot + Constants.ZUPGRADE_STATUS);
+    assertArrayEquals(GSON.get().toJson(cv2).getBytes(UTF_8), serialized);
+
+    cv2.updateMetadataVersion(ctx, AccumuloDataVersion.get());
+    cv2 = UpgradeProgressTracker.get(ctx);
+    assertNotNull(cv2);
+    assertEquals(AccumuloDataVersion.get(), cv2.getZooKeeperVersion());
+    assertEquals(AccumuloDataVersion.get(), cv2.getRootVersion());
+    assertEquals(AccumuloDataVersion.get(), cv2.getMetadataVersion());
+    serialized = zk.asReader().getData(zRoot + Constants.ZUPGRADE_STATUS);
+    assertArrayEquals(GSON.get().toJson(cv2).getBytes(UTF_8), serialized);
+
+  }
+
+  @Test
+  public void testCompleteUpgrade() throws KeeperException, InterruptedException {
+    expect(sd.getAccumuloPersistentVersion(volume)).andReturn(AccumuloDataVersion.get()).anyTimes();
+    replay(ctx, sd, vm);
+    final ComponentVersions cv = UpgradeProgressTracker.get(ctx);
+    assertNotNull(cv);
+    assertEquals(AccumuloDataVersion.get(), cv.getZooKeeperVersion());
+    assertEquals(AccumuloDataVersion.get(), cv.getRootVersion());
+    assertEquals(AccumuloDataVersion.get(), cv.getMetadataVersion());
+    byte[] serialized = zk.asReader().getData(zRoot + Constants.ZUPGRADE_STATUS);
+    assertArrayEquals(GSON.get().toJson(cv).getBytes(UTF_8), serialized);
+
+    UpgradeProgressTracker.upgradeComplete(ctx);
+    assertFalse(zk.asReader().exists(zRoot + Constants.ZUPGRADE_STATUS));
+  }
+
+}


### PR DESCRIPTION
During an upgrade the UpgradeCoordinator will run Upgraders for each version between the current version of the stored data and the current version of the installed software. The UpgradeCoordinator runs all of the necessary Upgraders on ZooKeeper, then runs all of them on the root table, and then finally runs all of them on the metadata table. This means that when upgrading through multiple versions the version of the data stored in ZooKeeper could be multiple versions ahead of the root and metadata tables, until the Upgraders are run on those tables.

When a failure occurs in the Upgrade the system is left in a partially upgraded state. The user needs to find and fix any issues before trying to start the system again. When the Manager starts the next time it will attempt to do the upgrade from the very beginning. An Upgrader implemention for one version needs to be coded to handle the upgrade process running again, so it needs to take into account the fact that the ZooKeeper data has already been modified and skip that step, for example. However, an Upgrader for one version can't account for the changes in a future version.

This change creates a temporary object stored in ZooKeeper that is created when an upgrade starts and deleted when the upgrade finishes. It keeps track of the version of the ZooKeeper, root, and metadata as the Upgraders are run against those objects. The UpgradeCoordinator has been modified to use this object so that it does not re-run Upgraders on those objects when they have already run successfully.

Closes #5347