### PR TITLE
Removes a constructor from SimpleLoadBalancer

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/TableLoadBalancer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/TableLoadBalancer.java
@@ -56,8 +56,8 @@ public class TableLoadBalancer implements TabletBalancer {
     String context = environment.tableContext(tableId);
     Class<? extends TabletBalancer> clazz =
         ClassLoaderUtil.loadClass(context, clazzName, TabletBalancer.class);
-    Constructor<? extends TabletBalancer> constructor = clazz.getConstructor(TableId.class);
-    return constructor.newInstance(tableId);
+    Constructor<? extends TabletBalancer> constructor = clazz.getConstructor();
+    return constructor.newInstance();
   }
 
   protected String getLoadBalancerClassNameForTable(TableId table) {
@@ -98,9 +98,8 @@ public class TableLoadBalancer implements TabletBalancer {
       }
 
       if (balancer == null) {
-        log.info("Creating balancer {} limited to balancing table {}",
-            SimpleLoadBalancer.class.getName(), tableId);
-        balancer = new SimpleLoadBalancer(tableId);
+        log.info("Creating balancer {} for table {}", SimpleLoadBalancer.class.getName(), tableId);
+        balancer = new SimpleLoadBalancer();
       }
       perTableBalancers.put(tableId, balancer);
       balancer.init(environment);

--- a/core/src/test/java/org/apache/accumulo/core/spi/balancer/TableLoadBalancerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/balancer/TableLoadBalancerTest.java
@@ -101,10 +101,6 @@ public class TableLoadBalancerTest {
 
   public static class TestSimpleLoadBalancer extends SimpleLoadBalancer {
 
-    public TestSimpleLoadBalancer(TableId table) {
-      super(table);
-    }
-
     @Override
     public void init(BalancerEnvironment balancerEnvironment) {}
 


### PR DESCRIPTION
Removes the single TableId constructor from SimpleLoadBalancer and modifies the balancer logic to use the tablesToBalance method from the balancerParams.

This ensures that the SimpleLoadBalancer will only balance on a subset of tables vs balancing all tables.

