### PR TITLE
Deprecate single table balancer constructors

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/GroupBalancer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/GroupBalancer.java
@@ -81,6 +81,7 @@ public abstract class GroupBalancer implements TabletBalancer {
    */
   protected abstract Function<TabletId,String> getPartitioner();
 
+  @Deprecated
   public GroupBalancer(TableId tableId) {
     this.tableId = tableId;
   }

--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/RegexGroupBalancer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/RegexGroupBalancer.java
@@ -58,6 +58,7 @@ public class RegexGroupBalancer extends GroupBalancer {
 
   private final TableId tableId;
 
+  @SuppressWarnings("deprecation")
   public RegexGroupBalancer(TableId tableId) {
     super(tableId);
     this.tableId = tableId;

--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/SimpleLoadBalancer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/SimpleLoadBalancer.java
@@ -77,6 +77,7 @@ public class SimpleLoadBalancer implements TabletBalancer {
 
   public SimpleLoadBalancer() {}
 
+  @Deprecated
   public SimpleLoadBalancer(TableId table) {
     tableToBalance = table;
   }

--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/TableLoadBalancer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/TableLoadBalancer.java
@@ -66,6 +66,7 @@ public class TableLoadBalancer implements TabletBalancer {
     return null;
   }
 
+  @SuppressWarnings("deprecation")
   protected TabletBalancer getBalancerForTable(TableId tableId) {
     TabletBalancer balancer = perTableBalancers.get(tableId);
 

--- a/core/src/test/java/org/apache/accumulo/core/spi/balancer/GroupBalancerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/balancer/GroupBalancerTest.java
@@ -85,6 +85,7 @@ public class GroupBalancerTest {
 
     public void balance(final int maxMigrations) {
       TableId tid = TableId.of("1");
+      @SuppressWarnings("deprecation")
       GroupBalancer balancer = new GroupBalancer(tid) {
 
         @Override

--- a/core/src/test/java/org/apache/accumulo/core/spi/balancer/TableLoadBalancerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/balancer/TableLoadBalancerTest.java
@@ -101,6 +101,7 @@ public class TableLoadBalancerTest {
 
   public static class TestSimpleLoadBalancer extends SimpleLoadBalancer {
 
+    @SuppressWarnings("deprecation")
     public TestSimpleLoadBalancer(TableId table) {
       super(table);
     }


### PR DESCRIPTION
Deprecate the single table constructors for balancers as they are removed in a future version of accumulo. 