### PR TITLE
Don't fully start some servers until upgrade is complete.

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/AbstractServer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/AbstractServer.java
@@ -268,7 +268,6 @@ public abstract class AbstractServer
       LOG.info("Waiting for upgrade to complete.");
       Thread.sleep(1000);
     }
-
   }
 
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/AbstractServer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/AbstractServer.java
@@ -263,4 +263,12 @@ public abstract class AbstractServer
   @Override
   public void close() {}
 
+  protected void waitForUpgrade() throws InterruptedException {
+    while (AccumuloDataVersion.getCurrentVersion(getContext()) < AccumuloDataVersion.get()) {
+      LOG.info("Waiting for upgrade to complete.");
+      Thread.sleep(1000);
+    }
+
+  }
+
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/AccumuloDataVersion.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/AccumuloDataVersion.java
@@ -78,4 +78,18 @@ public class AccumuloDataVersion {
 
   public static final Set<Integer> CAN_RUN =
       Set.of(SHORTEN_RFILE_KEYS, CRYPTO_CHANGES, CURRENT_VERSION);
+
+  /**
+   * Get the stored, current working version.
+   *
+   * @param context the server context
+   * @return the stored data version
+   */
+  public static int getCurrentVersion(ServerContext context) {
+    int cv =
+        context.getServerDirs().getAccumuloPersistentVersion(context.getVolumeManager().getFirst());
+    ServerContext.ensureDataVersionCompatible(cv);
+    return cv;
+  }
+
 }

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
@@ -269,6 +269,13 @@ public class CompactionCoordinator extends AbstractServer implements
   @SuppressFBWarnings(value = "DM_EXIT", justification = "main class can call System.exit")
   public void run() {
 
+    try {
+      waitForUpgrade();
+    } catch (InterruptedException e) {
+      LOG.error("Interrupted while waiting for upgrade to complete, exiting...");
+      System.exit(1);
+    }
+
     ServerAddress coordinatorAddress = null;
     try {
       coordinatorAddress = startCoordinatorClientService();
@@ -281,13 +288,6 @@ public class CompactionCoordinator extends AbstractServer implements
       getCoordinatorLock(clientAddress);
     } catch (KeeperException | InterruptedException e) {
       throw new IllegalStateException("Exception getting Coordinator lock", e);
-    }
-
-    try {
-      waitForUpgrade();
-    } catch (InterruptedException e) {
-      LOG.error("Interrupted while waiting for upgrade to complete, exiting...");
-      System.exit(1);
     }
 
     MetricsInfo metricsInfo = getContext().getMetricsInfo();

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
@@ -281,6 +281,13 @@ public class CompactionCoordinator extends AbstractServer implements
       throw new IllegalStateException("Exception getting Coordinator lock", e);
     }
 
+    try {
+      waitForUpgrade();
+    } catch (InterruptedException e) {
+      LOG.error("Interrupted while waiting for upgrade to complete, exiting...");
+      System.exit(1);
+    }
+
     MetricsInfo metricsInfo = getContext().getMetricsInfo();
     metricsInfo.init(getServiceTags(clientAddress));
 

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
@@ -101,6 +101,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.collect.Sets;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.micrometer.core.instrument.Tag;
 
 public class CompactionCoordinator extends AbstractServer implements
@@ -265,6 +266,7 @@ public class CompactionCoordinator extends AbstractServer implements
   }
 
   @Override
+  @SuppressFBWarnings(value = "DM_EXIT", justification = "main class can call System.exit")
   public void run() {
 
     ServerAddress coordinatorAddress = null;

--- a/server/compaction-coordinator/src/test/java/org/apache/accumulo/coordinator/CompactionCoordinatorTest.java
+++ b/server/compaction-coordinator/src/test/java/org/apache/accumulo/coordinator/CompactionCoordinatorTest.java
@@ -224,6 +224,10 @@ public class CompactionCoordinatorTest {
     public Collection<Tag> getServiceTags(HostAndPort clientAddr) {
       return List.of();
     }
+
+    @Override
+    protected void waitForUpgrade() throws InterruptedException {}
+
   }
 
   @Test

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -167,6 +167,13 @@ public class SimpleGarbageCollector extends AbstractServer
       System.exit(1);
     }
 
