### PR TITLE
Changed how mutations are collected in LogSorter.writeBuffer

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
@@ -274,12 +274,7 @@ public class LogSorter {
       var logFileKey = pair.getFirst();
       var logFileValue = pair.getSecond();
       Key k = logFileKey.toKey();
-      var list = keyListMap.putIfAbsent(k, logFileValue.mutations);
-      if (list != null) {
-        var muts = new ArrayList<>(list);
-        muts.addAll(logFileValue.mutations);
-        keyListMap.put(logFileKey.toKey(), muts);
-      }
+      keyListMap.computeIfAbsent(k, (key) -> new ArrayList<>()).addAll(logFileValue.mutations);
     }
 
     try (var writer = FileOperations.getInstance().newWriterBuilder()


### PR DESCRIPTION
The old code collected mutations by creating a new list, copying existing and new mutations into it, and putting the list into a map. The new code creates a single list, adds all of the mutations to that list, and puts the list in the map.

Closes #5496