### PR TITLE
uses try w/ resources to close rfile block

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/CachableBlockFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/CachableBlockFile.java
@@ -30,7 +30,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.accumulo.core.file.rfile.BlockIndex;
 import org.apache.accumulo.core.file.rfile.bcfile.BCFile;
 import org.apache.accumulo.core.file.rfile.bcfile.BCFile.Reader.BlockReader;
@@ -50,6 +49,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.cache.Cache;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * This is a wrapper class for BCFile that includes a cache for independent caches for datablocks
@@ -339,7 +340,7 @@ public class CachableBlockFile {
       }
 
       @SuppressFBWarnings(value = {"NP_LOAD_OF_KNOWN_NULL_VALUE"},
-              justification = "Spotbugs false positive, see spotbugs issue 2836.")
+          justification = "Spotbugs false positive, see spotbugs issue 2836.")
       @Override
       public byte[] load(int maxSize, Map<String,byte[]> dependencies) {
 

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/CachableBlockFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/CachableBlockFile.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.accumulo.core.file.rfile.BlockIndex;
 import org.apache.accumulo.core.file.rfile.bcfile.BCFile;
 import org.apache.accumulo.core.file.rfile.bcfile.BCFile.Reader.BlockReader;
@@ -337,6 +338,8 @@ public class CachableBlockFile {
         return Collections.emptyMap();
       }
 
+      @SuppressFBWarnings(value = {"NP_LOAD_OF_KNOWN_NULL_VALUE"},
+              justification = "Spotbugs false positive, see spotbugs issue 2836.")
       @Override
       public byte[] load(int maxSize, Map<String,byte[]> dependencies) {
 

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/CachableBlockFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/CachableBlockFile.java
@@ -351,23 +351,18 @@ public class CachableBlockFile {
             }
           }
 
-          BlockReader _currBlock = getBlockReader(maxSize, reader);
-          if (_currBlock == null) {
-            return null;
-          }
+          try (BlockReader _currBlock = getBlockReader(maxSize, reader)) {
+            if (_currBlock == null) {
+              return null;
+            }
 
-          byte[] b = null;
-          try {
-            b = new byte[(int) _currBlock.getRawSize()];
+            byte[] b = new byte[(int) _currBlock.getRawSize()];
             _currBlock.readFully(b);
+            return b;
           } catch (IOException e) {
             log.debug("Error full blockRead for file " + cacheId + " for block " + getBlockId(), e);
             throw new UncheckedIOException(e);
-          } finally {
-            _currBlock.close();
           }
-
-          return b;
         } catch (IOException e) {
           throw new UncheckedIOException(e);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -1276,7 +1276,7 @@
         <skipITs>true</skipITs>
         <skipTests>true</skipTests>
         <sort.skip>true</sort.skip>
-        <spotbugs.skip>false</spotbugs.skip>
+        <spotbugs.skip>true</spotbugs.skip>
         <warbucks.skip>true</warbucks.skip>
       </properties>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -1276,7 +1276,7 @@
         <skipITs>true</skipITs>
         <skipTests>true</skipTests>
         <sort.skip>true</sort.skip>
-        <spotbugs.skip>true</spotbugs.skip>
+        <spotbugs.skip>false</spotbugs.skip>
         <warbucks.skip>true</warbucks.skip>
       </properties>
     </profile>


### PR DESCRIPTION
Code to read an rfile data block would close in a finally block.  If close threw an IOException then any exception in the try block would be lost in the stack trace.  Changed the code to use try w/ resources which has much better exception handling for this case.