### PR TITLE
Fix WebViewsIT

### DIFF
--- a/server/monitor/src/test/java/org/apache/accumulo/monitor/it/WebViewsIT.java
+++ b/server/monitor/src/test/java/org/apache/accumulo/monitor/it/WebViewsIT.java
@@ -80,7 +80,7 @@ public class WebViewsIT extends JerseyTest {
     config.register(WebViewsIT.HashMapWriter.class);
   }
 
-  private static AtomicReference<Monitor> monitor = new AtomicReference<>(null);
+  private static final AtomicReference<Monitor> monitor = new AtomicReference<>(null);
 
   @BeforeAll
   public static void createMocks() throws TableNotFoundException {
@@ -123,10 +123,9 @@ public class WebViewsIT extends JerseyTest {
    * a registered MessageBodyWriter capable of serializing/writing the object returned from your
    * endpoint. We're using a simple stubbed out inner class HashMapWriter for this.
    *
-   * @throws Exception not expected
    */
   @Test
-  public void testGetTablesConstraintPassing() throws Exception {
+  public void testGetTablesConstraintPassing() {
     // Using the mocks we can verify that the getModel method gets called via debugger
     // however it's difficult to continue to mock through the jersey MVC code for the properly built
     // response.
@@ -134,7 +133,7 @@ public class WebViewsIT extends JerseyTest {
     Response output = target("tables/foo").request().get();
     assertEquals(200, output.getStatus(), "should return status 200");
     String responseBody = output.readEntity(String.class);
-    assertTrue(responseBody.contains("tableID=foo") && responseBody.contains("table=bar"));
+    assertTrue(responseBody.contains("tableId=foo") && responseBody.contains("table=bar"));
   }
 
   /**


### PR DESCRIPTION
In #5351 the URL parameter to request a page for a specific table changed from `tableID` to `tableId`. This PR updates the IT to the correct expected param `tableId`.

I also took this opportunity to make one var final in the test and remove an exception that wasn't being thrown.