### PR TITLE
removes root path from lock id serialization

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
@@ -45,7 +45,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.access.AccessEvaluator;
 import org.apache.accumulo.access.InvalidAccessExpressionException;
-import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.ConditionalWriter;
@@ -683,7 +682,7 @@ public class ConditionalWriterImpl implements ConditionalWriter {
 
     long startTime = System.currentTimeMillis();
 
-    LockID lid = new LockID(Constants.ZTSERVERS, sessionId.lockId);
+    LockID lid = LockID.deserialize(sessionId.lockId);
 
     while (true) {
       if (!ServiceLock.isLockHeld(context.getZooCache(), lid)) {

--- a/core/src/main/java/org/apache/accumulo/core/fate/FateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/FateStore.java
@@ -208,7 +208,7 @@ public interface FateStore<T> extends ReadOnlyFateStore<T> {
     private static byte[] serialize(ZooUtil.LockID lockID, UUID reservationUUID) {
       try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
           DataOutputStream dos = new DataOutputStream(baos)) {
-        dos.writeUTF(lockID.serialize("/"));
+        dos.writeUTF(lockID.serialize());
         dos.writeUTF(reservationUUID.toString());
         dos.close();
         return baos.toByteArray();
@@ -220,7 +220,7 @@ public interface FateStore<T> extends ReadOnlyFateStore<T> {
     public static FateReservation deserialize(byte[] serialized) {
       try (DataInputBuffer buffer = new DataInputBuffer()) {
         buffer.reset(serialized, serialized.length);
-        ZooUtil.LockID lockID = new ZooUtil.LockID("", buffer.readUTF());
+        ZooUtil.LockID lockID = ZooUtil.LockID.deserialize(buffer.readUTF());
         UUID reservationUUID = UUID.fromString(buffer.readUTF());
         return new FateReservation(lockID, reservationUUID);
       } catch (IOException e) {
@@ -230,7 +230,7 @@ public interface FateStore<T> extends ReadOnlyFateStore<T> {
 
     @Override
     public String toString() {
-      return lockID.serialize("/") + ":" + reservationUUID;
+      return lockID.serialize() + ":" + reservationUUID;
     }
 
     @Override

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooUtil.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
+import java.util.function.Supplier;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.data.InstanceId;
@@ -44,6 +45,9 @@ import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Suppliers;
 
 public class ZooUtil {
 
@@ -67,8 +71,39 @@ public class ZooUtil {
     public final long eid;
     public final String path;
     public final String node;
+    private final Supplier<String> serialized;
 
-    public LockID(String root, String serializedLID) {
+    public LockID(String path, String node, long eid) {
+      // Do not allow the path to end with / because this would cause problems for serialization. Do
+      // not allow $ char in path as this would cause problems for serialization. Current code does
+      // not pass these as input. The path is expected to be an absolute path, so check it starts
+      // with /.
+      Preconditions.checkArgument(
+          path != null && !path.contains("$") && path.startsWith("/") && !path.endsWith("/"),
+          "Illegal path %s", path);
+      // Do not allow $ and / chars in the node name as this would cause problems for serialization.
+      // Current code does not pass these as input.
+      Preconditions.checkArgument(
+          node != null && !node.contains("$") && !node.contains("/") && !node.isEmpty(),
+          "Illegal node name %s", node);
+      this.path = path;
+      this.node = node;
+      this.eid = eid;
+      this.serialized = Suppliers.memoize(() -> path + "/" + node + "$" + Long.toHexString(eid));
+    }
+
+    /**
+     * Returns serialized form of this object that can be deserialized using
+     * {@link #deserialize(String)}
+     */
+    public String serialize() {
+      return serialized.get();
+    }
+
+    /**
+     * Deserializes a lock id created by {@link #serialize()}
+     */
+    public static LockID deserialize(String serializedLID) {
       String[] sa = serializedLID.split("\\$");
       int lastSlash = sa[0].lastIndexOf('/');
 
@@ -76,24 +111,8 @@ public class ZooUtil {
         throw new IllegalArgumentException("Malformed serialized lock id " + serializedLID);
       }
 
-      var tmpPath = root + "/" + sa[0].substring(0, lastSlash);
-      if (tmpPath.endsWith("/") && tmpPath.length() > 1) {
-        tmpPath = tmpPath.substring(0, tmpPath.length() - 1);
-      }
-      path = tmpPath;
-
-      node = sa[0].substring(lastSlash + 1);
-      eid = Long.parseUnsignedLong(sa[1], 16);
-    }
-
-    public LockID(String path, String node, long eid) {
-      this.path = path;
-      this.node = node;
-      this.eid = eid;
-    }
-
-    public String serialize(String root) {
-      return path.substring(root.length()) + "/" + node + "$" + Long.toHexString(eid);
+      return new LockID(sa[0].substring(0, lastSlash), sa[0].substring(lastSlash + 1),
+          Long.parseUnsignedLong(sa[1], 16));
     }
 
     @Override

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooUtil.java
@@ -74,10 +74,7 @@ public class ZooUtil {
     private final Supplier<String> serialized;
 
     public LockID(String path, String node, long eid) {
-      // Do not allow the path to end with / because this would cause problems for serialization. Do
-      // not allow $ char in path as this would cause problems for serialization. Current code does
-      // not pass these as input. The path is expected to be an absolute path, so check it starts
-      // with /.
+      // path must start with a '/', must not end with one, and must not contain '$'.
       Preconditions.checkArgument(
           path != null && !path.contains("$") && path.startsWith("/") && !path.endsWith("/"),
           "Illegal path %s", path);

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooUtil.java
@@ -74,11 +74,13 @@ public class ZooUtil {
     private final Supplier<String> serialized;
 
     public LockID(String path, String node, long eid) {
-      // path must start with a '/', must not end with one, and must not contain '$'.
+      // path must start with a '/', must not end with one, and must not contain '$'. These chars
+      // would cause problems for serialization.
       Preconditions.checkArgument(
           path != null && !path.contains("$") && path.startsWith("/") && !path.endsWith("/"),
           "Illegal path %s", path);
-      // node must not contain '$' or '/'
+      // node must not contain '$' or '/' because these chars would cause problems for
+      // serialization.
       Preconditions.checkArgument(
           node != null && !node.contains("$") && !node.contains("/") && !node.isEmpty(),
           "Illegal node name %s", node);

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooUtil.java
@@ -78,8 +78,7 @@ public class ZooUtil {
       Preconditions.checkArgument(
           path != null && !path.contains("$") && path.startsWith("/") && !path.endsWith("/"),
           "Illegal path %s", path);
-      // Do not allow $ and / chars in the node name as this would cause problems for serialization.
-      // Current code does not pass these as input.
+      // node must not contain '$' or '/'
       Preconditions.checkArgument(
           node != null && !node.contains("$") && !node.contains("/") && !node.isEmpty(),
           "Illegal node name %s", node);

--- a/core/src/main/java/org/apache/accumulo/core/lock/ServiceLock.java
+++ b/core/src/main/java/org/apache/accumulo/core/lock/ServiceLock.java
@@ -370,6 +370,7 @@ public class ServiceLock implements Watcher {
   private void lostLock(LockLossReason reason) {
     LockWatcher localLw = lockWatcher;
     lockNodeName = null;
+    lockId = null;
     lockWatcher = null;
 
     localLw.lostLock(reason);
@@ -536,6 +537,7 @@ public class ServiceLock implements Watcher {
     String localLock = lockNodeName;
 
     lockNodeName = null;
+    lockId = null;
     lockWatcher = null;
 
     final String pathToDelete = path + "/" + localLock;
@@ -574,11 +576,18 @@ public class ServiceLock implements Watcher {
     return lockNodeName;
   }
 
+  private LockID lockId = null;
+
   public synchronized LockID getLockID() {
     if (lockNodeName == null) {
       throw new IllegalStateException("Lock not held");
     }
-    return new LockID(path.toString(), lockNodeName, zooKeeper.getSessionId());
+
+    if (lockId == null) {
+      lockId = new LockID(path.toString(), lockNodeName, zooKeeper.getSessionId());
+    }
+
+    return lockId;
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMutatorBase.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMutatorBase.java
@@ -195,7 +195,7 @@ public abstract class TabletMutatorBase<T extends Ample.TabletUpdates<T>>
 
   protected T putZooLock(ServiceLock zooLock) {
     Preconditions.checkState(updatesEnabled, "Cannot make updates after calling mutate.");
-    ServerColumnFamily.LOCK_COLUMN.put(mutation, new Value(zooLock.getLockID().serialize("/")));
+    ServerColumnFamily.LOCK_COLUMN.put(mutation, new Value(zooLock.getLockID().serialize()));
     return getThis();
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/fate/zookeeper/LockIdTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/fate/zookeeper/LockIdTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.fate.zookeeper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.apache.accumulo.core.fate.zookeeper.ZooUtil.LockID;
+import org.junit.jupiter.api.Test;
+
+public class LockIdTest {
+
+  @Test
+  public void testNormalUse() {
+    var lockId = new LockID("/p1", "n1", 42);
+    assertEquals("/p1", lockId.path);
+    assertEquals("n1", lockId.node);
+    assertEquals(42, lockId.eid);
+    assertEquals("/p1/n1$2a", lockId.serialize());
+    assertEquals(lockId, lockId);
+
+    var lockId2 = LockID.deserialize(lockId.serialize());
+    assertEquals("/p1", lockId2.path);
+    assertEquals("n1", lockId2.node);
+    assertEquals(42, lockId2.eid);
+    assertEquals("/p1/n1$2a", lockId2.serialize());
+
+    assertEquals(lockId.hashCode(), lockId2.hashCode());
+    assertEquals(lockId, lockId2);
+
+    var lockId3 = new LockID("/p2", lockId.node, lockId.eid);
+    assertNotEquals(lockId, lockId3);
+    assertNotEquals(lockId.hashCode(), lockId3.hashCode());
+
+    var lockId4 = new LockID(lockId.path, "n2", lockId.eid);
+    assertNotEquals(lockId, lockId4);
+    assertNotEquals(lockId.hashCode(), lockId4.hashCode());
+
+    var lockId5 = new LockID(lockId.path, lockId.node, lockId.eid + 1);
+    assertNotEquals(lockId, lockId5);
+    assertNotEquals(lockId.hashCode(), lockId5.hashCode());
+
+    var lockId6 = new LockID("/p1", "n1", -42);
+    assertEquals(-42, lockId6.eid);
+    assertEquals("/p1/n1$ffffffffffffffd6", lockId6.serialize());
+    assertEquals(lockId6, LockID.deserialize(lockId6.serialize()));
+    assertEquals(-42, LockID.deserialize(lockId6.serialize()).eid);
+  }
+
+  @Test
+  public void testUnexpected() {
+    // test illegal paths
+    assertThrows(IllegalArgumentException.class, () -> new LockID("", "n1", 42));
+    assertThrows(IllegalArgumentException.class, () -> new LockID("/p1/", "n1", 42));
+    assertThrows(IllegalArgumentException.class, () -> new LockID("p1/", "n1", 42));
+    assertThrows(IllegalArgumentException.class, () -> new LockID("/p$1", "n1", 42));
+    assertThrows(IllegalArgumentException.class, () -> new LockID(null, "n1", 42));
+
+    // test illegal node names
+    assertThrows(IllegalArgumentException.class, () -> new LockID("/p1", null, 42));
+    assertThrows(IllegalArgumentException.class, () -> new LockID("/p1", "", 42));
+    assertThrows(IllegalArgumentException.class, () -> new LockID("/p1", "/n1", 42));
+    assertThrows(IllegalArgumentException.class, () -> new LockID("/p1", "n$1", 42));
+
+    // test illegal serialized data
+    assertThrows(IllegalArgumentException.class, () -> LockID.deserialize("/p1/n1$"));
+    assertThrows(IllegalArgumentException.class, () -> LockID.deserialize("/p1/n1$foo"));
+    assertThrows(IllegalArgumentException.class, () -> LockID.deserialize(""));
+    assertThrows(IllegalArgumentException.class, () -> LockID.deserialize("/p1//n1$2a"));
+    assertThrows(IllegalArgumentException.class, () -> LockID.deserialize("/p1/n1/$2a"));
+    assertThrows(IllegalArgumentException.class, () -> LockID.deserialize("p1/n1$2a"));
+    assertThrows(IllegalArgumentException.class, () -> LockID.deserialize("/n1$2a"));
+    assertThrows(IllegalArgumentException.class, () -> LockID.deserialize("/p1/n1#2a"));
+    assertThrows(IllegalArgumentException.class, () -> LockID.deserialize("p1n1$2a"));
+
+    // Test equals w/ a different type
+    assertNotEquals(new LockID("/p1", "n1", 42), "/p1/n1$2a");
+  }
+
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
@@ -400,7 +400,8 @@ public class MetadataConstraints implements Constraint {
         String lockId = new String(columnUpdate.getValue(), UTF_8);
 
         try {
-          lockHeld = ServiceLock.isLockHeld(context.getZooCache(), new ZooUtil.LockID("", lockId));
+          lockHeld =
+              ServiceLock.isLockHeld(context.getZooCache(), ZooUtil.LockID.deserialize(lockId));
         } catch (Exception e) {
           log.debug("Failed to verify lock was held {} {}", lockId, e.getMessage());
         }

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/LiveTServerSet.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/LiveTServerSet.java
@@ -91,7 +91,7 @@ public class LiveTServerSet implements ZooCacheWatcher {
     }
 
     private String lockString(ServiceLock mlock) {
-      return mlock.getLockID().serialize(context.getServerPaths().createManagerPath().toString());
+      return mlock.getLockID().serialize();
     }
 
     private void loadTablet(TabletManagementClientService.Client client, ServiceLock lock,

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
@@ -93,7 +93,7 @@ public class MetadataTableUtil {
   private MetadataTableUtil() {}
 
   public static void putLockID(ServerContext context, ServiceLock zooLock, Mutation m) {
-    ServerColumnFamily.LOCK_COLUMN.put(m, new Value(zooLock.getLockID().serialize("/")));
+    ServerColumnFamily.LOCK_COLUMN.put(m, new Value(zooLock.getLockID().serialize()));
   }
 
   public static void deleteTable(TableId tableId, boolean insertDeletes, ServerContext context,

--- a/server/base/src/test/java/org/apache/accumulo/server/metadata/ConditionalTabletsMutatorImplTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/metadata/ConditionalTabletsMutatorImplTest.java
@@ -96,7 +96,7 @@ public class ConditionalTabletsMutatorImplTest {
     ServiceLock lock = EasyMock.createMock(ServiceLock.class);
     LockID lid = EasyMock.createMock(LockID.class);
     EasyMock.expect(lock.getLockID()).andReturn(lid).anyTimes();
-    EasyMock.expect(lid.serialize("/")).andReturn("/1234").anyTimes();
+    EasyMock.expect(lid.serialize()).andReturn("/1234").anyTimes();
     EasyMock.expect(context.getServiceLock()).andReturn(lock).anyTimes();
     EasyMock.replay(context, lock, lid);
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
@@ -799,7 +799,8 @@ public class TabletClientHandler implements TabletServerClientService.Iface,
         tableId, DurabilityImpl.fromThrift(tdurabilty));
 
     long sid = server.sessionManager.createSession(cs, false);
-    return new TConditionalSession(sid, server.getLockID(), server.sessionManager.getMaxIdleTime());
+    return new TConditionalSession(sid, server.getLockID().serialize(),
+        server.sessionManager.getMaxIdleTime());
   }
 
   @Override
@@ -967,8 +968,7 @@ public class TabletClientHandler implements TabletServerClientService.Iface,
     }
 
     if (lock != null) {
-      ZooUtil.LockID lid =
-          new ZooUtil.LockID(context.getServerPaths().createManagerPath().toString(), lock);
+      ZooUtil.LockID lid = ZooUtil.LockID.deserialize(lock);
 
       try {
         if (!ServiceLock.isLockHeld(server.getContext().getZooCache(), lid)) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -78,6 +78,7 @@ import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
+import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.accumulo.core.file.blockfile.cache.impl.BlockCacheConfiguration;
 import org.apache.accumulo.core.lock.ServiceLock;
@@ -213,7 +214,7 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
 
   private TServer server;
 
-  private String lockID;
+  private volatile ZooUtil.LockID lockID;
   private volatile long lockSessionId = -1;
 
   public static final AtomicLong seekCount = new AtomicLong(0);
@@ -370,7 +371,7 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
   private TabletClientHandler thriftClientHandler;
   private ThriftScanClientHandler scanClientHandler;
 
-  String getLockID() {
+  ZooUtil.LockID getLockID() {
     return lockID;
   }
 
@@ -510,7 +511,7 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
         }
 
         if (tabletServerLock.tryLock(lw, new ServiceLockData(descriptors))) {
-          lockID = tabletServerLock.getLockID().serialize(Constants.ZTSERVERS + "/");
+          lockID = tabletServerLock.getLockID();
           lockSessionId = tabletServerLock.getSessionId();
           log.debug("Obtained tablet server lock {} {}", tabletServerLock.getLockPath(),
               getTabletSession());


### PR DESCRIPTION
In order to make this change needed to analyze how the code uses LockId, based on this anylsis ended up making a few changes.

Some code was caching the serialized form of the lock id and keeping a string around.  Its better to keep the lock id type around instead of a string, so made lock id memoize serialization to support doing this.

The lock id constructor was removing extraneous slashes at the end of the lock path.  However it seemed this would never happen in the code. Removed this handling and instead added a check that paths do not end w/ a slash.  Also added some other validation in the constructor. Noticed this object is created alot in the manager and tablet server, to avoid the repeated validation made ServiceLock cache the LockId instead of always creating it.

fixes #5410