### PR TITLE
Fix resource group mapping in GarbageCollector compactor check

### DIFF
--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -328,7 +328,7 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
               String resourceGroup = tconf.get(TableLoadBalancer.TABLE_ASSIGNMENT_GROUP_PROPERTY);
               resourceGroup =
                   resourceGroup == null ? Constants.DEFAULT_RESOURCE_GROUP_NAME : resourceGroup;
-              resourceMapping.getOrDefault(resourceGroup, new HashSet<>()).add(tid);
+              resourceMapping.computeIfAbsent(resourceGroup, k -> new HashSet<>()).add(tid);
             }
             for (Entry<String,Set<TableId>> e : resourceMapping.entrySet()) {
               if (ExternalCompactionUtil.countCompactors(e.getKey(), getContext()) == 0) {
@@ -437,7 +437,7 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
             false, addresses);
     server.startThriftServer("GC Monitor Service");
     setHostname(server.address);
-    log.debug("Starting garbage collector listening on " + server.address);
+    log.debug("Starting garbage collector listening on {}", server.address);
     return server.address;
   }
 


### PR DESCRIPTION
This fixes a bug where new resource groups were never actually added to the resourceMapping map. The previous code used getOrDefault() to retrieve a set, but if the group wasn't already present in the map, it returned a temporary set that was modified but never stored. As a result, those resource groups and their associated tables were effectively ignored. Switching to computeIfAbsent() ensures the set is both created and inserted into the map before adding the table ID.

I also fixed a warning about non final String in the log message but thats trivial and unrelated.