### PR TITLE
Fixes unsafe iteration over a collection

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/AbstractFateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/AbstractFateStore.java
@@ -202,10 +202,12 @@ public abstract class AbstractFateStore<T> implements FateStore<T> {
       if (seen.get() == 0) {
         if (beforeCount == unreservedRunnableCount.getCount()) {
           long waitTime = 5000;
-          if (!deferred.isEmpty()) {
-            waitTime = deferred.values().stream()
-                .mapToLong(countDownTimer -> countDownTimer.timeLeft(TimeUnit.MILLISECONDS)).min()
-                .getAsLong();
+          synchronized (deferred) {
+            if (!deferred.isEmpty()) {
+              waitTime = deferred.values().stream()
+                  .mapToLong(countDownTimer -> countDownTimer.timeLeft(TimeUnit.MILLISECONDS)).min()
+                  .getAsLong();
+            }
           }
 
           if (waitTime > 0) {


### PR DESCRIPTION
AbstractFateStore's `deferred` collection was being iterated over without locking

Noticed when working on https://github.com/apache/accumulo/issues/5427