### PR TITLE
Fixes performance bug in GroupBalancer

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/GroupBalancer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/GroupBalancer.java
@@ -488,7 +488,7 @@ public abstract class GroupBalancer implements TabletBalancer {
     }
 
     ArrayList<Pair<String,TabletServerId>> serversGroupsToRemove = new ArrayList<>();
-    ArrayList<TabletServerId> serversToRemove = new ArrayList<>();
+    HashSet<TabletServerId> serversToRemove = new HashSet<>();
 
     for (TserverGroupInfo destTgi : tservers.values()) {
       if (surplusExtra.isEmpty()) {

--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/GroupBalancer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/GroupBalancer.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -611,7 +612,7 @@ public abstract class GroupBalancer implements TabletBalancer {
       }
     }
 
-    ArrayList<TabletServerId> emptyServers = new ArrayList<>();
+    HashSet<TabletServerId> emptyServers = new HashSet<>();
     ArrayList<Pair<String,TabletServerId>> emptyServerGroups = new ArrayList<>();
     for (TserverGroupInfo destTgi : tservers.values()) {
       if (extraSurplus.isEmpty()) {


### PR DESCRIPTION
Code in GroupBalancer was calling
`HashBasedTable.columnKeySet().removeAll(aList)`.  The Guava HashBasedTable code would iterator over all of its rows and columns and then call contains on the list passed in by GroupBalancer. So this code
was doing `ROWS*COLS*LIST_SIZE` operations.   Changed the list to a
hashset in this PR so now it only does `ROW*COLS` operations.