### PR TITLE
added missing log message to bulk load code

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
@@ -552,6 +552,7 @@ class LoadFiles extends ManagerRepo {
       }
 
       // we have found the first tablet in the range, add it to the list
+      log.trace("{}: Adding tablet: {} to overlapping list", fmtTid, currTablet.getExtent());
       tablets.add(currTablet);
 
       // find the remaining tablets within the loadRange by


### PR DESCRIPTION
Only a subset of tablet added for bulk load were logged.  Copied an existing log statement to another place where tablets were added.