### PR TITLE
Modified TabletMetadata to return HOSTED for all system tables

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -585,8 +585,7 @@ public class TabletMetadata {
   }
 
   public TabletAvailability getTabletAvailability() {
-    if (AccumuloTable.ROOT.tableId().equals(getTableId())
-        || AccumuloTable.METADATA.tableId().equals(getTableId())) {
+    if (AccumuloTable.allTableIds().contains(getTableId())) {
       // Override the availability for the system tables
       return TabletAvailability.HOSTED;
     }

--- a/test/src/main/java/org/apache/accumulo/test/functional/ManagerAssignmentIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ManagerAssignmentIT.java
@@ -120,7 +120,7 @@ public class ManagerAssignmentIT extends SharedMiniClusterBase {
 
   @Test
   public void test() throws Exception {
-    // Confirm that the root and metadata tables are hosted
+    // Confirm that the system tables are hosted
     Locations rootLocations = client.tableOperations().locate(AccumuloTable.ROOT.tableName(),
         Collections.singletonList(new Range()));
     rootLocations.groupByTablet().keySet()
@@ -130,6 +130,15 @@ public class ManagerAssignmentIT extends SharedMiniClusterBase {
         .locate(AccumuloTable.METADATA.tableName(), Collections.singletonList(new Range()));
     metadataLocations.groupByTablet().keySet()
         .forEach(tid -> assertNotNull(metadataLocations.getTabletLocation(tid)));
+
+    Locations fateLocations = client.tableOperations().locate(AccumuloTable.FATE.tableName(),
+        Collections.singletonList(new Range()));
+    fateLocations.groupByTablet().keySet()
+        .forEach(tid -> assertNotNull(fateLocations.getTabletLocation(tid)));
+
+    Locations scanRef = client.tableOperations().locate(AccumuloTable.SCAN_REF.tableName(),
+        Collections.singletonList(new Range()));
+    scanRef.groupByTablet().keySet().forEach(tid -> assertNotNull(scanRef.getTabletLocation(tid)));
 
     String tableName = super.getUniqueNames(1)[0];
     client.tableOperations().create(tableName);

--- a/test/src/main/java/org/apache/accumulo/test/functional/ManagerAssignmentIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ManagerAssignmentIT.java
@@ -121,24 +121,12 @@ public class ManagerAssignmentIT extends SharedMiniClusterBase {
   @Test
   public void test() throws Exception {
     // Confirm that the system tables are hosted
-    Locations rootLocations = client.tableOperations().locate(AccumuloTable.ROOT.tableName(),
-        Collections.singletonList(new Range()));
-    rootLocations.groupByTablet().keySet()
-        .forEach(tid -> assertNotNull(rootLocations.getTabletLocation(tid)));
 
-    Locations metadataLocations = client.tableOperations()
-        .locate(AccumuloTable.METADATA.tableName(), Collections.singletonList(new Range()));
-    metadataLocations.groupByTablet().keySet()
-        .forEach(tid -> assertNotNull(metadataLocations.getTabletLocation(tid)));
-
-    Locations fateLocations = client.tableOperations().locate(AccumuloTable.FATE.tableName(),
-        Collections.singletonList(new Range()));
-    fateLocations.groupByTablet().keySet()
-        .forEach(tid -> assertNotNull(fateLocations.getTabletLocation(tid)));
-
-    Locations scanRef = client.tableOperations().locate(AccumuloTable.SCAN_REF.tableName(),
-        Collections.singletonList(new Range()));
-    scanRef.groupByTablet().keySet().forEach(tid -> assertNotNull(scanRef.getTabletLocation(tid)));
+    for (AccumuloTable t : AccumuloTable.values()) {
+      Locations locs =
+          client.tableOperations().locate(t.tableName(), Collections.singletonList(new Range()));
+      locs.groupByTablet().keySet().forEach(tid -> assertNotNull(locs.getTabletLocation(tid)));
+    }
 
     String tableName = super.getUniqueNames(1)[0];
     client.tableOperations().create(tableName);

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletAvailabilityIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletAvailabilityIT.java
@@ -55,7 +55,7 @@ public class TabletAvailabilityIT extends AccumuloClusterHarness {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
       for (AccumuloTable t : AccumuloTable.values()) {
         assertThrows(IllegalArgumentException.class, () -> client.tableOperations()
-            .setTabletAvailability(t.tableName(), new Range(), HOSTED));
+            .setTabletAvailability(t.tableName(), new Range(), UNHOSTED));
       }
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletAvailabilityIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletAvailabilityIT.java
@@ -43,11 +43,22 @@ import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.client.admin.TabletAvailability;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.metadata.AccumuloTable;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.Test;
 
 public class TabletAvailabilityIT extends AccumuloClusterHarness {
+
+  @Test
+  public void testSystemFails() throws Exception {
+    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
+      for (AccumuloTable t : AccumuloTable.values()) {
+        assertThrows(IllegalArgumentException.class, () -> client.tableOperations()
+            .setTabletAvailability(t.tableName(), new Range(), HOSTED));
+      }
+    }
+  }
 
   @Test
   public void testOffline() throws Exception {


### PR DESCRIPTION
Modified TabletMetadata.getTabletAvailability to return HOSTED for tables in the system namespace. Added some more tests.