### PR TITLE
Fix ShellIT.configTest

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellIT.java
@@ -513,6 +513,12 @@ public class ShellIT extends SharedMiniClusterBase {
         case PATH:
         case PREFIX:
         case STRING:
+        case FATE_THREADPOOL_SIZE:
+          // deprecated value
+        case FATE_META_CONFIG:
+          // json based type
+        case FATE_USER_CONFIG:
+          // json based type
         case JSON:
           Shell.log.debug("Skipping " + propertyType + " Property Types");
           continue;


### PR DESCRIPTION
fixes test broken by changes in #5301

one property was deprecated in 4.0 and should no longer be used in 4.0... Just exists to point to the new properties that replace it. So test skips testing this property type.

the other 2 new property types are json based, and it doesn't seem like json types can be set using the shell, so skipping these as well.