### PR TITLE
Tablet server compaction metrics NPE fix

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/metrics/CompactionExecutorsMetrics.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/metrics/CompactionExecutorsMetrics.java
@@ -61,12 +61,8 @@ public class CompactionExecutorsMetrics implements MetricsProducer {
     public void close() {
       runningSupplier = () -> 0;
       queuedSupplier = () -> 0;
-      if (running != null) {
-        running.set(0);
-      }
-      if (queued != null) {
-        queued.set(0);
-      }
+      running.set(0);
+      queued.set(0);
     }
   }
 
@@ -135,34 +131,22 @@ public class CompactionExecutorsMetrics implements MetricsProducer {
             return m;
           });
 
-          if (exm.queued != null) {
-            exm.queued.set(ecm.queued);
-          }
-          if (exm.running != null) {
-            exm.running.set(ecm.running);
-          }
+          exm.queued.set(ecm.queued);
+          exm.running.set(ecm.running);
 
         });
 
         Sets.difference(exCeMetricsMap.keySet(), seenIds).forEach(unusedId -> {
           ExMetrics exm = exCeMetricsMap.get(unusedId);
-          if (exm.queued != null) {
-            exm.queued.set(0);
-          }
-          if (exm.running != null) {
-            exm.running.set(0);
-          }
+          exm.queued.set(0);
+          exm.running.set(0);
         });
 
       }
     }
     ceMetricsList.forEach(cem -> {
-      if (cem.running != null) {
-        cem.running.set(cem.runningSupplier.getAsInt());
-      }
-      if (cem.queued != null) {
-        cem.queued.set(cem.queuedSupplier.getAsInt());
-      }
+      cem.running.set(cem.runningSupplier.getAsInt());
+      cem.queued.set(cem.queuedSupplier.getAsInt());
     });
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/metrics/CompactionExecutorsMetrics.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/metrics/CompactionExecutorsMetrics.java
@@ -61,8 +61,12 @@ public class CompactionExecutorsMetrics implements MetricsProducer {
     public void close() {
       runningSupplier = () -> 0;
       queuedSupplier = () -> 0;
-      running.set(0);
-      queued.set(0);
+      if (running != null) {
+        running.set(0);
+      }
+      if (queued != null) {
+        queued.set(0);
+      }
     }
   }
 
@@ -131,22 +135,34 @@ public class CompactionExecutorsMetrics implements MetricsProducer {
             return m;
           });
 
-          exm.queued.set(ecm.queued);
-          exm.running.set(ecm.running);
+          if (exm.queued != null) {
+            exm.queued.set(ecm.queued);
+          }
+          if (exm.running != null) {
+            exm.running.set(ecm.running);
+          }
 
         });
 
         Sets.difference(exCeMetricsMap.keySet(), seenIds).forEach(unusedId -> {
           ExMetrics exm = exCeMetricsMap.get(unusedId);
-          exm.queued.set(0);
-          exm.running.set(0);
+          if (exm.queued != null) {
+            exm.queued.set(0);
+          }
+          if (exm.running != null) {
+            exm.running.set(0);
+          }
         });
 
       }
     }
     ceMetricsList.forEach(cem -> {
-      cem.running.set(cem.runningSupplier.getAsInt());
-      cem.queued.set(cem.queuedSupplier.getAsInt());
+      if (cem.running != null) {
+        cem.running.set(cem.runningSupplier.getAsInt());
+      }
+      if (cem.queued != null) {
+        cem.queued.set(cem.queuedSupplier.getAsInt());
+      }
     });
   }
 


### PR DESCRIPTION
CeMetrics.queued, CeMetrics.running, ExMetrics.queued, ExMetrics.running are only initialized if registry is not null, but have `set()` called on them without checking registry (or equivalently, queued/running). Now check if queued/running is null before calling `set()`.

Checked all fields in `CompactionExecutorsMetrics` to see if there were any other places a NPE might occur, those 4 fields were the only ones that seemed to have this issue.

closes #5356