### PR TITLE
Fixed UpgradeCoordinator, UpgradeProgressTracker, and Upgrader12to13

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeCoordinator.java
@@ -195,9 +195,9 @@ public class UpgradeCoordinator {
 
         for (int upgradeVersion = currentVersion; upgradeVersion < AccumuloDataVersion.get();
             upgradeVersion++) {
-          if (progress.getZooKeeperVersion() >= upgradeVersion) {
+          if (progress.getZooKeeperVersion() > upgradeVersion) {
             log.info(
-                "ZooKeeper has already been upgraded to version {}, moving on to next upgrader",
+                "ZooKeeper has already run upgrader for version {}, moving on to next upgrader",
                 upgradeVersion);
             continue;
           }
@@ -207,7 +207,11 @@ public class UpgradeCoordinator {
           Objects.requireNonNull(upgrader,
               "upgrade ZooKeeper: failed to find upgrader for version " + upgradeVersion);
           upgrader.upgradeZookeeper(context);
-          progressTracker.updateZooKeeperVersion(upgradeVersion);
+          // The current version and the versions in the upgraders map are equal. For example,
+          // if the current version is 10, then the code above will get the Upgrader for version
+          // 10 from the upgraders map. It will run the Upgrader10to11 code, which means that the
+          // current version of ZooKeeper after running the upgrade is 11.
+          progressTracker.updateZooKeeperVersion(upgradeVersion + 1);
         }
       }
 
@@ -235,9 +239,9 @@ public class UpgradeCoordinator {
               UpgradeProgress progress = progressTracker.getProgress();
               for (int upgradeVersion = currentVersion; upgradeVersion < AccumuloDataVersion.get();
                   upgradeVersion++) {
-                if (progress.getRootVersion() >= upgradeVersion) {
+                if (progress.getRootVersion() > upgradeVersion) {
                   log.info(
-                      "Root table has already been upgraded to version {}, moving on to next upgrader",
+                      "Root table has already run upgrader for version {}, moving on to next upgrader",
                       upgradeVersion);
                   continue;
                 }
@@ -247,15 +251,19 @@ public class UpgradeCoordinator {
                 Objects.requireNonNull(upgrader,
                     "upgrade root: failed to find root upgrader for version " + upgradeVersion);
                 upgraders.get(upgradeVersion).upgradeRoot(context);
-                progressTracker.updateRootVersion(upgradeVersion);
+                // The current version and the versions in the upgraders map are equal. For example,
+                // if the current version is 10, then the code above will get the Upgrader for
+                // version 10 from the upgraders map. It will run the Upgrader10to11 code, which
+                // means that the current version of ZooKeeper after running the upgrade is 11.
+                progressTracker.updateRootVersion(upgradeVersion + 1);
               }
               setStatus(UpgradeStatus.UPGRADED_ROOT, eventCoordinator);
 
               for (int upgradeVersion = currentVersion; upgradeVersion < AccumuloDataVersion.get();
                   upgradeVersion++) {
-                if (progress.getMetadataVersion() >= upgradeVersion) {
+                if (progress.getMetadataVersion() > upgradeVersion) {
                   log.info(
-                      "Metadata table has already been upgraded to version {}, moving on to next upgrader",
+                      "Metadata table has already run upgrader for version {}, moving on to next upgrader",
                       upgradeVersion);
                   continue;
                 }
@@ -266,7 +274,11 @@ public class UpgradeCoordinator {
                 Objects.requireNonNull(upgrader,
                     "upgrade metadata: failed to find upgrader for version " + upgradeVersion);
                 upgraders.get(upgradeVersion).upgradeMetadata(context);
-                progressTracker.updateMetadataVersion(upgradeVersion);
+                // The current version and the versions in the upgraders map are equal. For example,
+                // if the current version is 10, then the code above will get the Upgrader for
+                // version 10 from the upgraders map. It will run the Upgrader10to11 code, which
+                // means that the current version of ZooKeeper after running the upgrade is 11.
+                progressTracker.updateMetadataVersion(upgradeVersion + 1);
               }
               setStatus(UpgradeStatus.UPGRADED_METADATA, eventCoordinator);
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeProgressTracker.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeProgressTracker.java
@@ -90,7 +90,7 @@ public class UpgradeProgressTracker {
     checkArgument(newVersion > progress.getRootVersion(),
         "New ZooKeeper version (%s) expected to be greater than the root version (%s)", newVersion,
         progress.getRootVersion());
-    checkArgument(progress.getMetadataVersion() == progress.getRootVersion(),
+    checkState(progress.getMetadataVersion() == progress.getRootVersion(),
         "Root (%s) and Metadata (%s) versions expected to be equal when upgrading ZooKeeper",
         progress.getRootVersion(), progress.getMetadataVersion());
     progress.setZooKeeperVersion(newVersion);
@@ -98,7 +98,7 @@ public class UpgradeProgressTracker {
   }
 
   public synchronized void updateRootVersion(int newVersion) {
-    checkArgument(progress.getZooKeeperVersion() == AccumuloDataVersion.get(),
+    checkState(progress.getZooKeeperVersion() == AccumuloDataVersion.get(),
         "ZooKeeper has not been upgraded to version %s yet, currently at %s, cannot upgrade Root yet",
         AccumuloDataVersion.get(), progress.getZooKeeperVersion());
     checkArgument(newVersion <= AccumuloDataVersion.get(),
@@ -118,7 +118,7 @@ public class UpgradeProgressTracker {
   }
 
   public synchronized void updateMetadataVersion(int newVersion) {
-    checkArgument(progress.getRootVersion() == AccumuloDataVersion.get(),
+    checkState(progress.getRootVersion() == AccumuloDataVersion.get(),
         "Root has not been upgraded to version %s yet, currently at %s, cannot upgrade Metadata yet",
         AccumuloDataVersion.get(), progress.getRootVersion());
     checkArgument(newVersion <= AccumuloDataVersion.get(),
@@ -162,13 +162,13 @@ public class UpgradeProgressTracker {
   }
 
   public synchronized void upgradeComplete() {
-    checkArgument(progress.getZooKeeperVersion() == AccumuloDataVersion.get(),
+    checkState(progress.getZooKeeperVersion() == AccumuloDataVersion.get(),
         "ZooKeeper upgrade has not completed, expected version %s, currently at %s",
         AccumuloDataVersion.get(), progress.getZooKeeperVersion());
-    checkArgument(progress.getRootVersion() == AccumuloDataVersion.get(),
+    checkState(progress.getRootVersion() == AccumuloDataVersion.get(),
         "Root upgrade has not completed, expected version %s, currently at %s",
         AccumuloDataVersion.get(), progress.getRootVersion());
-    checkArgument(progress.getMetadataVersion() == AccumuloDataVersion.get(),
+    checkState(progress.getMetadataVersion() == AccumuloDataVersion.get(),
         "Metadata upgrade has not completed, expected version %s, currently at %s",
         AccumuloDataVersion.get(), progress.getMetadataVersion());
     // This should be updated prior to deleting the tracking data in zookeeper.

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeProgressTracker.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeProgressTracker.java
@@ -99,7 +99,7 @@ public class UpgradeProgressTracker {
 
   public synchronized void updateRootVersion(int newVersion) {
     checkArgument(progress.getZooKeeperVersion() == AccumuloDataVersion.get(),
-        "ZooKeeper has not been upgraded to version {} yet, currently at {}, cannot upgrade Root yet",
+        "ZooKeeper has not been upgraded to version %s yet, currently at %s, cannot upgrade Root yet",
         AccumuloDataVersion.get(), progress.getZooKeeperVersion());
     checkArgument(newVersion <= AccumuloDataVersion.get(),
         "New version (%s) cannot be larger than current data version (%s)", newVersion,
@@ -119,7 +119,7 @@ public class UpgradeProgressTracker {
 
   public synchronized void updateMetadataVersion(int newVersion) {
     checkArgument(progress.getRootVersion() == AccumuloDataVersion.get(),
-        "Root has not been upgraded to version {} yet, currently at {}, cannot upgrade Metadata yet",
+        "Root has not been upgraded to version %s yet, currently at %s, cannot upgrade Metadata yet",
         AccumuloDataVersion.get(), progress.getRootVersion());
     checkArgument(newVersion <= AccumuloDataVersion.get(),
         "New version (%s) cannot be larger than current data version (%s)", newVersion,
@@ -163,13 +163,13 @@ public class UpgradeProgressTracker {
 
   public synchronized void upgradeComplete() {
     checkArgument(progress.getZooKeeperVersion() == AccumuloDataVersion.get(),
-        "ZooKeeper upgrade has not completed, expected version {}, currently at {}",
+        "ZooKeeper upgrade has not completed, expected version %s, currently at %s",
         AccumuloDataVersion.get(), progress.getZooKeeperVersion());
     checkArgument(progress.getRootVersion() == AccumuloDataVersion.get(),
-        "Root upgrade has not completed, expected version {}, currently at {}",
+        "Root upgrade has not completed, expected version %s, currently at %s",
         AccumuloDataVersion.get(), progress.getRootVersion());
     checkArgument(progress.getMetadataVersion() == AccumuloDataVersion.get(),
-        "Metadata upgrade has not completed, expected version {}, currently at {}",
+        "Metadata upgrade has not completed, expected version %s, currently at %s",
         AccumuloDataVersion.get(), progress.getMetadataVersion());
     // This should be updated prior to deleting the tracking data in zookeeper.
     checkState(AccumuloDataVersion.getCurrentVersion(context) == AccumuloDataVersion.get(),

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeProgressTracker.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeProgressTracker.java
@@ -98,6 +98,9 @@ public class UpgradeProgressTracker {
   }
 
   public synchronized void updateRootVersion(int newVersion) {
+    checkArgument(progress.getZooKeeperVersion() == AccumuloDataVersion.get(),
+        "ZooKeeper has not been upgraded to version {} yet, currently at {}, cannot upgrade Root yet",
+        AccumuloDataVersion.get(), progress.getZooKeeperVersion());
     checkArgument(newVersion <= AccumuloDataVersion.get(),
         "New version (%s) cannot be larger than current data version (%s)", newVersion,
         AccumuloDataVersion.get());
@@ -115,6 +118,9 @@ public class UpgradeProgressTracker {
   }
 
   public synchronized void updateMetadataVersion(int newVersion) {
+    checkArgument(progress.getRootVersion() == AccumuloDataVersion.get(),
+        "Root has not been upgraded to version {} yet, currently at {}, cannot upgrade Metadata yet",
+        AccumuloDataVersion.get(), progress.getRootVersion());
     checkArgument(newVersion <= AccumuloDataVersion.get(),
         "New version (%s) cannot be larger than current data version (%s)", newVersion,
         AccumuloDataVersion.get());
@@ -156,6 +162,15 @@ public class UpgradeProgressTracker {
   }
 
   public synchronized void upgradeComplete() {
+    checkArgument(progress.getZooKeeperVersion() == AccumuloDataVersion.get(),
+        "ZooKeeper upgrade has not completed, expected version {}, currently at {}",
+        AccumuloDataVersion.get(), progress.getZooKeeperVersion());
+    checkArgument(progress.getRootVersion() == AccumuloDataVersion.get(),
+        "Root upgrade has not completed, expected version {}, currently at {}",
+        AccumuloDataVersion.get(), progress.getRootVersion());
+    checkArgument(progress.getMetadataVersion() == AccumuloDataVersion.get(),
+        "Metadata upgrade has not completed, expected version {}, currently at {}",
+        AccumuloDataVersion.get(), progress.getMetadataVersion());
     // This should be updated prior to deleting the tracking data in zookeeper.
     checkState(AccumuloDataVersion.getCurrentVersion(context) == AccumuloDataVersion.get(),
         "Upgrade completed, but current version (%s) is not equal to the software version (%s)",

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader12to13.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader12to13.java
@@ -87,8 +87,6 @@ public class Upgrader12to13 implements Upgrader {
 
   @Override
   public void upgradeRoot(ServerContext context) {
-    LOG.info("Creating table {}", AccumuloTable.FATE.tableName());
-    createFateTable(context);
     LOG.info("Looking for partial splits");
     handlePartialSplits(context, AccumuloTable.ROOT.tableName());
     LOG.info("setting metadata table hosting availability");
@@ -101,6 +99,8 @@ public class Upgrader12to13 implements Upgrader {
 
   @Override
   public void upgradeMetadata(ServerContext context) {
+    LOG.info("Creating table {}", AccumuloTable.FATE.tableName());
+    createFateTable(context);
     LOG.info("Looking for partial splits");
     handlePartialSplits(context, AccumuloTable.METADATA.tableName());
     LOG.info("setting hosting availability on user tables");
@@ -128,8 +128,20 @@ public class Upgrader12to13 implements Upgrader {
   }
 
   private void createFateTable(ServerContext context) {
-    ZooKeeperInitializer zkInit = new ZooKeeperInitializer();
-    zkInit.initFateTableState(context);
+
+    if (context.tableOperations().exists(AccumuloTable.FATE.tableName())) {
+      LOG.info("Fate table already exists");
+      return;
+    }
+
+    try {
+      ZooKeeperInitializer zkInit = new ZooKeeperInitializer();
+      zkInit.initFateTableState(context);
+    } catch (Exception e) {
+      if (e.getCause() instanceof KeeperException.NodeExistsException) {
+        LOG.debug("Fate table node already exists in ZooKeeper");
+      }
+    }
 
     try {
       FileSystemInitializer initializer = new FileSystemInitializer(
@@ -222,7 +234,7 @@ public class Upgrader12to13 implements Upgrader {
     // FATE transaction ids have changed from 3.x to 4.x which are used as the value for the bulk
     // file column. FATE ops won't persist through upgrade, so these columns can be safely deleted
     // if they exist.
-    try (var scanner = context.createScanner(tableName);
+    try (var scanner = context.createScanner(tableName, Authorizations.EMPTY);
         var writer = context.createBatchWriter(tableName)) {
       scanner.setRange(MetadataSchema.TabletsSection.getRange());
       scanner.fetchColumnFamily(TabletsSection.BulkFileColumnFamily.NAME);

--- a/test/src/main/java/org/apache/accumulo/test/upgrade/UpgradeProgressTrackerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/upgrade/UpgradeProgressTrackerIT.java
@@ -180,9 +180,9 @@ public class UpgradeProgressTrackerIT {
     assertArrayEquals(GSON.get().toJson(progress).getBytes(UTF_8), serialized);
 
     // Test updating out of order
-    assertThrows(IllegalArgumentException.class,
+    assertThrows(IllegalStateException.class,
         () -> progressTracker.updateMetadataVersion(AccumuloDataVersion.get()));
-    assertThrows(IllegalArgumentException.class,
+    assertThrows(IllegalStateException.class,
         () -> progressTracker.updateRootVersion(AccumuloDataVersion.get()));
     serialized = zk.asReader().getData(zRoot + Constants.ZUPGRADE_PROGRESS);
     assertArrayEquals(GSON.get().toJson(progress).getBytes(UTF_8), serialized);


### PR DESCRIPTION
Updated the UpgradeCoordinator to fix what is essentially an off by one bug. The version of the instance and the key in the upgraders map did not match the way the code was processing the versions.

Updated the UpgradeProgressTracker with additional checks.

Updated Upgrader12to13 methods to be invoked during the appropriate phase and to be re-entrant.