### PR TITLE
Fix MetadataIT tablet mergeability check

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/functional/MetadataIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MetadataIT.java
@@ -59,6 +59,7 @@ import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.TablePermission;
+import org.apache.accumulo.core.util.time.SteadyTime;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.AfterAll;
@@ -291,12 +292,23 @@ public class MetadataIT extends SharedMiniClusterBase {
     assertEquals(maxVersions,
         tableProps.get(Property.TABLE_ITERATOR_PREFIX.getKey() + "majc.vers.opt.maxVersions"));
 
-    // Verify all tablets are HOSTED and Mergeablity is NEVER
+    // Verify all tablets are HOSTED and initial TabletMergeability settings
+    var metaSplit = MetadataSchema.TabletsSection.getRange().getEndKey().getRow();
+    var initAlwaysMergeable =
+        TabletMergeabilityMetadata.always(SteadyTime.from(Duration.ofMillis(0)));
     try (var tablets = client.getAmple().readTablets().forTable(tableId).build()) {
       assertTrue(
           tablets.stream().allMatch(tm -> tm.getTabletAvailability() == TabletAvailability.HOSTED));
-      assertTrue(tablets.stream()
-          .allMatch(tm -> tm.getTabletMergeability().equals(TabletMergeabilityMetadata.never())));
+      assertTrue(tablets.stream().allMatch(tm -> {
+        // ROOT table and Metadata TabletsSection tablet should be set to never mergeable
+        // All other initial tablets for Metadata, Fate, Scanref should be always
+        if (AccumuloTable.ROOT.tableId().equals(tableId)
+            || (AccumuloTable.METADATA.tableId().equals(tableId)
+                && metaSplit.equals(tm.getEndRow()))) {
+          return tm.getTabletMergeability().equals(TabletMergeabilityMetadata.never());
+        }
+        return tm.getTabletMergeability().equals(initAlwaysMergeable);
+      }));
     }
   }
 }


### PR DESCRIPTION
PR #5353 changed the default TabletMergeability setting for initial system tablets to be always for scanref, fate, and the default metadata tablet. The root tablet and tablets section metadata tablet are still set to "never" and the test needed to be updated to account for this.

This closes #5406 