### PR TITLE
Created HostRegexTableLoadBalancer test for defining default pool

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancer.java
@@ -395,9 +395,8 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer {
     Map<String,SortedMap<TabletServerId,TServerStatus>> currentGrouped =
         splitCurrentByRegex(params.currentStatus());
 
-    if ((now
-        - this.lastOOBCheckTimes.getOrDefault(params.partitionName(), System.currentTimeMillis()))
-        > myConf.oobCheckMillis) {
+    if ((now - this.lastOOBCheckTimes.computeIfAbsent(params.partitionName(),
+        (p) -> System.currentTimeMillis())) > myConf.oobCheckMillis) {
       try {
         // Check to see if a tablet is assigned outside the bounds of the pool. If so, migrate it.
         for (String table : tableIdMap.keySet()) {

--- a/core/src/test/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancerTest.java
@@ -202,6 +202,70 @@ public class HostRegexTableLoadBalancerTest extends BaseHostRegexTableLoadBalanc
   }
 
   @Test
+  public void testSplitCurrentByRegexDefineDefaultPool() {
+    HashMap<String,String> props = new HashMap<>(DEFAULT_TABLE_PROPERTIES);
+    props.put(HostRegexTableLoadBalancer.HOST_BALANCER_PREFIX + FOO.getTableName(), "r01.*");
+    props.put(HostRegexTableLoadBalancer.HOST_BALANCER_PREFIX + BAR.getTableName(), "r02.*");
+    // Normally the DEFAULT pool would be comprised of the hosts not included in a regex.
+    // Here we are going to define it as also being on rack1
+    props.put(HostRegexTableLoadBalancer.HOST_BALANCER_PREFIX + DEFAULT_POOL, "r01.*");
+    init(props);
+    Map<String,SortedMap<TabletServerId,TServerStatus>> groups =
+        this.splitCurrentByRegex(createCurrent(15));
+    assertEquals(3, groups.size());
+    assertTrue(groups.containsKey(FOO.getTableName()));
+    SortedMap<TabletServerId,TServerStatus> fooHosts = groups.get(FOO.getTableName());
+    assertEquals(5, fooHosts.size());
+    assertTrue(
+        fooHosts.containsKey(new TabletServerIdImpl("192.168.0.1", 9997, Integer.toHexString(1))));
+    assertTrue(
+        fooHosts.containsKey(new TabletServerIdImpl("192.168.0.2", 9997, Integer.toHexString(1))));
+    assertTrue(
+        fooHosts.containsKey(new TabletServerIdImpl("192.168.0.3", 9997, Integer.toHexString(1))));
+    assertTrue(
+        fooHosts.containsKey(new TabletServerIdImpl("192.168.0.4", 9997, Integer.toHexString(1))));
+    assertTrue(
+        fooHosts.containsKey(new TabletServerIdImpl("192.168.0.5", 9997, Integer.toHexString(1))));
+    assertTrue(groups.containsKey(BAR.getTableName()));
+    SortedMap<TabletServerId,TServerStatus> barHosts = groups.get(BAR.getTableName());
+    assertEquals(5, barHosts.size());
+    assertTrue(
+        barHosts.containsKey(new TabletServerIdImpl("192.168.0.6", 9997, Integer.toHexString(1))));
+    assertTrue(
+        barHosts.containsKey(new TabletServerIdImpl("192.168.0.7", 9997, Integer.toHexString(1))));
+    assertTrue(
+        barHosts.containsKey(new TabletServerIdImpl("192.168.0.8", 9997, Integer.toHexString(1))));
+    assertTrue(
+        barHosts.containsKey(new TabletServerIdImpl("192.168.0.9", 9997, Integer.toHexString(1))));
+    assertTrue(
+        barHosts.containsKey(new TabletServerIdImpl("192.168.0.10", 9997, Integer.toHexString(1))));
+    assertTrue(groups.containsKey(DEFAULT_POOL));
+    SortedMap<TabletServerId,TServerStatus> defHosts = groups.get(DEFAULT_POOL);
+    assertEquals(10, defHosts.size());
+    assertTrue(
+        defHosts.containsKey(new TabletServerIdImpl("192.168.0.1", 9997, Integer.toHexString(1))));
+    assertTrue(
+        defHosts.containsKey(new TabletServerIdImpl("192.168.0.2", 9997, Integer.toHexString(1))));
+    assertTrue(
+        defHosts.containsKey(new TabletServerIdImpl("192.168.0.3", 9997, Integer.toHexString(1))));
+    assertTrue(
+        defHosts.containsKey(new TabletServerIdImpl("192.168.0.4", 9997, Integer.toHexString(1))));
+    assertTrue(
+        defHosts.containsKey(new TabletServerIdImpl("192.168.0.5", 9997, Integer.toHexString(1))));
+    assertTrue(
+        defHosts.containsKey(new TabletServerIdImpl("192.168.0.11", 9997, Integer.toHexString(1))));
+    assertTrue(
+        defHosts.containsKey(new TabletServerIdImpl("192.168.0.12", 9997, Integer.toHexString(1))));
+    assertTrue(
+        defHosts.containsKey(new TabletServerIdImpl("192.168.0.13", 9997, Integer.toHexString(1))));
+    assertTrue(
+        defHosts.containsKey(new TabletServerIdImpl("192.168.0.14", 9997, Integer.toHexString(1))));
+    assertTrue(
+        defHosts.containsKey(new TabletServerIdImpl("192.168.0.15", 9997, Integer.toHexString(1))));
+
+  }
+
+  @Test
   public void testSplitCurrentByRegexUsingOverlappingPools() {
     HashMap<String,String> props = new HashMap<>(DEFAULT_TABLE_PROPERTIES);
     props.put(HostRegexTableLoadBalancer.HOST_BALANCER_PREFIX + FOO.getTableName(), "r.*");

--- a/core/src/test/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancerTest.java
@@ -186,6 +186,7 @@ public class HostRegexTableLoadBalancerTest extends BaseHostRegexTableLoadBalanc
         barHosts.containsKey(new TabletServerIdImpl("192.168.0.9", 9997, Integer.toHexString(1))));
     assertTrue(
         barHosts.containsKey(new TabletServerIdImpl("192.168.0.10", 9997, Integer.toHexString(1))));
+    // confirms that the default pool contains un-assigned tservers
     assertTrue(groups.containsKey(DEFAULT_POOL));
     SortedMap<TabletServerId,TServerStatus> defHosts = groups.get(DEFAULT_POOL);
     assertEquals(5, defHosts.size());
@@ -202,7 +203,63 @@ public class HostRegexTableLoadBalancerTest extends BaseHostRegexTableLoadBalanc
   }
 
   @Test
-  public void testSplitCurrentByRegexDefineDefaultPool() {
+  public void testDefaultPoolAll() {
+    // If all tservers are included in regular expressions, the the default pool
+    // contains all tservers
+    HashMap<String,String> props = new HashMap<>(DEFAULT_TABLE_PROPERTIES);
+    props.put(HostRegexTableLoadBalancer.HOST_BALANCER_PREFIX + FOO.getTableName(), "r01.*");
+    props.put(HostRegexTableLoadBalancer.HOST_BALANCER_PREFIX + BAR.getTableName(), "r02.*");
+    props.put(HostRegexTableLoadBalancer.HOST_BALANCER_PREFIX + BAZ.getTableName(), "r03.*");
+    init(props);
+    Map<String,SortedMap<TabletServerId,TServerStatus>> groups =
+        this.splitCurrentByRegex(createCurrent(15));
+    assertEquals(4, groups.size());
+    assertTrue(groups.containsKey(FOO.getTableName()));
+    SortedMap<TabletServerId,TServerStatus> fooHosts = groups.get(FOO.getTableName());
+    assertEquals(5, fooHosts.size());
+    assertTrue(
+        fooHosts.containsKey(new TabletServerIdImpl("192.168.0.1", 9997, Integer.toHexString(1))));
+    assertTrue(
+        fooHosts.containsKey(new TabletServerIdImpl("192.168.0.2", 9997, Integer.toHexString(1))));
+    assertTrue(
+        fooHosts.containsKey(new TabletServerIdImpl("192.168.0.3", 9997, Integer.toHexString(1))));
+    assertTrue(
+        fooHosts.containsKey(new TabletServerIdImpl("192.168.0.4", 9997, Integer.toHexString(1))));
+    assertTrue(
+        fooHosts.containsKey(new TabletServerIdImpl("192.168.0.5", 9997, Integer.toHexString(1))));
+    assertTrue(groups.containsKey(BAR.getTableName()));
+    SortedMap<TabletServerId,TServerStatus> barHosts = groups.get(BAR.getTableName());
+    assertEquals(5, barHosts.size());
+    assertTrue(
+        barHosts.containsKey(new TabletServerIdImpl("192.168.0.6", 9997, Integer.toHexString(1))));
+    assertTrue(
+        barHosts.containsKey(new TabletServerIdImpl("192.168.0.7", 9997, Integer.toHexString(1))));
+    assertTrue(
+        barHosts.containsKey(new TabletServerIdImpl("192.168.0.8", 9997, Integer.toHexString(1))));
+    assertTrue(
+        barHosts.containsKey(new TabletServerIdImpl("192.168.0.9", 9997, Integer.toHexString(1))));
+    assertTrue(
+        barHosts.containsKey(new TabletServerIdImpl("192.168.0.10", 9997, Integer.toHexString(1))));
+    assertTrue(groups.containsKey(BAZ.getTableName()));
+    SortedMap<TabletServerId,TServerStatus> bazHosts = groups.get(BAZ.getTableName());
+    assertEquals(5, bazHosts.size());
+    assertTrue(
+        bazHosts.containsKey(new TabletServerIdImpl("192.168.0.11", 9997, Integer.toHexString(1))));
+    assertTrue(
+        bazHosts.containsKey(new TabletServerIdImpl("192.168.0.12", 9997, Integer.toHexString(1))));
+    assertTrue(
+        bazHosts.containsKey(new TabletServerIdImpl("192.168.0.13", 9997, Integer.toHexString(1))));
+    assertTrue(
+        bazHosts.containsKey(new TabletServerIdImpl("192.168.0.14", 9997, Integer.toHexString(1))));
+    assertTrue(
+        bazHosts.containsKey(new TabletServerIdImpl("192.168.0.15", 9997, Integer.toHexString(1))));
+    assertTrue(groups.containsKey(DEFAULT_POOL));
+    SortedMap<TabletServerId,TServerStatus> defHosts = groups.get(DEFAULT_POOL);
+    assertEquals(15, defHosts.size());
+  }
+
+  @Test
+  public void testSplitCurrentByRegexDefineDefaultPoolOverlapping() {
     HashMap<String,String> props = new HashMap<>(DEFAULT_TABLE_PROPERTIES);
     props.put(HostRegexTableLoadBalancer.HOST_BALANCER_PREFIX + FOO.getTableName(), "r01.*");
     props.put(HostRegexTableLoadBalancer.HOST_BALANCER_PREFIX + BAR.getTableName(), "r02.*");
@@ -252,6 +309,59 @@ public class HostRegexTableLoadBalancerTest extends BaseHostRegexTableLoadBalanc
         defHosts.containsKey(new TabletServerIdImpl("192.168.0.4", 9997, Integer.toHexString(1))));
     assertTrue(
         defHosts.containsKey(new TabletServerIdImpl("192.168.0.5", 9997, Integer.toHexString(1))));
+    assertTrue(
+        defHosts.containsKey(new TabletServerIdImpl("192.168.0.11", 9997, Integer.toHexString(1))));
+    assertTrue(
+        defHosts.containsKey(new TabletServerIdImpl("192.168.0.12", 9997, Integer.toHexString(1))));
+    assertTrue(
+        defHosts.containsKey(new TabletServerIdImpl("192.168.0.13", 9997, Integer.toHexString(1))));
+    assertTrue(
+        defHosts.containsKey(new TabletServerIdImpl("192.168.0.14", 9997, Integer.toHexString(1))));
+    assertTrue(
+        defHosts.containsKey(new TabletServerIdImpl("192.168.0.15", 9997, Integer.toHexString(1))));
+  }
+
+  @Test
+  public void testSplitCurrentByRegexDefineDefaultPoolNonOverlapping() {
+    HashMap<String,String> props = new HashMap<>(DEFAULT_TABLE_PROPERTIES);
+    props.put(HostRegexTableLoadBalancer.HOST_BALANCER_PREFIX + FOO.getTableName(), "r01.*");
+    props.put(HostRegexTableLoadBalancer.HOST_BALANCER_PREFIX + BAR.getTableName(), "r02.*");
+    // Normally the DEFAULT pool would be comprised of the hosts not included in a regex.
+    // Here we are going to define it as also being on rack3
+    props.put(HostRegexTableLoadBalancer.HOST_BALANCER_PREFIX + DEFAULT_POOL, "r03.*");
+    init(props);
+    Map<String,SortedMap<TabletServerId,TServerStatus>> groups =
+        this.splitCurrentByRegex(createCurrent(15));
+    assertEquals(3, groups.size());
+    assertTrue(groups.containsKey(FOO.getTableName()));
+    SortedMap<TabletServerId,TServerStatus> fooHosts = groups.get(FOO.getTableName());
+    assertEquals(5, fooHosts.size());
+    assertTrue(
+        fooHosts.containsKey(new TabletServerIdImpl("192.168.0.1", 9997, Integer.toHexString(1))));
+    assertTrue(
+        fooHosts.containsKey(new TabletServerIdImpl("192.168.0.2", 9997, Integer.toHexString(1))));
+    assertTrue(
+        fooHosts.containsKey(new TabletServerIdImpl("192.168.0.3", 9997, Integer.toHexString(1))));
+    assertTrue(
+        fooHosts.containsKey(new TabletServerIdImpl("192.168.0.4", 9997, Integer.toHexString(1))));
+    assertTrue(
+        fooHosts.containsKey(new TabletServerIdImpl("192.168.0.5", 9997, Integer.toHexString(1))));
+    assertTrue(groups.containsKey(BAR.getTableName()));
+    SortedMap<TabletServerId,TServerStatus> barHosts = groups.get(BAR.getTableName());
+    assertEquals(5, barHosts.size());
+    assertTrue(
+        barHosts.containsKey(new TabletServerIdImpl("192.168.0.6", 9997, Integer.toHexString(1))));
+    assertTrue(
+        barHosts.containsKey(new TabletServerIdImpl("192.168.0.7", 9997, Integer.toHexString(1))));
+    assertTrue(
+        barHosts.containsKey(new TabletServerIdImpl("192.168.0.8", 9997, Integer.toHexString(1))));
+    assertTrue(
+        barHosts.containsKey(new TabletServerIdImpl("192.168.0.9", 9997, Integer.toHexString(1))));
+    assertTrue(
+        barHosts.containsKey(new TabletServerIdImpl("192.168.0.10", 9997, Integer.toHexString(1))));
+    assertTrue(groups.containsKey(DEFAULT_POOL));
+    SortedMap<TabletServerId,TServerStatus> defHosts = groups.get(DEFAULT_POOL);
+    assertEquals(5, defHosts.size());
     assertTrue(
         defHosts.containsKey(new TabletServerIdImpl("192.168.0.11", 9997, Integer.toHexString(1))));
     assertTrue(


### PR DESCRIPTION
The HostRegexTableLoadBalancer creates a default pool of tablet servers
in which to assign and balance tablets for tables that do not have a regular
expression defined. Users can define a regex for the default pool and the
tablet servers matching the regex will be added to the default pool along
with all of the servers that do not match one of the defined regular expressions.
Added a test for this case.

Closes #5489