### PR TITLE
Protected against NPE in InstanceOperationsImpl.getServers

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
@@ -564,7 +564,7 @@ public class InstanceOperationsImpl implements InstanceOperations {
           String location = null;
           if (sld.isPresent()) {
             location = sld.orElseThrow().getAddressString(ThriftService.MANAGER);
-            if (addressSelector.getPredicate().test(location)) {
+            if (location != null && addressSelector.getPredicate().test(location)) {
               HostAndPort hp = HostAndPort.fromString(location);
               results.add(new ServerId(type, Constants.DEFAULT_RESOURCE_GROUP_NAME, hp.getHost(),
                   hp.getPort()));
@@ -579,7 +579,7 @@ public class InstanceOperationsImpl implements InstanceOperations {
           String location = null;
           if (sld.isPresent()) {
             location = sld.orElseThrow().getAddressString(ThriftService.NONE);
-            if (addressSelector.getPredicate().test(location)) {
+            if (location != null && addressSelector.getPredicate().test(location)) {
               HostAndPort hp = HostAndPort.fromString(location);
               results.add(new ServerId(type, Constants.DEFAULT_RESOURCE_GROUP_NAME, hp.getHost(),
                   hp.getPort()));
@@ -594,7 +594,7 @@ public class InstanceOperationsImpl implements InstanceOperations {
           String location = null;
           if (sld.isPresent()) {
             location = sld.orElseThrow().getAddressString(ThriftService.GC);
-            if (addressSelector.getPredicate().test(location)) {
+            if (location != null && addressSelector.getPredicate().test(location)) {
               HostAndPort hp = HostAndPort.fromString(location);
               results.add(new ServerId(type, Constants.DEFAULT_RESOURCE_GROUP_NAME, hp.getHost(),
                   hp.getPort()));


### PR DESCRIPTION
ServiceLockData.getAddressString returns null if the ThriftService parameter is not found. The code was not protecting against this condition, and it started occurring with the changes in Manager is fully up, but the lock exists.