### PR TITLE
prevents creating overlapping encryption streams

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/crypto/streams/BlockedOutputStream.java
+++ b/core/src/main/java/org/apache/accumulo/core/crypto/streams/BlockedOutputStream.java
@@ -22,7 +22,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Buffers all input in a growing buffer until flush() is called. Then entire buffer is written,
@@ -33,10 +33,10 @@ public class BlockedOutputStream extends OutputStream {
   int blockSize;
   DataOutputStream out;
   ByteBuffer bb;
-  private final AtomicInteger openCounter;
+  private final AtomicBoolean openTracker;
 
   public BlockedOutputStream(OutputStream out, int blockSize, int bufferSize,
-      AtomicInteger openCounter) {
+      AtomicBoolean openTracker) {
     if (bufferSize <= 0) {
       throw new IllegalArgumentException("bufferSize must be greater than 0.");
     }
@@ -53,7 +53,7 @@ public class BlockedOutputStream extends OutputStream {
     // some buffer space + bytes to make the buffer evened up with the cipher block size - 4 bytes
     // for the size int
     bb = ByteBuffer.allocate(bufferSize + remainder - 4);
-    this.openCounter = openCounter;
+    this.openTracker = openTracker;
   }
 
   @Override
@@ -117,6 +117,6 @@ public class BlockedOutputStream extends OutputStream {
   public void close() throws IOException {
     flush();
     out.close();
-    openCounter.compareAndSet(1, 0);
+    openTracker.compareAndSet(true, false);
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/spi/crypto/CryptoService.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/crypto/CryptoService.java
@@ -37,7 +37,8 @@ public interface CryptoService {
 
   /**
    * Initialize the FileEncrypter for the environment and return. This will get called once per
-   * R-File or Write Ahead Log. FileEncrypter implementation must be thread safe.
+   * R-File or Write Ahead Log. FileEncrypter implementation is not expected be called by multiple
+   * threads.
    */
   FileEncrypter getFileEncrypter(CryptoEnvironment environment);
 

--- a/core/src/main/java/org/apache/accumulo/core/spi/crypto/FileEncrypter.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/crypto/FileEncrypter.java
@@ -21,13 +21,14 @@ package org.apache.accumulo.core.spi.crypto;
 import java.io.OutputStream;
 
 /**
- * Class implementation that will encrypt a file. Make sure implementation is thread safe.
+ * Class implementation that will encrypt a file.
  *
  * @since 2.0
  */
 public interface FileEncrypter {
   /**
-   * Encrypt the OutputStream.
+   * Encrypt the OutputStream. Only one OutputStream is expected to be active at a time. Before a
+   * new encryption OutputStream is created the previous one is expected to be closed.
    */
   OutputStream encryptStream(OutputStream outputStream) throws CryptoService.CryptoException;
 

--- a/core/src/test/java/org/apache/accumulo/core/crypto/BlockedIOStreamTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/crypto/BlockedIOStreamTest.java
@@ -28,6 +28,7 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.security.SecureRandom;
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.accumulo.core.crypto.streams.BlockedInputStream;
 import org.apache.accumulo.core.crypto.streams.BlockedOutputStream;
@@ -44,7 +45,8 @@ public class BlockedIOStreamTest {
 
   private void writeRead(int blockSize, int expectedSize) throws IOException {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    BlockedOutputStream blockOut = new BlockedOutputStream(baos, blockSize, 1);
+    BlockedOutputStream blockOut =
+        new BlockedOutputStream(baos, blockSize, 1, new AtomicInteger(1));
 
     String contentString = "My Blocked Content String";
     byte[] content = contentString.getBytes(UTF_8);
@@ -86,7 +88,7 @@ public class BlockedIOStreamTest {
   public void testSpillingOverOutputStream() throws IOException {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     // buffer will be size 12
-    BlockedOutputStream blockOut = new BlockedOutputStream(baos, 16, 16);
+    BlockedOutputStream blockOut = new BlockedOutputStream(baos, 16, 16, new AtomicInteger(1));
 
     byte[] undersized = new byte[11];
     byte[] perfectSized = new byte[12];
@@ -129,7 +131,8 @@ public class BlockedIOStreamTest {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     int blockSize = 16;
     // buffer will be size 12
-    BlockedOutputStream blockOut = new BlockedOutputStream(baos, blockSize, blockSize);
+    BlockedOutputStream blockOut =
+        new BlockedOutputStream(baos, blockSize, blockSize, new AtomicInteger(1));
 
     int size = 1024 * 1024 * 128;
     byte[] giant = new byte[size];

--- a/core/src/test/java/org/apache/accumulo/core/crypto/BlockedIOStreamTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/crypto/BlockedIOStreamTest.java
@@ -28,7 +28,7 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.security.SecureRandom;
 import java.util.Arrays;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.accumulo.core.crypto.streams.BlockedInputStream;
 import org.apache.accumulo.core.crypto.streams.BlockedOutputStream;
@@ -46,7 +46,7 @@ public class BlockedIOStreamTest {
   private void writeRead(int blockSize, int expectedSize) throws IOException {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     BlockedOutputStream blockOut =
-        new BlockedOutputStream(baos, blockSize, 1, new AtomicInteger(1));
+        new BlockedOutputStream(baos, blockSize, 1, new AtomicBoolean(true));
 
     String contentString = "My Blocked Content String";
     byte[] content = contentString.getBytes(UTF_8);
@@ -88,7 +88,7 @@ public class BlockedIOStreamTest {
   public void testSpillingOverOutputStream() throws IOException {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     // buffer will be size 12
-    BlockedOutputStream blockOut = new BlockedOutputStream(baos, 16, 16, new AtomicInteger(1));
+    BlockedOutputStream blockOut = new BlockedOutputStream(baos, 16, 16, new AtomicBoolean(true));
 
     byte[] undersized = new byte[11];
     byte[] perfectSized = new byte[12];
@@ -132,7 +132,7 @@ public class BlockedIOStreamTest {
     int blockSize = 16;
     // buffer will be size 12
     BlockedOutputStream blockOut =
-        new BlockedOutputStream(baos, blockSize, blockSize, new AtomicInteger(1));
+        new BlockedOutputStream(baos, blockSize, blockSize, new AtomicBoolean(true));
 
     int size = 1024 * 1024 * 128;
     byte[] giant = new byte[size];

--- a/core/src/test/java/org/apache/accumulo/core/crypto/CryptoTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/crypto/CryptoTest.java
@@ -562,6 +562,30 @@ public class CryptoTest {
     }
   }
 
+  @Test
+  public void testOverlappingWrites() throws Exception {
+    testOverlappingWrites(WAL);
+    testOverlappingWrites(TABLE);
+  }
+
+  private void testOverlappingWrites(Scope scope) throws Exception {
+    AESCryptoService cs = new AESCryptoService();
+    cs.init(getAllCryptoProperties(ConfigMode.CRYPTO_TABLE_ON));
+    CryptoEnvironment encEnv = new CryptoEnvironmentImpl(scope, null, null);
+    FileEncrypter encrypter = cs.getFileEncrypter(encEnv);
+
+    ByteArrayOutputStream out1 = new ByteArrayOutputStream();
+    var es1 = encrypter.encryptStream(out1);
+
+    // try to create a new encryption stream w/o closing the previous one
+    ByteArrayOutputStream out2 = new ByteArrayOutputStream();
+    var ce = assertThrows(CryptoException.class, () -> encrypter.encryptStream(out2));
+    assertTrue(ce.getMessage().contains("closing previous"));
+
+    es1.close();
+    var es2 = encrypter.encryptStream(out2);
+  }
+
   private ArrayList<Key> testData() {
     ArrayList<Key> keys = new ArrayList<>();
     keys.add(new Key("a", "cf", "cq"));


### PR DESCRIPTION
Modified AESCryptoService to detect creation of multiple encryptions streams at the same time. The implementation in AESCryptoService does not support this because it uses shared Cipher object and shrared intialization vectors.  The code that uses CryptoService does not seem to have a need for creating more that one encryption stream at a time. If the usage pattern of the code change, then the detection added in this commit should catch that.

fixes #5386