### PR TITLE
Switch to using logger for conf build message

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancer.java
@@ -153,7 +153,7 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer {
     private final Map<String,Pattern> poolNameToRegexPattern;
 
     HrtlbConf(PluginEnvironment.Configuration conf) {
-      System.out.println("building hrtlb conf");
+      LOG.info("Building conf");
       String oobProperty = conf.get(HOST_BALANCER_OOB_CHECK_KEY);
       if (oobProperty != null) {
         oobCheckMillis = ConfigurationTypeHelper.getTimeInMillis(oobProperty);


### PR DESCRIPTION
This line is constantly generated in the `manager.out` log file if the HostRegexTableLoadBalancer is used.

Removed the word `hrtlb` as the logger name will be included in the log message layout.