### PR TITLE
prevent deleteRows of system tables

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
@@ -505,7 +505,7 @@ class FateServiceHandler implements FateService.Iface {
         TableOperation tableOp = TableOperation.DELETE_RANGE;
         validateArgumentCount(arguments, tableOp, 3);
         String tableName =
-            validateName(arguments.get(0), tableOp, EXISTING_TABLE_NAME.and(NOT_BUILTIN_TABLE));
+            validateName(arguments.get(0), tableOp, NOT_BUILTIN_TABLE.and(EXISTING_TABLE_NAME));
         Text startRow = ByteBufferUtil.toText(arguments.get(1));
         Text endRow = ByteBufferUtil.toText(arguments.get(2));
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
@@ -505,7 +505,7 @@ class FateServiceHandler implements FateService.Iface {
         TableOperation tableOp = TableOperation.DELETE_RANGE;
         validateArgumentCount(arguments, tableOp, 3);
         String tableName =
-            validateName(arguments.get(0), tableOp, EXISTING_TABLE_NAME.and(NOT_METADATA_TABLE));
+            validateName(arguments.get(0), tableOp, EXISTING_TABLE_NAME.and(NOT_BUILTIN_TABLE));
         Text startRow = ByteBufferUtil.toText(arguments.get(1));
         Text endRow = ByteBufferUtil.toText(arguments.get(2));
 


### PR DESCRIPTION
Prevents `tableOperations().deleteRows` of system tables in 4.0.

2.1 system tables:
- root <-- `cannot` delete rows
- metadata <-- `cannot` delete rows
- replication <-- `can` deleteRows

4.0 system tables:
- root <-- before: `cannot` delete rows, after: same
- metadata <-- before: `cannot` delete rows, after: same
- scan_ref <-- before: `can` delete rows, after: `cannot` delete rows
- fate <-- before: `can` delete rows, after: `cannot` delete rows

I did not target 2.1 because I was unsure if we want `deleteRows` for the replication table (seems like that was the intent, but table expectations changed in 4.0).

Created from discussion: https://github.com/apache/accumulo/pull/5474#discussion_r2042456618