### PR TITLE
adds prune command to accumulo-cluster

### DIFF
--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -750,6 +750,11 @@ function prune() {
     exit 1
   fi
 
+  if ! jq -h >&/dev/null; then
+    echo "$(red ERROR:) Missing $(green jq). Unable to continue."
+    exit 1
+  fi
+
   if [[ -z ${AC_TMP_DIR+x} ]]; then
     echo "AC_TMP_DIR is not set"
     exit 1

--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -807,7 +807,7 @@ function prune() {
     if [[ -n $ARG_COMPACTOR_GROUP ]]; then
       read -r -a groups <<<"$ARG_COMPACTOR_GROUP"
     else
-      # find all groups known in zookeeper, this will allow pruning entire groups that do not even exists in cluster.yaml
+      # find all groups known in zookeeper, this will allow pruning entire groups that do not even exist in cluster.yaml
       readarray -t groups < <(jq -r ".summaries.COMPACTOR.resourceGroups | .[] " "$service_json")
     fi
 

--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -54,6 +54,7 @@ $(cyan Commands):
   $(green stop)                       Stops Accumulo cluster services
   $(green restart)                    Restarts Accumulo cluster services
   $(green kill)                       Kills Accumulo cluster services
+  $(green prune)                      Reomves zookeeper locks of extra processes
 
   $(cyan Deprecated commands):
     $(green start-non-tservers)       $(yellow Deprecated). Alias for "start --no-tservers"
@@ -73,6 +74,8 @@ $(cyan Examples):
   $(purple 'accumulo-cluster start --sservers=group1')            $(blue '# start all group1 sservers')
   $(purple 'accumulo-cluster start --sservers="group1 group2"')   $(blue '# start all group1 and group2 sservers')
   $(purple 'accumulo-cluster start --local --manager --tservers') $(blue '# Start the local manager and local tservers')
+  $(purple 'accumulo-cluster prune --compactors')                 $(blue '# prune all extra compactors across all groups')
+  $(purple 'accumulo-cluster prune --compactors="group1"')        $(blue '# prune extra compactors running in group1')
 
 EOF
 }
@@ -324,8 +327,14 @@ function parse_config() {
     exit 1
   fi
 
-  trap 'rm -f "$CONFIG_FILE"' EXIT
-  CONFIG_FILE=$(mktemp --tmpdir "ClusterConfigParser-XXXXXXXX.out") || exit 1
+  AC_TMP_DIR=$(mktemp -t -d "accumulo-cluster-XXXXXXXX") || exit 1
+  if isDebug; then
+    echo "$(blue DEBUG): Temporary files for this run are in $AC_TMP_DIR"
+  else
+    trap 'rm -rf -- "$AC_TMP_DIR"' EXIT
+  fi
+
+  CONFIG_FILE="$AC_TMP_DIR/ClusterConfigParser.out"
   "$accumulo_cmd" org.apache.accumulo.core.conf.cluster.ClusterConfigParser "$conf/cluster.yaml" "$CONFIG_FILE" || parse_fail
   #shellcheck source=/dev/null
   . "$CONFIG_FILE"
@@ -646,10 +655,170 @@ function control_services() {
   if [[ $ARG_LOCAL == 0 && $ARG_ALL == 1 && ($operation == "stop" || $operation == "kill") ]]; then
     if ! isDebug; then
       echo "Cleaning all server entries in ZooKeeper"
-      "$accumulo_cmd" org.apache.accumulo.server.util.ZooZap -manager -tservers -compaction-coordinators -compactors -sservers
+      "$accumulo_cmd" org.apache.accumulo.server.util.ZooZap -manager -tservers -compaction-coordinators -compactors -sservers --gc --monitor
     fi
   fi
 
+}
+
+function prune_group() {
+  local service_type=$1
+  local group=$2
+  local expectedCount=$3
+  declare -a hosts
+  read -r -a hosts <<<"$4"
+
+  if isDebug; then
+    echo "$(blue DEBUG) starting prune for service:$service_type group:$group expected:$expectedCount"
+  fi
+
+  if [ -z ${AC_TMP_DIR+x} ]; then
+    echo "$(red ERROR): AC_TMP_DIR is not set"
+    exit 1
+  fi
+  local exclude_file="$AC_TMP_DIR/accumulo-zoozap-exclude-$service_type-$group.txt"
+  touch "$exclude_file"
+
+  # Determine the host:ports known by the accumulo cluster script, these should be kept
+  for host in "${hosts[@]}"; do
+    "${SSH[@]}" "$host" bash -c "'$bin/accumulo-service $service_type list'" | grep -E "^[a-zA-Z0-9]+_${group}_[0-9]+" | head -n "$expectedCount" | awk '{print $3}' | tr ',' '\n' | awk '{print "'"$host"':" $1}' >>"$exclude_file"
+  done
+
+  local lockTypeOpt
+  case $service_type in
+    manager)
+      lockTypeOpt="-manager"
+      ;;
+    compaction-coordinator)
+      lockTypeOpt="-compaction-coordinators"
+      ;;
+    compactor)
+      lockTypeOpt="-compactors"
+      ;;
+    tserver)
+      lockTypeOpt="-tservers"
+      ;;
+    sserver)
+      lockTypeOpt="-sservers"
+      ;;
+    gc)
+      lockTypeOpt="--gc"
+      ;;
+    monitor)
+      lockTypeOpt="--monitor"
+      ;;
+    *)
+      echo "Prune does not support $service_type"
+      exit 1
+      ;;
+  esac
+
+  if isDebug; then
+    "$accumulo_cmd" org.apache.accumulo.server.util.ZooZap "$lockTypeOpt" -verbose --include-groups "$group" --exclude-host-ports "$exclude_file" --dry-run
+  else
+    "$accumulo_cmd" org.apache.accumulo.server.util.ZooZap "$lockTypeOpt" -verbose --include-groups "$group" --exclude-host-ports "$exclude_file"
+  fi
+}
+
+# Kills extra server processes that are not needed according to the
+# cluster.yaml file.  Conceptually this code is trying to reconcile the
+# following three sets of servers.
+#
+#  1. The notional goal set of servers specified by cluster.yaml
+#  2. The set of servers processes seen in zookeeper
+#  3. The set of server processes known to the accumulo-cluster script.  This
+#     is derived from pid files on hosts in set 1.
+#
+# This function attempts to find extra servers in set 2 that are not specified
+# by set 1.  When it does find extra servers it removes their zookeeper locks
+# avoiding removing locks of servers in set 3. The following are different
+# situations the code will see and handle.
+#
+#  * When a host is not cluster.yaml but has some processes listed in
+#    zookeeper.  For this case all of the process with that host can be killed.
+#  * When a resource group is not in cluster.yaml but has some processes listed
+#    in zookeeper.  For this case all of the processes with that resource group
+#    can be killed.
+#  * When a host is in cluster.yaml with a target of 3 processes but has 6
+#    processes listed in zookeeper.  For this case want to kill 3 processes that
+#    do not have pid files on the host.
+#
+function prune() {
+  if [[ $ARG_LOCAL == 1 ]]; then
+    # Currently the code is structured to remove all extra servers in a single resource group.  Finer granularity is not supported.
+    echo "$(red ERROR): Prune does not support running locally"
+    exit 1
+  fi
+
+  if [[ -z ${AC_TMP_DIR+x} ]]; then
+    echo "AC_TMP_DIR is not set"
+    exit 1
+  fi
+  local service_json="$AC_TMP_DIR/accumulo-service.json"
+  "$accumulo_cmd" admin serviceStatus --json >"$service_json" 2>/dev/null || exit 1
+
+  local var_name
+  local hosts
+  declare -a groups
+
+  local manager
+  if [[ $ARG_ALL == 1 || $ARG_MANAGER == 1 ]]; then
+    prune_group "manager" "default" "1" "$MANAGER_HOSTS"
+  fi
+
+  if [[ $ARG_ALL == 1 || $ARG_GC == 1 ]]; then
+    prune_group "gc" "default" "1" "$GC_HOSTS"
+  fi
+
+  if [[ $ARG_ALL == 1 || $ARG_MONITOR == 1 ]]; then
+    prune_group "monitor" "default" "1" "$MONITOR_HOSTS"
+  fi
+
+  if [[ $ARG_ALL == 1 || $ARG_COORDINATOR == 1 ]]; then
+    prune_group "compaction-coordinator" "default" "1" "$COORDINATOR_HOSTS"
+  fi
+
+  if [[ $ARG_ALL == 1 || $ARG_TSERVER == 1 ]]; then
+    #TODO in main need to adapt to having RGs for tservers
+    prune_group "tserver" "default" "$TSERVERS_PER_HOST_default" "$TSERVER_HOSTS_default"
+  fi
+
+  if [[ $ARG_ALL == 1 || $ARG_SSERVER == 1 ]]; then
+    groups=()
+    if [[ -n $ARG_SSERVER_GROUP ]]; then
+      read -r -a groups <<<"$ARG_SSERVER_GROUP"
+    else
+      # find all groups known in zookeeper, this will allow pruning entire groups that do not even exists in cluster.yaml
+      readarray -t groups < <(jq -r ".summaries.S_SERVER.resourceGroups | .[] " "$service_json")
+    fi
+
+    for group in "${groups[@]}"; do
+      var_name="SSERVERS_PER_HOST_$group"
+      local expected=${!var_name:-0}
+
+      hosts="SSERVER_HOSTS_$group"
+      prune_group "sserver" "$group" "$expected" "${!hosts}"
+    done
+
+  fi
+
+  if [[ $ARG_ALL == 1 || $ARG_COMPACTOR == 1 ]]; then
+    groups=()
+    if [[ -n $ARG_COMPACTOR_GROUP ]]; then
+      read -r -a groups <<<"$ARG_COMPACTOR_GROUP"
+    else
+      # find all groups known in zookeeper, this will allow pruning entire groups that do not even exists in cluster.yaml
+      readarray -t groups < <(jq -r ".summaries.COMPACTOR.resourceGroups | .[] " "$service_json")
+    fi
+
+    for group in "${groups[@]}"; do
+      var_name="COMPACTORS_PER_HOST_$group"
+      local expected=${!var_name:-0}
+
+      hosts="COMPACTOR_HOSTS_$group"
+      prune_group "compactor" "$group" "$expected" "${!hosts}"
+    done
+  fi
 }
 
 function main() {
@@ -757,6 +926,10 @@ EOF
       ARG_LOCAL=1
       control_services stop
       control_services kill
+      ;;
+    prune)
+      parse_config
+      prune
       ;;
     start-non-tservers)
       echo "'$ARG_CMD' is deprecated. Please specify the servers you wish to start instead"

