### PR TITLE
Added 'a' short option to Shell merge --all command

### DIFF
--- a/shell/src/main/java/org/apache/accumulo/shell/commands/MergeCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/MergeCommand.java
@@ -95,8 +95,9 @@ public class MergeCommand extends Command {
         new Option("s", "size", true, "merge tablets to the given size over the entire table");
     forceOpt = new Option("f", "force", false,
         "merge small tablets to large tablets, even if it goes over the given size");
-    allOpt = new Option("a", "all", false, "allow an entire table to be merged into one tablet without prompting"
-        + " the user for confirmation");
+    allOpt = new Option("a", "all", false,
+        "allow an entire table to be merged into one tablet without prompting"
+            + " the user for confirmation");
     o.addOption(OptUtil.startRowOpt());
     o.addOption(OptUtil.endRowOpt());
     o.addOption(OptUtil.tableOpt("table to be merged"));

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/MergeCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/MergeCommand.java
@@ -95,11 +95,8 @@ public class MergeCommand extends Command {
         new Option("s", "size", true, "merge tablets to the given size over the entire table");
     forceOpt = new Option("f", "force", false,
         "merge small tablets to large tablets, even if it goes over the given size");
-    // Using the constructor does not allow for empty option
-    Option.Builder builder = Option.builder().longOpt("all").hasArg(false)
-        .desc("allow an entire table to be merged into one tablet without prompting"
-            + " the user for confirmation");
-    allOpt = builder.build();
+    allOpt = new Option("a", "all", false, "allow an entire table to be merged into one tablet without prompting"
+        + " the user for confirmation");
     o.addOption(OptUtil.startRowOpt());
     o.addOption(OptUtil.endRowOpt());
     o.addOption(OptUtil.tableOpt("table to be merged"));


### PR DESCRIPTION
Prior to #5450 the all option in the merge command used an empty
string for the short option. As part of which caused a failure because
commons-cli no longer allows an empty string as the short option
(see [1]). without a short option, which is allowed, but that appears
to have caused failures in ShellServerIT when the `merge --all` command
is used. This commit simply adds 'a' as the short option and removes
the Option.Builder modification.

[1] https://github.com/apache/commons-cli/commit/0ece5e45c0d5c713f1c3888281f8eb32c252d5db