### PR TITLE
Changed log4j2 statusLogger level from info to warn

### DIFF
--- a/assemble/conf/log4j2-service.properties
+++ b/assemble/conf/log4j2-service.properties
@@ -20,7 +20,7 @@
 ## Log4j2 file that configures logging for all Accumulo services
 ## The system properties referenced below are configured by accumulo-env.sh
 
-status = info
+status = warn
 dest = err
 name = AccumuloServiceLoggingProperties
 monitorInterval = 30

--- a/assemble/conf/log4j2.properties
+++ b/assemble/conf/log4j2.properties
@@ -19,7 +19,7 @@
 
 ## Log4j2 file that configures logging for processes other than Accumulo services
 
-status = info
+status = warn
 dest = err
 name = AccumuloDefaultLoggingProperties
 monitorInterval = 30

--- a/core/src/test/resources/log4j2-test.properties
+++ b/core/src/test/resources/log4j2-test.properties
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-status = info
+status = warn
 dest = err
 name = AccumuloCoreTestLoggingProperties
 

--- a/hadoop-mapreduce/src/test/resources/log4j2-test.properties
+++ b/hadoop-mapreduce/src/test/resources/log4j2-test.properties
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-status = info
+status = warn
 dest = err
 name = AccumuloHadoopMapReduceTestLoggingProperties
 

--- a/iterator-test-harness/src/test/resources/log4j2-test.properties
+++ b/iterator-test-harness/src/test/resources/log4j2-test.properties
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-status = info
+status = warn
 dest = err
 name = AccumuloIteratorTestHarnessTestLoggingProperties
 

--- a/minicluster/src/test/resources/log4j2-test.properties
+++ b/minicluster/src/test/resources/log4j2-test.properties
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-status = info
+status = warn
 dest = err
 name = AccumuloMiniclusterTestLoggingProperties
 

--- a/server/base/src/test/resources/log4j2-test.properties
+++ b/server/base/src/test/resources/log4j2-test.properties
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-status = info
+status = warn
 dest = err
 name = AccumuloServerBaseTestLoggingProperties
 

--- a/server/gc/src/test/resources/log4j2-test.properties
+++ b/server/gc/src/test/resources/log4j2-test.properties
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-status = info
+status = warn
 dest = err
 name = AccumuloGcTestLoggingProperties
 

--- a/server/manager/src/test/resources/log4j2-test.properties
+++ b/server/manager/src/test/resources/log4j2-test.properties
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-status = info
+status = warn
 dest = err
 name = AccumuloManagerTestLoggingProperties
 

--- a/server/monitor/src/test/resources/log4j2-test.properties
+++ b/server/monitor/src/test/resources/log4j2-test.properties
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-status = info
+status = warn
 dest = err
 name = AccumuloMonitorTestLoggingProperties
 

--- a/server/tserver/src/test/resources/log4j2-test.properties
+++ b/server/tserver/src/test/resources/log4j2-test.properties
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-status = info
+status = warn
 dest = err
 name = AccumuloTserverTestLoggingProperties
 

--- a/shell/src/test/resources/log4j2-test.properties
+++ b/shell/src/test/resources/log4j2-test.properties
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-status = info
+status = warn
 dest = err
 name = AccumuloShellTestLoggingProperties
 

--- a/start/src/test/resources/log4j2-test.properties
+++ b/start/src/test/resources/log4j2-test.properties
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-status = info
+status = warn
 dest = err
 name = AccumuloStartTestLoggingProperties
 

--- a/test/src/main/resources/log4j2-test.properties
+++ b/test/src/main/resources/log4j2-test.properties
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-status = info
+status = warn
 dest = err
 name = AccumuloITLoggingProperties
 


### PR DESCRIPTION
After bumping the log4j2 dependency to version 2.24.3 we started noticing extra logging output during the build. This issue has been reported at https://github.com/apache/logging-log4j2/issues/3100 and is due to the change to the AbstractConfiguration class in https://github.com/apache/logging-log4j2/pull/3043. As described in log4j2 issue #3100 and at
https://logging.apache.org/log4j/2.x/manual/status-logger.html the status configuration element is now deprecated and we are advised to use a system property instead.

Closes #5453