### PR TITLE
logs thread id for integration tests

### DIFF
--- a/test/src/main/resources/log4j2-test.properties
+++ b/test/src/main/resources/log4j2-test.properties
@@ -25,7 +25,7 @@ appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{ISO8601} [%c{2}] %-5p: %m%n
+appender.console.layout.pattern = %d{ISO8601} %T [%c{2}] %-5p: %m%n
 
 logger.01.name = org.apache.accumulo.core
 logger.01.level = debug


### PR DESCRIPTION
This change is already present in the main branch.  Pulling it back to 2.1 as its very useful for debugging some problems to know which thread logged a message.