### PR TITLE
Modified TabletMetadata to expose loaded column timestamp

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/manager/state/TabletManagement.java
+++ b/core/src/main/java/org/apache/accumulo/core/manager/state/TabletManagement.java
@@ -52,6 +52,7 @@ public class TabletManagement {
 
   public static enum ManagementAction {
     BAD_STATE,
+    FATE_OLD_BULK_IMPORT,
     NEEDS_COMPACTING,
     NEEDS_LOCATION_UPDATE,
     NEEDS_RECOVERY,

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ConditionalTabletMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ConditionalTabletMutatorImpl.java
@@ -37,6 +37,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.admin.TabletAvailability;
@@ -263,7 +264,9 @@ public class ConditionalTabletMutatorImpl extends TabletMutatorBase<Ample.Condit
         }
         break;
       case LOADED: {
-        Condition c = SetEncodingIterator.createCondition(tabletMetadata.getLoaded().keySet(),
+        Condition c = SetEncodingIterator.createCondition(
+            tabletMetadata.getLoaded().stream().map(triple -> triple.getLeft())
+                .collect(Collectors.toSet()),
             stf -> stf.getMetadata().getBytes(UTF_8), BulkFileColumnFamily.NAME);
         mutation.addCondition(c);
       }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
@@ -1243,7 +1243,7 @@ public class Admin implements KeywordExecutable {
    */
   private static void getAllFateIds(TabletMetadata tabletMetadata,
       Consumer<FateId> fateIdConsumer) {
-    tabletMetadata.getLoaded().values().forEach(fateIdConsumer);
+    tabletMetadata.getLoaded().stream().map(triple -> triple.getMiddle()).forEach(fateIdConsumer);
     if (tabletMetadata.getSelectedFiles() != null) {
       fateIdConsumer.accept(tabletMetadata.getSelectedFiles().getFateId());
     }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
@@ -52,7 +52,6 @@ import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.logging.TabletLogger;
 import org.apache.accumulo.core.manager.thrift.BulkImportState;
 import org.apache.accumulo.core.metadata.ReferencedTabletFile;
-import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.Ample.ConditionalResult.Status;
@@ -177,8 +176,8 @@ class LoadFiles extends ManagerRepo {
 
       // remove any tablets that already have loaded flags
       tablets = tablets.stream().filter(tabletMeta -> {
-        Set<ReferencedTabletFile> loaded = tabletMeta.getLoaded().keySet().stream()
-            .map(StoredTabletFile::getTabletFile).collect(Collectors.toSet());
+        Set<ReferencedTabletFile> loaded = tabletMeta.getLoaded().stream()
+            .map(triple -> triple.getLeft().getTabletFile()).collect(Collectors.toSet());
         boolean containsAll = loaded.containsAll(toLoad.keySet());
         // The tablet should either contain all loaded files or none. It should never contain a
         // subset. Loaded files are written in single mutation to accumulo, either all changes in a

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/RefreshTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/RefreshTablets.java
@@ -49,7 +49,8 @@ public class RefreshTablets extends ManagerRepo {
   public Repo<Manager> call(FateId fateId, Manager manager) throws Exception {
 
     TabletRefresher.refresh(manager, fateId, bulkInfo.tableId, bulkInfo.firstSplit,
-        bulkInfo.lastSplit, tabletMetadata -> tabletMetadata.getLoaded().containsValue(fateId));
+        bulkInfo.lastSplit, tabletMetadata -> tabletMetadata.getLoaded().stream()
+            .anyMatch(triple -> triple.getMiddle().equals(fateId)));
 
     return new CleanUpBulkImport(bulkInfo);
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/UpdateTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/UpdateTablets.java
@@ -229,7 +229,8 @@ public class UpdateTablets extends ManagerRepo {
             "Null TabletMergeability for extent %s is unexpected", newExtent);
         mutator.putTabletMergeability(
             TabletMergeabilityMetadata.toMetadata(mergeability, manager.getSteadyTime()));
-        tabletMetadata.getLoaded().forEach((k, v) -> mutator.putBulkFile(k.getTabletFile(), v));
+        tabletMetadata.getLoaded()
+            .forEach((t) -> mutator.putBulkFile(t.getLeft().getTabletFile(), t.getMiddle()));
 
         newTabletsFiles.get(newExtent).forEach(mutator::putFile);
 

--- a/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/merge/MergeTabletsTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/merge/MergeTabletsTest.java
@@ -193,7 +193,7 @@ public class MergeTabletsTest {
     EasyMock.expect(lastTabletMeta.getTime()).andReturn(tabletTime).atLeastOnce();
     EasyMock.expect(lastTabletMeta.getFlushId()).andReturn(flushID).anyTimes();
     EasyMock.expect(lastTabletMeta.getTabletAvailability()).andReturn(availability).atLeastOnce();
-    EasyMock.expect(lastTabletMeta.getLoaded()).andReturn(Map.of()).atLeastOnce();
+    EasyMock.expect(lastTabletMeta.getLoaded()).andReturn(List.of()).atLeastOnce();
     EasyMock.expect(lastTabletMeta.getHostingRequested()).andReturn(true).atLeastOnce();
     EasyMock.expect(lastTabletMeta.getSuspend()).andReturn(suspendingTServer).atLeastOnce();
     EasyMock.expect(lastTabletMeta.getLast()).andReturn(lastLocation).atLeastOnce();

--- a/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/split/UpdateTabletsTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/split/UpdateTabletsTest.java
@@ -68,6 +68,7 @@ import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.split.Splitter;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.metadata.ConditionalTabletMutatorImpl;
+import org.apache.commons.lang3.tuple.Triple;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 import org.easymock.EasyMock;
@@ -205,7 +206,7 @@ public class UpdateTabletsTest {
 
     var flid1 = FateId.from(FateInstanceType.USER, UUID.randomUUID());
     var flid2 = FateId.from(FateInstanceType.USER, UUID.randomUUID());
-    var loaded = Map.of(loaded1, flid1, loaded2, flid2);
+    var loaded = List.of(Triple.of(loaded1, flid1, 123L), Triple.of(loaded2, flid2, 1236L));
 
     var dfv1 = new DataFileValue(1000, 100, 20);
     var dfv2 = new DataFileValue(500, 50, 20);

--- a/test/src/main/java/org/apache/accumulo/test/functional/AmpleConditionalWriterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/AmpleConditionalWriterIT.java
@@ -109,6 +109,7 @@ import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.metadata.AsyncConditionalTabletsMutatorImpl;
 import org.apache.accumulo.server.metadata.ConditionalTabletsMutatorImpl;
 import org.apache.accumulo.test.util.Wait;
+import org.apache.commons.lang3.tuple.Triple;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.AfterAll;
@@ -1798,7 +1799,7 @@ public class AmpleConditionalWriterIT extends SharedMiniClusterBase {
       assertEquals(Status.ACCEPTED, ctmi.process().get(e1).getStatus());
     }
     assertEquals(Set.of(stf1, stf2), context.getAmple().readTablet(e1).getFiles());
-    assertEquals(Map.of(stf1, fateId1, stf2, fateId1),
+    assertEquals(List.of(Triple.of(stf1, fateId1, 0L), Triple.of(stf2, fateId1, 0L)),
         context.getAmple().readTablet(e1).getLoaded());
 
     FateId fateId2 = FateId.from(FateInstanceType.USER, UUID.randomUUID());
@@ -1810,8 +1811,8 @@ public class AmpleConditionalWriterIT extends SharedMiniClusterBase {
       assertEquals(Status.ACCEPTED, ctmi.process().get(e1).getStatus());
     }
     assertEquals(Set.of(stf1, stf2, stf3), context.getAmple().readTablet(e1).getFiles());
-    assertEquals(Map.of(stf1, fateId1, stf2, fateId1, stf3, fateId2),
-        context.getAmple().readTablet(e1).getLoaded());
+    assertEquals(List.of(Triple.of(stf1, fateId1, 0L), Triple.of(stf2, fateId1, 0L),
+        Triple.of(stf3, fateId2, 0L)), context.getAmple().readTablet(e1).getLoaded());
 
     // should fail because the loaded markers are present
     try (var ctmi = new ConditionalTabletsMutatorImpl(context)) {
@@ -1832,8 +1833,8 @@ public class AmpleConditionalWriterIT extends SharedMiniClusterBase {
     }
 
     assertEquals(Set.of(stf1, stf2, stf3), context.getAmple().readTablet(e1).getFiles());
-    assertEquals(Map.of(stf1, fateId1, stf2, fateId1, stf3, fateId2),
-        context.getAmple().readTablet(e1).getLoaded());
+    assertEquals(List.of(Triple.of(stf1, fateId1, 0L), Triple.of(stf2, fateId1, 0L),
+        Triple.of(stf3, fateId2, 0L)), context.getAmple().readTablet(e1).getLoaded());
     assertTrue(context.getAmple().readTablet(e1).getFlushId().isEmpty());
   }
 


### PR DESCRIPTION
Modifed TabletMetadata.getLoaded to return a list of Triple<StoredTabletFile, FateId, Long> instead of a Map<StoredTabletFile, FateId>. The Long in the triple is the timestamp from the Key, and is used in the
TabletManagementIterator to return the TabletMetadata to the TabletGroupWatcher if the column for the Fate bulk import transaction is over 24 hours old. In the TabletGroupWatcher the Manager logs this at a WARN level, and could increment a metric, to alert users to the fact that they have a failing or stuck bulk import.

Closes #5175