### PR TITLE
Reduce sleep time for finished bulkv2 jobs

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
@@ -504,15 +504,13 @@ class LoadFiles extends ManagerRepo {
     }
 
     long sleepTime = loader.finish();
-    if (sleepTime <= 1) {
-      log.trace("{}: Sleeping for {}ms", fmtTid, sleepTime);
-      return sleepTime;
+    // sleepTime of 0 or 1 are success cases where we don't want to sleep anymore
+    if (sleepTime > 1) {
+      log.trace("{}: Tablet Max Sleep is {}", fmtTid, sleepTime);
+      long scanTime = Math.min(totalProcessingTime.toMillis(), 30_000);
+      log.trace("{}: Scan time is {}", fmtTid, scanTime);
+      sleepTime = Math.max(sleepTime, scanTime * 2);
     }
-
-    log.trace("{}: Tablet Max Sleep is {}", fmtTid, sleepTime);
-    long scanTime = Math.min(totalProcessingTime.toMillis(), 30_000);
-    log.trace("{}: Scan time is {}", fmtTid, scanTime);
-    sleepTime = Math.max(sleepTime, scanTime * 2);
     log.trace("{}: Sleeping for {}ms", fmtTid, sleepTime);
     return sleepTime;
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
@@ -368,7 +368,7 @@ class LoadFiles extends ManagerRepo {
       }
 
       if (locationLess > 0) {
-        sleepTime = Math.max(Math.max(100L, locationLess), sleepTime);
+        sleepTime = Math.max(100L, locationLess);
       }
 
       return sleepTime;
@@ -504,12 +504,15 @@ class LoadFiles extends ManagerRepo {
     }
 
     long sleepTime = loader.finish();
-    if (sleepTime > 0) {
-      log.trace("{}: Tablet Max Sleep is {}", fmtTid, sleepTime);
-      long scanTime = Math.min(totalProcessingTime.toMillis(), 30_000);
-      log.trace("{}: Scan time is {}", fmtTid, scanTime);
-      sleepTime = Math.max(sleepTime, scanTime * 2);
+    if (sleepTime <= 1) {
+      log.trace("{}: Sleeping for {}ms", fmtTid, sleepTime);
+      return sleepTime;
     }
+
+    log.trace("{}: Tablet Max Sleep is {}", fmtTid, sleepTime);
+    long scanTime = Math.min(totalProcessingTime.toMillis(), 30_000);
+    log.trace("{}: Scan time is {}", fmtTid, scanTime);
+    sleepTime = Math.max(sleepTime, scanTime * 2);
     log.trace("{}: Sleeping for {}ms", fmtTid, sleepTime);
     return sleepTime;
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
@@ -504,7 +504,9 @@ class LoadFiles extends ManagerRepo {
     }
 
     long sleepTime = loader.finish();
-    // sleepTime of 0 or 1 are success cases where we don't want to sleep anymore
+    // sleepTime of 0 indicates success. sleepTime of 1 indicates all rpcs to tservers have
+    // completed but a final scan of the metadata table is required to verify success.
+    // This is accomplished by running this step again and finally returning a sleepTime of 0.
     if (sleepTime > 1) {
       log.trace("{}: Tablet Max Sleep is {}", fmtTid, sleepTime);
       long scanTime = Math.min(totalProcessingTime.toMillis(), 30_000);


### PR DESCRIPTION
Skips the sleep calculation when bulkv2 returns 1 or 0 as success cases. 
Also removes an unnecessary max comparison as `sleepTime` will always be less than or equal to `locationLess`