### PR TITLE
Modified Manager.run startup to account for upgrade stages

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -1298,8 +1298,8 @@ public class Manager extends AbstractServer
           break;
       }
       try {
-        Thread.sleep(1000);
         log.debug("Manager main thread is waiting for upgrade to complete");
+        Thread.sleep(1000);
       } catch (InterruptedException e) {
         throw new IllegalStateException("Interrupted while waiting for upgrade to complete", e);
       }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -1297,6 +1297,12 @@ public class Manager extends AbstractServer
         default:
           break;
       }
+      try {
+        Thread.sleep(1000);
+        log.debug("Manager main thread is waiting for upgrade to complete");
+      } catch (InterruptedException e) {
+        throw new IllegalStateException("Interrupted while waiting for upgrade to complete", e);
+      }
     }
 
     // In the case where an upgrade is not needed, then we may not

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -1185,6 +1185,14 @@ public class Manager extends AbstractServer
 
     context.getTableManager().addObserver(this);
 
+    tableInformationStatusPool = ThreadPools.getServerThreadPools()
+        .createExecutorService(getConfiguration(), Property.MANAGER_STATUS_THREAD_POOL_SIZE, false);
+
+    tabletRefreshThreadPool = ThreadPools.getServerThreadPools().getPoolBuilder("Tablet refresh ")
+        .numCoreThreads(getConfiguration().getCount(Property.MANAGER_TABLET_REFRESH_MINTHREADS))
+        .numMaxThreads(getConfiguration().getCount(Property.MANAGER_TABLET_REFRESH_MAXTHREADS))
+        .build();
+
     Thread statusThread = Threads.createThread("Status Thread", new StatusThread());
     statusThread.start();
 
@@ -1319,14 +1327,6 @@ public class Manager extends AbstractServer
     metricsInfo.addMetricsProducers(producers.toArray(new MetricsProducer[0]));
     metricsInfo.init(MetricsInfo.serviceTags(getContext().getInstanceName(), getApplicationName(),
         sa.getAddress(), getResourceGroup()));
-
-    tableInformationStatusPool = ThreadPools.getServerThreadPools()
-        .createExecutorService(getConfiguration(), Property.MANAGER_STATUS_THREAD_POOL_SIZE, false);
-
-    tabletRefreshThreadPool = ThreadPools.getServerThreadPools().getPoolBuilder("Tablet refresh ")
-        .numCoreThreads(getConfiguration().getCount(Property.MANAGER_TABLET_REFRESH_MINTHREADS))
-        .numMaxThreads(getConfiguration().getCount(Property.MANAGER_TABLET_REFRESH_MAXTHREADS))
-        .build();
 
     Threads.createThread("Migration Cleanup Thread", new MigrationCleanupThread()).start();
     Threads.createThread("ScanServer Cleanup Thread", new ScanServerZKCleaner()).start();


### PR DESCRIPTION
Updated Manager to account for the status of an upgrate when starting processes. For example, the new fate table is created during the 4.0 upgrade, so we can't start Fate or anything that uses Fate (e.g. Splitter) until after the table has been created.

Closes #5368