### PR TITLE
Log user attempting to use Authorization they don't have on server

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKAuthorizor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKAuthorizor.java
@@ -152,6 +152,9 @@ public class ZKAuthorizor implements Authorizor {
 
     for (ByteBuffer auth : auths) {
       if (!userauths.contains(ByteBufferUtil.toBytes(auth))) {
+        log.info(
+            "User {} attempted to use Authorization {} which they do not have assigned to them.",
+            user, new String(auth.array(), UTF_8));
         return false;
       }
     }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ThriftScanClientHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ThriftScanClientHandler.java
@@ -401,14 +401,9 @@ public class ThriftScanClientHandler implements TabletScanClientService.Iface {
       }
     }
 
-    try {
-      if (!security.authenticatedUserHasAuthorizations(credentials, authorizations)) {
-        throw new ThriftSecurityException(credentials.getPrincipal(),
-            SecurityErrorCode.BAD_AUTHORIZATIONS);
-      }
-    } catch (ThriftSecurityException tse) {
-      log.error("{} is not authorized", credentials.getPrincipal(), tse);
-      throw tse;
+    if (!security.authenticatedUserHasAuthorizations(credentials, authorizations)) {
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.BAD_AUTHORIZATIONS);
     }
 
     // @formatter:off


### PR DESCRIPTION
This change removes the logging of a stack trace with an unhelpful message that was done only for batch scans and replaces it with a log message that notes the specific Authorization that the user is trying to use that they don't have. This logging is only done on the server side, the client receives a BAD_AUTHORIZATIONS error.