### PR TITLE
Add deepCopy to VisibilityFilter

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/VisibilityFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/VisibilityFilter.java
@@ -72,6 +72,15 @@ public class VisibilityFilter extends Filter implements OptionDescriber {
   }
 
   @Override
+  public SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment env) {
+    VisibilityFilter result = (VisibilityFilter) super.deepCopy(env);
+    result.filterInvalid = this.filterInvalid;
+    result.accessEvaluator = this.accessEvaluator;
+    result.cache = this.cache;
+    return result;
+  }
+
+  @Override
   public boolean accept(Key k, Value v) {
     ByteSequence testVis = k.getColumnVisibilityData();
     if (filterInvalid) {

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/VisibilityFilterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/VisibilityFilterTest.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.core.iterators.user;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -240,6 +241,19 @@ public class VisibilityFilterTest {
     assertEquals("false", opts.get("filterInvalid"));
     assertEquals("true", opts.get("negate"));
     assertEquals(new Authorizations("abc", "def").serialize(), opts.get("auths"));
+  }
+
+  @Test
+  public void testDeepCopyAfterInit() throws IOException {
+    IteratorSetting is = new IteratorSetting(1, VisibilityFilter.class);
+    VisibilityFilter.setAuthorizations(is, new Authorizations("abc"));
+    Map<String,String> opts = is.getOptions();
+    Filter filter = new VisibilityFilter();
+    TreeMap<Key,Value> source = new TreeMap<>();
+    filter.init(new SortedMapIterator(source), opts, null);
+    Filter copyFilter = (Filter) filter.deepCopy(null);
+    Key k = new Key("row", "cf", "cq", "abc");
+    assertTrue(copyFilter.accept(k, new Value()));
   }
 
 }


### PR DESCRIPTION
This PR adds a `deepCopy` method to the user `VisibilityFilter` iterator.

This is a demonstration of how to solve #5372.