--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -793,7 +793,7 @@ function prune() {
     if [[ -n $ARG_SSERVER_GROUP ]]; then
       read -r -a groups <<<"$ARG_SSERVER_GROUP"
     else
-      # find all groups known in zookeeper, this will allow pruning entire groups that do not even exists in cluster.yaml
+      # find all groups known in zookeeper, this will allow pruning entire groups that do not even exist in cluster.yaml
       readarray -t groups < <(jq -r ".summaries.S_SERVER.resourceGroups | .[] " "$service_json")
     fi
 

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
@@ -838,7 +838,7 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
     // and not wait for the old locks to be cleaned up.
     try {
       new ZooZap().zap(getServerContext().getSiteConfiguration(), "-manager",
-          "-compaction-coordinators", "-tservers", "-compactors", "-sservers", "--gc", "--monitor");
+          "-compaction-coordinators", "-tservers", "-compactors", "-sservers", "--gc");
     } catch (RuntimeException e) {
       log.error("Error zapping zookeeper locks", e);
     }

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
@@ -838,7 +838,7 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
     // and not wait for the old locks to be cleaned up.
     try {
       new ZooZap().zap(getServerContext().getSiteConfiguration(), "-manager",
-          "-compaction-coordinators", "-tservers", "-compactors", "-sservers");
+          "-compaction-coordinators", "-tservers", "-compactors", "-sservers", "--gc", "--monitor");
     } catch (RuntimeException e) {
       log.error("Error zapping zookeeper locks", e);
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/UpgradeUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/UpgradeUtil.java
@@ -133,7 +133,7 @@ public class UpgradeUtil implements KeywordExecutable {
 
       LOG.info("Forcing removal of all server locks");
       new ZooZap().zap(siteConf, "-manager", "-compaction-coordinators", "-tservers", "-compactors",
-          "-sservers");
+          "-sservers", "--monitor", "--gc");
 
       LOG.info("Instance {} prepared for upgrade. Server processes will not start while"
           + " in this state. To undo this state and abort upgrade preparations delete"

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
@@ -196,7 +196,8 @@ public class ZooZap implements KeywordExecutable {
     if (opts.zapTservers) {
       String tserversPath = Constants.ZROOT + "/" + iid + Constants.ZTSERVERS;
       try {
-        if ((opts.zapManager || opts.zapMaster) && opts.hostPortExcludeFile == null) {
+        if ((opts.zapManager || opts.zapMaster) && opts.hostPortExcludeFile == null
+            && !opts.dryRun) {
           // When shutting down all tablet servers and the manager, then completely clean up all
           // tservers entries in zookeeper
           List<String> children = zoo.getChildren(tserversPath);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
@@ -18,7 +18,15 @@
  */
 package org.apache.accumulo.server.util;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.util.Arrays;
 import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.cli.Help;
@@ -30,6 +38,7 @@ import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil.NodeMissingPolicy;
 import org.apache.accumulo.core.singletons.SingletonManager;
 import org.apache.accumulo.core.singletons.SingletonManager.Mode;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.volume.VolumeConfiguration;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.security.SecurityUtil;
@@ -80,8 +89,21 @@ public class ZooZap implements KeywordExecutable {
     boolean zapCompactors = false;
     @Parameter(names = "-sservers", description = "remove scan server locks")
     boolean zapScanServers = false;
+    @Parameter(names = "--gc", description = "remove gc server locks")
+    boolean zapGc = false;
+    @Parameter(names = "--monitor", description = "remove monitor server locks")
+    boolean zapMonitor = false;
     @Parameter(names = "-verbose", description = "print out messages about progress")
     boolean verbose = false;
+    @Parameter(names = "--include-groups",
+        description = "Comma seperated list of resource groups to include")
+    String includeGroups;
+    @Parameter(names = "--exclude-host-ports",
+        description = "File with lines of <host>:<port> to exclude from removal")
+    String hostPortExcludeFile;
+    @Parameter(names = "--dry-run",
+        description = "Only print changes that would be made w/o actually making any change")
+    boolean dryRun = false;
   }
 
   public static void main(String[] args) throws Exception {
@@ -106,7 +128,31 @@ public class ZooZap implements KeywordExecutable {
     Opts opts = new Opts();
     opts.parseArgs(keyword(), args);
 
-    if (!opts.zapMaster && !opts.zapManager && !opts.zapTservers) {
+    final Predicate<String> groupPredicate;
+    final Predicate<HostAndPort> hostPortPredicate;
+
+    if (opts.hostPortExcludeFile != null) {
+      try {
+        var hostPorts = Files.lines(java.nio.file.Path.of(opts.hostPortExcludeFile))
+            .map(String::trim).map(HostAndPort::fromString).collect(Collectors.toSet());
+        hostPortPredicate = hp -> !hostPorts.contains(hp);
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    } else {
+      hostPortPredicate = hp -> true;
+    }
+
+    if (opts.includeGroups != null) {
+      var groups = Arrays.stream(opts.includeGroups.split(",")).map(String::trim)
+          .collect(Collectors.toSet());
+      groupPredicate = groups::contains;
+    } else {
+      groupPredicate = g -> true;
+    }
+
+    if (!opts.zapMaster && !opts.zapManager && !opts.zapTservers && !opts.zapCompactors
+        && !opts.zapCoordinators && !opts.zapScanServers && !opts.zapGc && !opts.zapMonitor) {
       new JCommander(opts).usage();
       return;
     }
@@ -123,34 +169,46 @@ public class ZooZap implements KeywordExecutable {
       String managerLockPath = Constants.ZROOT + "/" + iid + Constants.ZMANAGER_LOCK;
 
       try {
-        zapDirectory(zoo, managerLockPath, opts);
+        removeSingletonLock(zoo, managerLockPath, hostPortPredicate, opts);
       } catch (KeeperException | InterruptedException e) {
-        e.printStackTrace();
+        log.error("Error deleting manager lock", e);
+      }
+    }
+
+    if (opts.zapGc) {
+      String gcLockPath = Constants.ZROOT + "/" + iid + Constants.ZGC_LOCK;
+      try {
+        removeSingletonLock(zoo, gcLockPath, hostPortPredicate, opts);
+      } catch (KeeperException | InterruptedException e) {
+        log.error("Error deleting manager lock", e);
+      }
+    }
+
+    if (opts.zapMonitor) {
+      String monitorLockPath = Constants.ZROOT + "/" + iid + Constants.ZMONITOR_LOCK;
+      try {
+        removeSingletonLock(zoo, monitorLockPath, hostPortPredicate, opts);
+      } catch (KeeperException | InterruptedException e) {
+        log.error("Error deleting manager lock", e);
       }
     }
 
     if (opts.zapTservers) {
       String tserversPath = Constants.ZROOT + "/" + iid + Constants.ZTSERVERS;
       try {
-        List<String> children = zoo.getChildren(tserversPath);
-        for (String child : children) {
-          message("Deleting " + tserversPath + "/" + child + " from zookeeper", opts);
-
-          if (opts.zapManager || opts.zapMaster) {
+        if ((opts.zapManager || opts.zapMaster) && opts.hostPortExcludeFile == null) {
+          // When shutting down all tablet servers and the manager, then completely clean up all
+          // tservers entries in zookeeper
+          List<String> children = zoo.getChildren(tserversPath);
+          for (String child : children) {
+            message("Deleting " + tserversPath + "/" + child + " from zookeeper", opts);
             zoo.recursiveDelete(tserversPath + "/" + child, NodeMissingPolicy.SKIP);
-          } else {
-            var zLockPath = ServiceLock.path(tserversPath + "/" + child);
-            if (!zoo.getChildren(zLockPath.toString()).isEmpty()) {
-              try {
-                ServiceLock.deleteLock(zoo, zLockPath);
-              } catch (RuntimeException e) {
-                message("Did not delete " + tserversPath + "/" + child, opts);
-              }
-            }
           }
+        } else {
+          removeLocks(zoo, tserversPath, hostPortPredicate, opts);
         }
       } catch (KeeperException | InterruptedException e) {
-        log.error("{}", e.getMessage(), e);
+        log.error("Error deleting tserver locks", e);
       }
     }
 
@@ -166,26 +224,18 @@ public class ZooZap implements KeywordExecutable {
     if (opts.zapCoordinators) {
       final String coordinatorPath = Constants.ZROOT + "/" + iid + Constants.ZCOORDINATOR_LOCK;
       try {
-        if (zoo.exists(coordinatorPath)) {
-          zapDirectory(zoo, coordinatorPath, opts);
-        }
+        removeSingletonLock(zoo, coordinatorPath, hostPortPredicate, opts);
       } catch (KeeperException | InterruptedException e) {
-        log.error("Error deleting coordinator from zookeeper, {}", e.getMessage(), e);
+        log.error("Error deleting coordinator from zookeeper", e);
       }
     }
 
     if (opts.zapCompactors) {
       String compactorsBasepath = Constants.ZROOT + "/" + iid + Constants.ZCOMPACTORS;
       try {
-        if (zoo.exists(compactorsBasepath)) {
-          List<String> queues = zoo.getChildren(compactorsBasepath);
-          for (String queue : queues) {
-            message("Deleting " + compactorsBasepath + "/" + queue + " from zookeeper", opts);
-            zoo.recursiveDelete(compactorsBasepath + "/" + queue, NodeMissingPolicy.SKIP);
-          }
-        }
+        removeGroupedLocks(zoo, compactorsBasepath, groupPredicate, hostPortPredicate, opts);
       } catch (KeeperException | InterruptedException e) {
-        log.error("Error deleting compactors from zookeeper, {}", e.getMessage(), e);
+        log.error("Error deleting compactors from zookeeper", e);
       }
 
     }
@@ -193,22 +243,11 @@ public class ZooZap implements KeywordExecutable {
     if (opts.zapScanServers) {
       String sserversPath = Constants.ZROOT + "/" + iid + Constants.ZSSERVERS;
       try {
-        if (zoo.exists(sserversPath)) {
-          List<String> children = zoo.getChildren(sserversPath);
-          for (String child : children) {
-            message("Deleting " + sserversPath + "/" + child + " from zookeeper", opts);
-
-            var zLockPath = ServiceLock.path(sserversPath + "/" + child);
-            if (!zoo.getChildren(zLockPath.toString()).isEmpty()) {
-              ServiceLock.deleteLock(zoo, zLockPath);
-            }
-          }
-        }
+        removeGroupedLocks(zoo, sserversPath, groupPredicate, hostPortPredicate, opts);
       } catch (KeeperException | InterruptedException e) {
-        log.error("{}", e.getMessage(), e);
+        log.error("Error deleting scan server locks", e);
       }
     }
-
   }
 
   private static void zapDirectory(ZooReaderWriter zoo, String path, Opts opts)
@@ -216,7 +255,51 @@ public class ZooZap implements KeywordExecutable {
     List<String> children = zoo.getChildren(path);
     for (String child : children) {
       message("Deleting " + path + "/" + child + " from zookeeper", opts);
-      zoo.recursiveDelete(path + "/" + child, NodeMissingPolicy.SKIP);
+      if (!opts.dryRun) {
+        zoo.recursiveDelete(path + "/" + child, NodeMissingPolicy.SKIP);
+      }
     }
   }
+
+  private static void removeGroupedLocks(ZooReaderWriter zoo, String path,
+      Predicate<String> groupPredicate, Predicate<HostAndPort> hostPortPredicate, Opts opts)
+      throws KeeperException, InterruptedException {
+    if (zoo.exists(path)) {
+      List<String> groups = zoo.getChildren(path);
+      for (String group : groups) {
+        if (groupPredicate.test(group)) {
+          removeLocks(zoo, path + "/" + group, hostPortPredicate, opts);
+        }
+      }
+    }
+  }
+
+  private static void removeLocks(ZooReaderWriter zoo, String path,
+      Predicate<HostAndPort> hostPortPredicate, Opts opts)
+      throws KeeperException, InterruptedException {
+    if (zoo.exists(path)) {
+      List<String> children = zoo.getChildren(path);
+      for (String child : children) {
+        if (hostPortPredicate.test(HostAndPort.fromString(child))) {
+          message("Deleting " + path + "/" + child + " from zookeeper", opts);
+          if (!opts.dryRun) {
+            // TODO not sure this is the correct way to delete this lock.. the code was deleting
+            // locks in multiple different ways for diff servers types.
+            zoo.recursiveDelete(path + "/" + child, NodeMissingPolicy.SKIP);
+          }
+        }
+      }
+    }
+  }
+
+  private static void removeSingletonLock(ZooReaderWriter zoo, String path,
+      Predicate<HostAndPort> hostPortPredicate, Opts ops)
+      throws KeeperException, InterruptedException {
+    var lockData = ServiceLock.getLockData(zoo.getZooKeeper(), ServiceLock.path(path));
+    if (lockData != null
+        && hostPortPredicate.test(HostAndPort.fromString(new String(lockData, UTF_8)))) {
+      zapDirectory(zoo, path, ops);
+    }
+  }
+
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
@@ -189,7 +189,7 @@ public class ZooZap implements KeywordExecutable {
       try {
         removeSingletonLock(zoo, monitorLockPath, hostPortPredicate, opts);
       } catch (KeeperException | InterruptedException e) {
-        log.error("Error deleting manager lock", e);
+        log.error("Error deleting monitor lock", e);
       }
     }
 


### PR DESCRIPTION
As the cluster.yaml file is changed it can leave extra server process around. The accumulo-cluster script currently does not have a way to look for extra servers processes, it only operates on what is specified in the cluster.yaml file.  This WIP commit is initial work to make the accumulo-cluster script look for server processes in zookeeper that are not specified by the cluster.yaml file.  For example if host1 had 5 compactor processes for group G1 in zookeeper and cluster.yaml only specified 2, then there are 3 extra servers on host1.  Another example would be if some hosts were completely removed from cluster.yaml but still had servers in zookeeper.  The desired count for these host would be zero and the actual counts would greater than zero.

The goal would be to add commands like the following to the cluster script.

```
accumulo-cluster prune                       # finds extra servers and removes their locks in zookeeper
accumulo-cluster prune --dry-run             # only prints extra servers, does not remove any locks
accumulo-cluster prune --compactors="G1,G2"  # finds extra compactors in group G1 or G2 and removes their locks in zookeeper
```

This commit only adds some initial java code that flushes out the concept a bit.  Would eventually call this java code from the accumulo cluster script.  The java code reconciles actual server counts from zookeeper with desired server counts from cluster.yaml.

Curious if anyone has any feedback on this concept and how this problems should be solved.