### PR TITLE
fixes accumulo-cluster bug with starting multiple compactors

### DIFF
--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -361,17 +361,17 @@ function parse_config() {
   for group in $SSERVER_GROUPS; do
     var_name="NUM_SSERVERS_$group"
     if [[ -n ${!var_name} ]]; then
-      declare "SSERVERS_PER_HOST_$group"="${!var_name}"
+      declare -g "SSERVERS_PER_HOST_$group"="${!var_name}"
     else
-      declare "SSERVERS_PER_HOST_$group"="${NUM_SSERVERS:-1}"
+      declare -g "SSERVERS_PER_HOST_$group"="${NUM_SSERVERS:-1}"
     fi
   done
   for group in $COMPACTOR_GROUPS; do
     var_name="NUM_COMPACTORS_$group"
     if [[ -n ${!var_name} ]]; then
-      declare "COMPACTORS_PER_HOST_$group"="${!var_name}"
+      declare -g "COMPACTORS_PER_HOST_$group"="${!var_name}"
     else
-      declare "COMPACTORS_PER_HOST_$group"="${NUM_COMPACTORS:-1}"
+      declare -g "COMPACTORS_PER_HOST_$group"="${NUM_COMPACTORS:-1}"
     fi
   done
 


### PR DESCRIPTION
The parse_config function was dynamically creating variables that were scoped to the function. When the code attempted to read these variables in the execute_command function it did not find them. This caused the script to only start one compactor per host even if multiple were configured. Added -g to declare builtin to make the variables global.