### PR TITLE
implements interuption of compactions and adds an IT to verify compaction cancels on tablet migration

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/compaction/CompactionInfo.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/compaction/CompactionInfo.java
@@ -65,7 +65,7 @@ public class CompactionInfo {
   }
 
   public Thread getThread() {
-    return compactor.thread;
+    return compactor.getThread();
   }
 
   public String getOutputFile() {

--- a/server/base/src/main/java/org/apache/accumulo/server/compaction/FileCompactor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/compaction/FileCompactor.java
@@ -79,6 +79,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Collections2;
 
 import io.opentelemetry.api.trace.Span;
@@ -141,13 +142,48 @@ public class FileCompactor implements Callable<CompactionStats> {
 
   // a unique id to identify a compactor
   private final long compactorID = nextCompactorID.getAndIncrement();
-  protected volatile Thread thread;
+  private volatile Thread thread;
   private final ServerContext context;
 
   private final AtomicBoolean interruptFlag = new AtomicBoolean(false);
 
-  public void interrupt() {
+  public synchronized void interrupt() {
     interruptFlag.set(true);
+
+    if (thread != null) {
+      // Never want to interrupt the thread after clearThread was called as the thread could have
+      // moved on to something completely different than the compaction. This method and clearThread
+      // being synchronized and clearThread setting thread to null prevent this.
+      thread.interrupt();
+    }
+  }
+
+  private class ThreadClearer implements AutoCloseable {
+    @Override
+    public void close() throws InterruptedException {
+      clearThread();
+    }
+  }
+
+  private synchronized ThreadClearer setThread() {
+    thread = Thread.currentThread();
+    return new ThreadClearer();
+  }
+
+  private synchronized void clearThread() throws InterruptedException {
+    Preconditions.checkState(thread == Thread.currentThread());
+    thread = null;
+    // If the thread was interrupted during compaction do not want to allow the thread to continue
+    // w/ the interrupt status set as this could impact code unrelated to the compaction. For
+    // internal compactions the thread will execute metadata update code after the compaction and
+    // would not want the interrupt status set for that.
+    if (Thread.interrupted()) {
+      throw new InterruptedException();
+    }
+  }
+
+  Thread getThread() {
+    return thread;
   }
 
   public long getCompactorID() {
@@ -272,7 +308,8 @@ public class FileCompactor implements Callable<CompactionStats> {
   }
 
   @Override
-  public CompactionStats call() throws IOException, CompactionCanceledException {
+  public CompactionStats call()
+      throws IOException, CompactionCanceledException, InterruptedException {
 
     FileSKVWriter mfw = null;
 
@@ -290,8 +327,9 @@ public class FileCompactor implements Callable<CompactionStats> {
     String newThreadName =
         "MajC compacting " + extent + " started " + threadStartDate + " file: " + outputFile;
     Thread.currentThread().setName(newThreadName);
-    thread = Thread.currentThread();
-    try {
+    // Use try w/ resources for clearing the thread instead of finally because clearing may throw an
+    // exception. Java's handling of exceptions thrown in finally blocks is not good.
+    try (var ignored = setThread()) {
       FileOperations fileFactory = FileOperations.getInstance();
       FileSystem ns = this.fs.getFileSystemByPath(outputFile.getPath());
 
@@ -374,7 +412,6 @@ public class FileCompactor implements Callable<CompactionStats> {
     } finally {
       Thread.currentThread().setName(oldThreadName);
       if (remove) {
-        thread = null;
         runningCompactions.remove(this);
       }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
@@ -1337,6 +1337,7 @@ public class CompactableImpl implements Compactable {
       }
     }
 
+    @Override
     public void close() throws InterruptedException {
       synchronized (this) {
         Preconditions.checkState(thread == Thread.currentThread());

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
@@ -1313,6 +1313,55 @@ public class CompactableImpl implements Compactable {
     selectFiles();
   }
 
+  private final Set<CompactionInterrupter> compactionInterrupters = ConcurrentHashMap.newKeySet();
+
+  private class CompactionInterrupter implements AutoCloseable {
+    private Thread thread;
+
+    CompactionInterrupter() throws InterruptedException {
+
+      this.thread = Thread.currentThread();
+
+      if (Thread.currentThread().isInterrupted() || closed) {
+        throw new InterruptedException();
+      }
+
+      compactionInterrupters.add(this);
+      log.trace("Registered compaction interrupter for {} {}", thread.getId(), getExtent());
+    }
+
+    public synchronized void interrupt() {
+      if (thread != null) {
+        log.debug("Interrupting compaction thread {} for {}", thread.getId(), getExtent());
+        thread.interrupt();
+      }
+    }
+
+    public void close() throws InterruptedException {
+      synchronized (this) {
+        Preconditions.checkState(thread == Thread.currentThread());
+
+        // The goal of this class is not to interrupt the compaction thread after this close()
+        // method returns. Two things help achieve this goal, first we set the thread instance var
+        // null here. Second this code block and the interrupt() method are synchronized.
+        thread = null;
+      }
+
+      // call this outside of synchronized block to avoid deadlock with the locks inside the
+      // concurrent hash set
+      compactionInterrupters.remove(this);
+
+      log.trace("Unregistered compaction interrupter for {} {}", Thread.currentThread().getId(),
+          getExtent());
+
+      // Its possible the threads interrupt status was set but nothing ever checked it. For example
+      // interrupt() could have been called immediately before this method was called.
+      if (Thread.interrupted()) {
+        throw new InterruptedException();
+      }
+    }
+  }
+
   @Override
   public void compact(CompactionServiceId service, CompactionJob job, BooleanSupplier keepRunning,
       RateLimiter readLimiter, RateLimiter writeLimiter, long queuedTime) {
@@ -1332,6 +1381,7 @@ public class CompactableImpl implements Compactable {
     boolean successful = false;
     try {
       TabletLogger.compacting(getExtent(), job, cInfo.localCompactionCfg);
+
       tablet.incrementStatusMajor();
       var check = new CompactionCheck(service, kind, keepRunning, cInfo.checkCompactionId);
       TabletFile tmpFileName = tablet.getNextMapFilenameForMajc(cInfo.propagateDeletes);
@@ -1340,8 +1390,11 @@ public class CompactableImpl implements Compactable {
       SortedMap<StoredTabletFile,DataFileValue> allFiles = tablet.getDatafiles();
       HashMap<StoredTabletFile,DataFileValue> compactFiles = new HashMap<>();
       cInfo.jobFiles.forEach(file -> compactFiles.put(file, allFiles.get(file)));
-
-      stats = CompactableUtils.compact(tablet, job, cInfo, compactEnv, compactFiles, tmpFileName);
+      // Limit interrupting compactions to the part that reads and writes files and avoid
+      // interrupting the metadata table updates.
+      try (var ignored = new CompactionInterrupter()) {
+        stats = CompactableUtils.compact(tablet, job, cInfo, compactEnv, compactFiles, tmpFileName);
+      }
 
       newFile = CompactableUtils.bringOnline(tablet.getDatafileManager(), cInfo, stats,
           compactFiles, allFiles, kind, tmpFileName);
@@ -1598,6 +1651,8 @@ public class CompactableImpl implements Compactable {
       }
 
       closed = true;
+
+      compactionInterrupters.forEach(CompactionInterrupter::interrupt);
 
       // Wait while internal jobs are running or external compactions are committing. When
       // chopStatus is MARKING or selectStatus is SELECTING, there may be metadata table writes so

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
@@ -560,7 +560,7 @@ public class CompactableUtils {
   static CompactionStats compact(Tablet tablet, CompactionJob job,
       CompactableImpl.CompactionInfo cInfo, CompactionEnv cenv,
       Map<StoredTabletFile,DataFileValue> compactFiles, TabletFile tmpFileName)
-      throws IOException, CompactionCanceledException {
+      throws IOException, CompactionCanceledException, InterruptedException {
     TableConfiguration tableConf = tablet.getTableConfiguration();
 
     AccumuloConfiguration compactionConfig = getCompactionConfig(tableConf,
@@ -576,7 +576,7 @@ public class CompactableUtils {
       }
     };
     final ScheduledFuture<?> future = tablet.getContext().getScheduledExecutor()
-        .scheduleWithFixedDelay(compactionCancellerTask, 10, 10, TimeUnit.SECONDS);
+        .scheduleWithFixedDelay(compactionCancellerTask, 3, 3, TimeUnit.SECONDS);
     try {
       return compactor.call();
     } finally {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
@@ -137,7 +137,7 @@ public class MinorCompactor extends FileCompactor {
           log.warn("MinC failed ({}) to create {} retrying ...", e.getMessage(), outputFileName, e);
           reportedProblem = true;
           retryCounter++;
-        } catch (CompactionCanceledException e) {
+        } catch (CompactionCanceledException | InterruptedException e) {
           throw new IllegalStateException(e);
         }
 
@@ -161,7 +161,6 @@ public class MinorCompactor extends FileCompactor {
 
       } while (true);
     } finally {
-      thread = null;
       runningCompactions.remove(this);
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
@@ -807,51 +807,70 @@ public class CompactionIT extends AccumuloClusterHarness {
   @Test
   public void testMigrationCancelCompaction() throws Exception {
 
-    // This test creates 20 tablets w/ slow iterator, causes 20 compactions to start, and then
+    // This test creates 40 tablets w/ slow iterator, causes 40 compactions to start, and then
     // starts a new tablet server. Some of the tablets should migrate to the new tserver and cancel
     // their compaction. Because the test uses a slow iterator, if close blocks on compaction then
-    // the test should timeout.
+    // the test should timeout. Two tables are used to have different iterator settings inorder to
+    // test the two different way compactions can be canceled. Compactions can be canceled by thread
+    // interrupt or by a check that is done after a compaction iterator returns a key value.
 
-    final String table1 = this.getUniqueNames(1)[0];
+    final String[] tables = this.getUniqueNames(2);
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-
-      // TODO use newer property
-      client.instanceOperations().setProperty(Property.TSERV_MAJC_MAXCONCURRENT.getKey(), "20");
-
-      IteratorSetting setting = new IteratorSetting(50, "sleepy", SlowIterator.class);
-      setting.addOption("sleepTime", "3000");
-      setting.addOption("seekSleepTime", "3000");
+      client.instanceOperations().setProperty(
+          Property.TSERV_COMPACTION_SERVICE_DEFAULT_EXECUTORS.getKey(),
+          "[{'name':'any','numThreads':20}]".replaceAll("'", "\""));
 
       SortedSet<Text> splits = IntStream.range(1, 20).mapToObj(i -> String.format("%06d", i * 1000))
           .map(Text::new).collect(Collectors.toCollection(TreeSet::new));
-      client.tableOperations().create(table1, new NewTableConfiguration().withSplits(splits)
-          .attachIterator(setting, EnumSet.of(IteratorScope.majc)));
+
+      // This iterator is intended to cover the case of a compaction being canceled by thread
+      // interrupt.
+      IteratorSetting setting1 = new IteratorSetting(50, "sleepy", SlowIterator.class);
+      setting1.addOption("sleepTime", "300000");
+      setting1.addOption("seekSleepTime", "3000");
+      SlowIterator.sleepUninterruptibly(setting1, false);
+
+      client.tableOperations().create(tables[0], new NewTableConfiguration().withSplits(splits)
+          .attachIterator(setting1, EnumSet.of(IteratorScope.majc)));
+
+      // This iterator is intended to cover the case of compaction being canceled by the check after
+      // a key value is returned. The iterator is configured to ignore interrupts.
+      IteratorSetting setting2 = new IteratorSetting(50, "sleepy", SlowIterator.class);
+      setting2.addOption("sleepTime", "2000");
+      setting2.addOption("seekSleepTime", "2000");
+      SlowIterator.sleepUninterruptibly(setting2, true);
+
+      client.tableOperations().create(tables[1], new NewTableConfiguration().withSplits(splits)
+          .attachIterator(setting2, EnumSet.of(IteratorScope.majc)));
 
       // write files to each tablet, should cause compactions to start
-      for (int round = 0; round < 5; round++) {
-        try (var writer = client.createBatchWriter(table1)) {
-          for (int i = 0; i < 20_000; i++) {
-            Mutation m = new Mutation(String.format("%06d", i));
-            m.put("f", "q", "v");
-            writer.addMutation(m);
+      for (var table : tables) {
+        for (int round = 0; round < 5; round++) {
+          try (var writer = client.createBatchWriter(table)) {
+            for (int i = 0; i < 20_000; i++) {
+              Mutation m = new Mutation(String.format("%06d", i));
+              m.put("f", "q", "v");
+              writer.addMutation(m);
+            }
           }
+          client.tableOperations().flush(table, null, null, true);
         }
-        client.tableOperations().flush(table1, null, null, true);
       }
 
       assertEquals(2, client.instanceOperations().getTabletServers().size());
 
       var ctx = (ClientContext) client;
-      var tableId = ctx.getTableId(table1);
+      var tableId1 = ctx.getTableId(tables[0]);
+      var tableId2 = ctx.getTableId(tables[1]);
 
       Wait.waitFor(() -> {
         var runningCompactions = client.instanceOperations().getActiveCompactions().stream()
-            .filter(ac -> ac.getTablet().getTable().equals(tableId)).count();
+            .map(ac -> ac.getTablet().getTable())
+            .filter(tid -> tid.equals(tableId1) || tid.equals(tableId2)).count();
         log.debug("Running compactions {}", runningCompactions);
-        return runningCompactions == 20;
+        return runningCompactions == 40;
       });
 
-      // TODO is there a better w/ to do this w/o the cast?
       ((MiniAccumuloClusterImpl) getCluster()).getConfig().setNumTservers(3);
       getCluster().getClusterControl().start(ServerType.TABLET_SERVER, "localhost");
 
@@ -862,12 +881,17 @@ public class CompactionIT extends AccumuloClusterHarness {
       });
 
       Wait.waitFor(() -> {
-        try (var tablets = ctx.getAmple().readTablets().forTable(tableId)
+        try (var tablets = ctx.getAmple().readTablets().forLevel(Ample.DataLevel.USER)
             .fetch(ColumnType.LOCATION, ColumnType.PREV_ROW).build()) {
           Map<String,Long> counts = new HashMap<>();
           for (var tablet : tablets) {
-            if (tablet.getLocation() != null) {
-              counts.merge(tablet.getLocation().getHostPort().toString(), 1L, Long::sum);
+            if (!tablet.getTableId().equals(tableId1) && !tablet.getTableId().equals(tableId2)) {
+              continue;
+            }
+
+            if (tablet.getLocation() != null
+                && tablet.getLocation().getType() == TabletMetadata.LocationType.CURRENT) {
+              counts.merge(tablet.getLocation().getHostPort(), 1L, Long::sum);
             }
           }
 
@@ -876,12 +900,9 @@ public class CompactionIT extends AccumuloClusterHarness {
           var max = counts.values().stream().mapToLong(l -> l).max().orElse(100);
           var serversSeen = counts.keySet();
           log.debug("total:{} min:{} max:{} serversSeen:{}", total, min, max, serversSeen);
-          return total == 20 && min == 6 && max == 7 && serversSeen.size() == 3;
+          return total == 40 && min == 12 && max == 14 && serversSeen.size() == 3;
         }
       });
-
-      // TODO is there any way to check that a compaction was actually canceled? Looking in the
-      // tserver logs can see it happened.
     }
   }
 


### PR DESCRIPTION
Changed this from adding a test to adding a test and adding functionality.  Added the ability to interrupt compaction threads on tablet close.  Added an IT that covers the two ways compactions can be interrupted on compaction close.