### PR TITLE
Remove static methods and fields from TableManager

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/init/ZooKeeperInitializer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/ZooKeeperInitializer.java
@@ -49,7 +49,6 @@ import org.apache.accumulo.server.conf.codec.VersionedProperties;
 import org.apache.accumulo.server.conf.store.SystemPropKey;
 import org.apache.accumulo.server.log.WalStateManager;
 import org.apache.accumulo.server.metadata.RootGcCandidates;
-import org.apache.accumulo.server.tables.TableManager;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs;
 
@@ -103,15 +102,15 @@ public class ZooKeeperInitializer {
                 Namespace.ACCUMULO.id().canonical(), Namespace.ACCUMULO.name())),
         ZooUtil.NodeExistsPolicy.FAIL);
 
-    TableManager.prepareNewNamespaceState(context, Namespace.DEFAULT.id(), Namespace.DEFAULT.name(),
-        ZooUtil.NodeExistsPolicy.FAIL);
-    TableManager.prepareNewNamespaceState(context, Namespace.ACCUMULO.id(),
+    context.getTableManager().prepareNewNamespaceState(Namespace.DEFAULT.id(),
+        Namespace.DEFAULT.name(), ZooUtil.NodeExistsPolicy.FAIL);
+    context.getTableManager().prepareNewNamespaceState(Namespace.ACCUMULO.id(),
         Namespace.ACCUMULO.name(), ZooUtil.NodeExistsPolicy.FAIL);
 
-    TableManager.prepareNewTableState(context, AccumuloTable.ROOT.tableId(),
+    context.getTableManager().prepareNewTableState(AccumuloTable.ROOT.tableId(),
         Namespace.ACCUMULO.id(), AccumuloTable.ROOT.tableName(), TableState.ONLINE,
         ZooUtil.NodeExistsPolicy.FAIL);
-    TableManager.prepareNewTableState(context, AccumuloTable.METADATA.tableId(),
+    context.getTableManager().prepareNewTableState(AccumuloTable.METADATA.tableId(),
         Namespace.ACCUMULO.id(), AccumuloTable.METADATA.tableName(), TableState.ONLINE,
         ZooUtil.NodeExistsPolicy.FAIL);
     // Call this separately so the upgrader code can handle the zk node creation for scan refs
@@ -183,7 +182,7 @@ public class ZooKeeperInitializer {
 
   public void initScanRefTableState(ServerContext context) {
     try {
-      TableManager.prepareNewTableState(context, AccumuloTable.SCAN_REF.tableId(),
+      context.getTableManager().prepareNewTableState(AccumuloTable.SCAN_REF.tableId(),
           Namespace.ACCUMULO.id(), AccumuloTable.SCAN_REF.tableName(), TableState.ONLINE,
           ZooUtil.NodeExistsPolicy.FAIL);
     } catch (KeeperException | InterruptedException e) {
@@ -193,7 +192,7 @@ public class ZooKeeperInitializer {
 
   public void initFateTableState(ServerContext context) {
     try {
-      TableManager.prepareNewTableState(context, AccumuloTable.FATE.tableId(),
+      context.getTableManager().prepareNewTableState(AccumuloTable.FATE.tableId(),
           Namespace.ACCUMULO.id(), AccumuloTable.FATE.tableName(), TableState.ONLINE,
           ZooUtil.NodeExistsPolicy.FAIL);
     } catch (KeeperException | InterruptedException e) {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/PopulateZookeeperWithNamespace.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/PopulateZookeeperWithNamespace.java
@@ -28,7 +28,6 @@ import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.accumulo.server.conf.store.NamespacePropKey;
-import org.apache.accumulo.server.tables.TableManager;
 import org.apache.accumulo.server.util.PropUtil;
 
 class PopulateZookeeperWithNamespace extends ManagerRepo {
@@ -55,7 +54,7 @@ class PopulateZookeeperWithNamespace extends ManagerRepo {
       var context = manager.getContext();
       NamespaceMapping.put(context.getZooSession().asReaderWriter(), namespaceInfo.namespaceId,
           namespaceInfo.namespaceName);
-      TableManager.prepareNewNamespaceState(context, namespaceInfo.namespaceId,
+      context.getTableManager().prepareNewNamespaceState(namespaceInfo.namespaceId,
           namespaceInfo.namespaceName, NodeExistsPolicy.OVERWRITE);
 
       PropUtil.setProperties(context, NamespacePropKey.of(namespaceInfo.namespaceId),


### PR DESCRIPTION
Static methods are removed in favor of non-static ones, since these methods are only ever called with the ServerContext, which already has an instance of the TableManager object. This allows removing an overloaded prepareNewTableState method, since the extra parameters on the overloaded method are always provided by methods on the ServerContext anyway.

Additionally, this change removes the static set of registered ZooCache observers and table state cache, since the lifetime of ZooCache is already bound to the lifetime of the ServerContext, and these static objects should not exist longer than the TableManager instance attached to the same ServerContext.

This fixes a potential bug with the ZooCache observers registered statically never firing again if the ServerContext is closed, even if an attempt is made to register them again with a new ServerContext. There is usually only one ServerContext for the lifetime of a server process, so this bug would probably not exist in practice, but this change avoids a potential bug if that assumption did not hold.