### PR TITLE
Added property for setting setDropBehind on compaction input streams

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -1063,6 +1063,14 @@ public enum Property {
       "1.3.5"),
   TABLE_ARBITRARY_PROP_PREFIX("table.custom.", null, PropertyType.PREFIX,
       "Prefix to be used for user defined arbitrary properties.", "1.7.0"),
+  TABLE_MINC_INPUT_DROP_CACHE_EXCLUSIONS("table.compaction.minor.output.drop.cache.exclusions", "",
+      PropertyType.STRING,
+      "By default FSDataInputStream.setDropBehind(true) is set on all minor compaction"
+          + " input streams. The value of this property is a comma-separated list of Accumulo"
+          + " file type prefixes ('A', 'C', 'F', 'I', and 'M'). The value '*' can be used to"
+          + " specify all file types. When the input file prefix matches a value in this list,"
+          + " then setDropBehind will not be set on the FSDataInputStream.",
+      "2.1.4"),
   TABLE_MINC_OUTPUT_DROP_CACHE("table.compaction.minor.output.drop.cache", "false",
       PropertyType.BOOLEAN,
       "Setting this property to true will call"

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -1063,12 +1063,12 @@ public enum Property {
       "1.3.5"),
   TABLE_ARBITRARY_PROP_PREFIX("table.custom.", null, PropertyType.PREFIX,
       "Prefix to be used for user defined arbitrary properties.", "1.7.0"),
-  TABLE_MINC_INPUT_DROP_CACHE_EXCLUSIONS("table.compaction.minor.output.drop.cache.exclusions", "",
+  TABLE_COMPACTION_INPUT_DROP_CACHE_BEHIND("table.compaction.input.drop.cache", "*",
       PropertyType.STRING,
-      "By default FSDataInputStream.setDropBehind(true) is set on all minor compaction"
-          + " input streams. The value of this property is a comma-separated list of Accumulo"
+      "Sets FSDataInputStream.setDropBehind(true) is set on compaction"
+          + " input streams for the specified type of files. The value of this property is a comma-separated list of Accumulo"
           + " file type prefixes ('A', 'C', 'F', 'I', and 'M'). The value '*' can be used to"
-          + " specify all file types. When the input file prefix matches a value in this list,"
+          + " specify all file types (default). When the input file prefix matches a value in this list,"
           + " then setDropBehind will not be set on the FSDataInputStream.",
       "2.1.4"),
   TABLE_MINC_OUTPUT_DROP_CACHE("table.compaction.minor.output.drop.cache", "false",

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/AccumuloFileType.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/AccumuloFileType.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.fs;
+
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+
+public enum AccumuloFileType {
+
+  ALL("*"),
+  FLUSH("F"),
+  BULK_IMPORT("I"),
+  COMPACTION("C"),
+  FULL_COMPACTION("A"),
+  MERGING_MINOR_COMPACTION("M"),
+  UNKNOWN("?");
+
+  private static final Logger LOG = LoggerFactory.getLogger(AccumuloFileType.class);
+
+  private final String filePrefix;
+
+  private AccumuloFileType(String prefix) {
+    this.filePrefix = prefix;
+  }
+
+  public String getPrefix() {
+    return filePrefix;
+  }
+
+  public String createFileName(String fileName) {
+    if (this == ALL || this == UNKNOWN) {
+      throw new IllegalStateException("Unable to create filename with ALL or UNKNOWN prefix");
+    }
+    return filePrefix + fileName;
+  }
+
+  public static AccumuloFileType fromPrefix(String prefix) {
+    Objects.requireNonNull(prefix, "prefix must be supplied");
+    Preconditions.checkArgument(!prefix.isBlank(), "Empty prefix supplied");
+    Preconditions.checkArgument(prefix.length() == 1, "Invalid prefix supplied: " + prefix);
+    switch (prefix) {
+      case "A":
+        return FULL_COMPACTION;
+      case "C":
+        return COMPACTION;
+      case "F":
+        return FLUSH;
+      case "I":
+        return BULK_IMPORT;
+      case "M":
+        return MERGING_MINOR_COMPACTION;
+      default:
+        LOG.warn("Encountered unknown file prefix for file: {}", prefix);
+        return UNKNOWN;
+    }
+  }
+
+  public static AccumuloFileType fromFileName(String fileName) {
+    Objects.requireNonNull(fileName, "file name must be supplied");
+    Preconditions.checkArgument(!fileName.isBlank(), "Empty filename supplied");
+    String firstChar = fileName.substring(0, 1);
+    return fromPrefix(firstChar);
+  }
+
+}

--- a/server/base/src/test/java/org/apache/accumulo/server/fs/FileTypePrefixTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/fs/FileTypePrefixTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.fs;
+
+import static org.apache.accumulo.server.fs.FileTypePrefix.ALL;
+import static org.apache.accumulo.server.fs.FileTypePrefix.BULK_IMPORT;
+import static org.apache.accumulo.server.fs.FileTypePrefix.COMPACTION;
+import static org.apache.accumulo.server.fs.FileTypePrefix.FLUSH;
+import static org.apache.accumulo.server.fs.FileTypePrefix.FULL_COMPACTION;
+import static org.apache.accumulo.server.fs.FileTypePrefix.MERGING_MINOR_COMPACTION;
+import static org.apache.accumulo.server.fs.FileTypePrefix.UNKNOWN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.EnumSet;
+
+import org.junit.jupiter.api.Test;
+
+public class FileTypePrefixTest {
+
+  @Test
+  public void testCreateFileName() {
+    assertThrows(NullPointerException.class, () -> FLUSH.createFileName(null));
+    assertThrows(IllegalArgumentException.class, () -> FLUSH.createFileName(""));
+    assertThrows(IllegalStateException.class, () -> ALL.createFileName("file.rf"));
+    assertThrows(IllegalStateException.class, () -> UNKNOWN.createFileName("file.rf"));
+    assertThrows(IllegalStateException.class,
+        () -> MERGING_MINOR_COMPACTION.createFileName("file.rf"));
+    assertEquals("Afile.rf", FULL_COMPACTION.createFileName("file.rf"));
+    assertEquals("Cfile.rf", COMPACTION.createFileName("file.rf"));
+    assertEquals("Ffile.rf", FLUSH.createFileName("file.rf"));
+    assertEquals("Ifile.rf", BULK_IMPORT.createFileName("file.rf"));
+  }
+
+  @Test
+  public void testFromPrefix() {
+    assertThrows(NullPointerException.class, () -> FileTypePrefix.fromPrefix(null));
+    assertThrows(IllegalArgumentException.class, () -> FileTypePrefix.fromPrefix(""));
+    assertThrows(IllegalArgumentException.class, () -> FileTypePrefix.fromPrefix("AB"));
+    assertEquals(UNKNOWN, FileTypePrefix.fromPrefix("*"));
+    assertEquals(COMPACTION, FileTypePrefix.fromPrefix("c"));
+    assertEquals(COMPACTION, FileTypePrefix.fromPrefix("C"));
+    assertEquals(FULL_COMPACTION, FileTypePrefix.fromPrefix("a"));
+    assertEquals(FULL_COMPACTION, FileTypePrefix.fromPrefix("A"));
+    assertEquals(FLUSH, FileTypePrefix.fromPrefix("f"));
+    assertEquals(FLUSH, FileTypePrefix.fromPrefix("F"));
+    assertEquals(BULK_IMPORT, FileTypePrefix.fromPrefix("i"));
+    assertEquals(BULK_IMPORT, FileTypePrefix.fromPrefix("I"));
+    assertEquals(MERGING_MINOR_COMPACTION, FileTypePrefix.fromPrefix("m"));
+    assertEquals(MERGING_MINOR_COMPACTION, FileTypePrefix.fromPrefix("M"));
+  }
+
+  @Test
+  public void fromFileName() {
+    assertThrows(NullPointerException.class, () -> FileTypePrefix.fromFileName(null));
+    assertThrows(IllegalArgumentException.class, () -> FileTypePrefix.fromFileName(""));
+    assertEquals(UNKNOWN, FileTypePrefix.fromFileName("*file.rf"));
+    assertThrows(IllegalArgumentException.class, () -> FileTypePrefix.fromFileName("cfile.rf"));
+    assertEquals(COMPACTION, FileTypePrefix.fromFileName("Cfile.rf"));
+    assertThrows(IllegalArgumentException.class, () -> FileTypePrefix.fromFileName("afile.rf"));
+    assertEquals(FULL_COMPACTION, FileTypePrefix.fromFileName("Afile.rf"));
+    assertThrows(IllegalArgumentException.class, () -> FileTypePrefix.fromFileName("ffile.rf"));
+    assertEquals(FLUSH, FileTypePrefix.fromFileName("Ffile.rf"));
+    assertThrows(IllegalArgumentException.class, () -> FileTypePrefix.fromFileName("ifile.rf"));
+    assertEquals(BULK_IMPORT, FileTypePrefix.fromFileName("Ifile.rf"));
+    assertThrows(IllegalArgumentException.class, () -> FileTypePrefix.fromFileName("mfile.rf"));
+    assertEquals(MERGING_MINOR_COMPACTION, FileTypePrefix.fromFileName("Mfile.rf"));
+
+  }
+
+  @Test
+  public void testFromList() {
+    assertEquals(EnumSet.noneOf(FileTypePrefix.class), FileTypePrefix.typesFromList(""));
+    assertEquals(EnumSet.of(ALL), FileTypePrefix.typesFromList("*"));
+    assertEquals(EnumSet.of(ALL), FileTypePrefix.typesFromList("*, A"));
+    assertEquals(EnumSet.of(COMPACTION, FULL_COMPACTION), FileTypePrefix.typesFromList("C, A"));
+  }
+
+}

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/PrepBulkImport.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/PrepBulkImport.java
@@ -51,7 +51,7 @@ import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.accumulo.server.ServerContext;
-import org.apache.accumulo.server.fs.AccumuloFileType;
+import org.apache.accumulo.server.fs.FileTypePrefix;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.tablets.UniqueNameAllocator;
 import org.apache.accumulo.server.zookeeper.TransactionWatcher;
@@ -279,7 +279,7 @@ public class PrepBulkImport extends ManagerRepo {
 
     for (FileStatus file : files) {
       // since these are only valid files we know it has an extension
-      String newName = AccumuloFileType.BULK_IMPORT.createFileName(
+      String newName = FileTypePrefix.BULK_IMPORT.createFileName(
           namer.getNextName() + "." + FilenameUtils.getExtension(file.getPath().getName()));
       oldToNewNameMap.put(file.getPath().getName(), new Path(bulkDir, newName).getName());
     }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/PrepBulkImport.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/PrepBulkImport.java
@@ -51,6 +51,7 @@ import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.fs.AccumuloFileType;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.tablets.UniqueNameAllocator;
 import org.apache.accumulo.server.zookeeper.TransactionWatcher;
@@ -278,8 +279,8 @@ public class PrepBulkImport extends ManagerRepo {
 
     for (FileStatus file : files) {
       // since these are only valid files we know it has an extension
-      String newName =
-          "I" + namer.getNextName() + "." + FilenameUtils.getExtension(file.getPath().getName());
+      String newName = AccumuloFileType.BULK_IMPORT.createFileName(
+          namer.getNextName() + "." + FilenameUtils.getExtension(file.getPath().getName()));
       oldToNewNameMap.put(file.getPath().getName(), new Path(bulkDir, newName).getName());
     }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/MapImportFileNames.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/MapImportFileNames.java
@@ -33,6 +33,7 @@ import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.server.fs.AccumuloFileType;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.tablets.UniqueNameAllocator;
 import org.apache.hadoop.fs.FileStatus;
@@ -86,7 +87,8 @@ class MapImportFileNames extends ManagerRepo {
             extension = Constants.MAPFILE_EXTENSION;
           }
 
-          String newName = "I" + namer.getNextName() + "." + extension;
+          String newName =
+              AccumuloFileType.BULK_IMPORT.createFileName(namer.getNextName() + "." + extension);
 
           mappingsWriter.append(fileName);
           mappingsWriter.append(':');

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/MapImportFileNames.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/MapImportFileNames.java
@@ -33,7 +33,7 @@ import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
-import org.apache.accumulo.server.fs.AccumuloFileType;
+import org.apache.accumulo.server.fs.FileTypePrefix;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.tablets.UniqueNameAllocator;
 import org.apache.hadoop.fs.FileStatus;
@@ -88,7 +88,7 @@ class MapImportFileNames extends ManagerRepo {
           }
 
           String newName =
-              AccumuloFileType.BULK_IMPORT.createFileName(namer.getNextName() + "." + extension);
+              FileTypePrefix.BULK_IMPORT.createFileName(namer.getNextName() + "." + extension);
 
           mappingsWriter.append(fileName);
           mappingsWriter.append(':');

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactionTask.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactionTask.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.tserver.tablet;
 import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.trace.TraceUtil;
+import org.apache.accumulo.server.fs.AccumuloFileType;
 import org.apache.accumulo.tserver.MinorCompactionReason;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
@@ -74,7 +75,7 @@ class MinorCompactionTask implements Runnable {
           while (true) {
             try {
               if (newFile == null) {
-                newFile = tablet.getNextMapFilename("F");
+                newFile = tablet.getNextMapFilename(AccumuloFileType.FLUSH);
                 tmpFile = new TabletFile(new Path(newFile.getPathStr() + "_tmp"));
               }
               /*

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactionTask.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactionTask.java
@@ -21,7 +21,7 @@ package org.apache.accumulo.tserver.tablet;
 import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.trace.TraceUtil;
-import org.apache.accumulo.server.fs.AccumuloFileType;
+import org.apache.accumulo.server.fs.FileTypePrefix;
 import org.apache.accumulo.tserver.MinorCompactionReason;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
@@ -75,7 +75,7 @@ class MinorCompactionTask implements Runnable {
           while (true) {
             try {
               if (newFile == null) {
-                newFile = tablet.getNextMapFilename(AccumuloFileType.FLUSH);
+                newFile = tablet.getNextMapFilename(FileTypePrefix.FLUSH);
                 tmpFile = new TabletFile(new Path(newFile.getPathStr() + "_tmp"));
               }
               /*

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -97,6 +97,7 @@ import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.core.volume.Volume;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.compaction.CompactionStats;
+import org.apache.accumulo.server.fs.AccumuloFileType;
 import org.apache.accumulo.server.fs.VolumeChooserEnvironmentImpl;
 import org.apache.accumulo.server.fs.VolumeUtil;
 import org.apache.accumulo.server.fs.VolumeUtil.TabletFiles;
@@ -264,14 +265,16 @@ public class Tablet extends TabletBase {
     return dirUri;
   }
 
-  TabletFile getNextMapFilename(String prefix) throws IOException {
+  TabletFile getNextMapFilename(AccumuloFileType prefix) throws IOException {
     String extension = FileOperations.getNewFileExtension(tableConfiguration);
-    return new TabletFile(new Path(chooseTabletDir() + "/" + prefix
-        + context.getUniqueNameAllocator().getNextName() + "." + extension));
+    return new TabletFile(new Path(chooseTabletDir() + "/"
+        + prefix.createFileName(context.getUniqueNameAllocator().getNextName() + "." + extension)));
   }
 
   TabletFile getNextMapFilenameForMajc(boolean propagateDeletes) throws IOException {
-    String tmpFileName = getNextMapFilename(!propagateDeletes ? "A" : "C").getMetaInsert() + "_tmp";
+    AccumuloFileType prefix =
+        !propagateDeletes ? AccumuloFileType.FULL_COMPACTION : AccumuloFileType.COMPACTION;
+    String tmpFileName = getNextMapFilename(prefix).getMetaInsert() + "_tmp";
     return new TabletFile(new Path(tmpFileName));
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -97,7 +97,7 @@ import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.core.volume.Volume;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.compaction.CompactionStats;
-import org.apache.accumulo.server.fs.AccumuloFileType;
+import org.apache.accumulo.server.fs.FileTypePrefix;
 import org.apache.accumulo.server.fs.VolumeChooserEnvironmentImpl;
 import org.apache.accumulo.server.fs.VolumeUtil;
 import org.apache.accumulo.server.fs.VolumeUtil.TabletFiles;
@@ -265,15 +265,15 @@ public class Tablet extends TabletBase {
     return dirUri;
   }
 
-  TabletFile getNextMapFilename(AccumuloFileType prefix) throws IOException {
+  TabletFile getNextMapFilename(FileTypePrefix prefix) throws IOException {
     String extension = FileOperations.getNewFileExtension(tableConfiguration);
     return new TabletFile(new Path(chooseTabletDir() + "/"
         + prefix.createFileName(context.getUniqueNameAllocator().getNextName() + "." + extension)));
   }
 
   TabletFile getNextMapFilenameForMajc(boolean propagateDeletes) throws IOException {
-    AccumuloFileType prefix =
-        !propagateDeletes ? AccumuloFileType.FULL_COMPACTION : AccumuloFileType.COMPACTION;
+    FileTypePrefix prefix =
+        !propagateDeletes ? FileTypePrefix.FULL_COMPACTION : FileTypePrefix.COMPACTION;
     String tmpFileName = getNextMapFilename(prefix).getMetaInsert() + "_tmp";
     return new TabletFile(new Path(tmpFileName));
   }


### PR DESCRIPTION
In #3079 we modified the FileCompactor to call FSDataInputStream.setDropBehind on compaction input files. This could cause an issue when certain types of files are used for compaction input. Created a property to allow the user to specify which file types should be excluded from this behavior.