### PR TITLE
Test fix: Check compactions are system compactions in the wait condition

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
@@ -997,9 +997,9 @@ public class CompactionIT extends CompactionBaseIT {
         Wait.waitFor(() -> {
           var tabletMeta = ((ClientContext) client).getAmple().readTablet(extent);
           var externalCompactions = tabletMeta.getExternalCompactions();
-          assertTrue(externalCompactions.values().stream()
-              .allMatch(ec -> ec.getKind() == CompactionKind.SYSTEM));
-          return externalCompactions.size() == 1;
+          boolean allECAreSystem = externalCompactions.values().stream()
+              .allMatch(ec -> ec.getKind() == CompactionKind.SYSTEM);
+          return allECAreSystem && externalCompactions.size() == 1;
         }, Wait.MAX_WAIT_MILLIS, 10);
 
         // Wait for the user compaction to now run after the system finishes


### PR DESCRIPTION
Noticed that one of the tests failed the assertion, causing the test to fail instead of retrying the wait loop.