### PR TITLE
Fix CF and CQ cli options for DeleteMany and Grep commands

### DIFF
--- a/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteManyCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteManyCommand.java
@@ -63,6 +63,7 @@ public class DeleteManyCommand extends ScanCommand {
 
     // handle columns
     fetchColumns(cl, scanner, interpeter);
+    fetchColumsWithCFAndCQ(cl, scanner, interpeter);
 
     // output / delete the records
     final BatchWriter writer = shellState.getAccumuloClient().createBatchWriter(tableName,

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteManyCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteManyCommand.java
@@ -42,7 +42,7 @@ public class DeleteManyCommand extends ScanCommand {
     final String tableName = OptUtil.getTableOpt(cl, shellState);
 
     @SuppressWarnings("deprecation")
-    final org.apache.accumulo.core.util.interpret.ScanInterpreter interpeter =
+    final org.apache.accumulo.core.util.interpret.ScanInterpreter interpreter =
         getInterpreter(cl, tableName, shellState);
 
     // handle first argument, if present, the authorizations list to
@@ -57,13 +57,13 @@ public class DeleteManyCommand extends ScanCommand {
     addScanIterators(shellState, cl, scanner, tableName);
 
     // handle remaining optional arguments
-    scanner.setRange(getRange(cl, interpeter));
+    scanner.setRange(getRange(cl, interpreter));
 
     scanner.setTimeout(getTimeout(cl), TimeUnit.MILLISECONDS);
 
     // handle columns
-    fetchColumns(cl, scanner, interpeter);
-    fetchColumsWithCFAndCQ(cl, scanner, interpeter);
+    fetchColumns(cl, scanner, interpreter);
+    fetchColumsWithCFAndCQ(cl, scanner, interpreter);
 
     // output / delete the records
     final BatchWriter writer = shellState.getAccumuloClient().createBatchWriter(tableName,

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/GrepCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/GrepCommand.java
@@ -99,6 +99,7 @@ public class GrepCommand extends ScanCommand {
       try {
         // handle columns
         fetchColumns(cl, scanner, interpeter);
+        fetchColumsWithCFAndCQ(cl, scanner, interpeter);
 
         // output the records
         printRecords(cl, shellState, config, scanner, formatter, printFile);

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/GrepCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/GrepCommand.java
@@ -65,7 +65,7 @@ public class GrepCommand extends ScanCommand {
       }
       final Class<? extends Formatter> formatter = getFormatter(cl, tableName, shellState);
       @SuppressWarnings("deprecation")
-      final org.apache.accumulo.core.util.interpret.ScanInterpreter interpeter =
+      final org.apache.accumulo.core.util.interpret.ScanInterpreter interpreter =
           getInterpreter(cl, tableName, shellState);
 
       // handle first argument, if present, the authorizations list to
@@ -83,7 +83,7 @@ public class GrepCommand extends ScanCommand {
       final Authorizations auths = getAuths(cl, shellState);
       final BatchScanner scanner =
           shellState.getAccumuloClient().createBatchScanner(tableName, auths, numThreads);
-      scanner.setRanges(Collections.singletonList(getRange(cl, interpeter)));
+      scanner.setRanges(Collections.singletonList(getRange(cl, interpreter)));
 
       scanner.setTimeout(getTimeout(cl), TimeUnit.MILLISECONDS);
 
@@ -98,8 +98,8 @@ public class GrepCommand extends ScanCommand {
       }
       try {
         // handle columns
-        fetchColumns(cl, scanner, interpeter);
-        fetchColumsWithCFAndCQ(cl, scanner, interpeter);
+        fetchColumns(cl, scanner, interpreter);
+        fetchColumsWithCFAndCQ(cl, scanner, interpreter);
 
         // output the records
         printRecords(cl, shellState, config, scanner, formatter, printFile);

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ScanCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ScanCommand.java
@@ -58,7 +58,7 @@ import org.apache.hadoop.io.Text;
 public class ScanCommand extends Command {
 
   private Option scanOptAuths, scanOptRow, scanOptColumns, disablePaginationOpt, formatterOpt,
-      interpreterOpt, formatterInterpeterOpt, outputFileOpt, scanOptCf, scanOptCq;
+      interpreterOpt, formatterInterpreterOpt, outputFileOpt, scanOptCf, scanOptCq;
 
   protected Option showFewOpt;
   protected Option timestampOpt;
@@ -104,7 +104,7 @@ public class ScanCommand extends Command {
 
       final Class<? extends Formatter> formatter = getFormatter(cl, tableName, shellState);
       @SuppressWarnings("deprecation")
-      final org.apache.accumulo.core.util.interpret.ScanInterpreter interpeter =
+      final org.apache.accumulo.core.util.interpret.ScanInterpreter interpreter =
           getInterpreter(cl, tableName, shellState);
 
       String classLoaderContext = null;
@@ -121,11 +121,11 @@ public class ScanCommand extends Command {
       addScanIterators(shellState, cl, scanner, tableName);
 
       // handle remaining optional arguments
-      scanner.setRange(getRange(cl, interpeter));
+      scanner.setRange(getRange(cl, interpreter));
 
       // handle columns
-      fetchColumns(cl, scanner, interpeter);
-      fetchColumsWithCFAndCQ(cl, scanner, interpeter);
+      fetchColumns(cl, scanner, interpreter);
+      fetchColumsWithCFAndCQ(cl, scanner, interpreter);
 
       // set timeout
       scanner.setTimeout(getTimeout(cl), TimeUnit.MILLISECONDS);
@@ -244,11 +244,11 @@ public class ScanCommand extends Command {
 
         clazz = ClassLoaderUtil.loadClass(cl.getOptionValue(interpreterOpt.getOpt()),
             org.apache.accumulo.core.util.interpret.ScanInterpreter.class);
-      } else if (cl.hasOption(formatterInterpeterOpt.getOpt())) {
+      } else if (cl.hasOption(formatterInterpreterOpt.getOpt())) {
         Shell.log
             .warn("Scan Interpreter option is deprecated and will be removed in a future version.");
 
-        clazz = ClassLoaderUtil.loadClass(cl.getOptionValue(formatterInterpeterOpt.getOpt()),
+        clazz = ClassLoaderUtil.loadClass(cl.getOptionValue(formatterInterpreterOpt.getOpt()),
             org.apache.accumulo.core.util.interpret.ScanInterpreter.class);
       }
     } catch (ClassNotFoundException e) {
@@ -275,11 +275,11 @@ public class ScanCommand extends Command {
 
         return shellState.getClassLoader(cl, shellState)
             .loadClass(cl.getOptionValue(formatterOpt.getOpt())).asSubclass(Formatter.class);
-      } else if (cl.hasOption(formatterInterpeterOpt.getOpt())) {
+      } else if (cl.hasOption(formatterInterpreterOpt.getOpt())) {
         Shell.log.warn("Formatter option is deprecated and will be removed in a future version.");
 
         return shellState.getClassLoader(cl, shellState)
-            .loadClass(cl.getOptionValue(formatterInterpeterOpt.getOpt()))
+            .loadClass(cl.getOptionValue(formatterInterpreterOpt.getOpt()))
             .asSubclass(Formatter.class);
       }
     } catch (Exception e) {
@@ -323,7 +323,7 @@ public class ScanCommand extends Command {
   }
 
   protected void fetchColumsWithCFAndCQ(CommandLine cl, ScannerBase scanner,
-      @SuppressWarnings("deprecation") org.apache.accumulo.core.util.interpret.ScanInterpreter interpeter) {
+      @SuppressWarnings("deprecation") org.apache.accumulo.core.util.interpret.ScanInterpreter interpreter) {
     String cf = "";
     String cq = "";
     if (cl.hasOption(scanOptCf.getOpt())) {
@@ -339,14 +339,14 @@ public class ScanCommand extends Command {
       throw new IllegalArgumentException(formattedString);
     } else if (!cf.isEmpty() && cq.isEmpty()) {
       @SuppressWarnings("deprecation")
-      var interprettedCF = interpeter.interpretColumnFamily(new Text(cf.getBytes(Shell.CHARSET)));
+      var interprettedCF = interpreter.interpretColumnFamily(new Text(cf.getBytes(Shell.CHARSET)));
       scanner.fetchColumnFamily(interprettedCF);
     } else if (!cf.isEmpty() && !cq.isEmpty()) {
       @SuppressWarnings("deprecation")
-      var interprettedCF = interpeter.interpretColumnFamily(new Text(cf.getBytes(Shell.CHARSET)));
+      var interprettedCF = interpreter.interpretColumnFamily(new Text(cf.getBytes(Shell.CHARSET)));
       @SuppressWarnings("deprecation")
       var interprettedCQ =
-          interpeter.interpretColumnQualifier(new Text(cq.getBytes(Shell.CHARSET)));
+          interpreter.interpretColumnQualifier(new Text(cq.getBytes(Shell.CHARSET)));
       scanner.fetchColumn(interprettedCF, interprettedCQ);
 
     }
@@ -436,7 +436,7 @@ public class ScanCommand extends Command {
         new Option("fm", "formatter", true, "fully qualified name of the formatter class to use");
     interpreterOpt = new Option("i", "interpreter", true,
         "fully qualified name of the interpreter class to use");
-    formatterInterpeterOpt = new Option("fi", "fmt-interpreter", true,
+    formatterInterpreterOpt = new Option("fi", "fmt-interpreter", true,
         "fully qualified name of a class that is a formatter and interpreter");
     timeoutOption = new Option(null, "timeout", true,
         "time before scan should fail if no data is returned. If no unit is"
@@ -483,7 +483,7 @@ public class ScanCommand extends Command {
     o.addOption(OptUtil.tableOpt("table to be scanned"));
     o.addOption(formatterOpt);
     o.addOption(interpreterOpt);
-    o.addOption(formatterInterpeterOpt);
+    o.addOption(formatterInterpreterOpt);
     o.addOption(timeoutOption);
     if (Arrays.asList(ScanCommand.class.getName(), GrepCommand.class.getName(),
         EGrepCommand.class.getName()).contains(this.getClass().getName())) {

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ScanCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ScanCommand.java
@@ -322,7 +322,7 @@ public class ScanCommand extends Command {
     }
   }
 
-  private void fetchColumsWithCFAndCQ(CommandLine cl, Scanner scanner,
+  protected void fetchColumsWithCFAndCQ(CommandLine cl, ScannerBase scanner,
       @SuppressWarnings("deprecation") org.apache.accumulo.core.util.interpret.ScanInterpreter interpeter) {
     String cf = "";
     String cq = "";


### PR DESCRIPTION
DeleteMany, Grep, and MaxRow commands all extend the ScanCommand.

All of the valid command options for the scan command are also listed for each of these three commands.
This PR is a step towards fixing that behavior. 

See #5266