### PR TITLE
Modify FateStore to introduce a Seeder API

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
@@ -540,7 +540,9 @@ public class Fate<T> {
 
   public void seedTransaction(FateOperation fateOp, FateKey fateKey, Repo<T> repo,
       boolean autoCleanUp) {
-    store.seedTransaction(fateOp, fateKey, repo, autoCleanUp);
+    try (var seeder = store.beginSeeding()) {
+      var unused = seeder.attemptToSeedTransaction(fateOp, fateKey, repo, autoCleanUp);
+    }
   }
 
   // start work in the transaction.. it is safe to call this

--- a/core/src/main/java/org/apache/accumulo/core/logging/FateLogger.java
+++ b/core/src/main/java/org/apache/accumulo/core/logging/FateLogger.java
@@ -21,18 +21,22 @@ package org.apache.accumulo.core.logging;
 import java.io.Serializable;
 import java.util.EnumSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.apache.accumulo.core.fate.Fate;
+import org.apache.accumulo.core.fate.Fate.FateOperation;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.FateInstanceType;
 import org.apache.accumulo.core.fate.FateKey;
 import org.apache.accumulo.core.fate.FateStore;
 import org.apache.accumulo.core.fate.FateStore.FateTxStore;
+import org.apache.accumulo.core.fate.FateStore.Seeder;
 import org.apache.accumulo.core.fate.ReadOnlyFateStore;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.StackOverflowException;
@@ -150,19 +154,8 @@ public class FateLogger {
       }
 
       @Override
-      public Optional<FateId> seedTransaction(Fate.FateOperation fateOp, FateKey fateKey,
-          Repo<T> repo, boolean autoCleanUp) {
-        var optional = store.seedTransaction(fateOp, fateKey, repo, autoCleanUp);
-        if (storeLog.isTraceEnabled()) {
-          optional.ifPresentOrElse(fateId -> {
-            storeLog.trace("{} seeded {} {} {}", fateId, fateKey, toLogString.apply(repo),
-                autoCleanUp);
-          }, () -> {
-            storeLog.trace("Possibly unable to seed {} {} {}", fateKey, toLogString.apply(repo),
-                autoCleanUp);
-          });
-        }
-        return optional;
+      public Seeder<T> beginSeeding() {
+        return new SeederLogger<>(store, toLogString);
       }
 
       @Override
@@ -201,5 +194,42 @@ public class FateLogger {
         store.deleteDeadReservations();
       }
     };
+  }
+
+  public static class SeederLogger<T> implements Seeder<T> {
+    private final FateStore<T> store;
+    private final Seeder<T> seeder;
+    private final Function<Repo<T>,String> toLogString;
+
+    public SeederLogger(FateStore<T> store, Function<Repo<T>,String> toLogString) {
+      this.store = Objects.requireNonNull(store);
+      this.seeder = store.beginSeeding();
+      this.toLogString = Objects.requireNonNull(toLogString);
+    }
+
+    @Override
+    public CompletableFuture<Optional<FateId>> attemptToSeedTransaction(FateOperation fateOp,
+        FateKey fateKey, Repo<T> repo, boolean autoCleanUp) {
+      var future = this.seeder.attemptToSeedTransaction(fateOp, fateKey, repo, autoCleanUp);
+      return future.whenComplete((optional, throwable) -> {
+        if (storeLog.isTraceEnabled()) {
+          optional.ifPresentOrElse(fateId -> {
+            storeLog.trace("{} seeded {} {} {}", fateId, fateKey, toLogString.apply(repo),
+                autoCleanUp);
+          }, () -> {
+            storeLog.trace("Possibly unable to seed {} {} {}", fateKey, toLogString.apply(repo),
+                autoCleanUp);
+          });
+        }
+      });
+    }
+
+    @Override
+    public void close() {
+      seeder.close();
+      if (storeLog.isTraceEnabled()) {
+        storeLog.trace("attempted to close seeder for {}", store.type());
+      }
+    }
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/fate/TestStore.java
+++ b/core/src/test/java/org/apache/accumulo/core/fate/TestStore.java
@@ -29,10 +29,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
+import org.apache.accumulo.core.fate.Fate.FateOperation;
 import org.apache.accumulo.core.util.Pair;
 
 /**
@@ -53,9 +55,17 @@ public class TestStore implements FateStore<String> {
   }
 
   @Override
-  public Optional<FateId> seedTransaction(Fate.FateOperation fateOp, FateKey fateKey,
-      Repo<String> repo, boolean autoCleanUp) {
-    return Optional.empty();
+  public Seeder<String> beginSeeding() {
+    return new Seeder<>() {
+      @Override
+      public CompletableFuture<Optional<FateId>> attemptToSeedTransaction(FateOperation fateOp,
+          FateKey fateKey, Repo<String> repo, boolean autoCleanUp) {
+        return CompletableFuture.completedFuture(Optional.empty());
+      }
+
+      @Override
+      public void close() {}
+    };
   }
 
   @Override

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_1_IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_1_IT.java
@@ -32,6 +32,7 @@ import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.cr
 import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.row;
 import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.verify;
 import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.writeData;
+import static org.apache.accumulo.test.fate.FateStoreUtil.seedTransaction;
 import static org.apache.accumulo.test.util.FileMetadataUtil.countFencedFiles;
 import static org.apache.accumulo.test.util.FileMetadataUtil.splitFilesIntoRanges;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -381,7 +382,7 @@ public class ExternalCompaction_1_IT extends SharedMiniClusterBase {
     // should never run. Its purpose is to prevent the dead compaction detector
     // from deleting the id.
     Repo<Manager> repo = new FakeRepo();
-    var fateId = fateStore.seedTransaction(Fate.FateOperation.COMMIT_COMPACTION,
+    var fateId = seedTransaction(fateStore, Fate.FateOperation.COMMIT_COMPACTION,
         FateKey.forCompactionCommit(allCids.get(tableId).get(0)), repo, true).orElseThrow();
 
     // Read the tablet metadata

--- a/test/src/main/java/org/apache/accumulo/test/fate/FateStoreIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FateStoreIT.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.test.fate;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.test.fate.FateStoreUtil.TEST_FATE_OP;
+import static org.apache.accumulo.test.fate.FateStoreUtil.seedTransaction;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -299,8 +300,10 @@ public abstract class FateStoreIT extends SharedMiniClusterBase implements FateT
     FateKey fateKey2 =
         FateKey.forCompactionCommit(ExternalCompactionId.generate(UUID.randomUUID()));
 
-    var fateId1 = store.seedTransaction(TEST_FATE_OP, fateKey1, new TestRepo(), true).orElseThrow();
-    var fateId2 = store.seedTransaction(TEST_FATE_OP, fateKey2, new TestRepo(), true).orElseThrow();
+    var fateId1 =
+        seedTransaction(store, TEST_FATE_OP, fateKey1, new TestRepo(), true).orElseThrow();
+    var fateId2 =
+        seedTransaction(store, TEST_FATE_OP, fateKey2, new TestRepo(), true).orElseThrow();
 
     assertNotEquals(fateId1, fateId2);
 
@@ -334,10 +337,10 @@ public abstract class FateStoreIT extends SharedMiniClusterBase implements FateT
         new KeyExtent(TableId.of(getUniqueNames(1)[0]), new Text("zzz"), new Text("aaa"));
 
     FateKey fateKey = FateKey.forSplit(ke);
-    var fateId = store.seedTransaction(TEST_FATE_OP, fateKey, new TestRepo(), true).orElseThrow();
+    var fateId = seedTransaction(store, TEST_FATE_OP, fateKey, new TestRepo(), true).orElseThrow();
 
     // second call is empty
-    assertTrue(store.seedTransaction(TEST_FATE_OP, fateKey, new TestRepo(), true).isEmpty());
+    assertTrue(seedTransaction(store, TEST_FATE_OP, fateKey, new TestRepo(), true).isEmpty());
     assertFalse(store.seedTransaction(TEST_FATE_OP, fateId, new TestRepo(), true));
 
     var txStore = store.reserve(fateId);
@@ -363,7 +366,7 @@ public abstract class FateStoreIT extends SharedMiniClusterBase implements FateT
         new KeyExtent(TableId.of(getUniqueNames(1)[0]), new Text("zzz"), new Text("aaa"));
     FateKey fateKey = FateKey.forSplit(ke);
 
-    var fateId = store.seedTransaction(TEST_FATE_OP, fateKey, new TestRepo(), true).orElseThrow();
+    var fateId = seedTransaction(store, TEST_FATE_OP, fateKey, new TestRepo(), true).orElseThrow();
 
     var txStore = store.reserve(fateId);
     try {
@@ -372,7 +375,7 @@ public abstract class FateStoreIT extends SharedMiniClusterBase implements FateT
 
       // We have an existing transaction with the same key in progress
       // so should return an empty Optional
-      assertTrue(store.seedTransaction(TEST_FATE_OP, fateKey, new TestRepo(), true).isEmpty());
+      assertTrue(seedTransaction(store, TEST_FATE_OP, fateKey, new TestRepo(), true).isEmpty());
       assertEquals(TStatus.IN_PROGRESS, txStore.getStatus());
     } finally {
       txStore.setStatus(TStatus.SUCCESSFUL);
@@ -385,7 +388,7 @@ public abstract class FateStoreIT extends SharedMiniClusterBase implements FateT
     try {
       // After deletion, make sure we can create again with the same key
       var fateId2 =
-          store.seedTransaction(TEST_FATE_OP, fateKey, new TestRepo(), true).orElseThrow();
+          seedTransaction(store, TEST_FATE_OP, fateKey, new TestRepo(), true).orElseThrow();
       txStore = store.reserve(fateId);
       assertEquals(fateId, fateId2);
       assertTrue(txStore.timeCreated() > 0);
@@ -426,10 +429,11 @@ public abstract class FateStoreIT extends SharedMiniClusterBase implements FateT
     FateKey fateKey1 = FateKey.forSplit(ke1);
     FateKey fateKey2 = FateKey.forSplit(ke2);
 
-    var fateId1 = store.seedTransaction(TEST_FATE_OP, fateKey1, new TestRepo(), true).orElseThrow();
+    var fateId1 =
+        seedTransaction(store, TEST_FATE_OP, fateKey1, new TestRepo(), true).orElseThrow();
     var txStore = store.reserve(fateId1);
     try {
-      assertTrue(store.seedTransaction(TEST_FATE_OP, fateKey2, new TestRepo(), true).isEmpty());
+      assertTrue(seedTransaction(store, TEST_FATE_OP, fateKey2, new TestRepo(), true).isEmpty());
       assertEquals(fateKey1, txStore.getKey().orElseThrow());
     } finally {
       txStore.delete();
@@ -449,14 +453,14 @@ public abstract class FateStoreIT extends SharedMiniClusterBase implements FateT
         new KeyExtent(TableId.of(getUniqueNames(1)[0]), new Text("zzz"), new Text("aaa"));
 
     FateKey fateKey = FateKey.forSplit(ke);
-    var fateId = store.seedTransaction(TEST_FATE_OP, fateKey, new TestRepo(), true).orElseThrow();
+    var fateId = seedTransaction(store, TEST_FATE_OP, fateKey, new TestRepo(), true).orElseThrow();
 
     // After seeding a fate transaction using a key we can simulate a collision with
     // a random FateId by deleting the key out of Fate and calling seed again to
     // verify it detects the key is missing. Then we can continue and see if we can still use
     // the existing transaction.
     deleteKey(fateId, sctx);
-    assertTrue(store.seedTransaction(TEST_FATE_OP, fateKey, new TestRepo(), true).isEmpty());
+    assertTrue(seedTransaction(store, TEST_FATE_OP, fateKey, new TestRepo(), true).isEmpty());
 
     var txStore = store.reserve(fateId);
     // We should still be able to use the existing transaction
@@ -603,7 +607,7 @@ public abstract class FateStoreIT extends SharedMiniClusterBase implements FateT
       List<Future<Optional<FateId>>> futures = new ArrayList<>(10);
       for (int i = 0; i < 10; i++) {
         futures.add(executor
-            .submit(() -> store.seedTransaction(TEST_FATE_OP, fateKey, new TestRepo(), true)));
+            .submit(() -> seedTransaction(store, TEST_FATE_OP, fateKey, new TestRepo(), true)));
       }
 
       int idsSeen = 0;
@@ -685,7 +689,8 @@ public abstract class FateStoreIT extends SharedMiniClusterBase implements FateT
 
     Map<FateKey,FateId> fateKeyIds = new HashMap<>();
     for (FateKey fateKey : List.of(fateKey1, fateKey2, fateKey3, fateKey4)) {
-      var fateId = store.seedTransaction(TEST_FATE_OP, fateKey, new TestRepo(), true).orElseThrow();
+      var fateId =
+          seedTransaction(store, TEST_FATE_OP, fateKey, new TestRepo(), true).orElseThrow();
       fateKeyIds.put(fateKey, fateId);
     }
 


### PR DESCRIPTION
This adds a new Seeder API that can be used to seed transactions with a FateKey. The purpose of this new API is to allow for eventual batching of multiple seeding attempts together into one conditional mutation to improve performance. This change just updates the api and all calls to the seeder to attempt seeding will be performed individually. A future update will support the new functionality of batching and commiting all the changes together when the Seeder is closed.

This change is for Part 1 of #5160