### PR TITLE
Disabled metrics for ThreadPool used for resending failed mutations

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchWriter.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchWriter.java
@@ -65,6 +65,7 @@ import org.apache.accumulo.core.clientImpl.ClientTabletCache.TabletServerMutatio
 import org.apache.accumulo.core.clientImpl.thrift.SecurityErrorCode;
 import org.apache.accumulo.core.clientImpl.thrift.TInfo;
 import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
+import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.constraints.Violations;
 import org.apache.accumulo.core.data.ConstraintViolationSummary;
 import org.apache.accumulo.core.data.Mutation;
@@ -211,8 +212,10 @@ public class TabletServerBatchWriter implements AutoCloseable {
 
   public TabletServerBatchWriter(ClientContext context, BatchWriterConfig config) {
     this.context = context;
-    this.executor = context.threadPools()
-        .createGeneralScheduledExecutorService(this.context.getConfiguration());
+    // This does not use ThreadPools.createGeneralScheduledExecutorService because
+    // we are disabling metrics here.
+    this.executor = (ScheduledThreadPoolExecutor) context.threadPools().createExecutorService(
+        this.context.getConfiguration(), Property.GENERAL_THREADPOOL_SIZE, false);
     this.failedMutations = new FailedMutations();
     this.maxMem = config.getMaxMemory();
     this.maxLatency = config.getMaxLatency(MILLISECONDS) <= 0 ? Long.MAX_VALUE


### PR DESCRIPTION
The TabletServerBatchWriter uses a ScheduledExecutorThreadPool for dealing with failed mutations. The TabletServerBatchWriter code was calling ThreadPools.createGeneralScheduledExecutorService which creates the ThreadPoolExecutor with metrics enabled. If more than one TabletServerBatchWriter is created, then debug messages start showing up in the logs saying that the associated Gauge's have already been registered and will be ignored. This change calls the same underlying code, but disables metrics for the thread pool