+    try {
+      waitForUpgrade();
+    } catch (InterruptedException e) {
+      LOG.error("Interrupted while waiting for upgrade to complete, exiting...");
+      System.exit(1);
+    }
+
     MetricsInfo metricsInfo = getContext().getMetricsInfo();
 
     metricsInfo.addMetricsProducers(new GcMetrics(this));

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -152,6 +152,14 @@ public class SimpleGarbageCollector extends AbstractServer
   @Override
   @SuppressFBWarnings(value = "DM_EXIT", justification = "main class can call System.exit")
   public void run() {
+
+    try {
+      waitForUpgrade();
+    } catch (InterruptedException e) {
+      LOG.error("Interrupted while waiting for upgrade to complete, exiting...");
+      System.exit(1);
+    }
+
     final VolumeManager fs = getContext().getVolumeManager();
 
     // Sleep for an initial period, giving the manager time to start up and
@@ -164,13 +172,6 @@ public class SimpleGarbageCollector extends AbstractServer
       getZooLock(address);
     } catch (Exception ex) {
       log.error("{}", ex.getMessage(), ex);
-      System.exit(1);
-    }
-
-    try {
-      waitForUpgrade();
-    } catch (InterruptedException e) {
-      LOG.error("Interrupted while waiting for upgrade to complete, exiting...");
       System.exit(1);
     }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeCoordinator.java
@@ -160,9 +160,7 @@ public class UpgradeCoordinator {
         "Not currently in a suitable state to do zookeeper upgrade %s", status);
 
     try {
-      int cv = context.getServerDirs()
-          .getAccumuloPersistentVersion(context.getVolumeManager().getFirst());
-      ServerContext.ensureDataVersionCompatible(cv);
+      int cv = AccumuloDataVersion.getCurrentVersion(context);
       this.currentVersion = cv;
 
       if (cv == AccumuloDataVersion.get()) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -378,12 +378,21 @@ public class ScanServer extends AbstractServer
   public void run() {
     SecurityUtil.serverLogin(getConfiguration());
 
+    // Wait before getting the lock as clients using ScanServers
+    // use the lock to find them.
+    try {
+      waitForUpgrade();
+    } catch (InterruptedException e) {
+      LOG.error("Interrupted while waiting for upgrade to complete, exiting...");
+      System.exit(1);
+    }
+
     ServerAddress address = null;
     try {
       address = startScanServerClientService();
       clientAddress = address.getAddress();
     } catch (UnknownHostException e1) {
-      throw new RuntimeException("Failed to start the compactor client service", e1);
+      throw new RuntimeException("Failed to start the scan server client service", e1);
     }
 
     MetricsInfo metricsInfo = getContext().getMetricsInfo();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -127,6 +127,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 public class ScanServer extends AbstractServer
     implements TabletScanClientService.Iface, TabletHostingServer, ServerProcessService.Iface {
 
@@ -375,6 +377,7 @@ public class ScanServer extends AbstractServer
   }
 
   @Override
+  @SuppressFBWarnings(value = "DM_EXIT", justification = "main class can call System.exit")
   public void run() {
     SecurityUtil.serverLogin(getConfiguration());
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -379,16 +379,15 @@ public class ScanServer extends AbstractServer
   @Override
   @SuppressFBWarnings(value = "DM_EXIT", justification = "main class can call System.exit")
   public void run() {
-    SecurityUtil.serverLogin(getConfiguration());
 
-    // Wait before getting the lock as clients using ScanServers
-    // use the lock to find them.
     try {
       waitForUpgrade();
     } catch (InterruptedException e) {
       LOG.error("Interrupted while waiting for upgrade to complete, exiting...");
       System.exit(1);
     }
+
+    SecurityUtil.serverLogin(getConfiguration());
 
     ServerAddress address = null;
     try {


### PR DESCRIPTION
Prevent the CompactionCoordinator, GarbageCollector, and ScanServer from fully starting until the current version of software matches the version stored on disk. Backported AccumuloDataVersion.getCurrentVersion for this change.

Closes #5367