### PR TITLE
Add more test cases to bulk skip test

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/util/PeekingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/PeekingIterator.java
@@ -61,6 +61,10 @@ public class PeekingIterator<E> implements Iterator<E> {
     return this;
   }
 
+  /**
+   * @return If this iterator has a next this will return what calling next() would return otherwise
+   *         returns null.
+   */
   public E peek() {
     if (!isInitialized) {
       throw new IllegalStateException("Iterator has not yet been initialized");


### PR DESCRIPTION
Adds tablet gaps of size 1,2,3,...,9 tablets to the bulk import load plan in the skip test. The goal of this is to attempt to cover different edge case w/ the bulk import skip property.  Like when the skip property is set to 4 the load plan will have gaps of 3,4,5 tablets that is has to deal with.