### PR TITLE
WIP: Remove tableId constructor for load balancers

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/SimpleLoadBalancer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/SimpleLoadBalancer.java
@@ -66,14 +66,8 @@ public class SimpleLoadBalancer implements TabletBalancer {
   protected BalancerEnvironment environment;
 
   Iterator<TabletServerId> assignments;
-  // if tableToBalance is set, then only balance the given table
-  TableId tableToBalance = null;
 
   public SimpleLoadBalancer() {}
-
-  public SimpleLoadBalancer(TableId table) {
-    tableToBalance = table;
-  }
 
   @Override
   public void init(BalancerEnvironment balancerEnvironment) {
@@ -167,13 +161,7 @@ public class SimpleLoadBalancer implements TabletBalancer {
         int serverTotal = 0;
         if (entry.getValue() != null && entry.getValue().getTableMap() != null) {
           for (Entry<String,TableStatistics> e : entry.getValue().getTableMap().entrySet()) {
-            /*
-             * The check below was on entry.getKey(), but that resolves to a tabletserver not a
-             * tablename. Believe it should be e.getKey() which is a tablename
-             */
-            if (tableToBalance == null || tableToBalance.canonical().equals(e.getKey())) {
-              serverTotal += e.getValue().getOnlineTabletCount();
-            }
+            serverTotal += e.getValue().getOnlineTabletCount();
           }
         }
         totals.add(new ServerCounts(serverTotal, entry.getKey(), entry.getValue()));
@@ -287,10 +275,6 @@ public class SimpleLoadBalancer implements TabletBalancer {
 
   private TableId getTableToMigrate(ServerCounts tooMuch, Map<TableId,Integer> tooMuchMap,
       Map<TableId,Integer> tooLittleMap) {
-
-    if (tableToBalance != null) {
-      return tableToBalance;
-    }
 
     // find a table to migrate
     // look for an uneven table count

--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/TableLoadBalancer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/TableLoadBalancer.java
@@ -74,8 +74,8 @@ public class TableLoadBalancer implements TabletBalancer {
     String context = environment.tableContext(tableId);
     Class<? extends TabletBalancer> clazz =
         ClassLoaderUtil.loadClass(context, clazzName, TabletBalancer.class);
-    Constructor<? extends TabletBalancer> constructor = clazz.getConstructor(TableId.class);
-    return constructor.newInstance(tableId);
+    Constructor<? extends TabletBalancer> constructor = clazz.getConstructor();
+    return constructor.newInstance();
   }
 
   protected String getLoadBalancerClassNameForTable(TableId table) {
@@ -124,9 +124,8 @@ public class TableLoadBalancer implements TabletBalancer {
       }
 
       if (balancer == null) {
-        log.info("Creating balancer {} limited to balancing table {}",
-            SimpleLoadBalancer.class.getName(), tableId);
-        balancer = new SimpleLoadBalancer(tableId);
+        log.info("Creating balancer {} for table {}", SimpleLoadBalancer.class.getName(), tableId);
+        balancer = new SimpleLoadBalancer();
       }
       perTableBalancers.put(tableId, balancer);
       balancer.init(environment);

--- a/core/src/test/java/org/apache/accumulo/core/spi/balancer/TableLoadBalancerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/balancer/TableLoadBalancerTest.java
@@ -104,10 +104,6 @@ public class TableLoadBalancerTest {
 
   public static class TestSimpleLoadBalancer extends SimpleLoadBalancer {
 
-    public TestSimpleLoadBalancer(TableId table) {
-      super(table);
-    }
-
     @Override
     public void init(BalancerEnvironment balancerEnvironment) {}
 
@@ -147,7 +143,7 @@ public class TableLoadBalancerTest {
     tls.init(environment);
     tls.balance(
         new BalanceParamsImpl(state, Map.of(Constants.DEFAULT_RESOURCE_GROUP_NAME, state.keySet()),
-            migrations, migrationsOut, DataLevel.USER, tableIdMap));
+            migrations, migrationsOut, DataLevel.USER, Map.of("t1", TableId.of(t1Id))));
     assertEquals(0, migrationsOut.size());
 
     state.put(mkts("10.0.0.2", 2345, "0x02030405"), status());
@@ -155,7 +151,7 @@ public class TableLoadBalancerTest {
     tls.init(environment);
     tls.balance(
         new BalanceParamsImpl(state, Map.of(Constants.DEFAULT_RESOURCE_GROUP_NAME, state.keySet()),
-            migrations, migrationsOut, DataLevel.USER, tableIdMap));
+            migrations, migrationsOut, DataLevel.USER, Map.of("t1", TableId.of(t1Id))));
     int count = 0;
     Map<TableId,Integer> movedByTable = new HashMap<>();
     movedByTable.put(TableId.of(t1Id), 0);


### PR DESCRIPTION
Removes the single tableId constructor for SimpleLoadBalancer as it is no longer needed with the addition of the tablesToBalance map to the balancerParams.

This PR addresses the changes from #5363 but applied to `main`. 

Will also need to remove the single table constructors that are marked as deprecated in #5425 