### PR TITLE
Fixed MergeCommand to use longOpt for all option

### DIFF
--- a/shell/src/main/java/org/apache/accumulo/shell/commands/MergeCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/MergeCommand.java
@@ -46,7 +46,7 @@ public class MergeCommand extends Command {
     if (cl.hasOption(forceOpt.getOpt())) {
       force = true;
     }
-    if (cl.hasOption(allOpt.getOpt())) {
+    if (cl.hasOption(allOpt.getLongOpt())) {
       all = true;
     }
     if (cl.hasOption(sizeOpt.getOpt())) {

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/MergeCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/MergeCommand.java
@@ -46,7 +46,7 @@ public class MergeCommand extends Command {
     if (cl.hasOption(forceOpt.getOpt())) {
       force = true;
     }
-    if (cl.hasOption(allOpt.getLongOpt())) {
+    if (cl.hasOption(allOpt)) {
       all = true;
     }
     if (cl.hasOption(sizeOpt.getOpt())) {


### PR DESCRIPTION
Prior to #5450 the all option in the merge command used an empty string for the short option. In 5450 we changed MergeCommand to use the Option.Builder, which allows specifying a long option only, but
we didn't use the long option when getting the
option value which causes a ShellServerIT failure.