### PR TITLE
AccumuloTable changes

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
@@ -90,7 +90,7 @@ import org.apache.accumulo.core.lock.ServiceLockPaths;
 import org.apache.accumulo.core.lock.ServiceLockPaths.AddressSelector;
 import org.apache.accumulo.core.lock.ServiceLockPaths.ServiceLockPath;
 import org.apache.accumulo.core.manager.state.tables.TableState;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.MetadataCachedTabletObtainer;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.schema.Ample;
@@ -1105,16 +1105,16 @@ public class ClientContext implements AccumuloClient {
     return tabletLocationCache.get(DataLevel.of(tableId)).computeIfAbsent(tableId,
         (TableId key) -> {
           var lockChecker = getTServerLockChecker();
-          if (AccumuloTable.ROOT.tableId().equals(tableId)) {
+          if (AccumuloNamespace.ROOT.tableId().equals(tableId)) {
             return new RootClientTabletCache(lockChecker);
           }
           var mlo = new MetadataCachedTabletObtainer();
-          if (AccumuloTable.METADATA.tableId().equals(tableId)) {
-            return new ClientTabletCacheImpl(AccumuloTable.METADATA.tableId(),
-                getTabletLocationCache(AccumuloTable.ROOT.tableId()), mlo, lockChecker);
+          if (AccumuloNamespace.METADATA.tableId().equals(tableId)) {
+            return new ClientTabletCacheImpl(AccumuloNamespace.METADATA.tableId(),
+                getTabletLocationCache(AccumuloNamespace.ROOT.tableId()), mlo, lockChecker);
           } else {
             return new ClientTabletCacheImpl(tableId,
-                getTabletLocationCache(AccumuloTable.METADATA.tableId()), mlo, lockChecker);
+                getTabletLocationCache(AccumuloNamespace.METADATA.tableId()), mlo, lockChecker);
           }
         });
   }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientTabletCacheImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientTabletCacheImpl.java
@@ -52,7 +52,7 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.dataImpl.thrift.TKeyExtent;
 import org.apache.accumulo.core.manager.state.tables.TableState;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
 import org.apache.accumulo.core.trace.TraceUtil;
 import org.apache.accumulo.core.util.LockMap;
@@ -632,7 +632,7 @@ public class ClientTabletCacheImpl extends ClientTabletCache {
     }
 
     // System tables should always be hosted
-    if (AccumuloTable.allTableIds().contains(tableId)) {
+    if (AccumuloNamespace.containsTable(tableId)) {
       return;
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -148,7 +148,7 @@ import org.apache.accumulo.core.manager.thrift.ManagerClientService;
 import org.apache.accumulo.core.manager.thrift.TFateId;
 import org.apache.accumulo.core.manager.thrift.TFateInstanceType;
 import org.apache.accumulo.core.manager.thrift.TFateOperation;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.TabletState;
 import org.apache.accumulo.core.metadata.schema.TabletDeletedException;
@@ -223,8 +223,8 @@ public class TableOperationsImpl extends TableOperationsHelper {
   public boolean exists(String tableName) {
     EXISTING_TABLE_NAME.validate(tableName);
 
-    if (tableName.equals(AccumuloTable.METADATA.tableName())
-        || tableName.equals(AccumuloTable.ROOT.tableName())) {
+    if (tableName.equals(AccumuloNamespace.METADATA.tableName())
+        || tableName.equals(AccumuloNamespace.ROOT.tableName())) {
       return true;
     }
 
@@ -1511,15 +1511,15 @@ public class TableOperationsImpl extends TableOperationsHelper {
     switch (newState) {
       case OFFLINE:
         op = TFateOperation.TABLE_OFFLINE;
-        if (tableName.equals(AccumuloTable.METADATA.tableName())
-            || tableName.equals(AccumuloTable.ROOT.tableName())) {
+        if (tableName.equals(AccumuloNamespace.METADATA.tableName())
+            || tableName.equals(AccumuloNamespace.ROOT.tableName())) {
           throw new AccumuloException("Cannot set table to offline state");
         }
         break;
       case ONLINE:
         op = TFateOperation.TABLE_ONLINE;
-        if (tableName.equals(AccumuloTable.METADATA.tableName())
-            || tableName.equals(AccumuloTable.ROOT.tableName())) {
+        if (tableName.equals(AccumuloNamespace.METADATA.tableName())
+            || tableName.equals(AccumuloNamespace.ROOT.tableName())) {
           // Don't submit a Fate operation for this, these tables can only be online.
           return;
         }

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -35,7 +35,7 @@ import org.apache.accumulo.core.file.blockfile.cache.tinylfu.TinyLfuBlockCacheMa
 import org.apache.accumulo.core.file.rfile.RFile;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.iteratorsImpl.system.DeletingIterator;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.spi.compaction.RatioBasedCompactionPlanner;
 import org.apache.accumulo.core.spi.compaction.SimpleCompactionDispatcher;
 import org.apache.accumulo.core.spi.fs.RandomVolumeChooser;
@@ -479,7 +479,7 @@ public enum Property {
           + "indicates an unlimited number of threads will be used.",
       "1.8.0"),
   MANAGER_METADATA_SUSPENDABLE("manager.metadata.suspendable", "false", PropertyType.BOOLEAN,
-      "Allow tablets for the " + AccumuloTable.METADATA.tableName()
+      "Allow tablets for the " + AccumuloNamespace.METADATA.tableName()
           + " table to be suspended via table.suspend.duration.",
       "1.8.0"),
   MANAGER_STARTUP_TSERVER_AVAIL_MIN_COUNT("manager.startup.tserver.avail.min.count", "0",

--- a/core/src/main/java/org/apache/accumulo/core/dataImpl/KeyExtent.java
+++ b/core/src/main/java/org/apache/accumulo/core/dataImpl/KeyExtent.java
@@ -50,7 +50,7 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.TabletId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.thrift.TKeyExtent;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.util.ByteBufferUtil;
@@ -540,15 +540,15 @@ public class KeyExtent implements Comparable<KeyExtent> {
   }
 
   public boolean isSystemTable() {
-    return AccumuloTable.allTableIds().contains(tableId());
+    return AccumuloNamespace.containsTable(tableId());
   }
 
   public boolean isMeta() {
-    return tableId().equals(AccumuloTable.METADATA.tableId()) || isRootTablet();
+    return tableId().equals(AccumuloNamespace.METADATA.tableId()) || isRootTablet();
   }
 
   public boolean isRootTablet() {
-    return tableId().equals(AccumuloTable.ROOT.tableId());
+    return tableId().equals(AccumuloNamespace.ROOT.tableId());
   }
 
   public String obscured() {

--- a/core/src/main/java/org/apache/accumulo/core/fate/FateInstanceType.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/FateInstanceType.java
@@ -21,7 +21,7 @@ package org.apache.accumulo.core.fate;
 import org.apache.accumulo.core.clientImpl.Namespace;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.manager.thrift.TFateInstanceType;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 
 public enum FateInstanceType {
   META, USER;
@@ -54,6 +54,6 @@ public enum FateInstanceType {
   }
 
   public static FateInstanceType fromTableId(TableId tableId) {
-    return AccumuloTable.allTableIds().contains(tableId) ? META : USER;
+    return AccumuloNamespace.containsTable(tableId) ? META : USER;
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/AccumuloNamespace.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/AccumuloNamespace.java
@@ -28,7 +28,7 @@ import org.apache.accumulo.core.data.TableId;
 /**
  * Defines the name and id of all tables in the accumulo table namespace.
  */
-public enum AccumuloTable {
+public enum AccumuloNamespace {
 
   ROOT("root", "+r"),
   METADATA("metadata", "!0"),
@@ -46,15 +46,30 @@ public enum AccumuloTable {
     return tableId;
   }
 
-  AccumuloTable(String name, String id) {
+  AccumuloNamespace(String name, String id) {
     this.name = Namespace.ACCUMULO.name() + "." + name;
     this.tableId = TableId.of(id);
   }
 
-  private static final Set<TableId> ALL_IDS =
-      Arrays.stream(values()).map(AccumuloTable::tableId).collect(Collectors.toUnmodifiableSet());
+  private static final Set<TableId> ALL_IDS = Arrays.stream(values())
+      .map(AccumuloNamespace::tableId).collect(Collectors.toUnmodifiableSet());
+
+  private static final Set<String> ALL_NAMES = Arrays.stream(values())
+      .map(AccumuloNamespace::tableName).collect(Collectors.toUnmodifiableSet());
 
   public static Set<TableId> allTableIds() {
     return ALL_IDS;
+  }
+
+  public static Set<String> allTableNames() {
+    return ALL_NAMES;
+  }
+
+  public static boolean containsTable(TableId tableId) {
+    return ALL_IDS.contains(tableId);
+  }
+
+  public static boolean containsTable(String tableName) {
+    return ALL_NAMES.contains(tableName);
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/RootTable.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/RootTable.java
@@ -38,8 +38,9 @@ public class RootTable {
    */
   public static final String ZROOT_TABLET_GC_CANDIDATES = ZROOT_TABLET + "/gc_candidates";
 
-  public static final KeyExtent EXTENT = new KeyExtent(AccumuloTable.ROOT.tableId(), null, null);
-  public static final KeyExtent OLD_EXTENT = new KeyExtent(AccumuloTable.METADATA.tableId(),
-      TabletsSection.encodeRow(AccumuloTable.METADATA.tableId(), null), null);
+  public static final KeyExtent EXTENT =
+      new KeyExtent(AccumuloNamespace.ROOT.tableId(), null, null);
+  public static final KeyExtent OLD_EXTENT = new KeyExtent(AccumuloNamespace.METADATA.tableId(),
+      TabletsSection.encodeRow(AccumuloNamespace.METADATA.tableId(), null), null);
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
@@ -36,7 +36,7 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.gc.GcCandidate;
 import org.apache.accumulo.core.gc.ReferenceFile;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.ScanServerRefStore;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
@@ -81,8 +81,8 @@ public interface Ample {
    */
   public enum DataLevel {
     ROOT(null, null),
-    METADATA(AccumuloTable.ROOT.tableName(), AccumuloTable.ROOT.tableId()),
-    USER(AccumuloTable.METADATA.tableName(), AccumuloTable.METADATA.tableId());
+    METADATA(AccumuloNamespace.ROOT.tableName(), AccumuloNamespace.ROOT.tableId()),
+    USER(AccumuloNamespace.METADATA.tableName(), AccumuloNamespace.METADATA.tableId());
 
     private final String table;
     private final TableId id;
@@ -113,9 +113,9 @@ public interface Ample {
     }
 
     public static DataLevel of(TableId tableId) {
-      if (tableId.equals(AccumuloTable.ROOT.tableId())) {
+      if (tableId.equals(AccumuloNamespace.ROOT.tableId())) {
         return DataLevel.ROOT;
-      } else if (tableId.equals(AccumuloTable.METADATA.tableId())) {
+      } else if (tableId.equals(AccumuloNamespace.METADATA.tableId())) {
         return DataLevel.METADATA;
       } else {
         return DataLevel.USER;

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -69,7 +69,7 @@ import org.apache.accumulo.core.lock.ServiceLock;
 import org.apache.accumulo.core.lock.ServiceLockData;
 import org.apache.accumulo.core.lock.ServiceLockPaths.AddressSelector;
 import org.apache.accumulo.core.lock.ServiceLockPaths.ServiceLockPath;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.SuspendingTServer;
 import org.apache.accumulo.core.metadata.TServerInstance;
@@ -585,7 +585,7 @@ public class TabletMetadata {
   }
 
   public TabletAvailability getTabletAvailability() {
-    if (AccumuloTable.allTableIds().contains(getTableId())) {
+    if (AccumuloNamespace.containsTable(getTableId())) {
       // Override the availability for the system tables
       return TabletAvailability.HOSTED;
     }
@@ -781,8 +781,8 @@ public class TabletMetadata {
       }
     }
 
-    if (AccumuloTable.ROOT.tableId().equals(tmBuilder.tableId)
-        || AccumuloTable.METADATA.tableId().equals(tmBuilder.tableId)) {
+    if (AccumuloNamespace.ROOT.tableId().equals(tmBuilder.tableId)
+        || AccumuloNamespace.METADATA.tableId().equals(tmBuilder.tableId)) {
       // Override the availability for the system tables
       tmBuilder.availability(TabletAvailability.HOSTED);
     }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
@@ -55,7 +55,7 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.iterators.user.WholeRowIterator;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
@@ -476,7 +476,7 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
      * {@link TabletsSection#getRange()}
      */
     default RangeOptions scanMetadataTable() {
-      return scanTable(AccumuloTable.METADATA.tableName());
+      return scanTable(AccumuloNamespace.METADATA.tableName());
     }
 
     /**

--- a/core/src/main/java/org/apache/accumulo/core/util/Merge.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/Merge.java
@@ -36,7 +36,7 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.core.trace.TraceUtil;
 import org.apache.hadoop.io.Text;
@@ -143,7 +143,7 @@ public class Merge {
   public void mergomatic(AccumuloClient client, String table, Text start, Text end, long goalSize,
       boolean force) throws MergeException {
     try {
-      if (table.equals(AccumuloTable.METADATA.tableName())) {
+      if (table.equals(AccumuloNamespace.METADATA.tableName())) {
         throw new IllegalArgumentException("cannot merge tablets on the metadata table");
       }
       List<Size> sizes = new ArrayList<>();

--- a/core/src/main/java/org/apache/accumulo/core/util/Validators.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/Validators.java
@@ -24,7 +24,7 @@ import java.util.regex.Pattern;
 
 import org.apache.accumulo.core.clientImpl.Namespace;
 import org.apache.accumulo.core.data.TableId;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.util.tables.TableNameUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -155,7 +155,7 @@ public class Validators {
       new Validator<>(tableName -> _tableName(tableName, false));
 
   private static final List<String> metadataTables =
-      List.of(AccumuloTable.ROOT.tableName(), AccumuloTable.METADATA.tableName());
+      List.of(AccumuloNamespace.ROOT.tableName(), AccumuloNamespace.METADATA.tableName());
   public static final Validator<String> NOT_METADATA_TABLE = new Validator<>(t -> {
     if (t == null) {
       return NameSegment.Table.isNull();
@@ -192,8 +192,7 @@ public class Validators {
     if (id == null) {
       return Optional.of("Table id must not be null");
     }
-    if (AccumuloTable.allTableIds().contains(id)
-        || VALID_ID_PATTERN.matcher(id.canonical()).matches()) {
+    if (AccumuloNamespace.containsTable(id) || VALID_ID_PATTERN.matcher(id.canonical()).matches()) {
       return Validator.OK;
     }
     return Optional
@@ -204,13 +203,13 @@ public class Validators {
     if (id == null) {
       return Optional.of("Table id must not be null");
     }
-    if (id.equals(AccumuloTable.METADATA.tableId())) {
-      return Optional.of(
-          "Cloning " + AccumuloTable.METADATA.tableName() + " is dangerous and no longer supported,"
-              + " see https://github.com/apache/accumulo/issues/1309.");
+    if (id.equals(AccumuloNamespace.METADATA.tableId())) {
+      return Optional.of("Cloning " + AccumuloNamespace.METADATA.tableName()
+          + " is dangerous and no longer supported,"
+          + " see https://github.com/apache/accumulo/issues/1309.");
     }
-    if (id.equals(AccumuloTable.ROOT.tableId())) {
-      return Optional.of("Unable to clone " + AccumuloTable.ROOT.tableName());
+    if (id.equals(AccumuloNamespace.ROOT.tableId())) {
+      return Optional.of("Unable to clone " + AccumuloNamespace.ROOT.tableName());
     }
     return Validator.OK;
   });
@@ -219,9 +218,9 @@ public class Validators {
     if (id == null) {
       return Optional.of("Table id must not be null");
     }
-    if (AccumuloTable.ROOT.tableId().equals(id)) {
-      return Optional.of("Table must not be the " + AccumuloTable.ROOT.tableName() + "(Id: "
-          + AccumuloTable.ROOT.tableId() + ") table");
+    if (AccumuloNamespace.ROOT.tableId().equals(id)) {
+      return Optional.of("Table must not be the " + AccumuloNamespace.ROOT.tableName() + "(Id: "
+          + AccumuloNamespace.ROOT.tableId() + ") table");
     }
     return Validator.OK;
   });
@@ -230,9 +229,9 @@ public class Validators {
     if (id == null) {
       return Optional.of("Table id must not be null");
     }
-    if (AccumuloTable.METADATA.tableId().equals(id)) {
-      return Optional.of("Table must not be the " + AccumuloTable.METADATA.tableName() + "(Id: "
-          + AccumuloTable.METADATA.tableId() + ") table");
+    if (AccumuloNamespace.METADATA.tableId().equals(id)) {
+      return Optional.of("Table must not be the " + AccumuloNamespace.METADATA.tableName() + "(Id: "
+          + AccumuloNamespace.METADATA.tableId() + ") table");
     }
     return Validator.OK;
   });
@@ -241,7 +240,7 @@ public class Validators {
     if (id == null) {
       return Optional.of("Table id must not be null");
     }
-    if (AccumuloTable.allTableIds().contains(id)) {
+    if (AccumuloNamespace.containsTable(id)) {
       return Optional.of("Table must not be in the '" + Namespace.ACCUMULO.name() + "' namespace");
     }
     return Validator.OK;

--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionJobPrioritizer.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionJobPrioritizer.java
@@ -27,7 +27,7 @@ import java.util.function.Function;
 import org.apache.accumulo.core.clientImpl.Namespace;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.spi.compaction.CompactionJob;
 import org.apache.accumulo.core.spi.compaction.CompactionKind;
 import org.apache.accumulo.core.util.Pair;
@@ -73,15 +73,15 @@ public class CompactionJobPrioritizer {
 
   static {
     // root table
-    SYSTEM_TABLE_RANGES.put(new Pair<>(AccumuloTable.ROOT.tableId(), CompactionKind.USER),
+    SYSTEM_TABLE_RANGES.put(new Pair<>(AccumuloNamespace.ROOT.tableId(), CompactionKind.USER),
         ROOT_TABLE_USER);
-    SYSTEM_TABLE_RANGES.put(new Pair<>(AccumuloTable.ROOT.tableId(), CompactionKind.SYSTEM),
+    SYSTEM_TABLE_RANGES.put(new Pair<>(AccumuloNamespace.ROOT.tableId(), CompactionKind.SYSTEM),
         ROOT_TABLE_SYSTEM);
 
     // metadata table
-    SYSTEM_TABLE_RANGES.put(new Pair<>(AccumuloTable.METADATA.tableId(), CompactionKind.USER),
+    SYSTEM_TABLE_RANGES.put(new Pair<>(AccumuloNamespace.METADATA.tableId(), CompactionKind.USER),
         METADATA_TABLE_USER);
-    SYSTEM_TABLE_RANGES.put(new Pair<>(AccumuloTable.METADATA.tableId(), CompactionKind.SYSTEM),
+    SYSTEM_TABLE_RANGES.put(new Pair<>(AccumuloNamespace.METADATA.tableId(), CompactionKind.SYSTEM),
         METADATA_TABLE_SYSTEM);
 
     // metadata table

--- a/core/src/main/java/org/apache/accumulo/core/util/tables/TableZooHelper.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/tables/TableZooHelper.java
@@ -35,7 +35,7 @@ import org.apache.accumulo.core.clientImpl.Namespaces;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.manager.state.tables.TableState;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.util.cache.Caches.CacheName;
 import org.apache.accumulo.core.zookeeper.ZooCache;
 
@@ -62,7 +62,7 @@ public class TableZooHelper implements AutoCloseable {
    *         getCause() of NamespaceNotFoundException
    */
   public TableId getTableId(String tableName) throws TableNotFoundException {
-    for (AccumuloTable systemTable : AccumuloTable.values()) {
+    for (AccumuloNamespace systemTable : AccumuloNamespace.values()) {
       if (systemTable.tableName().equals(tableName)) {
         return systemTable.tableId();
       }
@@ -98,7 +98,7 @@ public class TableZooHelper implements AutoCloseable {
   }
 
   public String getTableName(TableId tableId) throws TableNotFoundException {
-    for (AccumuloTable systemTable : AccumuloTable.values()) {
+    for (AccumuloNamespace systemTable : AccumuloNamespace.values()) {
       if (systemTable.tableId().equals(tableId)) {
         return systemTable.tableName();
       }
@@ -194,7 +194,7 @@ public class TableZooHelper implements AutoCloseable {
     checkArgument(context != null, "instance is null");
     checkArgument(tableId != null, "tableId is null");
 
-    if (AccumuloTable.allTableIds().contains(tableId)) {
+    if (AccumuloNamespace.containsTable(tableId)) {
       return Namespace.ACCUMULO.id();
     }
 

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/ClientTabletCacheImplTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/ClientTabletCacheImplTest.java
@@ -64,7 +64,7 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.MetadataCachedTabletObtainer;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
@@ -79,7 +79,7 @@ public class ClientTabletCacheImplTest {
 
   private static final KeyExtent ROOT_TABLE_EXTENT = RootTable.EXTENT;
   private static final KeyExtent METADATA_TABLE_EXTENT =
-      new KeyExtent(AccumuloTable.METADATA.tableId(), null, ROOT_TABLE_EXTENT.endRow());
+      new KeyExtent(AccumuloNamespace.METADATA.tableId(), null, ROOT_TABLE_EXTENT.endRow());
 
   static KeyExtent createNewKeyExtent(String table, String endRow, String prevEndRow) {
     return new KeyExtent(TableId.of(table), endRow == null ? null : new Text(endRow),
@@ -177,7 +177,7 @@ public class ClientTabletCacheImplTest {
 
     RootClientTabletCache rtl = new TestRootClientTabletCache();
     ClientTabletCacheImpl rootTabletCache = new ClientTabletCacheImpl(
-        AccumuloTable.METADATA.tableId(), rtl, ttlo, new YesLockChecker());
+        AccumuloNamespace.METADATA.tableId(), rtl, ttlo, new YesLockChecker());
     ClientTabletCacheImpl tab1TabletCache =
         new ClientTabletCacheImpl(TableId.of(table), rootTabletCache, ttlo, tslc);
     // disable hosting requests for these tests
@@ -214,10 +214,10 @@ public class ClientTabletCacheImplTest {
     context = EasyMock.createMock(ClientContext.class);
     TableOperations tops = EasyMock.createMock(TableOperations.class);
     EasyMock.expect(context.tableOperations()).andReturn(tops).anyTimes();
-    EasyMock.expect(context.getTableName(AccumuloTable.ROOT.tableId()))
-        .andReturn(AccumuloTable.ROOT.tableName()).anyTimes();
-    EasyMock.expect(context.getTableName(AccumuloTable.METADATA.tableId()))
-        .andReturn(AccumuloTable.METADATA.tableName()).anyTimes();
+    EasyMock.expect(context.getTableName(AccumuloNamespace.ROOT.tableId()))
+        .andReturn(AccumuloNamespace.ROOT.tableName()).anyTimes();
+    EasyMock.expect(context.getTableName(AccumuloNamespace.METADATA.tableId()))
+        .andReturn(AccumuloNamespace.METADATA.tableName()).anyTimes();
     EasyMock.expect(context.getTableName(TableId.of("foo"))).andReturn("foo").anyTimes();
     EasyMock.expect(context.getTableName(TableId.of("0"))).andReturn("0").anyTimes();
     EasyMock.expect(context.getTableName(TableId.of("1"))).andReturn("1").anyTimes();
@@ -678,7 +678,7 @@ public class ClientTabletCacheImplTest {
 
     RootClientTabletCache rtl = new TestRootClientTabletCache();
     ClientTabletCacheImpl rootTabletCache = new ClientTabletCacheImpl(
-        AccumuloTable.METADATA.tableId(), rtl, ttlo, new YesLockChecker());
+        AccumuloNamespace.METADATA.tableId(), rtl, ttlo, new YesLockChecker());
     ClientTabletCacheImpl tab1TabletCache =
         new ClientTabletCacheImpl(TableId.of("tab1"), rootTabletCache, ttlo, new YesLockChecker());
 
@@ -751,10 +751,10 @@ public class ClientTabletCacheImplTest {
     context = EasyMock.createMock(ClientContext.class);
     TableOperations tops = EasyMock.createMock(TableOperations.class);
     EasyMock.expect(context.tableOperations()).andReturn(tops).anyTimes();
-    EasyMock.expect(context.getTableName(AccumuloTable.ROOT.tableId()))
-        .andReturn(AccumuloTable.ROOT.tableName()).anyTimes();
-    EasyMock.expect(context.getTableName(AccumuloTable.METADATA.tableId()))
-        .andReturn(AccumuloTable.METADATA.tableName()).anyTimes();
+    EasyMock.expect(context.getTableName(AccumuloNamespace.ROOT.tableId()))
+        .andReturn(AccumuloNamespace.ROOT.tableName()).anyTimes();
+    EasyMock.expect(context.getTableName(AccumuloNamespace.METADATA.tableId()))
+        .andReturn(AccumuloNamespace.METADATA.tableName()).anyTimes();
     EasyMock.expect(context.getTableName(TableId.of("foo"))).andReturn("foo").anyTimes();
     EasyMock.expect(context.getTableName(TableId.of("0"))).andReturn("0").anyTimes();
     EasyMock.expect(context.getTableName(TableId.of("1"))).andReturn("1").anyTimes();
@@ -774,9 +774,9 @@ public class ClientTabletCacheImplTest {
     locateTabletTest(tab1TabletCache, "r", tab1e22, "tserver3");
 
     // simulate the metadata table splitting
-    KeyExtent mte1 = new KeyExtent(AccumuloTable.METADATA.tableId(), tab1e21.toMetaRow(),
+    KeyExtent mte1 = new KeyExtent(AccumuloNamespace.METADATA.tableId(), tab1e21.toMetaRow(),
         ROOT_TABLE_EXTENT.endRow());
-    KeyExtent mte2 = new KeyExtent(AccumuloTable.METADATA.tableId(), null, tab1e21.toMetaRow());
+    KeyExtent mte2 = new KeyExtent(AccumuloNamespace.METADATA.tableId(), null, tab1e21.toMetaRow());
 
     setLocation(tservers, "tserver4", ROOT_TABLE_EXTENT, mte1, "tserver5");
     setLocation(tservers, "tserver4", ROOT_TABLE_EXTENT, mte2, "tserver6");
@@ -817,10 +817,10 @@ public class ClientTabletCacheImplTest {
     locateTabletTest(tab1TabletCache, "r", tab1e22, "tserver9");
 
     // simulate a hole in the metadata, caused by a partial split
-    KeyExtent mte11 = new KeyExtent(AccumuloTable.METADATA.tableId(), tab1e1.toMetaRow(),
+    KeyExtent mte11 = new KeyExtent(AccumuloNamespace.METADATA.tableId(), tab1e1.toMetaRow(),
         ROOT_TABLE_EXTENT.endRow());
-    KeyExtent mte12 =
-        new KeyExtent(AccumuloTable.METADATA.tableId(), tab1e21.toMetaRow(), tab1e1.toMetaRow());
+    KeyExtent mte12 = new KeyExtent(AccumuloNamespace.METADATA.tableId(), tab1e21.toMetaRow(),
+        tab1e1.toMetaRow());
     deleteServer(tservers, "tserver10");
     setLocation(tservers, "tserver4", ROOT_TABLE_EXTENT, mte12, "tserver10");
     setLocation(tservers, "tserver10", mte12, tab1e21, "tserver12");
@@ -1433,16 +1433,16 @@ public class ClientTabletCacheImplTest {
   @Test
   public void testBug1() throws Exception {
     // a bug that occurred while running continuous ingest
-    KeyExtent mte1 = new KeyExtent(AccumuloTable.METADATA.tableId(), new Text("0;0bc"),
+    KeyExtent mte1 = new KeyExtent(AccumuloNamespace.METADATA.tableId(), new Text("0;0bc"),
         ROOT_TABLE_EXTENT.endRow());
-    KeyExtent mte2 = new KeyExtent(AccumuloTable.METADATA.tableId(), null, new Text("0;0bc"));
+    KeyExtent mte2 = new KeyExtent(AccumuloNamespace.METADATA.tableId(), null, new Text("0;0bc"));
 
     TServers tservers = new TServers();
     TestCachedTabletObtainer ttlo = new TestCachedTabletObtainer(tservers);
 
     RootClientTabletCache rtl = new TestRootClientTabletCache();
     ClientTabletCacheImpl rootTabletCache = new ClientTabletCacheImpl(
-        AccumuloTable.METADATA.tableId(), rtl, ttlo, new YesLockChecker());
+        AccumuloNamespace.METADATA.tableId(), rtl, ttlo, new YesLockChecker());
     ClientTabletCacheImpl tab0TabletCache =
         new ClientTabletCacheImpl(TableId.of("0"), rootTabletCache, ttlo, new YesLockChecker());
 
@@ -1463,16 +1463,16 @@ public class ClientTabletCacheImplTest {
   @Test
   public void testBug2() throws Exception {
     // a bug that occurred while running a functional test
-    KeyExtent mte1 =
-        new KeyExtent(AccumuloTable.METADATA.tableId(), new Text("~"), ROOT_TABLE_EXTENT.endRow());
-    KeyExtent mte2 = new KeyExtent(AccumuloTable.METADATA.tableId(), null, new Text("~"));
+    KeyExtent mte1 = new KeyExtent(AccumuloNamespace.METADATA.tableId(), new Text("~"),
+        ROOT_TABLE_EXTENT.endRow());
+    KeyExtent mte2 = new KeyExtent(AccumuloNamespace.METADATA.tableId(), null, new Text("~"));
 
     TServers tservers = new TServers();
     TestCachedTabletObtainer ttlo = new TestCachedTabletObtainer(tservers);
 
     RootClientTabletCache rtl = new TestRootClientTabletCache();
     ClientTabletCacheImpl rootTabletCache = new ClientTabletCacheImpl(
-        AccumuloTable.METADATA.tableId(), rtl, ttlo, new YesLockChecker());
+        AccumuloNamespace.METADATA.tableId(), rtl, ttlo, new YesLockChecker());
     ClientTabletCacheImpl tab0TabletCache =
         new ClientTabletCacheImpl(TableId.of("0"), rootTabletCache, ttlo, new YesLockChecker());
 
@@ -1493,15 +1493,15 @@ public class ClientTabletCacheImplTest {
   // being merged away, caused locating tablets to fail
   @Test
   public void testBug3() throws Exception {
-    KeyExtent mte1 = new KeyExtent(AccumuloTable.METADATA.tableId(), new Text("1;c"),
+    KeyExtent mte1 = new KeyExtent(AccumuloNamespace.METADATA.tableId(), new Text("1;c"),
         ROOT_TABLE_EXTENT.endRow());
     KeyExtent mte2 =
-        new KeyExtent(AccumuloTable.METADATA.tableId(), new Text("1;f"), new Text("1;c"));
+        new KeyExtent(AccumuloNamespace.METADATA.tableId(), new Text("1;f"), new Text("1;c"));
     KeyExtent mte3 =
-        new KeyExtent(AccumuloTable.METADATA.tableId(), new Text("1;j"), new Text("1;f"));
+        new KeyExtent(AccumuloNamespace.METADATA.tableId(), new Text("1;j"), new Text("1;f"));
     KeyExtent mte4 =
-        new KeyExtent(AccumuloTable.METADATA.tableId(), new Text("1;r"), new Text("1;j"));
-    KeyExtent mte5 = new KeyExtent(AccumuloTable.METADATA.tableId(), null, new Text("1;r"));
+        new KeyExtent(AccumuloNamespace.METADATA.tableId(), new Text("1;r"), new Text("1;j"));
+    KeyExtent mte5 = new KeyExtent(AccumuloNamespace.METADATA.tableId(), null, new Text("1;r"));
 
     KeyExtent ke1 = new KeyExtent(TableId.of("1"), null, null);
 
@@ -1511,7 +1511,7 @@ public class ClientTabletCacheImplTest {
     RootClientTabletCache rtl = new TestRootClientTabletCache();
 
     ClientTabletCacheImpl rootTabletCache = new ClientTabletCacheImpl(
-        AccumuloTable.METADATA.tableId(), rtl, ttlo, new YesLockChecker());
+        AccumuloNamespace.METADATA.tableId(), rtl, ttlo, new YesLockChecker());
     ClientTabletCacheImpl tab0TabletCache =
         new ClientTabletCacheImpl(TableId.of("1"), rootTabletCache, ttlo, new YesLockChecker());
 
@@ -1931,8 +1931,8 @@ public class ClientTabletCacheImplTest {
     // This test ensures that when multiple threads all attempt to lookup data that is not currently
     // in the cache that the minimal amount of metadata lookups are done. Should only see one
     // concurrent lookup per metadata tablet and no more or less.
-    KeyExtent mte1 = new KeyExtent(AccumuloTable.METADATA.tableId(), new Text("foo;m"), null);
-    KeyExtent mte2 = new KeyExtent(AccumuloTable.METADATA.tableId(), null, new Text("foo;m"));
+    KeyExtent mte1 = new KeyExtent(AccumuloNamespace.METADATA.tableId(), new Text("foo;m"), null);
+    KeyExtent mte2 = new KeyExtent(AccumuloNamespace.METADATA.tableId(), null, new Text("foo;m"));
 
     var ke1 = createNewKeyExtent("foo", "m", null);
     var ke2 = createNewKeyExtent("foo", "q", "m");
@@ -1974,7 +1974,7 @@ public class ClientTabletCacheImplTest {
     RootClientTabletCache rtl = new TestRootClientTabletCache();
 
     ClientTabletCacheImpl rootTabletCache = new ClientTabletCacheImpl(
-        AccumuloTable.METADATA.tableId(), rtl, ttlo, new YesLockChecker());
+        AccumuloNamespace.METADATA.tableId(), rtl, ttlo, new YesLockChecker());
     ClientTabletCacheImpl metaCache =
         new ClientTabletCacheImpl(TableId.of("foo"), rootTabletCache, ttlo, new YesLockChecker());
 

--- a/core/src/test/java/org/apache/accumulo/core/data/TableIdTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/TableIdTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.accumulo.core.WithTestNames;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
@@ -51,7 +51,7 @@ public class TableIdTest extends WithTestNames {
 
     // the next line just preloads the built-ins, since they now exist in a separate class from
     // TableId, and aren't preloaded when the TableId class is referenced
-    assertNotSame(AccumuloTable.ROOT.tableId(), AccumuloTable.METADATA.tableId());
+    assertNotSame(AccumuloNamespace.ROOT.tableId(), AccumuloNamespace.METADATA.tableId());
 
     String tableString = "table-" + testName();
     long initialSize = cacheCount();
@@ -61,9 +61,9 @@ public class TableIdTest extends WithTestNames {
 
     // ensure duplicates are not created
     TableId builtInTableId = TableId.of("!0");
-    assertSame(AccumuloTable.METADATA.tableId(), builtInTableId);
+    assertSame(AccumuloNamespace.METADATA.tableId(), builtInTableId);
     builtInTableId = TableId.of("+r");
-    assertSame(AccumuloTable.ROOT.tableId(), builtInTableId);
+    assertSame(AccumuloNamespace.ROOT.tableId(), builtInTableId);
     table1 = TableId.of(tableString);
     assertEquals(initialSize + 1, cacheCount());
     assertEquals(tableString, table1.canonical());

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
@@ -71,7 +71,7 @@ import org.apache.accumulo.core.file.rfile.RFile.Reader;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.ColumnFamilySkippingIterator;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
@@ -2162,7 +2162,7 @@ public class RFileTest extends AbstractRFileTest {
 
     // mfw.startDefaultLocalityGroup();
 
-    Text tableExtent = new Text(TabletsSection.encodeRow(AccumuloTable.METADATA.tableId(),
+    Text tableExtent = new Text(TabletsSection.encodeRow(AccumuloNamespace.METADATA.tableId(),
         TabletsSection.getRange().getEndKey().getRow()));
 
     // table tablet's directory
@@ -2181,7 +2181,8 @@ public class RFileTest extends AbstractRFileTest {
     mfw.append(tablePrevRowKey, TabletColumnFamily.encodePrevEndRow(null));
 
     // ----------] default tablet info
-    Text defaultExtent = new Text(TabletsSection.encodeRow(AccumuloTable.METADATA.tableId(), null));
+    Text defaultExtent =
+        new Text(TabletsSection.encodeRow(AccumuloNamespace.METADATA.tableId(), null));
 
     // default's directory
     Key defaultDirKey =

--- a/core/src/test/java/org/apache/accumulo/core/util/MergeTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/MergeTest.java
@@ -28,7 +28,7 @@ import java.util.List;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.util.Merge.Size;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.Test;
@@ -60,7 +60,7 @@ public class MergeTest {
     @Override
     public void mergomatic(AccumuloClient client, String table, Text start, Text end, long goalSize,
         boolean force) throws MergeException {
-      if (table.equals(AccumuloTable.METADATA.tableName())) {
+      if (table.equals(AccumuloNamespace.METADATA.tableName())) {
         throw new IllegalArgumentException("cannot merge tablets on the metadata table");
       }
 

--- a/core/src/test/java/org/apache/accumulo/core/util/ValidatorsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/ValidatorsTest.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.clientImpl.Namespace;
 import org.apache.accumulo.core.data.TableId;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 
@@ -57,7 +57,8 @@ public class ValidatorsTest {
     Validator<TableId> v = Validators.CAN_CLONE_TABLE;
     checkNull(v::validate);
     assertAllValidate(v, List.of(TableId.of("id1")));
-    assertAllThrow(v, List.of(AccumuloTable.ROOT.tableId(), AccumuloTable.METADATA.tableId()));
+    assertAllThrow(v,
+        List.of(AccumuloNamespace.ROOT.tableId(), AccumuloNamespace.METADATA.tableId()));
   }
 
   @Test
@@ -74,8 +75,9 @@ public class ValidatorsTest {
     Validator<String> v = Validators.EXISTING_TABLE_NAME;
     checkNull(v::validate);
     assertAllValidate(v,
-        List.of(AccumuloTable.ROOT.tableName(), AccumuloTable.METADATA.tableName(), "normalTable",
-            "withNumber2", "has_underscore", "_underscoreStart", StringUtils.repeat("a", 1025),
+        List.of(AccumuloNamespace.ROOT.tableName(), AccumuloNamespace.METADATA.tableName(),
+            "normalTable", "withNumber2", "has_underscore", "_underscoreStart",
+            StringUtils.repeat("a", 1025),
             StringUtils.repeat("a", 1025) + "." + StringUtils.repeat("a", 1025)));
     assertAllThrow(v, List.of("has-dash", "has-dash.inNamespace", "has.dash-inTable", " hasSpace",
         ".", "has$dollar", "two.dots.here", ".startsDot"));
@@ -96,8 +98,9 @@ public class ValidatorsTest {
     Validator<String> v = Validators.NEW_TABLE_NAME;
     checkNull(v::validate);
     assertAllValidate(v,
-        List.of(AccumuloTable.ROOT.tableName(), AccumuloTable.METADATA.tableName(), "normalTable",
-            "withNumber2", "has_underscore", "_underscoreStart", StringUtils.repeat("a", 1024),
+        List.of(AccumuloNamespace.ROOT.tableName(), AccumuloNamespace.METADATA.tableName(),
+            "normalTable", "withNumber2", "has_underscore", "_underscoreStart",
+            StringUtils.repeat("a", 1024),
             StringUtils.repeat("a", 1025) + "." + StringUtils.repeat("a", 1024)));
     assertAllThrow(v,
         List.of("has-dash", "has-dash.inNamespace", "has.dash-inTable", " hasSpace", ".",
@@ -118,7 +121,8 @@ public class ValidatorsTest {
     Validator<String> v = Validators.NOT_BUILTIN_TABLE;
     checkNull(v::validate);
     assertAllValidate(v, List.of("root", "metadata", "user", "ns1.table2"));
-    assertAllThrow(v, List.of(AccumuloTable.ROOT.tableName(), AccumuloTable.METADATA.tableName()));
+    assertAllThrow(v,
+        List.of(AccumuloNamespace.ROOT.tableName(), AccumuloNamespace.METADATA.tableName()));
   }
 
   @Test
@@ -126,7 +130,8 @@ public class ValidatorsTest {
     Validator<String> v = Validators.NOT_METADATA_TABLE;
     checkNull(v::validate);
     assertAllValidate(v, List.of("root", "metadata", "user", "ns1.table2"));
-    assertAllThrow(v, List.of(AccumuloTable.ROOT.tableName(), AccumuloTable.METADATA.tableName()));
+    assertAllThrow(v,
+        List.of(AccumuloNamespace.ROOT.tableName(), AccumuloNamespace.METADATA.tableName()));
   }
 
   @Test
@@ -134,8 +139,8 @@ public class ValidatorsTest {
     Validator<TableId> v = Validators.NOT_ROOT_TABLE_ID;
     checkNull(v::validate);
     assertAllValidate(v,
-        List.of(TableId.of(""), AccumuloTable.METADATA.tableId(), TableId.of(" #0(U!$. ")));
-    assertAllThrow(v, List.of(AccumuloTable.ROOT.tableId()));
+        List.of(TableId.of(""), AccumuloNamespace.METADATA.tableId(), TableId.of(" #0(U!$. ")));
+    assertAllThrow(v, List.of(AccumuloNamespace.ROOT.tableId()));
   }
 
   @Test
@@ -143,15 +148,15 @@ public class ValidatorsTest {
     Validator<TableId> v = Validators.NOT_METADATA_TABLE_ID;
     checkNull(v::validate);
     assertAllValidate(v,
-        List.of(TableId.of(""), AccumuloTable.ROOT.tableId(), TableId.of(" #0(U!$. ")));
-    assertAllThrow(v, List.of(AccumuloTable.METADATA.tableId()));
+        List.of(TableId.of(""), AccumuloNamespace.ROOT.tableId(), TableId.of(" #0(U!$. ")));
+    assertAllThrow(v, List.of(AccumuloNamespace.METADATA.tableId()));
   }
 
   @Test
   public void test_VALID_TABLE_ID() {
     Validator<TableId> v = Validators.VALID_TABLE_ID;
     checkNull(v::validate);
-    assertAllValidate(v, Arrays.stream(AccumuloTable.values()).map(AccumuloTable::tableId)
+    assertAllValidate(v, Arrays.stream(AccumuloNamespace.values()).map(AccumuloNamespace::tableId)
         .collect(Collectors.toList()));
     assertAllValidate(v, List.of(TableId.of("111"), TableId.of("aaaa"), TableId.of("r2d2")));
     assertAllThrow(v, List.of(TableId.of(""), TableId.of("#0(U!$"), TableId.of(" #0(U!$. "),

--- a/core/src/test/java/org/apache/accumulo/core/util/compaction/CompactionPrioritizerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/compaction/CompactionPrioritizerTest.java
@@ -41,7 +41,7 @@ import java.util.List;
 import org.apache.accumulo.core.client.admin.compaction.CompactableFile;
 import org.apache.accumulo.core.clientImpl.Namespace;
 import org.apache.accumulo.core.data.TableId;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.spi.compaction.CompactionJob;
 import org.apache.accumulo.core.spi.compaction.CompactionKind;
 import org.apache.accumulo.core.spi.compaction.CompactorGroupId;
@@ -109,46 +109,48 @@ public class CompactionPrioritizerTest {
   public void testRootTablePriorities() {
     assertEquals(ROOT_TABLE_USER.getMinimum() + 1,
         CompactionJobPrioritizer.createPriority(Namespace.ACCUMULO.id(),
-            AccumuloTable.ROOT.tableId(), CompactionKind.USER, 0, 1, TABLET_FILE_MAX));
+            AccumuloNamespace.ROOT.tableId(), CompactionKind.USER, 0, 1, TABLET_FILE_MAX));
     assertEquals(ROOT_TABLE_USER.getMinimum() + 1010,
         CompactionJobPrioritizer.createPriority(Namespace.ACCUMULO.id(),
-            AccumuloTable.ROOT.tableId(), CompactionKind.USER, 1000, 10, TABLET_FILE_MAX));
+            AccumuloNamespace.ROOT.tableId(), CompactionKind.USER, 1000, 10, TABLET_FILE_MAX));
     assertEquals(ROOT_TABLE_USER.getMaximum(),
         CompactionJobPrioritizer.createPriority(Namespace.ACCUMULO.id(),
-            AccumuloTable.ROOT.tableId(), CompactionKind.USER, 3000, 100, TABLET_FILE_MAX));
+            AccumuloNamespace.ROOT.tableId(), CompactionKind.USER, 3000, 100, TABLET_FILE_MAX));
 
     assertEquals(ROOT_TABLE_SYSTEM.getMinimum() + 3,
         CompactionJobPrioritizer.createPriority(Namespace.ACCUMULO.id(),
-            AccumuloTable.ROOT.tableId(), CompactionKind.SYSTEM, 0, 3, TABLET_FILE_MAX));
+            AccumuloNamespace.ROOT.tableId(), CompactionKind.SYSTEM, 0, 3, TABLET_FILE_MAX));
     assertEquals(ROOT_TABLE_SYSTEM.getMinimum() + 1030,
         CompactionJobPrioritizer.createPriority(Namespace.ACCUMULO.id(),
-            AccumuloTable.ROOT.tableId(), CompactionKind.SYSTEM, 1000, 30, TABLET_FILE_MAX));
+            AccumuloNamespace.ROOT.tableId(), CompactionKind.SYSTEM, 1000, 30, TABLET_FILE_MAX));
     assertEquals(ROOT_TABLE_SYSTEM.getMaximum(),
         CompactionJobPrioritizer.createPriority(Namespace.ACCUMULO.id(),
-            AccumuloTable.ROOT.tableId(), CompactionKind.SYSTEM, 3000, 300, TABLET_FILE_MAX));
+            AccumuloNamespace.ROOT.tableId(), CompactionKind.SYSTEM, 3000, 300, TABLET_FILE_MAX));
   }
 
   @Test
   public void testMetaTablePriorities() {
     assertEquals(METADATA_TABLE_USER.getMinimum() + 4,
         CompactionJobPrioritizer.createPriority(Namespace.ACCUMULO.id(),
-            AccumuloTable.METADATA.tableId(), CompactionKind.USER, 0, 4, TABLET_FILE_MAX));
+            AccumuloNamespace.METADATA.tableId(), CompactionKind.USER, 0, 4, TABLET_FILE_MAX));
     assertEquals(METADATA_TABLE_USER.getMinimum() + 1040,
         CompactionJobPrioritizer.createPriority(Namespace.ACCUMULO.id(),
-            AccumuloTable.METADATA.tableId(), CompactionKind.USER, 1000, 40, TABLET_FILE_MAX));
+            AccumuloNamespace.METADATA.tableId(), CompactionKind.USER, 1000, 40, TABLET_FILE_MAX));
     assertEquals(METADATA_TABLE_USER.getMaximum(),
         CompactionJobPrioritizer.createPriority(Namespace.ACCUMULO.id(),
-            AccumuloTable.METADATA.tableId(), CompactionKind.USER, 3000, 400, TABLET_FILE_MAX));
+            AccumuloNamespace.METADATA.tableId(), CompactionKind.USER, 3000, 400, TABLET_FILE_MAX));
 
     assertEquals(METADATA_TABLE_SYSTEM.getMinimum() + 6,
         CompactionJobPrioritizer.createPriority(Namespace.ACCUMULO.id(),
-            AccumuloTable.METADATA.tableId(), CompactionKind.SYSTEM, 0, 6, TABLET_FILE_MAX));
+            AccumuloNamespace.METADATA.tableId(), CompactionKind.SYSTEM, 0, 6, TABLET_FILE_MAX));
     assertEquals(METADATA_TABLE_SYSTEM.getMinimum() + 1060,
         CompactionJobPrioritizer.createPriority(Namespace.ACCUMULO.id(),
-            AccumuloTable.METADATA.tableId(), CompactionKind.SYSTEM, 1000, 60, TABLET_FILE_MAX));
+            AccumuloNamespace.METADATA.tableId(), CompactionKind.SYSTEM, 1000, 60,
+            TABLET_FILE_MAX));
     assertEquals(METADATA_TABLE_SYSTEM.getMaximum(),
         CompactionJobPrioritizer.createPriority(Namespace.ACCUMULO.id(),
-            AccumuloTable.METADATA.tableId(), CompactionKind.SYSTEM, 3000, 600, TABLET_FILE_MAX));
+            AccumuloNamespace.METADATA.tableId(), CompactionKind.SYSTEM, 3000, 600,
+            TABLET_FILE_MAX));
   }
 
   @Test
@@ -193,20 +195,20 @@ public class CompactionPrioritizerTest {
     final TableId tid = TableId.of("someTable");
     assertEquals(ROOT_TABLE_SYSTEM.getMinimum() + 150,
         CompactionJobPrioritizer.createPriority(Namespace.ACCUMULO.id(),
-            AccumuloTable.ROOT.tableId(), CompactionKind.SYSTEM, 100, 50, tabletFileMax));
+            AccumuloNamespace.ROOT.tableId(), CompactionKind.SYSTEM, 100, 50, tabletFileMax));
     assertEquals(METADATA_TABLE_SYSTEM.getMinimum() + 150,
         CompactionJobPrioritizer.createPriority(Namespace.ACCUMULO.id(),
-            AccumuloTable.METADATA.tableId(), CompactionKind.SYSTEM, 100, 50, tabletFileMax));
+            AccumuloNamespace.METADATA.tableId(), CompactionKind.SYSTEM, 100, 50, tabletFileMax));
     assertEquals(SYSTEM_NS_SYSTEM.getMinimum() + 150, CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), tid, CompactionKind.SYSTEM, 100, 50, tabletFileMax));
     assertEquals(TABLE_OVER_SIZE.getMinimum() + 120, CompactionJobPrioritizer.createPriority(
         Namespace.DEFAULT.id(), tid, CompactionKind.SYSTEM, 100, 50, tabletFileMax));
     assertEquals(ROOT_TABLE_SYSTEM.getMaximum(),
         CompactionJobPrioritizer.createPriority(Namespace.ACCUMULO.id(),
-            AccumuloTable.ROOT.tableId(), CompactionKind.SYSTEM, 3000, 50, tabletFileMax));
+            AccumuloNamespace.ROOT.tableId(), CompactionKind.SYSTEM, 3000, 50, tabletFileMax));
     assertEquals(METADATA_TABLE_SYSTEM.getMaximum(),
         CompactionJobPrioritizer.createPriority(Namespace.ACCUMULO.id(),
-            AccumuloTable.METADATA.tableId(), CompactionKind.SYSTEM, 3000, 50, tabletFileMax));
+            AccumuloNamespace.METADATA.tableId(), CompactionKind.SYSTEM, 3000, 50, tabletFileMax));
     assertEquals(SYSTEM_NS_SYSTEM.getMaximum(), CompactionJobPrioritizer.createPriority(
         Namespace.ACCUMULO.id(), tid, CompactionKind.SYSTEM, 3000, 50, tabletFileMax));
     assertEquals(TABLE_OVER_SIZE.getMaximum(), CompactionJobPrioritizer.createPriority(

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/InputConfigurator.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/InputConfigurator.java
@@ -63,7 +63,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.manager.state.tables.TableState;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.FutureLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LastLocationColumnFamily;
@@ -856,7 +856,7 @@ public class InputConfigurator extends ConfiguratorBase {
       Range metadataRange =
           new Range(new KeyExtent(tableId, startRow, null).toMetaRow(), true, null, false);
       Scanner scanner =
-          context.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY);
+          context.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY);
       TabletColumnFamily.PREV_ROW_COLUMN.fetch(scanner);
       scanner.fetchColumnFamily(LastLocationColumnFamily.NAME);
       scanner.fetchColumnFamily(CurrentLocationColumnFamily.NAME);

--- a/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImplTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImplTest.java
@@ -35,7 +35,7 @@ import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.manager.thrift.ManagerGoalState;
 import org.apache.accumulo.core.manager.thrift.ManagerMonitorInfo;
 import org.apache.accumulo.core.manager.thrift.ManagerState;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.commons.io.FileUtils;
@@ -107,7 +107,7 @@ public class MiniAccumuloClusterImplTest {
   public void saneMonitorInfo() throws Exception {
     ManagerMonitorInfo stats;
     // Expecting default AccumuloTables + TEST_TABLE
-    int expectedNumTables = AccumuloTable.values().length + 1;
+    int expectedNumTables = AccumuloNamespace.values().length + 1;
     while (true) {
       stats = accumulo.getManagerMonitorInfo();
       if (stats.tableMap.size() < expectedNumTables) {
@@ -124,13 +124,13 @@ public class MiniAccumuloClusterImplTest {
     assertTrue(validGoals.contains(stats.goalState),
         "manager goal state should be in " + validGoals + ". is " + stats.goalState);
     assertNotNull(stats.tableMap, "should have a table map.");
-    assertTrue(stats.tableMap.containsKey(AccumuloTable.ROOT.tableId().canonical()),
+    assertTrue(stats.tableMap.containsKey(AccumuloNamespace.ROOT.tableId().canonical()),
         "root table should exist in " + stats.tableMap.keySet());
-    assertTrue(stats.tableMap.containsKey(AccumuloTable.METADATA.tableId().canonical()),
+    assertTrue(stats.tableMap.containsKey(AccumuloNamespace.METADATA.tableId().canonical()),
         "meta table should exist in " + stats.tableMap.keySet());
-    assertTrue(stats.tableMap.containsKey(AccumuloTable.FATE.tableId().canonical()),
+    assertTrue(stats.tableMap.containsKey(AccumuloNamespace.FATE.tableId().canonical()),
         "fate table should exist in " + stats.tableMap.keySet());
-    assertTrue(stats.tableMap.containsKey(AccumuloTable.SCAN_REF.tableId().canonical()),
+    assertTrue(stats.tableMap.containsKey(AccumuloNamespace.SCAN_REF.tableId().canonical()),
         "scan ref table should exist in " + stats.tableMap.keySet());
     assertTrue(stats.tableMap.containsKey(testTableID),
         "our test table should exist in " + stats.tableMap.keySet());

--- a/server/base/src/main/java/org/apache/accumulo/server/compaction/FileCompactor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/compaction/FileCompactor.java
@@ -65,7 +65,7 @@ import org.apache.accumulo.core.iteratorsImpl.system.InterruptibleIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.IterationInterruptedException;
 import org.apache.accumulo.core.iteratorsImpl.system.MultiIterator;
 import org.apache.accumulo.core.logging.TabletLogger;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
@@ -356,8 +356,8 @@ public class FileCompactor implements Callable<CompactionStats> {
       final boolean isMinC = env.getIteratorScope() == IteratorUtil.IteratorScope.minc;
 
       final boolean dropCacheBehindOutput =
-          !AccumuloTable.ROOT.tableId().equals(this.extent.tableId())
-              && !AccumuloTable.METADATA.tableId().equals(this.extent.tableId())
+          !AccumuloNamespace.ROOT.tableId().equals(this.extent.tableId())
+              && !AccumuloNamespace.METADATA.tableId().equals(this.extent.tableId())
               && ((isMinC && acuTableConf.getBoolean(Property.TABLE_MINC_OUTPUT_DROP_CACHE))
                   || (!isMinC && acuTableConf.getBoolean(Property.TABLE_MAJC_OUTPUT_DROP_CACHE)));
 

--- a/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
@@ -36,7 +36,7 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.core.lock.ServiceLock;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.SuspendingTServer;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
@@ -273,9 +273,9 @@ public class MetadataConstraints implements Constraint {
       case 4:
         return "Invalid metadata row format";
       case 5:
-        return "Row can not be less than " + AccumuloTable.METADATA.tableId();
+        return "Row can not be less than " + AccumuloNamespace.METADATA.tableId();
       case 6:
-        return "Empty values are not allowed for any " + AccumuloTable.METADATA.tableName()
+        return "Empty values are not allowed for any " + AccumuloNamespace.METADATA.tableName()
             + " column";
       case 7:
         return "Lock not held in zookeeper by writer";
@@ -351,7 +351,7 @@ public class MetadataConstraints implements Constraint {
     }
 
     // ensure row is not less than AccumuloTable.METADATA.tableId()
-    if (Arrays.compare(row, AccumuloTable.METADATA.tableId().canonical().getBytes(UTF_8)) < 0) {
+    if (Arrays.compare(row, AccumuloNamespace.METADATA.tableId().canonical().getBytes(UTF_8)) < 0) {
       addViolation(violations, 5);
     }
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/init/FileSystemInitializer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/FileSystemInitializer.java
@@ -40,7 +40,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileSKVWriter;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
@@ -127,32 +127,32 @@ public class FileSystemInitializer {
 
     VolumeChooserEnvironment chooserEnv =
         new VolumeChooserEnvironmentImpl(VolumeChooserEnvironment.Scope.INIT,
-            AccumuloTable.METADATA.tableId(), SPLIT_POINT, context);
+            AccumuloNamespace.METADATA.tableId(), SPLIT_POINT, context);
     String tableMetadataTabletDirUri =
         fs.choose(chooserEnv, context.getBaseUris()) + Constants.HDFS_TABLES_DIR + Path.SEPARATOR
-            + AccumuloTable.METADATA.tableId() + Path.SEPARATOR + TABLE_TABLETS_TABLET_DIR;
+            + AccumuloNamespace.METADATA.tableId() + Path.SEPARATOR + TABLE_TABLETS_TABLET_DIR;
     chooserEnv = new VolumeChooserEnvironmentImpl(VolumeChooserEnvironment.Scope.INIT,
-        AccumuloTable.FATE.tableId(), null, context);
+        AccumuloNamespace.FATE.tableId(), null, context);
 
     String fateTableDefaultTabletDirUri = fs.choose(chooserEnv, context.getBaseUris())
-        + Constants.HDFS_TABLES_DIR + Path.SEPARATOR + AccumuloTable.FATE.tableId() + Path.SEPARATOR
-        + MetadataSchema.TabletsSection.ServerColumnFamily.DEFAULT_TABLET_DIR_NAME;
-
-    chooserEnv = new VolumeChooserEnvironmentImpl(VolumeChooserEnvironment.Scope.INIT,
-        AccumuloTable.SCAN_REF.tableId(), null, context);
-
-    String scanRefTableDefaultTabletDirUri = fs.choose(chooserEnv, context.getBaseUris())
-        + Constants.HDFS_TABLES_DIR + Path.SEPARATOR + AccumuloTable.SCAN_REF.tableId()
+        + Constants.HDFS_TABLES_DIR + Path.SEPARATOR + AccumuloNamespace.FATE.tableId()
         + Path.SEPARATOR + MetadataSchema.TabletsSection.ServerColumnFamily.DEFAULT_TABLET_DIR_NAME;
 
     chooserEnv = new VolumeChooserEnvironmentImpl(VolumeChooserEnvironment.Scope.INIT,
-        AccumuloTable.METADATA.tableId(), null, context);
+        AccumuloNamespace.SCAN_REF.tableId(), null, context);
+
+    String scanRefTableDefaultTabletDirUri = fs.choose(chooserEnv, context.getBaseUris())
+        + Constants.HDFS_TABLES_DIR + Path.SEPARATOR + AccumuloNamespace.SCAN_REF.tableId()
+        + Path.SEPARATOR + MetadataSchema.TabletsSection.ServerColumnFamily.DEFAULT_TABLET_DIR_NAME;
+
+    chooserEnv = new VolumeChooserEnvironmentImpl(VolumeChooserEnvironment.Scope.INIT,
+        AccumuloNamespace.METADATA.tableId(), null, context);
 
     String defaultMetadataTabletDirName =
         MetadataSchema.TabletsSection.ServerColumnFamily.DEFAULT_TABLET_DIR_NAME;
     String defaultMetadataTabletDirUri =
         fs.choose(chooserEnv, context.getBaseUris()) + Constants.HDFS_TABLES_DIR + Path.SEPARATOR
-            + AccumuloTable.METADATA.tableId() + Path.SEPARATOR + defaultMetadataTabletDirName;
+            + AccumuloNamespace.METADATA.tableId() + Path.SEPARATOR + defaultMetadataTabletDirName;
 
     // create table and default tablets directories
     createDirectories(fs, rootTabletDirUri, tableMetadataTabletDirUri, defaultMetadataTabletDirUri,
@@ -173,10 +173,10 @@ public class FileSystemInitializer {
     // populate the root tablet with info about the metadata table's two initial tablets
     // For the default tablet we want to make that mergeable, but don't make the TabletsSection
     // tablet mergeable. This will prevent tablets from each either from being auto merged
-    InitialTablet tablesTablet = new InitialTablet(AccumuloTable.METADATA.tableId(),
+    InitialTablet tablesTablet = new InitialTablet(AccumuloNamespace.METADATA.tableId(),
         TABLE_TABLETS_TABLET_DIR, null, SPLIT_POINT, TabletMergeabilityMetadata.never(),
         StoredTabletFile.of(new Path(metadataFileName)).getMetadataPath());
-    InitialTablet defaultTablet = new InitialTablet(AccumuloTable.METADATA.tableId(),
+    InitialTablet defaultTablet = new InitialTablet(AccumuloNamespace.METADATA.tableId(),
         defaultMetadataTabletDirName, SPLIT_POINT, null, always);
     createMetadataFile(fs, rootTabletFileUri, tablesTablet, defaultTablet);
   }
@@ -202,10 +202,11 @@ public class FileSystemInitializer {
 
   private void initSystemTablesConfig(final ServerContext context)
       throws IOException, InterruptedException, KeeperException {
-    setTableProperties(context, AccumuloTable.ROOT.tableId(), initConfig.getRootTableConf());
-    setTableProperties(context, AccumuloTable.ROOT.tableId(), initConfig.getRootMetaConf());
-    setTableProperties(context, AccumuloTable.METADATA.tableId(), initConfig.getRootMetaConf());
-    setTableProperties(context, AccumuloTable.METADATA.tableId(), initConfig.getMetaTableConf());
+    setTableProperties(context, AccumuloNamespace.ROOT.tableId(), initConfig.getRootTableConf());
+    setTableProperties(context, AccumuloNamespace.ROOT.tableId(), initConfig.getRootMetaConf());
+    setTableProperties(context, AccumuloNamespace.METADATA.tableId(), initConfig.getRootMetaConf());
+    setTableProperties(context, AccumuloNamespace.METADATA.tableId(),
+        initConfig.getMetaTableConf());
   }
 
   private void setTableProperties(final ServerContext context, TableId tableId,
@@ -245,18 +246,19 @@ public class FileSystemInitializer {
 
   public InitialTablet createScanRefTablet(ServerContext context,
       TabletMergeabilityMetadata mergeability) throws IOException {
-    setTableProperties(context, AccumuloTable.SCAN_REF.tableId(), initConfig.getScanRefTableConf());
+    setTableProperties(context, AccumuloNamespace.SCAN_REF.tableId(),
+        initConfig.getScanRefTableConf());
 
-    return new InitialTablet(AccumuloTable.SCAN_REF.tableId(),
+    return new InitialTablet(AccumuloNamespace.SCAN_REF.tableId(),
         MetadataSchema.TabletsSection.ServerColumnFamily.DEFAULT_TABLET_DIR_NAME, null, null,
         mergeability);
   }
 
   public InitialTablet createFateRefTablet(ServerContext context,
       TabletMergeabilityMetadata mergeability) throws IOException {
-    setTableProperties(context, AccumuloTable.FATE.tableId(), initConfig.getFateTableConf());
+    setTableProperties(context, AccumuloNamespace.FATE.tableId(), initConfig.getFateTableConf());
 
-    return new InitialTablet(AccumuloTable.FATE.tableId(),
+    return new InitialTablet(AccumuloNamespace.FATE.tableId(),
         MetadataSchema.TabletsSection.ServerColumnFamily.DEFAULT_TABLET_DIR_NAME, null, null,
         mergeability);
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/init/InitialConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/InitialConfiguration.java
@@ -27,7 +27,7 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.fate.user.schema.FateSchema;
 import org.apache.accumulo.core.iterators.user.VersioningIterator;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.volume.VolumeConfiguration;
 import org.apache.accumulo.server.constraints.MetadataConstraints;
@@ -111,9 +111,9 @@ public class InitialConfiguration {
   private void setMetadataReplication(int replication, String reason) {
     String rep = System.console()
         .readLine("Your HDFS replication " + reason + " is not compatible with our default "
-            + AccumuloTable.METADATA.tableName()
+            + AccumuloNamespace.METADATA.tableName()
             + " replication of 5. What do you want to set your "
-            + AccumuloTable.METADATA.tableName() + " replication to? (" + replication + ") ");
+            + AccumuloNamespace.METADATA.tableName() + " replication to? (" + replication + ") ");
     if (rep == null || rep.isEmpty()) {
       rep = Integer.toString(replication);
     } else {

--- a/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
@@ -41,7 +41,7 @@ import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.file.FileOperations;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.spi.fs.VolumeChooserEnvironment.Scope;
 import org.apache.accumulo.core.volume.VolumeConfiguration;
@@ -161,12 +161,12 @@ public class Initialize implements KeywordExecutable {
 
     try (ServerContext context =
         ServerContext.initialize(initConfig.getSiteConf(), instanceName, instanceId)) {
-      var chooserEnv =
-          new VolumeChooserEnvironmentImpl(Scope.INIT, AccumuloTable.ROOT.tableId(), null, context);
+      var chooserEnv = new VolumeChooserEnvironmentImpl(Scope.INIT,
+          AccumuloNamespace.ROOT.tableId(), null, context);
       String rootTabletDirName = RootTable.ROOT_TABLET_DIR_NAME;
       String ext = FileOperations.getNewFileExtension(DefaultConfiguration.getInstance());
       String rootTabletFileUri = new Path(fs.choose(chooserEnv, initConfig.getVolumeUris())
-          + SEPARATOR + TABLE_DIR + SEPARATOR + AccumuloTable.ROOT.tableId() + SEPARATOR
+          + SEPARATOR + TABLE_DIR + SEPARATOR + AccumuloNamespace.ROOT.tableId() + SEPARATOR
           + rootTabletDirName + SEPARATOR + "00000_00000." + ext).toString();
       zki.initialize(context, rootTabletDirName, rootTabletFileUri);
 
@@ -176,7 +176,7 @@ public class Initialize implements KeywordExecutable {
       var fileSystemInitializer = new FileSystemInitializer(initConfig);
       var rootVol = fs.choose(chooserEnv, initConfig.getVolumeUris());
       var rootPath = new Path(rootVol + SEPARATOR + TABLE_DIR + SEPARATOR
-          + AccumuloTable.ROOT.tableId() + SEPARATOR + rootTabletDirName);
+          + AccumuloNamespace.ROOT.tableId() + SEPARATOR + rootTabletDirName);
       fileSystemInitializer.initialize(fs, rootPath.toString(), rootTabletFileUri, context);
 
       checkSASL(initConfig);

--- a/server/base/src/main/java/org/apache/accumulo/server/init/ZooKeeperInitializer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/ZooKeeperInitializer.java
@@ -36,7 +36,7 @@ import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.core.manager.thrift.ManagerGoalState;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
@@ -107,11 +107,11 @@ public class ZooKeeperInitializer {
     context.getTableManager().prepareNewNamespaceState(Namespace.ACCUMULO.id(),
         Namespace.ACCUMULO.name(), ZooUtil.NodeExistsPolicy.FAIL);
 
-    context.getTableManager().prepareNewTableState(AccumuloTable.ROOT.tableId(),
-        Namespace.ACCUMULO.id(), AccumuloTable.ROOT.tableName(), TableState.ONLINE,
+    context.getTableManager().prepareNewTableState(AccumuloNamespace.ROOT.tableId(),
+        Namespace.ACCUMULO.id(), AccumuloNamespace.ROOT.tableName(), TableState.ONLINE,
         ZooUtil.NodeExistsPolicy.FAIL);
-    context.getTableManager().prepareNewTableState(AccumuloTable.METADATA.tableId(),
-        Namespace.ACCUMULO.id(), AccumuloTable.METADATA.tableName(), TableState.ONLINE,
+    context.getTableManager().prepareNewTableState(AccumuloNamespace.METADATA.tableId(),
+        Namespace.ACCUMULO.id(), AccumuloNamespace.METADATA.tableName(), TableState.ONLINE,
         ZooUtil.NodeExistsPolicy.FAIL);
     // Call this separately so the upgrader code can handle the zk node creation for scan refs
     initScanRefTableState(context);
@@ -182,8 +182,8 @@ public class ZooKeeperInitializer {
 
   public void initScanRefTableState(ServerContext context) {
     try {
-      context.getTableManager().prepareNewTableState(AccumuloTable.SCAN_REF.tableId(),
-          Namespace.ACCUMULO.id(), AccumuloTable.SCAN_REF.tableName(), TableState.ONLINE,
+      context.getTableManager().prepareNewTableState(AccumuloNamespace.SCAN_REF.tableId(),
+          Namespace.ACCUMULO.id(), AccumuloNamespace.SCAN_REF.tableName(), TableState.ONLINE,
           ZooUtil.NodeExistsPolicy.FAIL);
     } catch (KeeperException | InterruptedException e) {
       throw new RuntimeException(e);
@@ -192,8 +192,8 @@ public class ZooKeeperInitializer {
 
   public void initFateTableState(ServerContext context) {
     try {
-      context.getTableManager().prepareNewTableState(AccumuloTable.FATE.tableId(),
-          Namespace.ACCUMULO.id(), AccumuloTable.FATE.tableName(), TableState.ONLINE,
+      context.getTableManager().prepareNewTableState(AccumuloNamespace.FATE.tableId(),
+          Namespace.ACCUMULO.id(), AccumuloNamespace.FATE.tableName(), TableState.ONLINE,
           ZooUtil.NodeExistsPolicy.FAIL);
     } catch (KeeperException | InterruptedException e) {
       throw new RuntimeException(e);

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/MetaDataStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/MetaDataStateStore.java
@@ -26,7 +26,7 @@ import java.util.List;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.manager.state.TabletManagement;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.Ample.ConditionalResult.Status;
 import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
@@ -52,7 +52,7 @@ class MetaDataStateStore extends AbstractTabletStateStore implements TabletState
   }
 
   MetaDataStateStore(DataLevel level, ServerContext context) {
-    this(level, context, AccumuloTable.METADATA.tableName());
+    this(level, context, AccumuloNamespace.METADATA.tableName());
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/RootTabletStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/RootTabletStateStore.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.manager.state.TabletManagement;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
 import org.apache.accumulo.server.ServerContext;
 
@@ -31,14 +31,15 @@ import com.google.common.base.Preconditions;
 class RootTabletStateStore extends MetaDataStateStore {
 
   RootTabletStateStore(DataLevel level, ServerContext context) {
-    super(level, context, AccumuloTable.ROOT.tableName());
+    super(level, context, AccumuloNamespace.ROOT.tableName());
   }
 
   @Override
   public ClosableIterator<TabletManagement> iterator(List<Range> ranges,
       TabletManagementParameters parameters) {
     Preconditions.checkArgument(parameters.getLevel() == getLevel());
-    return new TabletManagementScanner(context, ranges, parameters, AccumuloTable.ROOT.tableName());
+    return new TabletManagementScanner(context, ranges, parameters,
+        AccumuloNamespace.ROOT.tableName());
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/ZooTabletStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/ZooTabletStateStore.java
@@ -36,7 +36,7 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.iteratorsImpl.system.SortedMapIterator;
 import org.apache.accumulo.core.manager.state.TabletManagement;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.schema.Ample;
@@ -75,7 +75,8 @@ class ZooTabletStateStore extends AbstractTabletStateStore implements TabletStat
     Preconditions.checkArgument(parameters.getLevel() == getLevel());
 
     final TabletIteratorEnvironment env = new TabletIteratorEnvironment(ctx, IteratorScope.scan,
-        ctx.getTableConfiguration(AccumuloTable.ROOT.tableId()), AccumuloTable.ROOT.tableId());
+        ctx.getTableConfiguration(AccumuloNamespace.ROOT.tableId()),
+        AccumuloNamespace.ROOT.tableId());
     final TabletManagementIterator tmi = new TabletManagementIterator();
     final AtomicBoolean closed = new AtomicBoolean(false);
 

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/RootConditionalWriter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/RootConditionalWriter.java
@@ -36,7 +36,7 @@ import org.apache.accumulo.core.dataImpl.thrift.TCMResult;
 import org.apache.accumulo.core.dataImpl.thrift.TConditionalMutation;
 import org.apache.accumulo.core.iteratorsImpl.system.ColumnFamilySkippingIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.SortedMapIterator;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.schema.RootTabletMetadata;
 import org.apache.accumulo.server.ServerContext;
@@ -85,7 +85,7 @@ public class RootConditionalWriter implements ConditionalWriter {
     TConditionalMutation tcm =
         ConditionalWriterImpl.convertConditionalMutation(compressedIters, mutation, 1);
     ConditionCheckerContext checkerContext = new ConditionCheckerContext(context, compressedIters,
-        context.getTableConfiguration(AccumuloTable.ROOT.tableId()));
+        context.getTableConfiguration(AccumuloNamespace.ROOT.tableId()));
 
     ServerConditionalMutation scm = new ServerConditionalMutation(tcm);
 

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
@@ -40,7 +40,7 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.gc.GcCandidate;
 import org.apache.accumulo.core.gc.ReferenceFile;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.ScanServerRefStore;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
@@ -74,7 +74,7 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
     super(context, tableMapper);
     this.context = context;
     this.scanServerRefStore =
-        new ScanServerRefStoreImpl(context, AccumuloTable.SCAN_REF.tableName());
+        new ScanServerRefStoreImpl(context, AccumuloNamespace.SCAN_REF.tableName());
   }
 
   @Override
@@ -129,7 +129,7 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
   @Override
   public void putGcCandidates(TableId tableId, Collection<StoredTabletFile> candidates) {
 
-    if (AccumuloTable.ROOT.tableId().equals(tableId)) {
+    if (AccumuloNamespace.ROOT.tableId().equals(tableId)) {
       mutateRootGcCandidates(rgcc -> rgcc.add(candidates.stream()));
       return;
     }
@@ -170,7 +170,7 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
     Mutation m = new Mutation(BlipSection.getRowPrefix() + path);
     m.put(EMPTY_TEXT, EMPTY_TEXT, new Value(fateId.canonical()));
 
-    try (BatchWriter bw = context.createBatchWriter(AccumuloTable.METADATA.tableName())) {
+    try (BatchWriter bw = context.createBatchWriter(AccumuloNamespace.METADATA.tableName())) {
       bw.addMutation(m);
     } catch (MutationsRejectedException | TableNotFoundException e) {
       throw new IllegalStateException(e);
@@ -185,7 +185,7 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
     Mutation m = new Mutation(BlipSection.getRowPrefix() + path);
     m.putDelete(EMPTY_TEXT, EMPTY_TEXT);
 
-    try (BatchWriter bw = context.createBatchWriter(AccumuloTable.METADATA.tableName())) {
+    try (BatchWriter bw = context.createBatchWriter(AccumuloNamespace.METADATA.tableName())) {
       bw.addMutation(m);
     } catch (MutationsRejectedException | TableNotFoundException e) {
       throw new IllegalStateException(e);

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletsMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletsMutatorImpl.java
@@ -26,7 +26,7 @@ import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
 import org.apache.accumulo.core.metadata.schema.Ample.TabletsMutator;
@@ -51,10 +51,10 @@ public class TabletsMutatorImpl implements TabletsMutator {
 
   private BatchWriter getWriter(TableId tableId) {
 
-    Preconditions.checkArgument(!AccumuloTable.ROOT.tableId().equals(tableId));
+    Preconditions.checkArgument(!AccumuloNamespace.ROOT.tableId().equals(tableId));
 
     try {
-      if (AccumuloTable.METADATA.tableId().equals(tableId)) {
+      if (AccumuloNamespace.METADATA.tableId().equals(tableId)) {
         if (rootWriter == null) {
           rootWriter = context.createBatchWriter(tableMapper.apply(DataLevel.METADATA));
         }

--- a/server/base/src/main/java/org/apache/accumulo/server/security/AuditedSecurityOperation.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/AuditedSecurityOperation.java
@@ -42,7 +42,7 @@ import org.apache.accumulo.core.dataImpl.thrift.IterInfo;
 import org.apache.accumulo.core.dataImpl.thrift.TColumn;
 import org.apache.accumulo.core.dataImpl.thrift.TRange;
 import org.apache.accumulo.core.manager.thrift.TFateOperation;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.SystemPermission;
 import org.apache.accumulo.core.security.TablePermission;
@@ -85,7 +85,7 @@ public class AuditedSecurityOperation extends SecurityOperation {
 
   private boolean shouldAudit(TCredentials credentials, TableId tableId) {
     return (audit.isInfoEnabled() || audit.isWarnEnabled())
-        && !tableId.equals(AccumuloTable.METADATA.tableId()) && shouldAudit(credentials);
+        && !tableId.equals(AccumuloNamespace.METADATA.tableId()) && shouldAudit(credentials);
   }
 
   // Is INFO the right level to check? Do we even need that check?

--- a/server/base/src/main/java/org/apache/accumulo/server/security/SecurityOperation.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/SecurityOperation.java
@@ -38,7 +38,7 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.manager.thrift.TFateOperation;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.NamespacePermission;
 import org.apache.accumulo.core.security.SystemPermission;
@@ -125,8 +125,8 @@ public class SecurityOperation {
     authorizor.initializeSecurity(credentials, rootPrincipal);
     permHandle.initializeSecurity(credentials, rootPrincipal);
     try {
-      permHandle.grantTablePermission(rootPrincipal, AccumuloTable.METADATA.tableId().canonical(),
-          TablePermission.ALTER_TABLE);
+      permHandle.grantTablePermission(rootPrincipal,
+          AccumuloNamespace.METADATA.tableId().canonical(), TablePermission.ALTER_TABLE);
     } catch (TableNotFoundException e) {
       // Shouldn't happen
       throw new IllegalStateException(e);
@@ -355,8 +355,9 @@ public class SecurityOperation {
       boolean useCached) throws ThriftSecurityException {
     targetUserExists(user);
 
-    if ((table.equals(AccumuloTable.METADATA.tableId())
-        || table.equals(AccumuloTable.ROOT.tableId())) && permission.equals(TablePermission.READ)) {
+    if ((table.equals(AccumuloNamespace.METADATA.tableId())
+        || table.equals(AccumuloNamespace.ROOT.tableId()))
+        && permission.equals(TablePermission.READ)) {
       return true;
     }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKPermHandler.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKPermHandler.java
@@ -38,7 +38,7 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil.NodeMissingPolicy;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.security.NamespacePermission;
 import org.apache.accumulo.core.security.SystemPermission;
 import org.apache.accumulo.core.security.TablePermission;
@@ -386,9 +386,9 @@ public class ZKPermHandler implements PermissionHandler {
     Collections.addAll(rootPerms, SystemPermission.values());
     Map<TableId,Set<TablePermission>> tablePerms = new HashMap<>();
     // Allow the root user to flush the system tables
-    tablePerms.put(AccumuloTable.ROOT.tableId(),
+    tablePerms.put(AccumuloNamespace.ROOT.tableId(),
         Collections.singleton(TablePermission.ALTER_TABLE));
-    tablePerms.put(AccumuloTable.METADATA.tableId(),
+    tablePerms.put(AccumuloNamespace.METADATA.tableId(),
         Collections.singleton(TablePermission.ALTER_TABLE));
     // essentially the same but on the system namespace, the ALTER_TABLE permission is now redundant
     Map<NamespaceId,Set<NamespacePermission>> namespacePerms = new HashMap<>();

--- a/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
@@ -79,7 +79,7 @@ import org.apache.accumulo.core.lock.ServiceLockPaths.AddressSelector;
 import org.apache.accumulo.core.lock.ServiceLockPaths.ServiceLockPath;
 import org.apache.accumulo.core.manager.thrift.FateService;
 import org.apache.accumulo.core.manager.thrift.TFateId;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.process.thrift.ServerProcessService;
 import org.apache.accumulo.core.rpc.ThriftUtil;
@@ -612,7 +612,7 @@ public class Admin implements KeywordExecutable {
       try {
         Set<String> tables = context.tableOperations().tableIdMap().keySet();
         for (String table : tables) {
-          if (table.equals(AccumuloTable.METADATA.tableName())) {
+          if (table.equals(AccumuloNamespace.METADATA.tableName())) {
             continue;
           }
           try {
@@ -1017,7 +1017,7 @@ public class Admin implements KeywordExecutable {
     var lockId = adminLock.getLockID();
     MetaFateStore<Admin> mfs = new MetaFateStore<>(zk, lockId, null);
     UserFateStore<Admin> ufs =
-        new UserFateStore<>(context, AccumuloTable.FATE.tableName(), lockId, null);
+        new UserFateStore<>(context, AccumuloNamespace.FATE.tableName(), lockId, null);
     return Map.of(FateInstanceType.META, mfs, FateInstanceType.USER, ufs);
   }
 
@@ -1026,7 +1026,7 @@ public class Admin implements KeywordExecutable {
           throws InterruptedException, KeeperException {
     MetaFateStore<Admin> readOnlyMFS = new MetaFateStore<>(zk, null, null);
     UserFateStore<Admin> readOnlyUFS =
-        new UserFateStore<>(context, AccumuloTable.FATE.tableName(), null, null);
+        new UserFateStore<>(context, AccumuloNamespace.FATE.tableName(), null, null);
     return Map.of(FateInstanceType.META, readOnlyMFS, FateInstanceType.USER, readOnlyUFS);
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/CheckForMetadataProblems.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/CheckForMetadataProblems.java
@@ -33,7 +33,7 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
@@ -199,10 +199,10 @@ public class CheckForMetadataProblems {
     boolean sawProblems;
     try (Scope scope = span.makeCurrent()) {
 
-      sawProblems = checkMetadataAndRootTableEntries(AccumuloTable.ROOT.tableName(), opts,
+      sawProblems = checkMetadataAndRootTableEntries(AccumuloNamespace.ROOT.tableName(), opts,
           System.out::println, System.out::println);
       System.out.println();
-      sawProblems = checkMetadataAndRootTableEntries(AccumuloTable.METADATA.tableName(), opts,
+      sawProblems = checkMetadataAndRootTableEntries(AccumuloNamespace.METADATA.tableName(), opts,
           System.out::println, System.out::println) || sawProblems;
       if (sawProblems) {
         throw new IllegalStateException();

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FindOfflineTablets.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FindOfflineTablets.java
@@ -26,7 +26,7 @@ import java.util.function.Consumer;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.admin.TabletAvailability;
 import org.apache.accumulo.core.manager.state.tables.TableState;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.TabletState;
 import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
@@ -92,12 +92,12 @@ public class FindOfflineTablets {
       }
     }
 
-    if (AccumuloTable.ROOT.tableName().equals(tableName)) {
+    if (AccumuloNamespace.ROOT.tableName().equals(tableName)) {
       return 0;
     }
 
     if (!skipRootScan) {
-      printInfoMethod.accept("Scanning " + AccumuloTable.ROOT.tableName());
+      printInfoMethod.accept("Scanning " + AccumuloNamespace.ROOT.tableName());
       try (TabletsMetadata tabletsMetadata =
           context.getAmple().readTablets().forLevel(DataLevel.METADATA).build()) {
         if ((offline =
@@ -107,11 +107,11 @@ public class FindOfflineTablets {
       }
     }
 
-    if (AccumuloTable.METADATA.tableName().equals(tableName)) {
+    if (AccumuloNamespace.METADATA.tableName().equals(tableName)) {
       return 0;
     }
 
-    printInfoMethod.accept("Scanning " + AccumuloTable.METADATA.tableName());
+    printInfoMethod.accept("Scanning " + AccumuloNamespace.METADATA.tableName());
 
     try (var metaScanner = context.getAmple().readTablets().forLevel(DataLevel.USER).build()) {
       return checkTablets(context, metaScanner.iterator(), tservers, printProblemMethod);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ListOnlineOnDemandTablets.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ListOnlineOnDemandTablets.java
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.admin.TabletAvailability;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.TabletState;
 import org.apache.accumulo.core.metadata.schema.Ample;
@@ -75,7 +75,7 @@ public class ListOnlineOnDemandTablets {
     tservers.startListeningForTabletServerChanges();
     scanning.set(true);
 
-    System.out.println("Scanning " + AccumuloTable.METADATA.tableName());
+    System.out.println("Scanning " + AccumuloNamespace.METADATA.tableName());
 
     try (TabletsMetadata metaScanner =
         context.getAmple().readTablets().forLevel(Ample.DataLevel.USER).build()) {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
@@ -57,7 +57,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.gc.ReferenceFile;
 import org.apache.accumulo.core.lock.ServiceLock;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
@@ -100,8 +100,8 @@ public class MetadataTableUtil {
       ServiceLock lock) throws AccumuloException {
     try (
         Scanner ms =
-            new ScannerImpl(context, AccumuloTable.METADATA.tableId(), Authorizations.EMPTY);
-        BatchWriter bw = new BatchWriterImpl(context, AccumuloTable.METADATA.tableId(),
+            new ScannerImpl(context, AccumuloNamespace.METADATA.tableId(), Authorizations.EMPTY);
+        BatchWriter bw = new BatchWriterImpl(context, AccumuloNamespace.METADATA.tableId(),
             new BatchWriterConfig().setMaxMemory(1000000)
                 .setMaxLatency(120000L, TimeUnit.MILLISECONDS).setMaxWriteThreads(2))) {
 
@@ -213,11 +213,11 @@ public class MetadataTableUtil {
     if (testTableName != null) {
       tableName = testTableName;
       range = TabletsSection.getRange(tableId);
-    } else if (tableId.equals(AccumuloTable.METADATA.tableId())) {
-      tableName = AccumuloTable.ROOT.tableName();
+    } else if (tableId.equals(AccumuloNamespace.METADATA.tableId())) {
+      tableName = AccumuloNamespace.ROOT.tableName();
       range = TabletsSection.getRange();
     } else {
-      tableName = AccumuloTable.METADATA.tableName();
+      tableName = AccumuloNamespace.METADATA.tableName();
       range = TabletsSection.getRange(tableId);
     }
 
@@ -345,7 +345,7 @@ public class MetadataTableUtil {
   public static void cloneTable(ServerContext context, TableId srcTableId, TableId tableId)
       throws Exception {
 
-    try (BatchWriter bw = context.createBatchWriter(AccumuloTable.METADATA.tableName())) {
+    try (BatchWriter bw = context.createBatchWriter(AccumuloNamespace.METADATA.tableName())) {
 
       while (true) {
 
@@ -382,7 +382,7 @@ public class MetadataTableUtil {
 
       // delete the clone markers and create directory entries
       Scanner mscanner =
-          context.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY);
+          context.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY);
       mscanner.setRange(new KeyExtent(tableId, null, null).toMetaRange());
       mscanner.fetchColumnFamily(ClonedColumnFamily.NAME);
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/RemoveEntriesForMissingFiles.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/RemoveEntriesForMissingFiles.java
@@ -38,7 +38,7 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
@@ -143,7 +143,7 @@ public class RemoveEntriesForMissingFiles {
     BatchWriter writer = null;
 
     if (fix) {
-      writer = context.createBatchWriter(AccumuloTable.METADATA.tableName());
+      writer = context.createBatchWriter(AccumuloNamespace.METADATA.tableName());
     }
 
     for (Entry<Key,Value> entry : metadata) {
@@ -200,12 +200,12 @@ public class RemoveEntriesForMissingFiles {
 
   static int checkAllTables(ServerContext context, boolean fix, Consumer<String> printInfoMethod,
       Consumer<String> printProblemMethod) throws Exception {
-    int missing = checkTable(context, AccumuloTable.ROOT.tableName(), TabletsSection.getRange(),
+    int missing = checkTable(context, AccumuloNamespace.ROOT.tableName(), TabletsSection.getRange(),
         fix, printInfoMethod, printProblemMethod);
 
     if (missing == 0) {
-      return checkTable(context, AccumuloTable.METADATA.tableName(), TabletsSection.getRange(), fix,
-          printInfoMethod, printProblemMethod);
+      return checkTable(context, AccumuloNamespace.METADATA.tableName(), TabletsSection.getRange(),
+          fix, printInfoMethod, printProblemMethod);
     } else {
       return missing;
     }
@@ -213,16 +213,16 @@ public class RemoveEntriesForMissingFiles {
 
   public static int checkTable(ServerContext context, String tableName, boolean fix,
       Consumer<String> printInfoMethod, Consumer<String> printProblemMethod) throws Exception {
-    if (tableName.equals(AccumuloTable.ROOT.tableName())) {
+    if (tableName.equals(AccumuloNamespace.ROOT.tableName())) {
       throw new IllegalArgumentException("Can not check root table");
-    } else if (tableName.equals(AccumuloTable.METADATA.tableName())) {
-      return checkTable(context, AccumuloTable.ROOT.tableName(), TabletsSection.getRange(), fix,
+    } else if (tableName.equals(AccumuloNamespace.METADATA.tableName())) {
+      return checkTable(context, AccumuloNamespace.ROOT.tableName(), TabletsSection.getRange(), fix,
           printInfoMethod, printProblemMethod);
     } else {
       TableId tableId = context.getTableId(tableName);
       Range range = new KeyExtent(tableId, null, null).toMetaRange();
-      return checkTable(context, AccumuloTable.METADATA.tableName(), range, fix, printInfoMethod,
-          printProblemMethod);
+      return checkTable(context, AccumuloNamespace.METADATA.tableName(), range, fix,
+          printInfoMethod, printProblemMethod);
     }
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/checkCommand/MetadataTableCheckRunner.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/checkCommand/MetadataTableCheckRunner.java
@@ -23,7 +23,7 @@ import java.util.Set;
 
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.data.TableId;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.ColumnFQ;
@@ -39,12 +39,12 @@ public class MetadataTableCheckRunner implements MetadataCheckRunner {
 
   @Override
   public String tableName() {
-    return AccumuloTable.METADATA.tableName();
+    return AccumuloNamespace.METADATA.tableName();
   }
 
   @Override
   public TableId tableId() {
-    return AccumuloTable.METADATA.tableId();
+    return AccumuloNamespace.METADATA.tableId();
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/util/checkCommand/RootMetadataCheckRunner.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/checkCommand/RootMetadataCheckRunner.java
@@ -25,7 +25,7 @@ import java.util.Set;
 
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.data.TableId;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.metadata.schema.RootTabletMetadata;
@@ -75,7 +75,7 @@ public class RootMetadataCheckRunner implements MetadataCheckRunner {
     printRunning();
 
     log.trace("********** Looking for offline tablets **********");
-    if (FindOfflineTablets.findOffline(context, AccumuloTable.ROOT.tableName(), false, true,
+    if (FindOfflineTablets.findOffline(context, AccumuloNamespace.ROOT.tableName(), false, true,
         log::trace, log::warn) != 0) {
       status = Admin.CheckCommand.CheckStatus.FAILED;
     } else {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/checkCommand/RootTableCheckRunner.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/checkCommand/RootTableCheckRunner.java
@@ -23,7 +23,7 @@ import java.util.Set;
 
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.data.TableId;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.ColumnFQ;
@@ -39,12 +39,12 @@ public class RootTableCheckRunner implements MetadataCheckRunner {
 
   @Override
   public String tableName() {
-    return AccumuloTable.ROOT.tableName();
+    return AccumuloNamespace.ROOT.tableName();
   }
 
   @Override
   public TableId tableId() {
-    return AccumuloTable.ROOT.tableId();
+    return AccumuloNamespace.ROOT.tableId();
   }
 
   @Override
@@ -67,7 +67,7 @@ public class RootTableCheckRunner implements MetadataCheckRunner {
     printRunning();
 
     log.trace("********** Looking for offline tablets **********");
-    if (FindOfflineTablets.findOffline(context, AccumuloTable.METADATA.tableName(), true, false,
+    if (FindOfflineTablets.findOffline(context, AccumuloNamespace.METADATA.tableName(), true, false,
         log::trace, log::warn) != 0) {
       status = Admin.CheckCommand.CheckStatus.FAILED;
     } else {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/checkCommand/SystemFilesCheckRunner.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/checkCommand/SystemFilesCheckRunner.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.server.util.checkCommand;
 
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.cli.ServerUtilOpts;
 import org.apache.accumulo.server.util.Admin;
@@ -34,7 +34,7 @@ public class SystemFilesCheckRunner implements CheckRunner {
     printRunning();
 
     log.trace("********** Looking for missing system files **********");
-    if (RemoveEntriesForMissingFiles.checkTable(context, AccumuloTable.METADATA.tableName(),
+    if (RemoveEntriesForMissingFiles.checkTable(context, AccumuloNamespace.METADATA.tableName(),
         fixFiles, log::trace, log::warn) != 0) {
       status = Admin.CheckCommand.CheckStatus.FAILED;
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/checkCommand/TableLocksCheckRunner.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/checkCommand/TableLocksCheckRunner.java
@@ -28,7 +28,7 @@ import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.FateInstanceType;
 import org.apache.accumulo.core.fate.user.UserFateStore;
 import org.apache.accumulo.core.fate.zookeeper.MetaFateStore;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.cli.ServerUtilOpts;
 import org.apache.accumulo.server.util.Admin;
@@ -63,7 +63,7 @@ public class TableLocksCheckRunner implements CheckRunner {
     final var zk = context.getZooSession();
     final MetaFateStore<Admin> mfs = new MetaFateStore<>(zk, null, null);
     final UserFateStore<Admin> ufs =
-        new UserFateStore<>(context, AccumuloTable.FATE.tableName(), null, null);
+        new UserFateStore<>(context, AccumuloNamespace.FATE.tableName(), null, null);
 
     log.trace("Ensuring table and namespace locks are valid...");
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/checkCommand/UserFilesCheckRunner.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/checkCommand/UserFilesCheckRunner.java
@@ -20,7 +20,7 @@ package org.apache.accumulo.server.util.checkCommand;
 
 import static org.apache.accumulo.server.util.Admin.CheckCommand.Check;
 
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.cli.ServerUtilOpts;
 import org.apache.accumulo.server.util.Admin;
@@ -38,7 +38,7 @@ public class UserFilesCheckRunner implements CheckRunner {
     log.trace("********** Looking for missing user files **********");
     for (String tableName : context.tableOperations().list()) {
       var tableId = context.getTableId(tableName);
-      if (!AccumuloTable.allTableIds().contains(context.getTableId(tableName))) {
+      if (!AccumuloNamespace.containsTable(context.getTableId(tableName))) {
         log.trace("Checking table {} ({}) for missing files\n", tableName, tableId);
         if (RemoveEntriesForMissingFiles.checkTable(context, tableName, fixFiles, log::trace,
             log::warn) != 0) {

--- a/server/base/src/test/java/org/apache/accumulo/server/constraints/MetadataConstraintsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/constraints/MetadataConstraintsTest.java
@@ -40,7 +40,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.FateInstanceType;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.SuspendingTServer;
@@ -135,7 +135,7 @@ public class MetadataConstraintsTest {
 
     assertTrue(violations.isEmpty());
 
-    m = new Mutation(new Text(AccumuloTable.METADATA.tableId().canonical() + "<"));
+    m = new Mutation(new Text(AccumuloNamespace.METADATA.tableId().canonical() + "<"));
     TabletColumnFamily.PREV_ROW_COLUMN.put(m, new Value("bar"));
 
     violations = mc.check(createEnv(), m);

--- a/server/base/src/test/java/org/apache/accumulo/server/util/TableDiskUsageTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/TableDiskUsageTest.java
@@ -37,7 +37,7 @@ import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
@@ -64,8 +64,9 @@ public class TableDiskUsageTest {
 
   @BeforeAll
   public static void beforeClass() {
-    tableIdToNameMap.put(AccumuloTable.ROOT.tableId(), AccumuloTable.METADATA.tableName());
-    tableIdToNameMap.put(AccumuloTable.METADATA.tableId(), AccumuloTable.METADATA.tableName());
+    tableIdToNameMap.put(AccumuloNamespace.ROOT.tableId(), AccumuloNamespace.METADATA.tableName());
+    tableIdToNameMap.put(AccumuloNamespace.METADATA.tableId(),
+        AccumuloNamespace.METADATA.tableName());
     tableIdToNameMap.put(tableId1, "table1");
     tableIdToNameMap.put(tableId2, "table2");
     tableIdToNameMap.put(tableId3, "table3");
@@ -137,19 +138,20 @@ public class TableDiskUsageTest {
     final ClientContext client = EasyMock.createMock(ClientContext.class);
     EasyMock.expect(client.getTableIdToNameMap()).andReturn(tableIdToNameMap);
     final TabletsMetadata mockTabletsMetadata =
-        mockTabletsMetadata(client, AccumuloTable.METADATA.tableId());
+        mockTabletsMetadata(client, AccumuloNamespace.METADATA.tableId());
 
     List<TabletMetadata> realTabletsMetadata = new ArrayList<>();
-    appendFileMetadata(realTabletsMetadata, getTabletFile(volume1, AccumuloTable.METADATA.tableId(),
-        AccumuloTable.METADATA.tableName(), "C0001.rf"), 1024);
+    appendFileMetadata(realTabletsMetadata, getTabletFile(volume1,
+        AccumuloNamespace.METADATA.tableId(), AccumuloNamespace.METADATA.tableName(), "C0001.rf"),
+        1024);
     mockTabletsMetadataIter(mockTabletsMetadata, realTabletsMetadata.iterator());
 
     EasyMock.replay(client, mockTabletsMetadata);
 
     Map<SortedSet<String>,Long> result =
-        TableDiskUsage.getDiskUsage(tableSet(AccumuloTable.METADATA.tableId()), client);
+        TableDiskUsage.getDiskUsage(tableSet(AccumuloNamespace.METADATA.tableId()), client);
 
-    assertEquals(1024, getTotalUsage(result, AccumuloTable.METADATA.tableId()));
+    assertEquals(1024, getTotalUsage(result, AccumuloNamespace.METADATA.tableId()));
     assertEquals(1, result.size());
     Map.Entry<SortedSet<String>,Long> firstResult =
         result.entrySet().stream().findFirst().orElseThrow();

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
@@ -55,7 +55,7 @@ import org.apache.accumulo.core.gc.GcCandidate;
 import org.apache.accumulo.core.gc.Reference;
 import org.apache.accumulo.core.gc.ReferenceFile;
 import org.apache.accumulo.core.manager.state.tables.TableState;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.ValidationUtil;
@@ -269,7 +269,7 @@ public class GCRun implements GarbageCollectionEnvironment {
   public void deleteConfirmedCandidates(SortedMap<String,GcCandidate> confirmedDeletes) {
     final VolumeManager fs = context.getVolumeManager();
     var metadataLocation = level == Ample.DataLevel.ROOT
-        ? ZooUtil.getRoot(context.getInstanceID()) + " for " + AccumuloTable.ROOT.tableName()
+        ? ZooUtil.getRoot(context.getInstanceID()) + " for " + AccumuloNamespace.ROOT.tableName()
         : level.metaTable();
 
     if (inSafeMode()) {
@@ -551,9 +551,9 @@ public class GCRun implements GarbageCollectionEnvironment {
   @Override
   public Set<TableId> getCandidateTableIDs() throws InterruptedException {
     if (level == DataLevel.ROOT) {
-      return Set.of(AccumuloTable.ROOT.tableId());
+      return Set.of(AccumuloNamespace.ROOT.tableId());
     } else if (level == DataLevel.METADATA) {
-      return Set.of(AccumuloTable.METADATA.tableId());
+      return Set.of(AccumuloNamespace.METADATA.tableId());
     } else if (level == DataLevel.USER) {
       Set<TableId> tableIds = new HashSet<>();
       getTableIDs().forEach((k, v) -> {
@@ -563,8 +563,8 @@ public class GCRun implements GarbageCollectionEnvironment {
           tableIds.add(k);
         }
       });
-      tableIds.remove(AccumuloTable.METADATA.tableId());
-      tableIds.remove(AccumuloTable.ROOT.tableId());
+      tableIds.remove(AccumuloNamespace.METADATA.tableId());
+      tableIds.remove(AccumuloNamespace.ROOT.tableId());
       return tableIds;
     } else {
       throw new IllegalArgumentException("Unexpected level in GC Env: " + this.level.name());

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionEnvironment.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionEnvironment.java
@@ -32,6 +32,7 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.gc.GcCandidate;
 import org.apache.accumulo.core.gc.Reference;
 import org.apache.accumulo.core.manager.state.tables.TableState;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.Ample.GcCandidateType;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ScanFileColumnFamily;
@@ -40,8 +41,8 @@ public interface GarbageCollectionEnvironment {
 
   /**
    * Return an iterator which points to a list of paths to files and dirs which are candidates for
-   * deletion from a given table, {@link org.apache.accumulo.core.metadata.AccumuloTable#ROOT} or
-   * {@link org.apache.accumulo.core.metadata.AccumuloTable#METADATA}
+   * deletion from a given table, {@link AccumuloNamespace#ROOT} or
+   * {@link AccumuloNamespace#METADATA}
    *
    * @return an iterator referencing a List containing deletion candidates
    */
@@ -58,8 +59,7 @@ public interface GarbageCollectionEnvironment {
 
   /**
    * Fetch a list of paths for all bulk loads in progress (blip) from a given table,
-   * {@link org.apache.accumulo.core.metadata.AccumuloTable#ROOT} or
-   * {@link org.apache.accumulo.core.metadata.AccumuloTable#METADATA}
+   * {@link AccumuloNamespace#ROOT} or {@link AccumuloNamespace#METADATA}
    *
    * @return The list of files for each bulk load currently in progress.
    */

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -48,7 +48,7 @@ import org.apache.accumulo.core.lock.ServiceLock;
 import org.apache.accumulo.core.lock.ServiceLockData;
 import org.apache.accumulo.core.lock.ServiceLockData.ThriftService;
 import org.apache.accumulo.core.lock.ServiceLockSupport.HAServiceLockWatcher;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
 import org.apache.accumulo.core.metrics.MetricsInfo;
 import org.apache.accumulo.core.securityImpl.thrift.TCredentials;
@@ -284,16 +284,16 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
 
             switch (action) {
               case "compact":
-                accumuloClient.tableOperations().compact(AccumuloTable.METADATA.tableName(), null,
+                accumuloClient.tableOperations().compact(AccumuloNamespace.METADATA.tableName(),
+                    null, null, true, true);
+                accumuloClient.tableOperations().compact(AccumuloNamespace.ROOT.tableName(), null,
                     null, true, true);
-                accumuloClient.tableOperations().compact(AccumuloTable.ROOT.tableName(), null, null,
-                    true, true);
                 break;
               case "flush":
-                accumuloClient.tableOperations().flush(AccumuloTable.METADATA.tableName(), null,
+                accumuloClient.tableOperations().flush(AccumuloNamespace.METADATA.tableName(), null,
                     null, true);
-                accumuloClient.tableOperations().flush(AccumuloTable.ROOT.tableName(), null, null,
-                    true);
+                accumuloClient.tableOperations().flush(AccumuloNamespace.ROOT.tableName(), null,
+                    null, true);
                 break;
               default:
                 log.trace("'none - no action' or invalid value provided: {}", action);
@@ -323,7 +323,7 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
 
           if (lastCompactorCheck.hasElapsed(gcDelay * 3, MILLISECONDS)) {
             Map<String,Set<TableId>> resourceMapping = new HashMap<>();
-            for (TableId tid : AccumuloTable.allTableIds()) {
+            for (TableId tid : AccumuloNamespace.allTableIds()) {
               TableConfiguration tconf = getContext().getTableConfiguration(tid);
               String resourceGroup = tconf.get(TableLoadBalancer.TABLE_ASSIGNMENT_GROUP_PROPERTY);
               resourceGroup =

--- a/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
@@ -42,7 +42,7 @@ import org.apache.accumulo.core.gc.GcCandidate;
 import org.apache.accumulo.core.gc.Reference;
 import org.apache.accumulo.core.gc.ReferenceFile;
 import org.apache.accumulo.core.manager.state.tables.TableState;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.Ample.GcCandidateType;
 import org.apache.hadoop.fs.Path;
@@ -195,9 +195,9 @@ public class GarbageCollectionTest {
     @Override
     public Set<TableId> getCandidateTableIDs() {
       if (level == Ample.DataLevel.ROOT) {
-        return Set.of(AccumuloTable.ROOT.tableId());
+        return Set.of(AccumuloNamespace.ROOT.tableId());
       } else if (level == Ample.DataLevel.METADATA) {
-        return Collections.singleton(AccumuloTable.METADATA.tableId());
+        return Collections.singleton(AccumuloNamespace.METADATA.tableId());
       } else if (level == Ample.DataLevel.USER) {
         Set<TableId> tableIds = new HashSet<>();
         getTableIDs().forEach((k, v) -> {
@@ -207,8 +207,8 @@ public class GarbageCollectionTest {
             tableIds.add(k);
           }
         });
-        tableIds.remove(AccumuloTable.METADATA.tableId());
-        tableIds.remove(AccumuloTable.ROOT.tableId());
+        tableIds.remove(AccumuloNamespace.METADATA.tableId());
+        tableIds.remove(AccumuloNamespace.ROOT.tableId());
         return tableIds;
       } else {
         throw new IllegalArgumentException("unknown level " + level);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -101,7 +101,7 @@ import org.apache.accumulo.core.manager.thrift.ManagerMonitorInfo;
 import org.apache.accumulo.core.manager.thrift.ManagerState;
 import org.apache.accumulo.core.manager.thrift.TableInfo;
 import org.apache.accumulo.core.manager.thrift.TabletServerStatus;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
@@ -375,8 +375,8 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener {
   }
 
   private int nonMetaDataTabletsAssignedOrHosted() {
-    return totalAssignedOrHosted() - assignedOrHosted(AccumuloTable.METADATA.tableId())
-        - assignedOrHosted(AccumuloTable.ROOT.tableId());
+    return totalAssignedOrHosted() - assignedOrHosted(AccumuloNamespace.METADATA.tableId())
+        - assignedOrHosted(AccumuloNamespace.ROOT.tableId());
   }
 
   private int notHosted() {
@@ -410,14 +410,14 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener {
       case SAFE_MODE:
         // Count offline tablets for the metadata table
         for (TabletGroupWatcher watcher : watchers) {
-          TableCounts counts = watcher.getStats(AccumuloTable.METADATA.tableId());
+          TableCounts counts = watcher.getStats(AccumuloNamespace.METADATA.tableId());
           result += counts.unassigned() + counts.suspended();
         }
         break;
       case UNLOAD_METADATA_TABLETS:
       case UNLOAD_ROOT_TABLET:
         for (TabletGroupWatcher watcher : watchers) {
-          TableCounts counts = watcher.getStats(AccumuloTable.METADATA.tableId());
+          TableCounts counts = watcher.getStats(AccumuloNamespace.METADATA.tableId());
           result += counts.unassigned() + counts.suspended();
         }
         break;
@@ -742,7 +742,7 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener {
                 }
                   break;
                 case UNLOAD_METADATA_TABLETS: {
-                  int count = assignedOrHosted(AccumuloTable.METADATA.tableId());
+                  int count = assignedOrHosted(AccumuloNamespace.METADATA.tableId());
                   log.debug(
                       String.format("There are %d metadata tablets assigned or hosted", count));
                   if (count == 0 && goodStats()) {
@@ -751,12 +751,12 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener {
                 }
                   break;
                 case UNLOAD_ROOT_TABLET:
-                  int count = assignedOrHosted(AccumuloTable.METADATA.tableId());
+                  int count = assignedOrHosted(AccumuloNamespace.METADATA.tableId());
                   if (count > 0 && goodStats()) {
                     log.debug(String.format("%d metadata tablets online", count));
                     setManagerState(ManagerState.UNLOAD_ROOT_TABLET);
                   }
-                  int root_count = assignedOrHosted(AccumuloTable.ROOT.tableId());
+                  int root_count = assignedOrHosted(AccumuloNamespace.ROOT.tableId());
                   if (root_count > 0 && goodStats()) {
                     log.debug("The root tablet is still assigned or hosted");
                   }
@@ -869,23 +869,23 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener {
         final Map<String,TableInfo> newTableMap =
             new HashMap<>(dl == DataLevel.USER ? oldTableMap.size() : 1);
         if (dl == DataLevel.ROOT) {
-          if (oldTableMap.containsKey(AccumuloTable.ROOT.tableId().canonical())) {
-            newTableMap.put(AccumuloTable.ROOT.tableId().canonical(),
-                oldTableMap.get(AccumuloTable.ROOT.tableId().canonical()));
+          if (oldTableMap.containsKey(AccumuloNamespace.ROOT.tableId().canonical())) {
+            newTableMap.put(AccumuloNamespace.ROOT.tableId().canonical(),
+                oldTableMap.get(AccumuloNamespace.ROOT.tableId().canonical()));
           }
         } else if (dl == DataLevel.METADATA) {
-          if (oldTableMap.containsKey(AccumuloTable.METADATA.tableId().canonical())) {
-            newTableMap.put(AccumuloTable.METADATA.tableId().canonical(),
-                oldTableMap.get(AccumuloTable.METADATA.tableId().canonical()));
+          if (oldTableMap.containsKey(AccumuloNamespace.METADATA.tableId().canonical())) {
+            newTableMap.put(AccumuloNamespace.METADATA.tableId().canonical(),
+                oldTableMap.get(AccumuloNamespace.METADATA.tableId().canonical()));
           }
         } else if (dl == DataLevel.USER) {
-          if (!oldTableMap.containsKey(AccumuloTable.METADATA.tableId().canonical())
-              && !oldTableMap.containsKey(AccumuloTable.ROOT.tableId().canonical())) {
+          if (!oldTableMap.containsKey(AccumuloNamespace.METADATA.tableId().canonical())
+              && !oldTableMap.containsKey(AccumuloNamespace.ROOT.tableId().canonical())) {
             newTableMap.putAll(oldTableMap);
           } else {
             oldTableMap.forEach((table, info) -> {
-              if (!table.equals(AccumuloTable.ROOT.tableId().canonical())
-                  && !table.equals(AccumuloTable.METADATA.tableId().canonical())) {
+              if (!table.equals(AccumuloNamespace.ROOT.tableId().canonical())
+                  && !table.equals(AccumuloNamespace.METADATA.tableId().canonical())) {
                 newTableMap.put(table, info);
               }
             });
@@ -902,12 +902,13 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener {
     private Map<String,TableId> getTablesForLevel(DataLevel dataLevel) {
       switch (dataLevel) {
         case ROOT:
-          return Map.of(AccumuloTable.ROOT.tableName(), AccumuloTable.ROOT.tableId());
+          return Map.of(AccumuloNamespace.ROOT.tableName(), AccumuloNamespace.ROOT.tableId());
         case METADATA:
-          return Map.of(AccumuloTable.METADATA.tableName(), AccumuloTable.METADATA.tableId());
+          return Map.of(AccumuloNamespace.METADATA.tableName(),
+              AccumuloNamespace.METADATA.tableId());
         case USER: {
           Map<String,TableId> userTables = new HashMap<>(getContext().getTableNameToIdMap());
-          for (var accumuloTable : AccumuloTable.values()) {
+          for (var accumuloTable : AccumuloNamespace.values()) {
             if (DataLevel.of(accumuloTable.tableId()) != DataLevel.USER) {
               userTables.remove(accumuloTable.tableName());
             }
@@ -1347,7 +1348,7 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener {
       var metaInstance = initializeFateInstance(context,
           new MetaFateStore<>(context.getZooSession(), managerLock.getLockID(), isLockHeld));
       var userInstance = initializeFateInstance(context, new UserFateStore<>(context,
-          AccumuloTable.FATE.tableName(), managerLock.getLockID(), isLockHeld));
+          AccumuloNamespace.FATE.tableName(), managerLock.getLockID(), isLockHeld));
 
       if (!fateRefs.compareAndSet(null,
           Map.of(FateInstanceType.META, metaInstance, FateInstanceType.USER, userInstance))) {
@@ -1714,10 +1715,10 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener {
     Set<TableId> result = new HashSet<>();
     if (getManagerState() != ManagerState.NORMAL) {
       if (getManagerState() != ManagerState.UNLOAD_METADATA_TABLETS) {
-        result.add(AccumuloTable.METADATA.tableId());
+        result.add(AccumuloNamespace.METADATA.tableId());
       }
       if (getManagerState() != ManagerState.UNLOAD_ROOT_TABLET) {
-        result.add(AccumuloTable.ROOT.tableId());
+        result.add(AccumuloNamespace.ROOT.tableId());
       }
       return result;
     }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/ManagerClientServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/ManagerClientServiceHandler.java
@@ -68,7 +68,7 @@ import org.apache.accumulo.core.manager.thrift.ManagerState;
 import org.apache.accumulo.core.manager.thrift.TTabletMergeability;
 import org.apache.accumulo.core.manager.thrift.TabletLoadState;
 import org.apache.accumulo.core.manager.thrift.ThriftPropertyException;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.schema.Ample.ConditionalResult.Status;
 import org.apache.accumulo.core.metadata.schema.TabletDeletedException;
@@ -174,7 +174,7 @@ public class ManagerClientServiceHandler implements ManagerClientService.Iface {
         }
       }
 
-      if (tableId.equals(AccumuloTable.ROOT.tableId())) {
+      if (tableId.equals(AccumuloNamespace.ROOT.tableId())) {
         break; // this code does not properly handle the root tablet. See #798
       }
 
@@ -218,7 +218,7 @@ public class ManagerClientServiceHandler implements ManagerClientService.Iface {
 
       } catch (TabletDeletedException e) {
         Manager.log.debug("Failed to scan {} table to wait for flush {}",
-            AccumuloTable.METADATA.tableName(), tableId, e);
+            AccumuloNamespace.METADATA.tableName(), tableId, e);
       }
     }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/user/UserFateMetrics.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/user/UserFateMetrics.java
@@ -20,7 +20,7 @@ package org.apache.accumulo.manager.metrics.fate.user;
 
 import org.apache.accumulo.core.fate.ReadOnlyFateStore;
 import org.apache.accumulo.core.fate.user.UserFateStore;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.manager.metrics.fate.FateMetrics;
 import org.apache.accumulo.server.ServerContext;
 
@@ -33,7 +33,7 @@ public class UserFateMetrics extends FateMetrics<UserFateMetricValues> {
   @Override
   protected ReadOnlyFateStore<FateMetrics<UserFateMetricValues>>
       buildReadOnlyStore(ServerContext context) {
-    return new UserFateStore<>(context, AccumuloTable.FATE.tableName(), null, null);
+    return new UserFateStore<>(context, AccumuloNamespace.FATE.tableName(), null, null);
   }
 
   @Override

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriver.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriver.java
@@ -48,7 +48,7 @@ import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.logging.TabletLogger;
 import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.core.metadata.AbstractTabletFile;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.Ample.ConditionalResult.Status;
@@ -91,7 +91,7 @@ public class CompactionDriver extends ManagerRepo {
   @Override
   public long isReady(FateId fateId, Manager manager) throws Exception {
 
-    if (tableId.equals(AccumuloTable.ROOT.tableId())) {
+    if (tableId.equals(AccumuloNamespace.ROOT.tableId())) {
       // this codes not properly handle the root table. See #798
       return 0;
     }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/CleanUp.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/CleanUp.java
@@ -36,7 +36,7 @@ import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.iterators.user.GrepIterator;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
@@ -73,8 +73,8 @@ class CleanUp extends ManagerRepo {
     try {
       // look for other tables that references this table's files
       AccumuloClient client = manager.getContext();
-      try (BatchScanner bs =
-          client.createBatchScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY, 8)) {
+      try (BatchScanner bs = client.createBatchScanner(AccumuloNamespace.METADATA.tableName(),
+          Authorizations.EMPTY, 8)) {
         Range allTables = TabletsSection.getRange();
         Range tableRange = TabletsSection.getRange(tableId);
         Range beforeTable =
@@ -95,7 +95,7 @@ class CleanUp extends ManagerRepo {
 
     } catch (Exception e) {
       refCount = -1;
-      log.error("Failed to scan " + AccumuloTable.METADATA.tableName()
+      log.error("Failed to scan " + AccumuloNamespace.METADATA.tableName()
           + " looking for references to deleted table " + tableId, e);
     }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/TableRangeOp.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/TableRangeOp.java
@@ -24,7 +24,7 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.util.TextUtil;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
@@ -57,9 +57,9 @@ public class TableRangeOp extends ManagerRepo {
   @Override
   public Repo<Manager> call(FateId fateId, Manager env) throws Exception {
 
-    if (AccumuloTable.ROOT.tableId().equals(data.tableId) && data.op.isMergeOp()) {
+    if (AccumuloNamespace.ROOT.tableId().equals(data.tableId) && data.op.isMergeOp()) {
       log.warn("Attempt to merge tablets for {} does nothing. It is not splittable.",
-          AccumuloTable.ROOT.tableName());
+          AccumuloNamespace.ROOT.tableName());
     }
 
     env.mustBeOnline(data.tableId);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableExport/WriteExportFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableExport/WriteExportFiles.java
@@ -51,7 +51,7 @@ import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.manager.state.tables.TableState;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.ValidationUtil;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
@@ -107,7 +107,7 @@ class WriteExportFiles extends ManagerRepo {
     checkOffline(manager.getContext());
 
     Scanner metaScanner =
-        client.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY);
+        client.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY);
     metaScanner.setRange(new KeyExtent(tableInfo.tableID, null, null).toMetaRange());
 
     // scan for locations
@@ -232,7 +232,7 @@ class WriteExportFiles extends ManagerRepo {
     Map<String,String> uniqueFiles = new HashMap<>();
 
     Scanner metaScanner =
-        context.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY);
+        context.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY);
     metaScanner.fetchColumnFamily(DataFileColumnFamily.NAME);
     TabletColumnFamily.AVAILABILITY_COLUMN.fetch(metaScanner);
     TabletColumnFamily.PREV_ROW_COLUMN.fetch(metaScanner);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/PopulateMetadataTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/PopulateMetadataTable.java
@@ -46,7 +46,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
@@ -103,7 +103,7 @@ class PopulateMetadataTable extends ManagerRepo {
 
     try (
         BatchWriter mbw =
-            manager.getContext().createBatchWriter(AccumuloTable.METADATA.tableName());
+            manager.getContext().createBatchWriter(AccumuloNamespace.METADATA.tableName());
         FSDataInputStream fsDataInputStream = fs.open(path);
         ZipInputStream zis = new ZipInputStream(fsDataInputStream)) {
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader11to12.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader11to12.java
@@ -51,7 +51,7 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
@@ -293,7 +293,7 @@ public class Upgrader11to12 implements Upgrader {
       FileSystemInitializer.InitialTablet scanRefTablet =
           initializer.createScanRefTablet(context, TabletMergeabilityMetadata.never());
       // Add references to the Metadata Table
-      try (BatchWriter writer = context.createBatchWriter(AccumuloTable.METADATA.tableName())) {
+      try (BatchWriter writer = context.createBatchWriter(AccumuloNamespace.METADATA.tableName())) {
         writer.addMutation(scanRefTablet.createMutation());
       } catch (MutationsRejectedException | TableNotFoundException e) {
         log.error("Failed to write tablet refs to metadata table");
@@ -344,8 +344,8 @@ public class Upgrader11to12 implements Upgrader {
   private void removeMetadataProblemReports(ServerContext context) {
     try (
         var scanner =
-            context.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY);
-        var writer = context.createBatchWriter(AccumuloTable.METADATA.tableName())) {
+            context.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY);
+        var writer = context.createBatchWriter(AccumuloNamespace.METADATA.tableName())) {
       scanner.setRange(ProblemSection.getRange());
       for (Map.Entry<Key,Value> entry : scanner) {
         var pr = ProblemReport.decodeMetadataEntry(entry.getKey(), entry.getValue());

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader12to13.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader12to13.java
@@ -42,7 +42,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.fate.zookeeper.ZooReader;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil.NodeMissingPolicy;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
 import org.apache.accumulo.core.metadata.schema.Ample.TabletsMutator;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
@@ -89,21 +89,21 @@ public class Upgrader12to13 implements Upgrader {
   @Override
   public void upgradeRoot(ServerContext context) {
     LOG.info("Looking for partial splits");
-    handlePartialSplits(context, AccumuloTable.ROOT.tableName());
+    handlePartialSplits(context, AccumuloNamespace.ROOT.tableName());
     LOG.info("setting metadata table hosting availability");
     addHostingGoals(context, TabletAvailability.HOSTED, DataLevel.METADATA);
     LOG.info("Removing MetadataBulkLoadFilter iterator from root table");
-    removeMetaDataBulkLoadFilter(context, AccumuloTable.ROOT.tableId());
+    removeMetaDataBulkLoadFilter(context, AccumuloNamespace.ROOT.tableId());
     LOG.info("Removing compact columns from metadata tablets");
-    removeCompactColumnsFromTable(context, AccumuloTable.ROOT.tableName());
+    removeCompactColumnsFromTable(context, AccumuloNamespace.ROOT.tableName());
   }
 
   @Override
   public void upgradeMetadata(ServerContext context) {
-    LOG.info("Creating table {}", AccumuloTable.FATE.tableName());
+    LOG.info("Creating table {}", AccumuloNamespace.FATE.tableName());
     createFateTable(context);
     LOG.info("Looking for partial splits");
-    handlePartialSplits(context, AccumuloTable.METADATA.tableName());
+    handlePartialSplits(context, AccumuloNamespace.METADATA.tableName());
     LOG.info("setting hosting availability on user tables");
     addHostingGoals(context, TabletAvailability.ONDEMAND, DataLevel.USER);
     LOG.info("Deleting external compaction final states from user tables");
@@ -111,11 +111,11 @@ public class Upgrader12to13 implements Upgrader {
     LOG.info("Deleting external compaction from user tables");
     deleteExternalCompactions(context);
     LOG.info("Removing MetadataBulkLoadFilter iterator from metadata table");
-    removeMetaDataBulkLoadFilter(context, AccumuloTable.METADATA.tableId());
+    removeMetaDataBulkLoadFilter(context, AccumuloNamespace.METADATA.tableId());
     LOG.info("Removing compact columns from user tables");
-    removeCompactColumnsFromTable(context, AccumuloTable.METADATA.tableName());
+    removeCompactColumnsFromTable(context, AccumuloNamespace.METADATA.tableName());
     LOG.info("Removing bulk file columns from metadata table");
-    removeBulkFileColumnsFromTable(context, AccumuloTable.METADATA.tableName());
+    removeBulkFileColumnsFromTable(context, AccumuloNamespace.METADATA.tableName());
   }
 
   private static void addCompactionsNode(ServerContext context) {
@@ -129,7 +129,7 @@ public class Upgrader12to13 implements Upgrader {
 
   private void createFateTable(ServerContext context) {
 
-    if (context.tableOperations().exists(AccumuloTable.FATE.tableName())) {
+    if (context.tableOperations().exists(AccumuloNamespace.FATE.tableName())) {
       LOG.info("Fate table already exists");
       return;
     }
@@ -156,7 +156,7 @@ public class Upgrader12to13 implements Upgrader {
       FileSystemInitializer.InitialTablet fateTableTableTablet =
           initializer.createFateRefTablet(context, TabletMergeabilityMetadata.never());
       // Add references to the Metadata Table
-      try (BatchWriter writer = context.createBatchWriter(AccumuloTable.METADATA.tableName())) {
+      try (BatchWriter writer = context.createBatchWriter(AccumuloNamespace.METADATA.tableName())) {
         writer.addMutation(fateTableTableTablet.createMutation());
       } catch (MutationsRejectedException | TableNotFoundException e) {
         LOG.error("Failed to write tablet refs to metadata table");
@@ -297,8 +297,8 @@ public class Upgrader12to13 implements Upgrader {
     // not be easy to test so its better for correctness to delete them and redo the work.
     try (
         var scanner =
-            context.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY);
-        var writer = context.createBatchWriter(AccumuloTable.METADATA.tableName())) {
+            context.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY);
+        var writer = context.createBatchWriter(AccumuloNamespace.METADATA.tableName())) {
       var section = new Section(RESERVED_PREFIX + "ecomp", true, RESERVED_PREFIX + "ecomq", false);
       scanner.setRange(section.getRange());
 
@@ -334,8 +334,8 @@ public class Upgrader12to13 implements Upgrader {
     // external compaction metadata.
     try (
         var scanner =
-            context.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY);
-        var writer = context.createBatchWriter(AccumuloTable.METADATA.tableName())) {
+            context.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY);
+        var writer = context.createBatchWriter(AccumuloNamespace.METADATA.tableName())) {
       scanner.setRange(TabletsSection.getRange());
       scanner.fetchColumnFamily(ExternalCompactionColumnFamily.NAME);
 

--- a/server/manager/src/test/java/org/apache/accumulo/manager/compaction/queue/CompactionJobQueuesTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/compaction/queue/CompactionJobQueuesTest.java
@@ -42,7 +42,7 @@ import java.util.stream.Stream;
 import org.apache.accumulo.core.client.admin.compaction.CompactableFile;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.CompactableFileImpl;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
@@ -231,7 +231,7 @@ public class CompactionJobQueuesTest {
     var tid = TableId.of("1");
     var extent1 = new KeyExtent(tid, new Text("z"), new Text("q"));
     var extent2 = new KeyExtent(tid, new Text("q"), new Text("l"));
-    var meta = new KeyExtent(AccumuloTable.METADATA.tableId(), new Text("l"), new Text("c"));
+    var meta = new KeyExtent(AccumuloNamespace.METADATA.tableId(), new Text("l"), new Text("c"));
     var root = RootTable.EXTENT;
 
     var cg1 = CompactorGroupId.of("CG1");

--- a/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/Upgrader10to11Test.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/Upgrader10to11Test.java
@@ -39,7 +39,7 @@ import java.util.stream.Collectors;
 import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.manager.state.tables.TableState;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.zookeeper.ZooSession;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.conf.codec.VersionedProperties;
@@ -88,7 +88,7 @@ class Upgrader10to11Test {
     zk.delete(buildRepTablePath(instanceId), -1);
     expectLastCall().once();
 
-    expect(propStore.get(TablePropKey.of(AccumuloTable.METADATA.tableId())))
+    expect(propStore.get(TablePropKey.of(AccumuloNamespace.METADATA.tableId())))
         .andReturn(new VersionedProperties()).once();
 
     replay(context, zk, propStore);
@@ -116,7 +116,7 @@ class Upgrader10to11Test {
     expect(zk.getChildren(buildRepTablePath(instanceId), null)).andReturn(List.of());
     zk.delete(buildRepTablePath(instanceId), -1);
     expectLastCall().once();
-    expect(propStore.get(TablePropKey.of(AccumuloTable.METADATA.tableId())))
+    expect(propStore.get(TablePropKey.of(AccumuloNamespace.METADATA.tableId())))
         .andReturn(new VersionedProperties()).once();
 
     replay(context, zk, propStore);

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/SystemInformation.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/SystemInformation.java
@@ -44,7 +44,7 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.TabletId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.dataImpl.TabletIdImpl;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.TabletState;
 import org.apache.accumulo.core.metrics.flatbuffers.FMetric;
 import org.apache.accumulo.core.metrics.flatbuffers.FTag;
@@ -496,7 +496,7 @@ public class SystemInformation {
           .computeIfAbsent(serverId.getType().name(), t -> new ProcessSummary())
           .addNotResponded(serverId);
     });
-    for (AccumuloTable table : AccumuloTable.values()) {
+    for (AccumuloNamespace table : AccumuloNamespace.values()) {
       TableConfiguration tconf = this.ctx.getTableConfiguration(table.tableId());
       String balancerRG = tconf.get(TableLoadBalancer.TABLE_ASSIGNMENT_GROUP_PROPERTY);
       balancerRG = balancerRG == null ? Constants.DEFAULT_RESOURCE_GROUP_NAME : balancerRG;

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tables/TablesResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tables/TablesResource.java
@@ -41,7 +41,7 @@ import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.core.manager.thrift.ManagerMonitorInfo;
 import org.apache.accumulo.core.manager.thrift.TableInfo;
 import org.apache.accumulo.core.manager.thrift.TabletServerStatus;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
@@ -140,7 +140,7 @@ public class TablesResource {
     }
 
     TreeSet<String> locs = new TreeSet<>();
-    if (AccumuloTable.ROOT.tableId().equals(tableId)) {
+    if (AccumuloNamespace.ROOT.tableId().equals(tableId)) {
       var rootLoc = monitor.getContext().getAmple().readTablet(RootTable.EXTENT).getLocation();
       if (rootLoc != null && rootLoc.getType() == TabletMetadata.LocationType.CURRENT) {
         locs.add(rootLoc.getHostPort());

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
@@ -73,7 +73,7 @@ import org.apache.accumulo.core.lock.ServiceLock;
 import org.apache.accumulo.core.lock.ServiceLockPaths;
 import org.apache.accumulo.core.logging.TabletLogger;
 import org.apache.accumulo.core.manager.thrift.TabletServerStatus;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.securityImpl.thrift.TCredentials;
 import org.apache.accumulo.core.spi.cache.BlockCache;
@@ -816,8 +816,8 @@ public class TabletClientHandler implements TabletServerClientService.Iface,
         throw new NoSuchScanIDException();
       }
 
-      if (!cs.tableId.equals(AccumuloTable.METADATA.tableId())
-          && !cs.tableId.equals(AccumuloTable.ROOT.tableId())) {
+      if (!cs.tableId.equals(AccumuloNamespace.METADATA.tableId())
+          && !cs.tableId.equals(AccumuloNamespace.ROOT.tableId())) {
         try {
           server.resourceManager.waitUntilCommitsAreEnabled();
         } catch (HoldTimeoutException hte) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -93,7 +93,7 @@ import org.apache.accumulo.core.manager.thrift.Compacting;
 import org.apache.accumulo.core.manager.thrift.ManagerClientService;
 import org.apache.accumulo.core.manager.thrift.TableInfo;
 import org.apache.accumulo.core.manager.thrift.TabletServerStatus;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
@@ -917,9 +917,9 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
   private Durability getMincEventDurability(KeyExtent extent) {
     TableConfiguration conf;
     if (extent.isMeta()) {
-      conf = getContext().getTableConfiguration(AccumuloTable.ROOT.tableId());
+      conf = getContext().getTableConfiguration(AccumuloNamespace.ROOT.tableId());
     } else {
-      conf = getContext().getTableConfiguration(AccumuloTable.METADATA.tableId());
+      conf = getContext().getTableConfiguration(AccumuloNamespace.METADATA.tableId());
     }
     return DurabilityImpl.fromString(conf.get(Property.TABLE_DURABILITY));
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -65,7 +65,7 @@ import org.apache.accumulo.core.lock.ServiceLock;
 import org.apache.accumulo.core.logging.ConditionalLogger.DeduplicatingLogger;
 import org.apache.accumulo.core.logging.TabletLogger;
 import org.apache.accumulo.core.manager.state.tables.TableState;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.TServerInstance;
@@ -1029,7 +1029,7 @@ public class Tablet extends TabletBase {
 
       if (!tabletMeta.getLogs().isEmpty()) {
         String msg = "Closed tablet " + extent + " has walog entries in "
-            + AccumuloTable.METADATA.tableName() + " " + tabletMeta.getLogs();
+            + AccumuloNamespace.METADATA.tableName() + " " + tabletMeta.getLogs();
         log.error(msg);
         throw new RuntimeException(msg);
       }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletBase.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletBase.java
@@ -42,7 +42,7 @@ import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iterators.YieldCallback;
 import org.apache.accumulo.core.iteratorsImpl.system.IterationInterruptedException;
 import org.apache.accumulo.core.iteratorsImpl.system.SourceSwitchingIterator;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
@@ -93,7 +93,7 @@ public abstract class TabletBase {
     this.context = server.getContext();
     this.server = server;
     this.extent = extent;
-    this.isUserTable = !AccumuloTable.allTableIds().contains(extent.tableId());
+    this.isUserTable = !AccumuloNamespace.containsTable(extent.tableId());
 
     TableConfiguration tblConf = context.getTableConfiguration(extent.tableId());
     if (tblConf == null) {

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/GetSplitsCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/GetSplitsCommand.java
@@ -30,7 +30,7 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.TextUtil;
@@ -63,8 +63,8 @@ public class GetSplitsCommand extends Command {
     try (PrintLine p =
         outputFile == null ? new PrintShell(shellState.getReader()) : new PrintFile(outputFile)) {
       if (verbose) {
-        String systemTableToCheck = AccumuloTable.METADATA.tableName().equals(tableName)
-            ? AccumuloTable.ROOT.tableName() : AccumuloTable.METADATA.tableName();
+        String systemTableToCheck = AccumuloNamespace.METADATA.tableName().equals(tableName)
+            ? AccumuloNamespace.ROOT.tableName() : AccumuloNamespace.METADATA.tableName();
         final Scanner scanner =
             shellState.getAccumuloClient().createScanner(systemTableToCheck, Authorizations.EMPTY);
         TabletColumnFamily.PREV_ROW_COLUMN.fetch(scanner);

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/OfflineCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/OfflineCommand.java
@@ -21,7 +21,7 @@ package org.apache.accumulo.shell.commands;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.TableNotFoundException;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.shell.Shell;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
@@ -40,8 +40,8 @@ public class OfflineCommand extends TableOperation {
   @Override
   protected void doTableOp(final Shell shellState, final String tableName)
       throws AccumuloException, AccumuloSecurityException, TableNotFoundException {
-    if (tableName.equals(AccumuloTable.METADATA.tableName())) {
-      Shell.log.info("  You cannot take the {} offline.", AccumuloTable.METADATA.tableName());
+    if (tableName.equals(AccumuloNamespace.METADATA.tableName())) {
+      Shell.log.info("  You cannot take the {} offline.", AccumuloNamespace.METADATA.tableName());
     } else {
       shellState.getAccumuloClient().tableOperations().offline(tableName, wait);
       Shell.log.info("Offline of table {} {}", tableName, wait ? " completed." : " initiated...");

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/OnlineCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/OnlineCommand.java
@@ -21,7 +21,7 @@ package org.apache.accumulo.shell.commands;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.TableNotFoundException;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.shell.Shell;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
@@ -40,8 +40,8 @@ public class OnlineCommand extends TableOperation {
   @Override
   protected void doTableOp(final Shell shellState, final String tableName)
       throws AccumuloException, AccumuloSecurityException, TableNotFoundException {
-    if (tableName.equals(AccumuloTable.ROOT.tableName())) {
-      Shell.log.info("  The {} is always online.", AccumuloTable.ROOT.tableName());
+    if (tableName.equals(AccumuloNamespace.ROOT.tableName())) {
+      Shell.log.info("  The {} is always online.", AccumuloNamespace.ROOT.tableName());
     } else {
       shellState.getAccumuloClient().tableOperations().online(tableName, wait);
       Shell.log.info("Online of table {} {}", tableName, wait ? " completed." : " initiated...");

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/SetIterCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/SetIterCommand.java
@@ -40,7 +40,7 @@ import org.apache.accumulo.core.iterators.user.AgeOffFilter;
 import org.apache.accumulo.core.iterators.user.RegExFilter;
 import org.apache.accumulo.core.iterators.user.ReqVisFilter;
 import org.apache.accumulo.core.iterators.user.VersioningIterator;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.shell.Shell;
 import org.apache.accumulo.shell.Shell.Command;
 import org.apache.accumulo.shell.ShellCommandException;
@@ -92,7 +92,7 @@ public class SetIterCommand extends Command {
     String configuredName;
     try {
       if (profileOpt != null && (currentTableName == null || currentTableName.isBlank())) {
-        tmpTable = AccumuloTable.METADATA.tableName();
+        tmpTable = AccumuloNamespace.METADATA.tableName();
         shellState.setTableName(tmpTable);
         tables = cl.hasOption(OptUtil.tableOpt().getOpt()) || !currentTableName.isEmpty();
       }

--- a/shell/src/test/java/org/apache/accumulo/shell/commands/DeleteTableCommandTest.java
+++ b/shell/src/test/java/org/apache/accumulo/shell/commands/DeleteTableCommandTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Set;
 
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Sets;
@@ -31,8 +31,8 @@ public class DeleteTableCommandTest {
 
   @Test
   public void removeAccumuloNamespaceTables() {
-    Set<String> tables = Sets.newHashSet(AccumuloTable.METADATA.tableName(),
-        AccumuloTable.ROOT.tableName(), "a1", "a2");
+    Set<String> tables = Sets.newHashSet(AccumuloNamespace.METADATA.tableName(),
+        AccumuloNamespace.ROOT.tableName(), "a1", "a2");
     DeleteTableCommand cmd = new DeleteTableCommand();
     cmd.pruneTables(tables);
 

--- a/test/src/main/java/org/apache/accumulo/test/BadDeleteMarkersCreatedIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/BadDeleteMarkersCreatedIT.java
@@ -39,7 +39,7 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.lock.ServiceLock;
 import org.apache.accumulo.core.lock.ServiceLockData;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.DeletesSection;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.zookeeper.ZooCache;
@@ -166,7 +166,7 @@ public class BadDeleteMarkersCreatedIT extends AccumuloClusterHarness {
       log.info("Verifying that delete markers were deleted");
       // look for delete markers
       try (Scanner scanner =
-          c.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
+          c.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY)) {
         scanner.setRange(DeletesSection.getRange());
         for (Entry<Key,Value> entry : scanner) {
           String row = entry.getKey().getRow().toString();

--- a/test/src/main/java/org/apache/accumulo/test/BalanceIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/BalanceIT.java
@@ -38,7 +38,7 @@ import org.apache.accumulo.core.client.admin.TabletAvailability;
 import org.apache.accumulo.core.client.admin.servers.ServerId;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.conf.Property;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.test.functional.ConfigurableMacBase;
@@ -97,13 +97,13 @@ public class BalanceIT extends ConfigurableMacBase {
 
       var metaSplits = IntStream.range(1, 100).mapToObj(i -> Integer.toString(i, 36)).map(Text::new)
           .collect(Collectors.toCollection(TreeSet::new));
-      c.tableOperations().addSplits(AccumuloTable.METADATA.tableName(), metaSplits);
+      c.tableOperations().addSplits(AccumuloNamespace.METADATA.tableName(), metaSplits);
 
-      var locCounts = countLocations(c, AccumuloTable.METADATA.tableName());
+      var locCounts = countLocations(c, AccumuloNamespace.METADATA.tableName());
 
       c.instanceOperations().waitForBalance();
 
-      locCounts = countLocations(c, AccumuloTable.METADATA.tableName());
+      locCounts = countLocations(c, AccumuloNamespace.METADATA.tableName());
       var stats = locCounts.values().stream().mapToInt(i -> i).summaryStatistics();
       assertTrue(stats.getMax() <= 51, locCounts.toString());
       assertTrue(stats.getMin() >= 50, locCounts.toString());
@@ -115,14 +115,14 @@ public class BalanceIT extends ConfigurableMacBase {
       getCluster().getClusterControl().start(ServerType.TABLET_SERVER);
 
       Wait.waitFor(() -> {
-        var lc = countLocations(c, AccumuloTable.METADATA.tableName());
+        var lc = countLocations(c, AccumuloNamespace.METADATA.tableName());
         log.info("locations:{}", lc);
         return lc.size() == 4;
       });
 
       c.instanceOperations().waitForBalance();
 
-      locCounts = countLocations(c, AccumuloTable.METADATA.tableName());
+      locCounts = countLocations(c, AccumuloNamespace.METADATA.tableName());
       stats = locCounts.values().stream().mapToInt(i -> i).summaryStatistics();
       assertTrue(stats.getMax() <= 26, locCounts.toString());
       assertTrue(stats.getMin() >= 25, locCounts.toString());

--- a/test/src/main/java/org/apache/accumulo/test/ChaoticLoadBalancer.java
+++ b/test/src/main/java/org/apache/accumulo/test/ChaoticLoadBalancer.java
@@ -30,7 +30,7 @@ import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.TabletId;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.spi.balancer.BalancerEnvironment;
 import org.apache.accumulo.core.spi.balancer.TabletBalancer;
 import org.apache.accumulo.core.spi.balancer.data.TServerStatus;
@@ -133,7 +133,7 @@ public class ChaoticLoadBalancer implements TabletBalancer {
     for (Entry<TabletServerId,TServerStatus> e : params.currentStatus().entrySet()) {
       for (String tableId : e.getValue().getTableMap().keySet()) {
         TableId id = TableId.of(tableId);
-        if (!moveMetadata && AccumuloTable.METADATA.tableId().equals(id)) {
+        if (!moveMetadata && AccumuloNamespace.METADATA.tableId().equals(id)) {
           continue;
         }
         try {

--- a/test/src/main/java/org/apache/accumulo/test/CleanWalIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/CleanWalIT.java
@@ -34,7 +34,7 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LogColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
@@ -82,14 +82,14 @@ public class CleanWalIT extends AccumuloClusterHarness {
 
       getCluster().getClusterControl().startAllServers(ServerType.TABLET_SERVER);
 
-      for (String table : new String[] {AccumuloTable.METADATA.tableName(),
-          AccumuloTable.ROOT.tableName()}) {
+      for (String table : new String[] {AccumuloNamespace.METADATA.tableName(),
+          AccumuloNamespace.ROOT.tableName()}) {
         client.tableOperations().flush(table, null, null, true);
       }
       log.debug("Checking entries for {}", tableName);
       assertEquals(1, count(tableName, client));
-      for (String table : new String[] {AccumuloTable.METADATA.tableName(),
-          AccumuloTable.ROOT.tableName()}) {
+      for (String table : new String[] {AccumuloNamespace.METADATA.tableName(),
+          AccumuloNamespace.ROOT.tableName()}) {
         log.debug("Checking logs for {}", table);
         assertEquals(0, countLogs(client), "Found logs for " + table);
       }
@@ -101,8 +101,8 @@ public class CleanWalIT extends AccumuloClusterHarness {
       }
       assertEquals(0, count(tableName, client));
       client.tableOperations().flush(tableName, null, null, true);
-      client.tableOperations().flush(AccumuloTable.METADATA.tableName(), null, null, true);
-      client.tableOperations().flush(AccumuloTable.ROOT.tableName(), null, null, true);
+      client.tableOperations().flush(AccumuloNamespace.METADATA.tableName(), null, null, true);
+      client.tableOperations().flush(AccumuloNamespace.ROOT.tableName(), null, null, true);
       try {
         getCluster().getClusterControl().stopAllServers(ServerType.TABLET_SERVER);
         Thread.sleep(SECONDS.toMillis(3));
@@ -116,7 +116,7 @@ public class CleanWalIT extends AccumuloClusterHarness {
   private int countLogs(AccumuloClient client) throws TableNotFoundException {
     int count = 0;
     try (Scanner scanner =
-        client.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
+        client.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY)) {
       scanner.fetchColumnFamily(LogColumnFamily.NAME);
       scanner.setRange(TabletsSection.getRange());
       for (Entry<Key,Value> entry : scanner) {

--- a/test/src/main/java/org/apache/accumulo/test/CreateTableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/CreateTableIT.java
@@ -24,7 +24,7 @@ import java.time.Duration;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -61,7 +61,7 @@ public class CreateTableIT extends SharedMiniClusterBase {
       }
       // Confirm all 500 user tables exist in addition to Root, Metadata,
       // and ScanRef tables
-      assertEquals(500 + AccumuloTable.allTableIds().size(),
+      assertEquals(500 + AccumuloNamespace.allTableIds().size(),
           client.tableOperations().list().size());
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/DetectDeadTabletServersIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/DetectDeadTabletServersIT.java
@@ -29,7 +29,7 @@ import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.conf.ClientProperty;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.manager.thrift.ManagerMonitorInfo;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.trace.TraceUtil;
@@ -52,7 +52,7 @@ public class DetectDeadTabletServersIT extends ConfigurableMacBase {
     try (AccumuloClient c = Accumulo.newClient().from(getClientProperties()).build()) {
       log.info("verifying that everything is up");
       try (Scanner scanner =
-          c.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
+          c.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY)) {
         scanner.forEach((k, v) -> {});
       }
       ManagerMonitorInfo stats = getStats(c);

--- a/test/src/main/java/org/apache/accumulo/test/DumpConfigIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/DumpConfigIT.java
@@ -28,7 +28,7 @@ import java.time.Duration;
 import java.util.Collections;
 
 import org.apache.accumulo.core.conf.Property;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.server.util.Admin;
 import org.apache.accumulo.test.functional.ConfigurableMacBase;
@@ -68,14 +68,14 @@ public class DumpConfigIT extends ConfigurableMacBase {
     assertTrue(site.contains(Property.TABLE_FILE_BLOCK_SIZE.getKey()));
     assertTrue(site.contains("1234567"));
     String meta = FunctionalTestUtils.readAll(
-        new FileInputStream(new File(folder, AccumuloTable.METADATA.tableName() + ".cfg")));
+        new FileInputStream(new File(folder, AccumuloNamespace.METADATA.tableName() + ".cfg")));
     assertTrue(meta.contains(Property.TABLE_FILE_REPLICATION.getKey()));
     String systemPerm =
         FunctionalTestUtils.readAll(new FileInputStream(new File(folder, "root_user.cfg")));
     assertTrue(systemPerm.contains("grant System.ALTER_USER -s -u root"));
     assertTrue(systemPerm
-        .contains("grant Table.READ -t " + AccumuloTable.METADATA.tableName() + " -u root"));
+        .contains("grant Table.READ -t " + AccumuloNamespace.METADATA.tableName() + " -u root"));
     assertFalse(systemPerm
-        .contains("grant Table.DROP -t " + AccumuloTable.METADATA.tableName() + " -u root"));
+        .contains("grant Table.DROP -t " + AccumuloNamespace.METADATA.tableName() + " -u root"));
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/ExistingMacIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ExistingMacIT.java
@@ -42,7 +42,7 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl;
@@ -101,8 +101,8 @@ public class ExistingMacIT extends ConfigurableMacBase {
     }
 
     client.tableOperations().flush(table, null, null, true);
-    client.tableOperations().flush(AccumuloTable.METADATA.tableName(), null, null, true);
-    client.tableOperations().flush(AccumuloTable.ROOT.tableName(), null, null, true);
+    client.tableOperations().flush(AccumuloNamespace.METADATA.tableName(), null, null, true);
+    client.tableOperations().flush(AccumuloNamespace.ROOT.tableName(), null, null, true);
 
     Set<Entry<ServerType,Collection<ProcessReference>>> procs =
         getCluster().getProcesses().entrySet();

--- a/test/src/main/java/org/apache/accumulo/test/GCRunIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/GCRunIT.java
@@ -39,7 +39,7 @@ import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.gc.Reference;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.security.ColumnVisibility;
@@ -115,7 +115,7 @@ public class GCRunIT extends SharedMiniClusterBase {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
 
       client.securityOperations().grantTablePermission(getAdminPrincipal(),
-          AccumuloTable.METADATA.tableName(), TablePermission.WRITE);
+          AccumuloNamespace.METADATA.tableName(), TablePermission.WRITE);
 
       String cloneId = client.tableOperations().tableIdMap().get(clone1);
 
@@ -125,7 +125,7 @@ public class GCRunIT extends SharedMiniClusterBase {
       final Text colq = new Text(DIRECTORY_QUAL);
       m.putDelete(colf, colq, new ColumnVisibility());
 
-      try (BatchWriter bw = client.createBatchWriter(AccumuloTable.METADATA.tableName(),
+      try (BatchWriter bw = client.createBatchWriter(AccumuloNamespace.METADATA.tableName(),
           new BatchWriterConfig().setMaxMemory(Math.max(m.estimatedMemoryUsed(), 1024))
               .setMaxWriteThreads(1).setTimeout(5_000, TimeUnit.MILLISECONDS))) {
         log.info("forcing delete of srv:dir with mutation {}", m.prettyPrint());
@@ -187,8 +187,8 @@ public class GCRunIT extends SharedMiniClusterBase {
       client.tableOperations().compact(table1, new CompactionConfig().setWait(true));
       client.tableOperations().delete(table1);
 
-      client.tableOperations().flush(AccumuloTable.METADATA.tableName(), null, null, true);
-      client.tableOperations().flush(AccumuloTable.ROOT.tableName(), null, null, true);
+      client.tableOperations().flush(AccumuloNamespace.METADATA.tableName(), null, null, true);
+      client.tableOperations().flush(AccumuloNamespace.ROOT.tableName(), null, null, true);
 
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/GarbageCollectWALIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/GarbageCollectWALIT.java
@@ -27,7 +27,7 @@ import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.conf.Property;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl;
@@ -71,7 +71,7 @@ public class GarbageCollectWALIT extends ConfigurableMacBase {
       cluster.getClusterControl().start(ServerType.GARBAGE_COLLECTOR);
       cluster.getClusterControl().start(ServerType.TABLET_SERVER);
       try (Scanner scanner =
-          c.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
+          c.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY)) {
         scanner.forEach((k, v) -> {});
       }
       Wait.waitFor(() -> countWALsInFS(cluster) == 2, SECONDS.toMillis(120), SECONDS.toMillis(15));

--- a/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
@@ -61,7 +61,7 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.TabletId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.manager.state.tables.TableState;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
@@ -201,7 +201,7 @@ public class ImportExportIT extends AccumuloClusterHarness {
     log.info("Imported into table with ID: {}", tableId);
 
     try (Scanner s =
-        client.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
+        client.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY)) {
       s.setRange(TabletsSection.getRange(TableId.of(tableId)));
       s.fetchColumnFamily(DataFileColumnFamily.NAME);
       ServerColumnFamily.DIRECTORY_COLUMN.fetch(s);
@@ -360,7 +360,7 @@ public class ImportExportIT extends AccumuloClusterHarness {
 
       // Get all `file` colfams from the metadata table for the new table
       try (Scanner s =
-          client.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
+          client.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY)) {
         s.setRange(TabletsSection.getRange(TableId.of(tableId)));
         s.fetchColumnFamily(DataFileColumnFamily.NAME);
         ServerColumnFamily.DIRECTORY_COLUMN.fetch(s);
@@ -585,7 +585,7 @@ public class ImportExportIT extends AccumuloClusterHarness {
       assertEquals(7, rowCount);
       int metaFileCount = 0;
       try (Scanner s =
-          client.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
+          client.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY)) {
         TableId tid = TableId.of(client.tableOperations().tableIdMap().get(table));
         s.setRange(TabletsSection.getRange(tid));
         s.fetchColumnFamily(DataFileColumnFamily.NAME);

--- a/test/src/main/java/org/apache/accumulo/test/MetaConstraintRetryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MetaConstraintRetryIT.java
@@ -30,7 +30,7 @@ import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.manager.upgrade.SplitRecovery12to13;
@@ -49,7 +49,7 @@ public class MetaConstraintRetryIT extends AccumuloClusterHarness {
   public void test() throws Exception {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
       client.securityOperations().grantTablePermission(getAdminPrincipal(),
-          AccumuloTable.METADATA.tableName(), TablePermission.WRITE);
+          AccumuloNamespace.METADATA.tableName(), TablePermission.WRITE);
 
       ServerContext context = getServerContext();
       KeyExtent extent = new KeyExtent(TableId.of("5"), null, null);

--- a/test/src/main/java/org/apache/accumulo/test/MetaGetsReadersIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MetaGetsReadersIT.java
@@ -36,7 +36,7 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.test.functional.ConfigurableMacBase;
@@ -101,7 +101,8 @@ public class MetaGetsReadersIT extends ConfigurableMacBase {
       Thread.sleep(500);
       long now = System.currentTimeMillis();
 
-      try (Scanner s = c.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
+      try (Scanner s =
+          c.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY)) {
         s.forEach((k, v) -> {});
       }
 

--- a/test/src/main/java/org/apache/accumulo/test/MetaRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MetaRecoveryIT.java
@@ -32,7 +32,7 @@ import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.test.functional.ConfigurableMacBase;
@@ -78,14 +78,14 @@ public class MetaRecoveryIT extends ConfigurableMacBase {
         log.info("Data written to table {}", i);
         i++;
       }
-      c.tableOperations().flush(AccumuloTable.METADATA.tableName(), null, null, true);
-      c.tableOperations().flush(AccumuloTable.ROOT.tableName(), null, null, true);
+      c.tableOperations().flush(AccumuloNamespace.METADATA.tableName(), null, null, true);
+      c.tableOperations().flush(AccumuloNamespace.ROOT.tableName(), null, null, true);
       SortedSet<Text> splits = new TreeSet<>();
       for (i = 1; i < tables.length; i++) {
         splits.add(new Text("" + i));
       }
-      c.tableOperations().addSplits(AccumuloTable.METADATA.tableName(), splits);
-      log.info("Added {} splits to {}", splits.size(), AccumuloTable.METADATA.tableName());
+      c.tableOperations().addSplits(AccumuloNamespace.METADATA.tableName(), splits);
+      log.info("Added {} splits to {}", splits.size(), AccumuloNamespace.METADATA.tableName());
       c.instanceOperations().waitForBalance();
       log.info("Restarting");
       getCluster().getClusterControl().kill(ServerType.TABLET_SERVER, "localhost");

--- a/test/src/main/java/org/apache/accumulo/test/MetaSplitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MetaSplitIT.java
@@ -45,7 +45,7 @@ import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.hadoop.io.Text;
@@ -70,14 +70,14 @@ public class MetaSplitIT extends AccumuloClusterHarness {
     if (getClusterType() == ClusterType.STANDALONE) {
       try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
         Collection<Text> splits =
-            client.tableOperations().listSplits(AccumuloTable.METADATA.tableName());
+            client.tableOperations().listSplits(AccumuloNamespace.METADATA.tableName());
         // We expect a single split
         if (!splits.equals(Arrays.asList(new Text("~")))) {
           log.info("Existing splits on metadata table. Saving them, and applying"
               + " single original split of '~'");
           metadataSplits = splits;
-          client.tableOperations().merge(AccumuloTable.METADATA.tableName(), null, null);
-          client.tableOperations().addSplits(AccumuloTable.METADATA.tableName(),
+          client.tableOperations().merge(AccumuloNamespace.METADATA.tableName(), null, null);
+          client.tableOperations().addSplits(AccumuloNamespace.METADATA.tableName(),
               new TreeSet<>(Collections.singleton(new Text("~"))));
         }
       }
@@ -89,8 +89,8 @@ public class MetaSplitIT extends AccumuloClusterHarness {
     if (metadataSplits != null) {
       log.info("Restoring split on metadata table");
       try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-        client.tableOperations().merge(AccumuloTable.METADATA.tableName(), null, null);
-        client.tableOperations().addSplits(AccumuloTable.METADATA.tableName(),
+        client.tableOperations().merge(AccumuloNamespace.METADATA.tableName(), null, null);
+        client.tableOperations().addSplits(AccumuloNamespace.METADATA.tableName(),
             new TreeSet<>(metadataSplits));
       }
     }
@@ -102,14 +102,14 @@ public class MetaSplitIT extends AccumuloClusterHarness {
       SortedSet<Text> splits = new TreeSet<>();
       splits.add(new Text("5"));
       assertThrows(AccumuloException.class,
-          () -> client.tableOperations().addSplits(AccumuloTable.ROOT.tableName(), splits));
+          () -> client.tableOperations().addSplits(AccumuloNamespace.ROOT.tableName(), splits));
     }
   }
 
   @Test
   public void testRootTableMerge() throws Exception {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-      client.tableOperations().merge(AccumuloTable.ROOT.tableName(), null, null);
+      client.tableOperations().merge(AccumuloNamespace.ROOT.tableName(), null, null);
     }
   }
 
@@ -118,14 +118,14 @@ public class MetaSplitIT extends AccumuloClusterHarness {
     for (String point : points) {
       splits.add(new Text(point));
     }
-    opts.addSplits(AccumuloTable.METADATA.tableName(), splits);
+    opts.addSplits(AccumuloNamespace.METADATA.tableName(), splits);
   }
 
   @Test
   public void testMetadataTableSplit() throws Exception {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
       // disable compactions
-      client.tableOperations().setProperty(AccumuloTable.METADATA.tableName(),
+      client.tableOperations().setProperty(AccumuloNamespace.METADATA.tableName(),
           Property.TABLE_MAJC_RATIO.getKey(), "9999");
 
       TableOperations opts = client.tableOperations();
@@ -133,47 +133,53 @@ public class MetaSplitIT extends AccumuloClusterHarness {
         opts.create(Integer.toString(i));
       }
       try {
-        assertEquals(0, countFencedFiles(getServerContext(), AccumuloTable.METADATA.tableName()));
+        assertEquals(0,
+            countFencedFiles(getServerContext(), AccumuloNamespace.METADATA.tableName()));
         verifyMetadataTableScan(client);
-        opts.merge(AccumuloTable.METADATA.tableName(), new Text("01"), new Text("02"));
+        opts.merge(AccumuloNamespace.METADATA.tableName(), new Text("01"), new Text("02"));
         checkMetadataSplits(1, opts);
         verifyMetadataTableScan(client);
         addSplits(opts, "4 5 6 7 8".split(" "));
         checkMetadataSplits(6, opts);
         verifyMetadataTableScan(client);
 
-        opts.merge(AccumuloTable.METADATA.tableName(), new Text("6"), new Text("9"));
+        opts.merge(AccumuloNamespace.METADATA.tableName(), new Text("6"), new Text("9"));
         checkMetadataSplits(4, opts);
         // Merging tablets should produce fenced files because of no-chop merge
-        assertTrue(countFencedFiles(getServerContext(), AccumuloTable.METADATA.tableName()) > 0);
+        assertTrue(
+            countFencedFiles(getServerContext(), AccumuloNamespace.METADATA.tableName()) > 0);
         verifyMetadataTableScan(client);
         // Verify that the MERGED marker was cleared and doesn't exist on any tablet
-        verifyMergedMarkerCleared(getServerContext(), AccumuloTable.METADATA.tableId());
+        verifyMergedMarkerCleared(getServerContext(), AccumuloNamespace.METADATA.tableId());
 
         addSplits(opts, "44 55 66 77 88".split(" "));
         checkMetadataSplits(9, opts);
-        assertTrue(countFencedFiles(getServerContext(), AccumuloTable.METADATA.tableName()) > 0);
+        assertTrue(
+            countFencedFiles(getServerContext(), AccumuloNamespace.METADATA.tableName()) > 0);
         verifyMetadataTableScan(client);
         // Verify that the MERGED marker was cleared and doesn't exist on any tablet
-        verifyMergedMarkerCleared(getServerContext(), AccumuloTable.METADATA.tableId());
+        verifyMergedMarkerCleared(getServerContext(), AccumuloNamespace.METADATA.tableId());
 
-        opts.merge(AccumuloTable.METADATA.tableName(), new Text("5"), new Text("7"));
+        opts.merge(AccumuloNamespace.METADATA.tableName(), new Text("5"), new Text("7"));
         checkMetadataSplits(6, opts);
-        assertTrue(countFencedFiles(getServerContext(), AccumuloTable.METADATA.tableName()) > 0);
+        assertTrue(
+            countFencedFiles(getServerContext(), AccumuloNamespace.METADATA.tableName()) > 0);
         verifyMetadataTableScan(client);
         // Verify that the MERGED marker was cleared and doesn't exist on any tablet
-        verifyMergedMarkerCleared(getServerContext(), AccumuloTable.METADATA.tableId());
+        verifyMergedMarkerCleared(getServerContext(), AccumuloNamespace.METADATA.tableId());
 
-        opts.merge(AccumuloTable.METADATA.tableName(), null, null);
+        opts.merge(AccumuloNamespace.METADATA.tableName(), null, null);
         checkMetadataSplits(0, opts);
-        assertTrue(countFencedFiles(getServerContext(), AccumuloTable.METADATA.tableName()) > 0);
+        assertTrue(
+            countFencedFiles(getServerContext(), AccumuloNamespace.METADATA.tableName()) > 0);
         verifyMetadataTableScan(client);
         // Verify that the MERGED marker was cleared and doesn't exist on any tablet
-        verifyMergedMarkerCleared(getServerContext(), AccumuloTable.METADATA.tableId());
+        verifyMergedMarkerCleared(getServerContext(), AccumuloNamespace.METADATA.tableId());
 
-        opts.compact(AccumuloTable.METADATA.tableName(), new CompactionConfig());
+        opts.compact(AccumuloNamespace.METADATA.tableName(), new CompactionConfig());
         // Should be no more fenced files after compaction
-        assertEquals(0, countFencedFiles(getServerContext(), AccumuloTable.METADATA.tableName()));
+        assertEquals(0,
+            countFencedFiles(getServerContext(), AccumuloNamespace.METADATA.tableName()));
         verifyMetadataTableScan(client);
       } finally {
         for (int i = 1; i <= 10; i++) {
@@ -189,8 +195,8 @@ public class MetaSplitIT extends AccumuloClusterHarness {
   private void verifyMetadataTableScan(AccumuloClient client) throws Exception {
     var tables = client.tableOperations().tableIdMap();
     var expectedExtents = tables.entrySet().stream()
-        .filter(e -> !e.getKey().equals(AccumuloTable.ROOT.tableName())
-            && !e.getKey().equals(AccumuloTable.METADATA.tableName()))
+        .filter(e -> !e.getKey().equals(AccumuloNamespace.ROOT.tableName())
+            && !e.getKey().equals(AccumuloNamespace.METADATA.tableName()))
         .map(Map.Entry::getValue).map(TableId::of).map(tid -> new KeyExtent(tid, null, null))
         .collect(Collectors.toSet());
     // Verify we have 12 tablets for metadata (Includes FateTable and ScanRef table)
@@ -215,12 +221,12 @@ public class MetaSplitIT extends AccumuloClusterHarness {
       throws AccumuloSecurityException, TableNotFoundException, AccumuloException,
       InterruptedException {
     for (int i = 0; i < 10; i++) {
-      if (opts.listSplits(AccumuloTable.METADATA.tableName()).size() == numSplits) {
+      if (opts.listSplits(AccumuloNamespace.METADATA.tableName()).size() == numSplits) {
         break;
       }
       Thread.sleep(2000);
     }
-    Collection<Text> splits = opts.listSplits(AccumuloTable.METADATA.tableName());
+    Collection<Text> splits = opts.listSplits(AccumuloNamespace.METADATA.tableName());
     assertEquals(numSplits, splits.size(), "Actual metadata table splits: " + splits);
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/MissingWalHeaderCompletesRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MissingWalHeaderCompletesRecoveryIT.java
@@ -35,7 +35,7 @@ import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.TableId;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.TablePermission;
@@ -82,10 +82,10 @@ public class MissingWalHeaderCompletesRecoveryIT extends ConfigurableMacBase {
   public void setupMetadataPermission() throws Exception {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProperties()).build()) {
       rootHasWritePermission = client.securityOperations().hasTablePermission("root",
-          AccumuloTable.METADATA.tableName(), TablePermission.WRITE);
+          AccumuloNamespace.METADATA.tableName(), TablePermission.WRITE);
       if (!rootHasWritePermission) {
-        client.securityOperations().grantTablePermission("root", AccumuloTable.METADATA.tableName(),
-            TablePermission.WRITE);
+        client.securityOperations().grantTablePermission("root",
+            AccumuloNamespace.METADATA.tableName(), TablePermission.WRITE);
         // Make sure it propagates through ZK
         Thread.sleep(5000);
       }
@@ -97,15 +97,15 @@ public class MissingWalHeaderCompletesRecoveryIT extends ConfigurableMacBase {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProperties()).build()) {
       // Final state doesn't match the original
       if (rootHasWritePermission != client.securityOperations().hasTablePermission("root",
-          AccumuloTable.METADATA.tableName(), TablePermission.WRITE)) {
+          AccumuloNamespace.METADATA.tableName(), TablePermission.WRITE)) {
         if (rootHasWritePermission) {
           // root had write permission when starting, ensure root still does
           client.securityOperations().grantTablePermission("root",
-              AccumuloTable.METADATA.tableName(), TablePermission.WRITE);
+              AccumuloNamespace.METADATA.tableName(), TablePermission.WRITE);
         } else {
           // root did not have write permission when starting, ensure that it does not
           client.securityOperations().revokeTablePermission("root",
-              AccumuloTable.METADATA.tableName(), TablePermission.WRITE);
+              AccumuloNamespace.METADATA.tableName(), TablePermission.WRITE);
         }
       }
     }
@@ -128,8 +128,9 @@ public class MissingWalHeaderCompletesRecoveryIT extends ConfigurableMacBase {
 
       fs.create(new Path(emptyWalog.toURI())).close();
 
-      assertTrue(client.securityOperations().hasTablePermission("root",
-          AccumuloTable.METADATA.tableName(), TablePermission.WRITE),
+      assertTrue(
+          client.securityOperations().hasTablePermission("root",
+              AccumuloNamespace.METADATA.tableName(), TablePermission.WRITE),
           "root user did not have write permission to metadata table");
 
       String tableName = getUniqueNames(1)[0];
@@ -149,7 +150,7 @@ public class MissingWalHeaderCompletesRecoveryIT extends ConfigurableMacBase {
       Mutation m = new Mutation(row);
       logEntry.addToMutation(m);
 
-      try (BatchWriter bw = client.createBatchWriter(AccumuloTable.METADATA.tableName())) {
+      try (BatchWriter bw = client.createBatchWriter(AccumuloNamespace.METADATA.tableName())) {
         bw.addMutation(m);
       }
 
@@ -187,8 +188,9 @@ public class MissingWalHeaderCompletesRecoveryIT extends ConfigurableMacBase {
           DfsLogger.LOG_FILE_HEADER_V4.length() / 2);
       wal.close();
 
-      assertTrue(client.securityOperations().hasTablePermission("root",
-          AccumuloTable.METADATA.tableName(), TablePermission.WRITE),
+      assertTrue(
+          client.securityOperations().hasTablePermission("root",
+              AccumuloNamespace.METADATA.tableName(), TablePermission.WRITE),
           "root user did not have write permission to metadata table");
 
       String tableName = getUniqueNames(1)[0];
@@ -208,7 +210,7 @@ public class MissingWalHeaderCompletesRecoveryIT extends ConfigurableMacBase {
       Mutation m = new Mutation(row);
       logEntry.addToMutation(m);
 
-      try (BatchWriter bw = client.createBatchWriter(AccumuloTable.METADATA.tableName())) {
+      try (BatchWriter bw = client.createBatchWriter(AccumuloNamespace.METADATA.tableName())) {
         bw.addMutation(m);
       }
 

--- a/test/src/main/java/org/apache/accumulo/test/MultiTableRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MultiTableRecoveryIT.java
@@ -38,7 +38,7 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
@@ -132,7 +132,7 @@ public class MultiTableRecoveryIT extends ConfigurableMacBase {
           getCluster().start();
           // read the metadata table to know everything is back up
           try (Scanner scanner =
-              client.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
+              client.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY)) {
             scanner.forEach((k, v) -> {});
           }
           i++;

--- a/test/src/main/java/org/apache/accumulo/test/NamespacesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/NamespacesIT.java
@@ -73,7 +73,7 @@ import org.apache.accumulo.core.iterators.Filter;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iterators.user.VersioningIterator;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.NamespacePermission;
 import org.apache.accumulo.core.security.SystemPermission;
@@ -896,8 +896,8 @@ public class NamespacesIT extends SharedMiniClusterBase {
     // nobody should have any of these properties yet
     assertFalse(c.instanceOperations().getSystemConfiguration().containsValue(v));
     assertFalse(checkNamespaceHasProp(Namespace.ACCUMULO.name(), k, v));
-    assertFalse(checkTableHasProp(AccumuloTable.ROOT.tableName(), k, v));
-    assertFalse(checkTableHasProp(AccumuloTable.METADATA.tableName(), k, v));
+    assertFalse(checkTableHasProp(AccumuloNamespace.ROOT.tableName(), k, v));
+    assertFalse(checkTableHasProp(AccumuloNamespace.METADATA.tableName(), k, v));
     assertFalse(checkNamespaceHasProp(Namespace.DEFAULT.name(), k, v));
     assertFalse(checkTableHasProp(defaultNamespaceTable, k, v));
     assertFalse(checkNamespaceHasProp(namespace, k, v));
@@ -911,9 +911,9 @@ public class NamespacesIT extends SharedMiniClusterBase {
     assertEquals(systemNamespaceShouldInherit,
         checkNamespaceHasProp(Namespace.ACCUMULO.name(), k, v));
     assertEquals(systemNamespaceShouldInherit,
-        checkTableHasProp(AccumuloTable.ROOT.tableName(), k, v));
+        checkTableHasProp(AccumuloNamespace.ROOT.tableName(), k, v));
     assertEquals(systemNamespaceShouldInherit,
-        checkTableHasProp(AccumuloTable.METADATA.tableName(), k, v));
+        checkTableHasProp(AccumuloNamespace.METADATA.tableName(), k, v));
     assertTrue(checkNamespaceHasProp(Namespace.DEFAULT.name(), k, v));
     assertTrue(checkTableHasProp(defaultNamespaceTable, k, v));
     assertTrue(checkNamespaceHasProp(namespace, k, v));
@@ -925,8 +925,8 @@ public class NamespacesIT extends SharedMiniClusterBase {
     Thread.sleep(250);
     assertFalse(c.instanceOperations().getSystemConfiguration().containsValue(v));
     assertFalse(checkNamespaceHasProp(Namespace.ACCUMULO.name(), k, v));
-    assertFalse(checkTableHasProp(AccumuloTable.ROOT.tableName(), k, v));
-    assertFalse(checkTableHasProp(AccumuloTable.METADATA.tableName(), k, v));
+    assertFalse(checkTableHasProp(AccumuloNamespace.ROOT.tableName(), k, v));
+    assertFalse(checkTableHasProp(AccumuloNamespace.METADATA.tableName(), k, v));
     assertFalse(checkNamespaceHasProp(Namespace.DEFAULT.name(), k, v));
     assertFalse(checkTableHasProp(defaultNamespaceTable, k, v));
     assertFalse(checkNamespaceHasProp(namespace, k, v));

--- a/test/src/main/java/org/apache/accumulo/test/RecoveryCompactionsAreFlushesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/RecoveryCompactionsAreFlushesIT.java
@@ -32,7 +32,7 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
@@ -95,7 +95,8 @@ public class RecoveryCompactionsAreFlushesIT extends AccumuloClusterHarness {
       }
 
       // ensure that the recovery was not a merging minor compaction
-      try (Scanner s = c.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
+      try (Scanner s =
+          c.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY)) {
         s.fetchColumnFamily(DataFileColumnFamily.NAME);
         for (Entry<Key,Value> entry : s) {
           String filename = entry.getKey().getColumnQualifier().toString();

--- a/test/src/main/java/org/apache/accumulo/test/ScanConsistencyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ScanConsistencyIT.java
@@ -58,7 +58,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.Filter;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.hadoop.conf.Configuration;
@@ -153,7 +153,7 @@ public class ScanConsistencyIT extends AccumuloClusterHarness {
           while (keepLogging.get()) {
             Thread.sleep(10000);
             if (keepLogging.get()) {
-              try (var scanner = client.createScanner(AccumuloTable.METADATA.tableName())) {
+              try (var scanner = client.createScanner(AccumuloNamespace.METADATA.tableName())) {
                 log.debug("Scanning metadata table");
                 scanner.forEach((k, v) -> log.debug(k.toStringNoTruncate() + " " + v));
               }

--- a/test/src/main/java/org/apache/accumulo/test/ScanServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ScanServerIT.java
@@ -60,7 +60,7 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.FateInstanceType;
 import org.apache.accumulo.core.lock.ServiceLockPaths.AddressSelector;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.Ample.TabletsMutator;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
@@ -440,7 +440,7 @@ public class ScanServerIT extends SharedMiniClusterBase {
   }
 
   protected static int getNumHostedTablets(AccumuloClient client, String tableId) throws Exception {
-    try (Scanner scanner = client.createScanner(AccumuloTable.METADATA.tableName())) {
+    try (Scanner scanner = client.createScanner(AccumuloNamespace.METADATA.tableName())) {
       scanner.setRange(new Range(tableId, tableId + "<"));
       scanner.fetchColumnFamily(CurrentLocationColumnFamily.NAME);
       return Iterables.size(scanner);

--- a/test/src/main/java/org/apache/accumulo/test/ScanServerMetadataEntriesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ScanServerMetadataEntriesIT.java
@@ -47,7 +47,7 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.gc.Reference;
 import org.apache.accumulo.core.lock.ServiceLockPaths.AddressSelector;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.ScanServerRefTabletFile;
 import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
 import org.apache.accumulo.core.security.Authorizations;
@@ -231,7 +231,7 @@ public class ScanServerMetadataEntriesIT extends SharedMiniClusterBase {
 
       List<Entry<Key,Value>> metadataEntries = null;
       try (Scanner scanner2 =
-          client.createScanner(AccumuloTable.SCAN_REF.tableName(), Authorizations.EMPTY)) {
+          client.createScanner(AccumuloNamespace.SCAN_REF.tableName(), Authorizations.EMPTY)) {
         metadataEntries = scanner2.stream().distinct().collect(Collectors.toList());
       }
       assertEquals(fileCount, metadataEntries.size());

--- a/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
@@ -68,7 +68,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.data.constraints.DefaultKeySizeConstraint;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.dataImpl.TabletIdImpl;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
@@ -436,10 +436,10 @@ public class TableOperationsIT extends AccumuloClusterHarness {
     assertEquals(TimeType.LOGICAL, timeType);
 
     // check system tables
-    timeType = accumuloClient.tableOperations().getTimeType(AccumuloTable.METADATA.tableName());
+    timeType = accumuloClient.tableOperations().getTimeType(AccumuloNamespace.METADATA.tableName());
     assertEquals(TimeType.LOGICAL, timeType);
 
-    timeType = accumuloClient.tableOperations().getTimeType(AccumuloTable.ROOT.tableName());
+    timeType = accumuloClient.tableOperations().getTimeType(AccumuloNamespace.ROOT.tableName());
     assertEquals(TimeType.LOGICAL, timeType);
 
     // test non-existent table

--- a/test/src/main/java/org/apache/accumulo/test/UnusedWALIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/UnusedWALIT.java
@@ -35,7 +35,7 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.minicluster.ServerType;
@@ -105,7 +105,7 @@ public class UnusedWALIT extends ConfigurableMacBase {
 
       // wait for the metadata table to be online
       try (Scanner scanner =
-          c.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
+          c.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY)) {
         scanner.forEach((k, v) -> {});
       }
 

--- a/test/src/main/java/org/apache/accumulo/test/VerifySerialRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/VerifySerialRecoveryIT.java
@@ -35,7 +35,7 @@ import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Mutation;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl.ProcessInfo;
@@ -130,8 +130,8 @@ public class VerifySerialRecoveryIT extends ConfigurableMacBase {
           Pattern.compile(".*recovered \\d+ mutations creating \\d+ entries from \\d+ walogs.*");
       for (String line : result.split("\n")) {
         // ignore metadata and root tables
-        if (line.contains(AccumuloTable.METADATA.tableId().canonical())
-            || line.contains(AccumuloTable.ROOT.tableId().canonical())) {
+        if (line.contains(AccumuloNamespace.METADATA.tableId().canonical())
+            || line.contains(AccumuloNamespace.ROOT.tableId().canonical())) {
           continue;
         }
         if (line.contains("recovering data from walogs")) {

--- a/test/src/main/java/org/apache/accumulo/test/VolumeChooserIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/VolumeChooserIT.java
@@ -45,7 +45,7 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LogColumnFamily;
@@ -184,8 +184,8 @@ public class VolumeChooserIT extends ConfigurableMacBase {
 
     TreeSet<String> volumesSeen = new TreeSet<>();
     int fileCount = 0;
-    try (Scanner scanner =
-        accumuloClient.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
+    try (Scanner scanner = accumuloClient.createScanner(AccumuloNamespace.METADATA.tableName(),
+        Authorizations.EMPTY)) {
       scanner.setRange(tableRange);
       scanner.fetchColumnFamily(DataFileColumnFamily.NAME);
       for (Entry<Key,Value> entry : scanner) {
@@ -208,8 +208,8 @@ public class VolumeChooserIT extends ConfigurableMacBase {
 
   public static void verifyNoVolumes(AccumuloClient accumuloClient, Range tableRange)
       throws Exception {
-    try (Scanner scanner =
-        accumuloClient.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
+    try (Scanner scanner = accumuloClient.createScanner(AccumuloNamespace.METADATA.tableName(),
+        Authorizations.EMPTY)) {
       scanner.setRange(tableRange);
       scanner.fetchColumnFamily(DataFileColumnFamily.NAME);
       for (Entry<Key,Value> entry : scanner) {
@@ -250,8 +250,8 @@ public class VolumeChooserIT extends ConfigurableMacBase {
     Collections.addAll(volumes, vol.split(","));
 
     TreeSet<String> volumesSeen = new TreeSet<>();
-    try (Scanner scanner =
-        accumuloClient.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
+    try (Scanner scanner = accumuloClient.createScanner(AccumuloNamespace.METADATA.tableName(),
+        Authorizations.EMPTY)) {
       scanner.setRange(tableRange);
       scanner.fetchColumnFamily(LogColumnFamily.NAME);
       for (Entry<Key,Value> entry : scanner) {

--- a/test/src/main/java/org/apache/accumulo/test/VolumeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/VolumeIT.java
@@ -43,7 +43,7 @@ import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
@@ -83,7 +83,7 @@ public class VolumeIT extends VolumeITBase {
       }
       // verify the new files are written to the different volumes
       try (Scanner scanner =
-          client.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
+          client.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY)) {
         scanner.setRange(new Range("1", "1<"));
         scanner.fetchColumnFamily(DataFileColumnFamily.NAME);
         int fileCount = 0;
@@ -198,7 +198,7 @@ public class VolumeIT extends VolumeITBase {
 
       verifyVolumesUsed(client, tableNames[0], true, v2);
 
-      client.tableOperations().compact(AccumuloTable.ROOT.tableName(),
+      client.tableOperations().compact(AccumuloNamespace.ROOT.tableName(),
           new CompactionConfig().setWait(true));
 
       // check that root tablet is not on volume 1
@@ -214,8 +214,8 @@ public class VolumeIT extends VolumeITBase {
       client.tableOperations().clone(tableNames[0], tableNames[1], true, new HashMap<>(),
           new HashSet<>());
 
-      client.tableOperations().flush(AccumuloTable.METADATA.tableName(), null, null, true);
-      client.tableOperations().flush(AccumuloTable.ROOT.tableName(), null, null, true);
+      client.tableOperations().flush(AccumuloNamespace.METADATA.tableName(), null, null, true);
+      client.tableOperations().flush(AccumuloNamespace.ROOT.tableName(), null, null, true);
 
       verifyVolumesUsed(client, tableNames[0], true, v2);
       verifyVolumesUsed(client, tableNames[1], true, v2);

--- a/test/src/main/java/org/apache/accumulo/test/VolumeITBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/VolumeITBase.java
@@ -57,7 +57,7 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
@@ -185,7 +185,7 @@ public abstract class VolumeITBase extends ConfigurableMacBase {
 
     TableId tableId = TableId.of(client.tableOperations().tableIdMap().get(tableName));
     try (Scanner metaScanner =
-        client.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
+        client.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY)) {
       metaScanner.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);
       metaScanner.setRange(new KeyExtent(tableId, null, null).toMetaRange());
 
@@ -304,7 +304,7 @@ public abstract class VolumeITBase extends ConfigurableMacBase {
     verifyVolumesUsed(client, tableNames[0], true, false, v8, v9);
     verifyVolumesUsed(client, tableNames[1], true, false, v8, v9);
 
-    client.tableOperations().compact(AccumuloTable.ROOT.tableName(),
+    client.tableOperations().compact(AccumuloNamespace.ROOT.tableName(),
         new CompactionConfig().setWait(true));
 
     // check that root tablet is not on volume 1 or 2
@@ -321,8 +321,8 @@ public abstract class VolumeITBase extends ConfigurableMacBase {
     client.tableOperations().clone(tableNames[1], tableNames[2], true, new HashMap<>(),
         new HashSet<>());
 
-    client.tableOperations().flush(AccumuloTable.METADATA.tableName(), null, null, true);
-    client.tableOperations().flush(AccumuloTable.ROOT.tableName(), null, null, true);
+    client.tableOperations().flush(AccumuloNamespace.METADATA.tableName(), null, null, true);
+    client.tableOperations().flush(AccumuloNamespace.ROOT.tableName(), null, null, true);
 
     verifyVolumesUsed(client, tableNames[0], true, v8, v9);
     verifyVolumesUsed(client, tableNames[1], true, v8, v9);
@@ -354,7 +354,7 @@ public abstract class VolumeITBase extends ConfigurableMacBase {
   // files with ranges work properly with volume replacement
   private void splitFilesWithRange(AccumuloClient client, String tableName) throws Exception {
     client.securityOperations().grantTablePermission(cluster.getConfig().getRootUserName(),
-        AccumuloTable.METADATA.tableName(), TablePermission.WRITE);
+        AccumuloNamespace.METADATA.tableName(), TablePermission.WRITE);
     final ServerContext ctx = getServerContext();
     ctx.setCredentials(new SystemCredentials(client.instanceOperations().getInstanceId(), "root",
         new PasswordToken(ROOT_PASSWORD)));

--- a/test/src/main/java/org/apache/accumulo/test/WaitForBalanceIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/WaitForBalanceIT.java
@@ -36,7 +36,7 @@ import org.apache.accumulo.core.client.admin.TabletAvailability;
 import org.apache.accumulo.core.client.admin.servers.ServerId.Type;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
@@ -62,7 +62,7 @@ public class WaitForBalanceIT extends ConfigurableMacBase {
       assertEquals(2, c.instanceOperations().getServers(Type.TABLET_SERVER).size());
       // ensure the metadata table is online
       try (Scanner scanner =
-          c.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
+          c.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY)) {
         scanner.forEach((k, v) -> {});
       }
       c.instanceOperations().waitForBalance();
@@ -94,8 +94,8 @@ public class WaitForBalanceIT extends ConfigurableMacBase {
     c.instanceOperations().getServers(Type.TABLET_SERVER)
         .forEach(ts -> tserverCounts.put(ts.toHostPortString(), 0));
     int offline = 0;
-    for (String tableName : new String[] {AccumuloTable.METADATA.tableName(),
-        AccumuloTable.ROOT.tableName()}) {
+    for (String tableName : new String[] {AccumuloNamespace.METADATA.tableName(),
+        AccumuloNamespace.ROOT.tableName()}) {
       try (Scanner s = c.createScanner(tableName, Authorizations.EMPTY)) {
         s.setRange(TabletsSection.getRange());
         s.fetchColumnFamily(CurrentLocationColumnFamily.NAME);

--- a/test/src/main/java/org/apache/accumulo/test/ample/metadata/TestAmple.java
+++ b/test/src/main/java/org/apache/accumulo/test/ample/metadata/TestAmple.java
@@ -47,7 +47,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.iterators.user.WholeRowIterator;
 import org.apache.accumulo.core.lock.ServiceLock;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
@@ -175,7 +175,7 @@ public class TestAmple {
     public void createMetadataFromExisting(AccumuloClient client, TableId tableId,
         BiPredicate<Key,Value> includeColumn) throws Exception {
       try (Scanner scanner =
-          client.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
+          client.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY)) {
         scanner.setRange(TabletsSection.getRange(tableId));
         IteratorSetting iterSetting = new IteratorSetting(100, WholeRowIterator.class);
         scanner.addScanIterator(iterSetting);
@@ -263,11 +263,11 @@ public class TestAmple {
 
   public static void createMetadataTable(ClientContext client, String table) throws Exception {
     final var metadataTableProps =
-        client.tableOperations().getTableProperties(AccumuloTable.METADATA.tableName());
+        client.tableOperations().getTableProperties(AccumuloNamespace.METADATA.tableName());
 
     TabletAvailability availability;
     try (var tabletStream = client.tableOperations()
-        .getTabletInformation(AccumuloTable.METADATA.tableName(), new Range())) {
+        .getTabletInformation(AccumuloNamespace.METADATA.tableName(), new Range())) {
       availability = tabletStream.map(TabletInformation::getTabletAvailability).distinct()
           .collect(MoreCollectors.onlyElement());
     }

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction2BaseIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction2BaseIT.java
@@ -52,7 +52,7 @@ import org.apache.accumulo.core.clientImpl.TableOperationsImpl;
 import org.apache.accumulo.core.compaction.thrift.TCompactionState;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.TableId;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
@@ -237,7 +237,7 @@ public abstract class ExternalCompaction2BaseIT extends SharedMiniClusterBase {
           TCompactionState.CANCELLED);
 
       // Ensure compaction did not write anything to metadata table after delete table
-      try (var scanner = client.createScanner(AccumuloTable.METADATA.tableName())) {
+      try (var scanner = client.createScanner(AccumuloNamespace.METADATA.tableName())) {
         scanner.setRange(MetadataSchema.TabletsSection.getRange(tid));
         assertEquals(0, scanner.stream().count());
       }

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_1_IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_1_IT.java
@@ -91,7 +91,7 @@ import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.lock.ServiceLock;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.schema.CompactionMetadata;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
@@ -255,10 +255,10 @@ public class ExternalCompaction_1_IT extends SharedMiniClusterBase {
         new MetaFateStore<>(ctx.getZooSession(), testLock.getLockID(), null);
 
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
-      var tableId = ctx.getTableId(AccumuloTable.ROOT.tableName());
+      var tableId = ctx.getTableId(AccumuloNamespace.ROOT.tableName());
       var allCids = new HashMap<TableId,List<ExternalCompactionId>>();
       var fateId = createCompactionCommitAndDeadMetadata(c, metaFateStore,
-          AccumuloTable.ROOT.tableName(), allCids);
+          AccumuloNamespace.ROOT.tableName(), allCids);
       verifyCompactionCommitAndDead(metaFateStore, tableId, fateId, allCids.get(tableId));
     }
   }
@@ -275,10 +275,10 @@ public class ExternalCompaction_1_IT extends SharedMiniClusterBase {
 
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
       // Metadata table by default already has 2 tablets
-      var tableId = ctx.getTableId(AccumuloTable.METADATA.tableName());
+      var tableId = ctx.getTableId(AccumuloNamespace.METADATA.tableName());
       var allCids = new HashMap<TableId,List<ExternalCompactionId>>();
       var fateId = createCompactionCommitAndDeadMetadata(c, metaFateStore,
-          AccumuloTable.METADATA.tableName(), allCids);
+          AccumuloNamespace.METADATA.tableName(), allCids);
       verifyCompactionCommitAndDead(metaFateStore, tableId, fateId, allCids.get(tableId));
     }
   }
@@ -294,7 +294,7 @@ public class ExternalCompaction_1_IT extends SharedMiniClusterBase {
 
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
       UserFateStore<Manager> userFateStore =
-          new UserFateStore<>(ctx, AccumuloTable.FATE.tableName(), testLock.getLockID(), null);
+          new UserFateStore<>(ctx, AccumuloNamespace.FATE.tableName(), testLock.getLockID(), null);
       SortedSet<Text> splits = new TreeSet<>();
       splits.add(new Text(row(MAX_DATA / 2)));
       c.tableOperations().create(tableName, new NewTableConfiguration().withSplits(splits));
@@ -318,7 +318,7 @@ public class ExternalCompaction_1_IT extends SharedMiniClusterBase {
 
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
       UserFateStore<Manager> userFateStore =
-          new UserFateStore<>(ctx, AccumuloTable.FATE.tableName(), testLock.getLockID(), null);
+          new UserFateStore<>(ctx, AccumuloNamespace.FATE.tableName(), testLock.getLockID(), null);
       FateStore<Manager> metaFateStore =
           new MetaFateStore<>(ctx.getZooSession(), testLock.getLockID(), null);
 
@@ -331,8 +331,8 @@ public class ExternalCompaction_1_IT extends SharedMiniClusterBase {
       Map<TableId,List<ExternalCompactionId>> allCids = new HashMap<>();
 
       // create compaction metadata for each data level to test
-      for (String tableName : List.of(AccumuloTable.ROOT.tableName(),
-          AccumuloTable.METADATA.tableName(), userTable)) {
+      for (String tableName : List.of(AccumuloNamespace.ROOT.tableName(),
+          AccumuloNamespace.METADATA.tableName(), userTable)) {
         var tableId = ctx.getTableId(tableName);
         var fateStore = FateInstanceType.fromTableId(tableId) == FateInstanceType.USER
             ? userFateStore : metaFateStore;
@@ -387,7 +387,7 @@ public class ExternalCompaction_1_IT extends SharedMiniClusterBase {
     var tabletsMeta = ctx.getAmple().readTablets().forTable(tableId).build().stream()
         .collect(Collectors.toList());
     // Root is always 1 tablet
-    if (!tableId.equals(AccumuloTable.ROOT.tableId())) {
+    if (!tableId.equals(AccumuloNamespace.ROOT.tableId())) {
       assertEquals(2, tabletsMeta.size());
     }
 

--- a/test/src/main/java/org/apache/accumulo/test/fate/FateOpsCommandsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FateOpsCommandsIT.java
@@ -64,7 +64,7 @@ import org.apache.accumulo.core.fate.zookeeper.MetaFateStore;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.core.iterators.IteratorUtil;
 import org.apache.accumulo.core.lock.ServiceLockPaths.AddressSelector;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.zookeeper.ZooSession;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl.ProcessInfo;
@@ -698,8 +698,8 @@ public abstract class FateOpsCommandsIT extends ConfigurableMacBase
       Method listMethod = UserFateStore.class.getMethod("list");
       mockedStore = EasyMock.createMockBuilder(UserFateStore.class)
           .withConstructor(ClientContext.class, String.class, ZooUtil.LockID.class, Predicate.class)
-          .withArgs(sctx, AccumuloTable.FATE.tableName(), null, null).addMockedMethod(listMethod)
-          .createMock();
+          .withArgs(sctx, AccumuloNamespace.FATE.tableName(), null, null)
+          .addMockedMethod(listMethod).createMock();
     } else {
       Method listMethod = MetaFateStore.class.getMethod("list");
       mockedStore = EasyMock.createMockBuilder(MetaFateStore.class)

--- a/test/src/main/java/org/apache/accumulo/test/fate/FateTestUtil.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FateTestUtil.java
@@ -39,7 +39,7 @@ import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.FateKey;
 import org.apache.accumulo.core.fate.FateStore;
 import org.apache.accumulo.core.fate.Repo;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.zookeeper.ZooSession;
 import org.apache.accumulo.test.zookeeper.ZooKeeperTestingServer;
 import org.junit.jupiter.api.Tag;
@@ -61,11 +61,11 @@ public class FateTestUtil {
    */
   public static void createFateTable(ClientContext client, String table) throws Exception {
     final var fateTableProps =
-        client.tableOperations().getTableProperties(AccumuloTable.FATE.tableName());
+        client.tableOperations().getTableProperties(AccumuloNamespace.FATE.tableName());
 
     TabletAvailability availability;
     try (var tabletStream = client.tableOperations()
-        .getTabletInformation(AccumuloTable.FATE.tableName(), new Range())) {
+        .getTabletInformation(AccumuloNamespace.FATE.tableName(), new Range())) {
       availability = tabletStream.map(TabletInformation::getTabletAvailability).distinct()
           .collect(MoreCollectors.onlyElement());
     }

--- a/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateIT.java
@@ -38,7 +38,7 @@ import org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus;
 import org.apache.accumulo.core.fate.user.UserFateStore;
 import org.apache.accumulo.core.fate.user.schema.FateSchema.TxColumnFamily;
 import org.apache.accumulo.core.iterators.user.VersioningIterator;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.server.ServerContext;
@@ -84,7 +84,7 @@ public class UserFateIT extends FateIT {
       // It is important here to use getTableProperties() and not getConfiguration()
       // because we want only the table properties and not a merged view
       var fateTableProps =
-          client.tableOperations().getTableProperties(AccumuloTable.FATE.tableName());
+          client.tableOperations().getTableProperties(AccumuloNamespace.FATE.tableName());
 
       // Verify properties all have a table. prefix
       assertTrue(fateTableProps.keySet().stream().allMatch(key -> key.startsWith("table.")));
@@ -113,7 +113,7 @@ public class UserFateIT extends FateIT {
 
       // Verify all tablets are HOSTED
       try (var tablets =
-          client.getAmple().readTablets().forTable(AccumuloTable.FATE.tableId()).build()) {
+          client.getAmple().readTablets().forTable(AccumuloNamespace.FATE.tableId()).build()) {
         assertTrue(tablets.stream()
             .allMatch(tm -> tm.getTabletAvailability() == TabletAvailability.HOSTED));
       }

--- a/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateOpsCommandsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateOpsCommandsIT.java
@@ -25,7 +25,7 @@ import org.apache.accumulo.core.fate.FateStore;
 import org.apache.accumulo.core.fate.user.UserFateStore;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.core.lock.ServiceLock;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.test.fate.FateOpsCommandsIT;
 import org.apache.accumulo.test.fate.MultipleStoresIT.LatchTestEnv;
 import org.apache.accumulo.test.fate.TestLock;
@@ -41,7 +41,7 @@ public class UserFateOpsCommandsIT extends FateOpsCommandsIT {
       AbstractFateStore.FateIdGenerator fateIdGenerator) throws Exception {
     var context = getCluster().getServerContext();
     // the test should not be reserving or checking reservations, so null lockID and isLockHeld
-    testMethod.execute(new UserFateStore<>(context, AccumuloTable.FATE.tableName(), null, null),
+    testMethod.execute(new UserFateStore<>(context, AccumuloNamespace.FATE.tableName(), null, null),
         context);
   }
 
@@ -62,7 +62,7 @@ public class UserFateOpsCommandsIT extends FateOpsCommandsIT {
       Predicate<ZooUtil.LockID> isLockHeld =
           lock -> ServiceLock.isLockHeld(context.getZooCache(), lock);
       testMethod.execute(
-          new UserFateStore<>(context, AccumuloTable.FATE.tableName(), lockID, isLockHeld),
+          new UserFateStore<>(context, AccumuloNamespace.FATE.tableName(), lockID, isLockHeld),
           context);
     } finally {
       if (testLock != null) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/AmpleConditionalWriterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/AmpleConditionalWriterIT.java
@@ -75,7 +75,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.FateInstanceType;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
@@ -148,7 +148,7 @@ public class AmpleConditionalWriterIT extends SharedMiniClusterBase {
       c.tableOperations().create(tableName,
           new NewTableConfiguration().withSplits(splits).createOffline());
 
-      c.securityOperations().grantTablePermission("root", AccumuloTable.METADATA.tableName(),
+      c.securityOperations().grantTablePermission("root", AccumuloNamespace.METADATA.tableName(),
           TablePermission.WRITE);
 
       tid = TableId.of(c.tableOperations().tableIdMap().get(tableName));
@@ -685,7 +685,7 @@ public class AmpleConditionalWriterIT extends SharedMiniClusterBase {
       final Text selectedColumnQualifier = SELECTED_COLUMN.getColumnQualifier();
 
       Supplier<String> selectedMetadataValue = () -> {
-        try (Scanner scanner = client.createScanner(AccumuloTable.METADATA.tableName())) {
+        try (Scanner scanner = client.createScanner(AccumuloNamespace.METADATA.tableName())) {
           scanner.fetchColumn(selectedColumnFamily, selectedColumnQualifier);
           scanner.setRange(new Range(row));
 
@@ -719,7 +719,7 @@ public class AmpleConditionalWriterIT extends SharedMiniClusterBase {
           "Test json should have reverse file order of actual metadata");
 
       // write the json with reverse file order
-      try (BatchWriter bw = client.createBatchWriter(AccumuloTable.METADATA.tableName())) {
+      try (BatchWriter bw = client.createBatchWriter(AccumuloNamespace.METADATA.tableName())) {
         Mutation mutation = new Mutation(row);
         mutation.put(selectedColumnFamily, selectedColumnQualifier,
             new Value(newJson.getBytes(UTF_8)));

--- a/test/src/main/java/org/apache/accumulo/test/functional/BigRootTabletIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BigRootTabletIT.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.conf.Property;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
@@ -52,17 +52,17 @@ public class BigRootTabletIT extends AccumuloClusterHarness {
   @Test
   public void test() throws Exception {
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
-      c.tableOperations().addSplits(AccumuloTable.METADATA.tableName(),
+      c.tableOperations().addSplits(AccumuloNamespace.METADATA.tableName(),
           FunctionalTestUtils.splits("0 1 2 3 4 5 6 7 8 9 a".split(" ")));
       String[] names = getUniqueNames(10);
       for (String name : names) {
         c.tableOperations().create(name);
-        c.tableOperations().flush(AccumuloTable.METADATA.tableName(), null, null, true);
-        c.tableOperations().flush(AccumuloTable.ROOT.tableName(), null, null, true);
+        c.tableOperations().flush(AccumuloNamespace.METADATA.tableName(), null, null, true);
+        c.tableOperations().flush(AccumuloNamespace.ROOT.tableName(), null, null, true);
       }
       cluster.stop();
       cluster.start();
-      assertTrue(c.createScanner(AccumuloTable.ROOT.tableName(), Authorizations.EMPTY).stream()
+      assertTrue(c.createScanner(AccumuloNamespace.ROOT.tableName(), Authorizations.EMPTY).stream()
           .findAny().isPresent());
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/BinaryStressIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BinaryStressIT.java
@@ -32,7 +32,7 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.minicluster.ServerType;
@@ -92,7 +92,8 @@ public class BinaryStressIT extends AccumuloClusterHarness {
 
   private int getTabletCount(AccumuloClient c, String tableId) throws TableNotFoundException {
     Set<Text> tablets = new HashSet<>();
-    try (Scanner s = c.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
+    try (
+        Scanner s = c.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY)) {
       s.setRange(Range.prefix(tableId));
       for (Entry<Key,Value> entry : s) {
         tablets.add(entry.getKey().getRow());

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
@@ -87,7 +87,7 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileSKVWriter;
 import org.apache.accumulo.core.file.rfile.RFile;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.UnreferencedTabletFile;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
@@ -1397,12 +1397,12 @@ public class BulkNewIT extends SharedMiniClusterBase {
   static void setupBulkConstraint(String principal, AccumuloClient c)
       throws AccumuloException, AccumuloSecurityException, TableNotFoundException {
     // add a constraint to the metadata table that disallows bulk import files to be added
-    c.securityOperations().grantTablePermission(principal, AccumuloTable.METADATA.tableName(),
+    c.securityOperations().grantTablePermission(principal, AccumuloNamespace.METADATA.tableName(),
         TablePermission.WRITE);
-    c.securityOperations().grantTablePermission(principal, AccumuloTable.METADATA.tableName(),
+    c.securityOperations().grantTablePermission(principal, AccumuloNamespace.METADATA.tableName(),
         TablePermission.ALTER_TABLE);
 
-    c.tableOperations().addConstraint(AccumuloTable.METADATA.tableName(),
+    c.tableOperations().addConstraint(AccumuloNamespace.METADATA.tableName(),
         NoBulkConstratint.class.getName());
 
     var metaConstraints = new MetadataConstraints();
@@ -1413,7 +1413,7 @@ public class BulkNewIT extends SharedMiniClusterBase {
 
     // wait for the constraint to be active on the metadata table
     Wait.waitFor(() -> {
-      try (var bw = c.createBatchWriter(AccumuloTable.METADATA.tableName())) {
+      try (var bw = c.createBatchWriter(AccumuloNamespace.METADATA.tableName())) {
         Mutation m = new Mutation("~garbage");
         m.put("", "", NoBulkConstratint.CANARY_VALUE);
         // This test assume the metadata constraint check will not flag this mutation, the following
@@ -1428,7 +1428,7 @@ public class BulkNewIT extends SharedMiniClusterBase {
     });
 
     // delete the junk added to the metadata table
-    try (var bw = c.createBatchWriter(AccumuloTable.METADATA.tableName())) {
+    try (var bw = c.createBatchWriter(AccumuloNamespace.METADATA.tableName())) {
       Mutation m = new Mutation("~garbage");
       m.putDelete("", "");
       bw.addMutation(m);
@@ -1437,12 +1437,12 @@ public class BulkNewIT extends SharedMiniClusterBase {
 
   static void removeBulkConstraint(String principal, AccumuloClient c)
       throws AccumuloException, TableNotFoundException, AccumuloSecurityException {
-    int constraintNum = c.tableOperations().listConstraints(AccumuloTable.METADATA.tableName())
+    int constraintNum = c.tableOperations().listConstraints(AccumuloNamespace.METADATA.tableName())
         .get(NoBulkConstratint.class.getName());
-    c.tableOperations().removeConstraint(AccumuloTable.METADATA.tableName(), constraintNum);
-    c.securityOperations().revokeTablePermission(principal, AccumuloTable.METADATA.tableName(),
+    c.tableOperations().removeConstraint(AccumuloNamespace.METADATA.tableName(), constraintNum);
+    c.securityOperations().revokeTablePermission(principal, AccumuloNamespace.METADATA.tableName(),
         TablePermission.WRITE);
-    c.securityOperations().revokeTablePermission(principal, AccumuloTable.METADATA.tableName(),
+    c.securityOperations().revokeTablePermission(principal, AccumuloNamespace.METADATA.tableName(),
         TablePermission.ALTER_TABLE);
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkNewMetadataSkipIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkNewMetadataSkipIT.java
@@ -48,7 +48,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileSKVWriter;
 import org.apache.accumulo.core.file.rfile.RFile;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.UnreferencedTabletFile;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.spi.crypto.NoCryptoServiceFactory;
@@ -198,7 +198,7 @@ public class BulkNewMetadataSkipIT extends AccumuloClusterHarness {
       TableId tid = TableId.of(c.tableOperations().tableIdMap().get(tableName));
 
       final SortedSet<Text> metadataSplits = new TreeSet<>();
-      Scanner s = c.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY);
+      Scanner s = c.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY);
       final String mdTablePrefix = tid.canonical() + ";";
       s.forEach(e -> {
         final String row = e.getKey().getRow().toString();
@@ -206,7 +206,7 @@ public class BulkNewMetadataSkipIT extends AccumuloClusterHarness {
           metadataSplits.add(new Text(row + "\\x00"));
         }
       });
-      c.tableOperations().addSplits(AccumuloTable.METADATA.tableName(), metadataSplits);
+      c.tableOperations().addSplits(AccumuloNamespace.METADATA.tableName(), metadataSplits);
 
       c.tableOperations().importDirectory(dir).to(tableName).plan(loadPlan).load();
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/CloneTestIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CloneTestIT.java
@@ -60,7 +60,7 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.manager.state.tables.TableState;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
@@ -156,7 +156,7 @@ public class CloneTestIT extends SharedMiniClusterBase {
 
   private void checkMetadata(String table, AccumuloClient client) throws Exception {
     try (Scanner s =
-        client.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
+        client.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY)) {
 
       s.fetchColumnFamily(DataFileColumnFamily.NAME);
       ServerColumnFamily.DIRECTORY_COLUMN.fetch(s);
@@ -360,7 +360,7 @@ public class CloneTestIT extends SharedMiniClusterBase {
   public void testCloneRootTable() {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
       assertThrows(AccumuloException.class, () -> client.tableOperations()
-          .clone(AccumuloTable.ROOT.tableName(), "rc1", CloneConfiguration.empty()));
+          .clone(AccumuloNamespace.ROOT.tableName(), "rc1", CloneConfiguration.empty()));
     }
   }
 
@@ -368,7 +368,7 @@ public class CloneTestIT extends SharedMiniClusterBase {
   public void testCloneMetadataTable() {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
       assertThrows(AccumuloException.class, () -> client.tableOperations()
-          .clone(AccumuloTable.METADATA.tableName(), "mc1", CloneConfiguration.empty()));
+          .clone(AccumuloNamespace.METADATA.tableName(), "mc1", CloneConfiguration.empty()));
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
@@ -85,7 +85,7 @@ import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iterators.user.GrepIterator;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
@@ -577,7 +577,7 @@ public class CompactionIT extends CompactionBaseIT {
 
       Set<StoredTabletFile> mfiles1;
       try (TabletsMetadata tabletsMetadata = getServerContext().getAmple().readTablets()
-          .forTable(AccumuloTable.METADATA.tableId()).build()) {
+          .forTable(AccumuloNamespace.METADATA.tableId()).build()) {
         mfiles1 = tabletsMetadata.iterator().next().getFiles();
       }
       var rootFiles1 = getServerContext().getAmple().readTablet(RootTable.EXTENT).getFiles();
@@ -587,8 +587,8 @@ public class CompactionIT extends CompactionBaseIT {
       log.debug("rootFiles1 {}",
           rootFiles1.stream().map(StoredTabletFile::getFileName).collect(toList()));
 
-      c.tableOperations().flush(AccumuloTable.METADATA.tableName(), null, null, true);
-      c.tableOperations().flush(AccumuloTable.ROOT.tableName(), null, null, true);
+      c.tableOperations().flush(AccumuloNamespace.METADATA.tableName(), null, null, true);
+      c.tableOperations().flush(AccumuloNamespace.ROOT.tableName(), null, null, true);
 
       // create another table to cause more metadata writes
       c.tableOperations().create(tableNames[1]);
@@ -600,8 +600,8 @@ public class CompactionIT extends CompactionBaseIT {
       c.tableOperations().flush(tableNames[1], null, null, true);
 
       // create another metadata file
-      c.tableOperations().flush(AccumuloTable.METADATA.tableName(), null, null, true);
-      c.tableOperations().flush(AccumuloTable.ROOT.tableName(), null, null, true);
+      c.tableOperations().flush(AccumuloNamespace.METADATA.tableName(), null, null, true);
+      c.tableOperations().flush(AccumuloNamespace.ROOT.tableName(), null, null, true);
 
       // The multiple flushes should create multiple files. We expect the file sets to changes and
       // eventually equal one.
@@ -609,7 +609,7 @@ public class CompactionIT extends CompactionBaseIT {
       Wait.waitFor(() -> {
         Set<StoredTabletFile> mfiles2;
         try (TabletsMetadata tabletsMetadata = getServerContext().getAmple().readTablets()
-            .forTable(AccumuloTable.METADATA.tableId()).build()) {
+            .forTable(AccumuloNamespace.METADATA.tableId()).build()) {
           mfiles2 = tabletsMetadata.iterator().next().getFiles();
         }
         log.debug("mfiles2 {}",
@@ -1204,7 +1204,8 @@ public class CompactionIT extends CompactionBaseIT {
    */
   private int countFiles(AccumuloClient c, String tableName) throws Exception {
     var tableId = getCluster().getServerContext().getTableId(tableName);
-    try (Scanner s = c.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
+    try (
+        Scanner s = c.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY)) {
       s.setRange(MetadataSchema.TabletsSection.getRange(tableId));
       TabletColumnFamily.PREV_ROW_COLUMN.fetch(s);
       s.fetchColumnFamily(new Text(DataFileColumnFamily.NAME));

--- a/test/src/main/java/org/apache/accumulo/test/functional/CredentialsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CredentialsIT.java
@@ -40,7 +40,7 @@ import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -109,7 +109,7 @@ public class CredentialsIT extends AccumuloClusterHarness {
       try (
           AccumuloClient userAccumuloClient =
               Accumulo.newClient().from(client.properties()).as(username, token).build();
-          Scanner scanner = userAccumuloClient.createScanner(AccumuloTable.METADATA.tableName(),
+          Scanner scanner = userAccumuloClient.createScanner(AccumuloNamespace.METADATA.tableName(),
               Authorizations.EMPTY)) {
         assertFalse(token.isDestroyed());
         token.destroy();

--- a/test/src/main/java/org/apache/accumulo/test/functional/DurabilityIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/DurabilityIT.java
@@ -31,7 +31,7 @@ import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Mutation;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
@@ -157,7 +157,7 @@ public class DurabilityIT extends ConfigurableMacBase {
       String tableName = getUniqueNames(1)[0];
       c.instanceOperations().setProperty(Property.TABLE_DURABILITY.getKey(), "none");
       Map<String,String> props =
-          c.tableOperations().getConfiguration(AccumuloTable.METADATA.tableName());
+          c.tableOperations().getConfiguration(AccumuloNamespace.METADATA.tableName());
       assertEquals("sync", props.get(Property.TABLE_DURABILITY.getKey()));
       c.tableOperations().create(tableName);
       props = c.tableOperations().getConfiguration(tableName);

--- a/test/src/main/java/org/apache/accumulo/test/functional/FateConcurrencyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FateConcurrencyIT.java
@@ -53,7 +53,7 @@ import org.apache.accumulo.core.fate.ReadOnlyFateStore;
 import org.apache.accumulo.core.fate.user.UserFateStore;
 import org.apache.accumulo.core.fate.zookeeper.MetaFateStore;
 import org.apache.accumulo.core.manager.state.tables.TableState;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.util.compaction.ExternalCompactionUtil;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl;
@@ -258,7 +258,7 @@ public class FateConcurrencyIT extends AccumuloClusterHarness {
         var zk = context.getZooSession();
         MetaFateStore<String> readOnlyMFS = new MetaFateStore<>(zk, null, null);
         UserFateStore<String> readOnlyUFS =
-            new UserFateStore<>(context, AccumuloTable.FATE.tableName(), null, null);
+            new UserFateStore<>(context, AccumuloNamespace.FATE.tableName(), null, null);
         var lockPath = context.getServerPaths().createTableLocksPath(tableId);
         Map<FateInstanceType,ReadOnlyFateStore<String>> readOnlyFateStores =
             Map.of(FateInstanceType.META, readOnlyMFS, FateInstanceType.USER, readOnlyUFS);
@@ -379,7 +379,7 @@ public class FateConcurrencyIT extends AccumuloClusterHarness {
       log.trace("tid: {}", tableId);
 
       UserFateStore<String> readOnlyUFS =
-          new UserFateStore<>(context, AccumuloTable.FATE.tableName(), null, null);
+          new UserFateStore<>(context, AccumuloNamespace.FATE.tableName(), null, null);
       AdminUtil.FateStatus fateStatus = admin.getStatus(readOnlyUFS, null, null, null);
 
       log.trace("current fates: {}", fateStatus.getTransactions().size());

--- a/test/src/main/java/org/apache/accumulo/test/functional/FileMetadataIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FileMetadataIT.java
@@ -40,7 +40,7 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.Ample.TabletMutator;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
@@ -119,7 +119,7 @@ public class FileMetadataIT extends AccumuloClusterHarness {
     try (AccumuloClient accumuloClient = Accumulo.newClient().from(getClientProps()).build()) {
       // Need permission to write to metadata
       accumuloClient.securityOperations().grantTablePermission(accumuloClient.whoami(),
-          AccumuloTable.METADATA.tableName(), TablePermission.WRITE);
+          AccumuloNamespace.METADATA.tableName(), TablePermission.WRITE);
 
       final int rows = 10000;
       final String tableName = getUniqueNames(1)[0];
@@ -190,7 +190,7 @@ public class FileMetadataIT extends AccumuloClusterHarness {
     try (AccumuloClient accumuloClient = Accumulo.newClient().from(getClientProps()).build()) {
       // Need permission to write to metadata
       accumuloClient.securityOperations().grantTablePermission(accumuloClient.whoami(),
-          AccumuloTable.METADATA.tableName(), TablePermission.WRITE);
+          AccumuloNamespace.METADATA.tableName(), TablePermission.WRITE);
 
       final int rows = 10000;
       final int ranges = 4;
@@ -281,7 +281,7 @@ public class FileMetadataIT extends AccumuloClusterHarness {
     try (AccumuloClient accumuloClient = Accumulo.newClient().from(getClientProps()).build()) {
       // Need permission to write to metadata
       accumuloClient.securityOperations().grantTablePermission(accumuloClient.whoami(),
-          AccumuloTable.METADATA.tableName(), TablePermission.WRITE);
+          AccumuloNamespace.METADATA.tableName(), TablePermission.WRITE);
 
       final int rows = 100000;
       final String tableName = getUniqueNames(1)[0];
@@ -358,7 +358,7 @@ public class FileMetadataIT extends AccumuloClusterHarness {
     try (AccumuloClient accumuloClient = Accumulo.newClient().from(getClientProps()).build()) {
       // Need permission to write to metadata
       accumuloClient.securityOperations().grantTablePermission(accumuloClient.whoami(),
-          AccumuloTable.METADATA.tableName(), TablePermission.WRITE);
+          AccumuloNamespace.METADATA.tableName(), TablePermission.WRITE);
 
       final int rows = 100000;
       final int ranges = 4;

--- a/test/src/main/java/org/apache/accumulo/test/functional/FileNormalizationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FileNormalizationIT.java
@@ -36,7 +36,7 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.security.TablePermission;
@@ -200,7 +200,7 @@ public class FileNormalizationIT extends SharedMiniClusterBase {
   }
 
   private Scanner createMetadataFileScanner(AccumuloClient client, String table) throws Exception {
-    var scanner = client.createScanner(AccumuloTable.METADATA.tableName());
+    var scanner = client.createScanner(AccumuloNamespace.METADATA.tableName());
     var tableId = TableId.of(client.tableOperations().tableIdMap().get(table));
     var range = new KeyExtent(tableId, null, null).toMetaRange();
     scanner.setRange(range);
@@ -212,10 +212,10 @@ public class FileNormalizationIT extends SharedMiniClusterBase {
     client.tableOperations().offline(table, true);
 
     client.securityOperations().grantTablePermission(getPrincipal(),
-        AccumuloTable.METADATA.tableName(), TablePermission.WRITE);
+        AccumuloNamespace.METADATA.tableName(), TablePermission.WRITE);
 
     try (var scanner = createMetadataFileScanner(client, table);
-        var writer = client.createBatchWriter(AccumuloTable.METADATA.tableName())) {
+        var writer = client.createBatchWriter(AccumuloNamespace.METADATA.tableName())) {
       scanner.forEach((k, v) -> {
         Mutation m = new Mutation(k.getRow());
         var qual = k.getColumnQualifierData().toString();
@@ -231,7 +231,7 @@ public class FileNormalizationIT extends SharedMiniClusterBase {
       });
     } finally {
       client.securityOperations().revokeTablePermission(getPrincipal(),
-          AccumuloTable.METADATA.tableName(), TablePermission.WRITE);
+          AccumuloNamespace.METADATA.tableName(), TablePermission.WRITE);
       client.tableOperations().online(table, true);
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/FunctionalTestUtils.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FunctionalTestUtils.java
@@ -63,7 +63,7 @@ import org.apache.accumulo.core.fate.FateInstanceType;
 import org.apache.accumulo.core.fate.ReadOnlyFateStore;
 import org.apache.accumulo.core.fate.user.UserFateStore;
 import org.apache.accumulo.core.fate.zookeeper.MetaFateStore;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
@@ -85,7 +85,7 @@ public class FunctionalTestUtils {
 
   public static int countRFiles(AccumuloClient c, String tableName) throws Exception {
     try (Scanner scanner =
-        c.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
+        c.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY)) {
       TableId tableId = TableId.of(c.tableOperations().tableIdMap().get(tableName));
       scanner.setRange(TabletsSection.getRange(tableId));
       scanner.fetchColumnFamily(DataFileColumnFamily.NAME);
@@ -102,7 +102,7 @@ public class FunctionalTestUtils {
       throws Exception {
     List<StoredTabletFile> files = new ArrayList<>();
     try (Scanner scanner =
-        c.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
+        c.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY)) {
       TableId tableId = TableId.of(c.tableOperations().tableIdMap().get(tableName));
       scanner.setRange(TabletsSection.getRange(tableId));
       scanner.fetchColumnFamily(DataFileColumnFamily.NAME);
@@ -114,7 +114,7 @@ public class FunctionalTestUtils {
   static void checkRFiles(AccumuloClient c, String tableName, int minTablets, int maxTablets,
       int minRFiles, int maxRFiles) throws Exception {
     try (Scanner scanner =
-        c.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
+        c.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY)) {
       String tableId = c.tableOperations().tableIdMap().get(tableName);
       scanner.setRange(new Range(new Text(tableId + ";"), true, new Text(tableId + "<"), true));
       scanner.fetchColumnFamily(DataFileColumnFamily.NAME);
@@ -233,7 +233,7 @@ public class FunctionalTestUtils {
       var zk = context.getZooSession();
       MetaFateStore<String> readOnlyMFS = new MetaFateStore<>(zk, null, null);
       UserFateStore<String> readOnlyUFS =
-          new UserFateStore<>(context, AccumuloTable.FATE.tableName(), null, null);
+          new UserFateStore<>(context, AccumuloNamespace.FATE.tableName(), null, null);
       Map<FateInstanceType,ReadOnlyFateStore<String>> readOnlyFateStores =
           Map.of(FateInstanceType.META, readOnlyMFS, FateInstanceType.USER, readOnlyUFS);
       var lockPath = context.getServerPaths().createTableLocksPath();

--- a/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorIT.java
@@ -54,7 +54,7 @@ import org.apache.accumulo.core.gc.ReferenceFile;
 import org.apache.accumulo.core.lock.ServiceLock;
 import org.apache.accumulo.core.lock.ServiceLockData;
 import org.apache.accumulo.core.lock.ServiceLockData.ThriftService;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
@@ -213,7 +213,7 @@ public class GarbageCollectorIT extends ConfigurableMacBase {
       cluster.start();
       // did it recover?
       try (Scanner scanner =
-          c.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
+          c.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY)) {
         scanner.forEach((k, v) -> {});
       }
     }
@@ -242,9 +242,9 @@ public class GarbageCollectorIT extends ConfigurableMacBase {
       c.tableOperations().flush(table, null, null, true);
 
       // ensure an invalid delete entry does not cause GC to go berserk ACCUMULO-2520
-      c.securityOperations().grantTablePermission(c.whoami(), AccumuloTable.METADATA.tableName(),
-          TablePermission.WRITE);
-      try (BatchWriter bw = c.createBatchWriter(AccumuloTable.METADATA.tableName())) {
+      c.securityOperations().grantTablePermission(c.whoami(),
+          AccumuloNamespace.METADATA.tableName(), TablePermission.WRITE);
+      try (BatchWriter bw = c.createBatchWriter(AccumuloNamespace.METADATA.tableName())) {
         bw.addMutation(createDelMutation("", "", "", ""));
         bw.addMutation(createDelMutation("", "testDel", "test", "valueTest"));
         // path is invalid but value is expected - only way the invalid entry will come through
@@ -451,8 +451,8 @@ public class GarbageCollectorIT extends ConfigurableMacBase {
   private void addEntries(AccumuloClient client) throws Exception {
     Ample ample = getServerContext().getAmple();
     client.securityOperations().grantTablePermission(client.whoami(),
-        AccumuloTable.METADATA.tableName(), TablePermission.WRITE);
-    try (BatchWriter bw = client.createBatchWriter(AccumuloTable.METADATA.tableName())) {
+        AccumuloNamespace.METADATA.tableName(), TablePermission.WRITE);
+    try (BatchWriter bw = client.createBatchWriter(AccumuloNamespace.METADATA.tableName())) {
       for (int i = 0; i < 100000; ++i) {
         String longpath = "aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee"
             + "ffffffffffgggggggggghhhhhhhhhhiiiiiiiiiijjjjjjjjjj";

--- a/test/src/main/java/org/apache/accumulo/test/functional/KerberosIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/KerberosIT.java
@@ -59,7 +59,7 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.accumulo.core.security.SystemPermission;
@@ -176,8 +176,8 @@ public class KerberosIT extends AccumuloITBase {
       }
 
       // and the ability to modify the root and metadata tables
-      for (String table : Arrays.asList(AccumuloTable.ROOT.tableName(),
-          AccumuloTable.METADATA.tableName())) {
+      for (String table : Arrays.asList(AccumuloNamespace.ROOT.tableName(),
+          AccumuloNamespace.METADATA.tableName())) {
         assertTrue(client.securityOperations().hasTablePermission(client.whoami(), table,
             TablePermission.ALTER_TABLE));
       }

--- a/test/src/main/java/org/apache/accumulo/test/functional/LocalityGroupIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/LocalityGroupIT.java
@@ -48,7 +48,7 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.file.rfile.PrintInfo;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.security.Authorizations;
@@ -132,7 +132,7 @@ public class LocalityGroupIT extends AccumuloClusterHarness {
     verify(accumuloClient, 2000, 1, 50, 0, tableName);
     accumuloClient.tableOperations().flush(tableName, null, null, true);
     try (BatchScanner bscanner = accumuloClient
-        .createBatchScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY, 1)) {
+        .createBatchScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY, 1)) {
       String tableId = accumuloClient.tableOperations().tableIdMap().get(tableName);
       bscanner.setRanges(
           Collections.singletonList(new Range(new Text(tableId + ";"), new Text(tableId + "<"))));

--- a/test/src/main/java/org/apache/accumulo/test/functional/ManagerAssignmentIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ManagerAssignmentIT.java
@@ -65,7 +65,7 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.FateInstanceType;
 import org.apache.accumulo.core.lock.ServiceLock;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
@@ -114,15 +114,15 @@ public class ManagerAssignmentIT extends SharedMiniClusterBase {
 
   @BeforeEach
   public void before() throws Exception {
-    Wait.waitFor(() -> countTabletsWithLocation(client, AccumuloTable.ROOT.tableId()) > 0);
-    Wait.waitFor(() -> countTabletsWithLocation(client, AccumuloTable.METADATA.tableId()) > 0);
+    Wait.waitFor(() -> countTabletsWithLocation(client, AccumuloNamespace.ROOT.tableId()) > 0);
+    Wait.waitFor(() -> countTabletsWithLocation(client, AccumuloNamespace.METADATA.tableId()) > 0);
   }
 
   @Test
   public void test() throws Exception {
     // Confirm that the system tables are hosted
 
-    for (AccumuloTable t : AccumuloTable.values()) {
+    for (AccumuloNamespace t : AccumuloNamespace.values()) {
       Locations locs =
           client.tableOperations().locate(t.tableName(), Collections.singletonList(new Range()));
       locs.groupByTablet().keySet().forEach(tid -> assertNotNull(locs.getTabletLocation(tid)));
@@ -385,7 +385,7 @@ public class ManagerAssignmentIT extends SharedMiniClusterBase {
         .map(Text::toString).collect(Collectors.toSet()));
 
     client.securityOperations().grantTablePermission(getPrincipal(),
-        AccumuloTable.METADATA.tableName(), TablePermission.WRITE);
+        AccumuloNamespace.METADATA.tableName(), TablePermission.WRITE);
 
     var ample = getCluster().getServerContext().getAmple();
     var extent = new KeyExtent(tableId, new Text("m"), new Text("f"));
@@ -567,7 +567,7 @@ public class ManagerAssignmentIT extends SharedMiniClusterBase {
     // could potentially send a kill -9 to the process. Shut the tablet
     // servers down in a more graceful way.
 
-    Locations locs = client.tableOperations().locate(AccumuloTable.ROOT.tableName(),
+    Locations locs = client.tableOperations().locate(AccumuloNamespace.ROOT.tableName(),
         Collections.singletonList(TabletsSection.getRange()));
     locs.groupByTablet().keySet().stream().map(locs::getTabletLocation).forEach(location -> {
       HostAndPort address = HostAndPort.fromString(location);

--- a/test/src/main/java/org/apache/accumulo/test/functional/MemoryStarvedScanIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MemoryStarvedScanIT.java
@@ -47,7 +47,7 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metrics.MetricsInfo;
 import org.apache.accumulo.core.spi.metrics.LoggingMeterRegistryFactory;
 import org.apache.accumulo.harness.MiniClusterConfigurationCallback;
@@ -185,7 +185,7 @@ public class MemoryStarvedScanIT extends SharedMiniClusterBase {
     // Scan the metadata table as this is not prevented when the
     // server is low on memory. Use the MemoryFreeingIterator as it
     // will free the memory on init()
-    try (Scanner scanner = client.createScanner(AccumuloTable.METADATA.tableName())) {
+    try (Scanner scanner = client.createScanner(AccumuloNamespace.METADATA.tableName())) {
       IteratorSetting is = new IteratorSetting(11, MemoryFreeingIterator.class, Map.of());
       scanner.addScanIterator(is);
       assertNotEquals(0, Iterables.size(scanner)); // consume the key/values

--- a/test/src/main/java/org/apache/accumulo/test/functional/MergeTabletsBaseIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MergeTabletsBaseIT.java
@@ -61,7 +61,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.FateInstanceType;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.CompactionMetadata;
@@ -188,7 +188,7 @@ public abstract class MergeTabletsBaseIT extends SharedMiniClusterBase {
       // Verify that the MERGED marker was cleared
       verifyMergedMarkerCleared(getCluster().getServerContext(),
           TableId.of(c.tableOperations().tableIdMap().get(tableName)));
-      try (Scanner s = c.createScanner(AccumuloTable.METADATA.tableName())) {
+      try (Scanner s = c.createScanner(AccumuloNamespace.METADATA.tableName())) {
         String tid = c.tableOperations().tableIdMap().get(tableName);
         s.setRange(new Range(tid + ";g"));
         TabletColumnFamily.PREV_ROW_COLUMN.fetch(s);

--- a/test/src/main/java/org/apache/accumulo/test/functional/MetadataIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MetadataIT.java
@@ -49,7 +49,7 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.user.VersioningIterator;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.DeletesSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
@@ -93,7 +93,7 @@ public class MetadataIT extends SharedMiniClusterBase {
       c.tableOperations().create(tableNames[0]);
 
       try (Scanner rootScanner =
-          c.createScanner(AccumuloTable.ROOT.tableName(), Authorizations.EMPTY)) {
+          c.createScanner(AccumuloNamespace.ROOT.tableName(), Authorizations.EMPTY)) {
         rootScanner.setRange(TabletsSection.getRange());
         rootScanner.fetchColumnFamily(DataFileColumnFamily.NAME);
 
@@ -103,7 +103,7 @@ public class MetadataIT extends SharedMiniClusterBase {
         }
 
         c.tableOperations().create(tableNames[1]);
-        c.tableOperations().flush(AccumuloTable.METADATA.tableName(), null, null, true);
+        c.tableOperations().flush(AccumuloNamespace.METADATA.tableName(), null, null, true);
 
         Set<String> files2 = new HashSet<>();
         for (Entry<Key,Value> entry : rootScanner) {
@@ -114,7 +114,8 @@ public class MetadataIT extends SharedMiniClusterBase {
         assertTrue(!files2.isEmpty());
         assertNotEquals(files1, files2);
 
-        c.tableOperations().compact(AccumuloTable.METADATA.tableName(), null, null, false, true);
+        c.tableOperations().compact(AccumuloNamespace.METADATA.tableName(), null, null, false,
+            true);
 
         Set<String> files3 = new HashSet<>();
         for (Entry<Key,Value> entry : rootScanner) {
@@ -135,17 +136,18 @@ public class MetadataIT extends SharedMiniClusterBase {
       for (String id : "1 2 3 4 5".split(" ")) {
         splits.add(new Text(id));
       }
-      c.tableOperations().addSplits(AccumuloTable.METADATA.tableName(), splits);
+      c.tableOperations().addSplits(AccumuloNamespace.METADATA.tableName(), splits);
       for (String tableName : names) {
         c.tableOperations().create(tableName);
       }
-      c.tableOperations().merge(AccumuloTable.METADATA.tableName(), null, null);
-      try (Scanner s = c.createScanner(AccumuloTable.ROOT.tableName(), Authorizations.EMPTY)) {
+      c.tableOperations().merge(AccumuloNamespace.METADATA.tableName(), null, null);
+      try (Scanner s = c.createScanner(AccumuloNamespace.ROOT.tableName(), Authorizations.EMPTY)) {
         s.setRange(DeletesSection.getRange());
         while (s.stream().findAny().isEmpty()) {
           Thread.sleep(100);
         }
-        assertEquals(0, c.tableOperations().listSplits(AccumuloTable.METADATA.tableName()).size());
+        assertEquals(0,
+            c.tableOperations().listSplits(AccumuloNamespace.METADATA.tableName()).size());
       }
     }
   }
@@ -157,13 +159,13 @@ public class MetadataIT extends SharedMiniClusterBase {
       c.tableOperations().create(tableName);
 
       // batch scan regular metadata table
-      try (BatchScanner s = c.createBatchScanner(AccumuloTable.METADATA.tableName())) {
+      try (BatchScanner s = c.createBatchScanner(AccumuloNamespace.METADATA.tableName())) {
         s.setRanges(Collections.singleton(new Range()));
         assertTrue(s.stream().anyMatch(Objects::nonNull));
       }
 
       // batch scan root metadata table
-      try (BatchScanner s = c.createBatchScanner(AccumuloTable.ROOT.tableName())) {
+      try (BatchScanner s = c.createBatchScanner(AccumuloNamespace.ROOT.tableName())) {
         s.setRanges(Collections.singleton(new Range()));
         assertTrue(s.stream().anyMatch(Objects::nonNull));
       }
@@ -174,8 +176,8 @@ public class MetadataIT extends SharedMiniClusterBase {
   public void testAmpleReadTablets() throws Exception {
 
     try (ClientContext cc = (ClientContext) Accumulo.newClient().from(getClientProps()).build()) {
-      cc.securityOperations().grantTablePermission(cc.whoami(), AccumuloTable.METADATA.tableName(),
-          TablePermission.WRITE);
+      cc.securityOperations().grantTablePermission(cc.whoami(),
+          AccumuloNamespace.METADATA.tableName(), TablePermission.WRITE);
 
       SortedSet<Text> partitionKeys = new TreeSet<>();
       partitionKeys.add(new Text("a"));
@@ -245,15 +247,15 @@ public class MetadataIT extends SharedMiniClusterBase {
       // It is important here to use getTableProperties() and not getConfiguration()
       // because we want only the table properties and not a merged view
       var rootTableProps =
-          client.tableOperations().getTableProperties(AccumuloTable.ROOT.tableName());
+          client.tableOperations().getTableProperties(AccumuloNamespace.ROOT.tableName());
       var metadataTableProps =
-          client.tableOperations().getTableProperties(AccumuloTable.METADATA.tableName());
+          client.tableOperations().getTableProperties(AccumuloNamespace.METADATA.tableName());
 
       // Verify root table config
-      testCommonSystemTableConfig(client, AccumuloTable.ROOT.tableId(), rootTableProps);
+      testCommonSystemTableConfig(client, AccumuloNamespace.ROOT.tableId(), rootTableProps);
 
       // Verify metadata table config
-      testCommonSystemTableConfig(client, AccumuloTable.METADATA.tableId(), metadataTableProps);
+      testCommonSystemTableConfig(client, AccumuloNamespace.METADATA.tableId(), metadataTableProps);
     }
   }
 
@@ -302,8 +304,8 @@ public class MetadataIT extends SharedMiniClusterBase {
       assertTrue(tablets.stream().allMatch(tm -> {
         // ROOT table and Metadata TabletsSection tablet should be set to never mergeable
         // All other initial tablets for Metadata, Fate, Scanref should be always
-        if (AccumuloTable.ROOT.tableId().equals(tableId)
-            || (AccumuloTable.METADATA.tableId().equals(tableId)
+        if (AccumuloNamespace.ROOT.tableId().equals(tableId)
+            || (AccumuloNamespace.METADATA.tableId().equals(tableId)
                 && metaSplit.equals(tm.getEndRow()))) {
           return tm.getTabletMergeability().equals(TabletMergeabilityMetadata.never());
         }

--- a/test/src/main/java/org/apache/accumulo/test/functional/MetadataMaxFilesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MetadataMaxFilesIT.java
@@ -34,7 +34,7 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.manager.thrift.ManagerMonitorInfo;
 import org.apache.accumulo.core.manager.thrift.TableInfo;
 import org.apache.accumulo.core.manager.thrift.TabletServerStatus;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
 import org.apache.accumulo.core.trace.TraceUtil;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
@@ -64,7 +64,7 @@ public class MetadataMaxFilesIT extends ConfigurableMacBase {
       for (int i = 0; i < 1000; i++) {
         splits.add(new Text(String.format("%03d", i)));
       }
-      c.tableOperations().setProperty(AccumuloTable.METADATA.tableName(),
+      c.tableOperations().setProperty(AccumuloNamespace.METADATA.tableName(),
           Property.TABLE_SPLIT_THRESHOLD.getKey(), "10000");
       // propagation time
       Thread.sleep(SECONDS.toMillis(5));
@@ -75,8 +75,8 @@ public class MetadataMaxFilesIT extends ConfigurableMacBase {
             .withInitialTabletAvailability(TabletAvailability.HOSTED);
         c.tableOperations().create(tableName, ntc);
         log.info("flushing");
-        c.tableOperations().flush(AccumuloTable.METADATA.tableName(), null, null, true);
-        c.tableOperations().flush(AccumuloTable.ROOT.tableName(), null, null, true);
+        c.tableOperations().flush(AccumuloNamespace.METADATA.tableName(), null, null, true);
+        c.tableOperations().flush(AccumuloNamespace.ROOT.tableName(), null, null, true);
       }
 
       while (true) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/MetadataSplitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MetadataSplitIT.java
@@ -27,7 +27,7 @@ import java.time.Duration;
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.conf.Property;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.junit.jupiter.api.Test;
 
 public class MetadataSplitIT extends ConfigurableMacBase {
@@ -40,15 +40,16 @@ public class MetadataSplitIT extends ConfigurableMacBase {
   @Test
   public void test() throws Exception {
     try (AccumuloClient c = Accumulo.newClient().from(getClientProperties()).build()) {
-      assertEquals(1, c.tableOperations().listSplits(AccumuloTable.METADATA.tableName()).size());
-      c.tableOperations().setProperty(AccumuloTable.METADATA.tableName(),
+      assertEquals(1,
+          c.tableOperations().listSplits(AccumuloNamespace.METADATA.tableName()).size());
+      c.tableOperations().setProperty(AccumuloNamespace.METADATA.tableName(),
           Property.TABLE_SPLIT_THRESHOLD.getKey(), "500");
       for (int i = 0; i < 10; i++) {
         c.tableOperations().create("table" + i);
-        c.tableOperations().flush(AccumuloTable.METADATA.tableName(), null, null, true);
+        c.tableOperations().flush(AccumuloNamespace.METADATA.tableName(), null, null, true);
       }
       Thread.sleep(SECONDS.toMillis(10));
-      assertTrue(c.tableOperations().listSplits(AccumuloTable.METADATA.tableName()).size() > 2);
+      assertTrue(c.tableOperations().listSplits(AccumuloNamespace.METADATA.tableName()).size() > 2);
     }
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/functional/PermissionsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/PermissionsIT.java
@@ -51,7 +51,7 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.SystemPermission;
 import org.apache.accumulo.core.security.TablePermission;
@@ -693,7 +693,7 @@ public class PermissionsIT extends AccumuloClusterHarness {
 
         // check for read-only access to metadata table
         loginAs(rootUser);
-        verifyHasOnlyTheseTablePermissions(c, c.whoami(), AccumuloTable.METADATA.tableName(),
+        verifyHasOnlyTheseTablePermissions(c, c.whoami(), AccumuloNamespace.METADATA.tableName(),
             TablePermission.READ, TablePermission.ALTER_TABLE);
         String tableName = getUniqueNames(1)[0] + "__TABLE_PERMISSION_TEST__";
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/RecoveryWithEmptyRFileIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/RecoveryWithEmptyRFileIT.java
@@ -31,7 +31,7 @@ import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
@@ -85,7 +85,7 @@ public class RecoveryWithEmptyRFileIT extends ConfigurableMacBase {
 
       log.debug("Replacing rfile(s) with empty");
       try (Scanner meta =
-          client.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
+          client.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY)) {
         String tableId = client.tableOperations().tableIdMap().get(tableName);
         meta.setRange(new Range(new Text(tableId + ";"), new Text(tableId + "<")));
         meta.fetchColumnFamily(DataFileColumnFamily.NAME);

--- a/test/src/main/java/org/apache/accumulo/test/functional/RegexGroupBalanceIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/RegexGroupBalanceIT.java
@@ -37,7 +37,7 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
@@ -182,7 +182,7 @@ public class RegexGroupBalanceIT extends ConfigurableMacBase {
   private Table<String,String,MutableInt> getCounts(AccumuloClient client, String tablename)
       throws TableNotFoundException {
     try (Scanner s =
-        client.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
+        client.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY)) {
       s.fetchColumnFamily(CurrentLocationColumnFamily.NAME);
       TableId tableId = TableId.of(client.tableOperations().tableIdMap().get(tablename));
       s.setRange(TabletsSection.getRange(tableId));

--- a/test/src/main/java/org/apache/accumulo/test/functional/RestartIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/RestartIT.java
@@ -37,7 +37,7 @@ import org.apache.accumulo.core.conf.ClientProperty;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.lock.ServiceLock;
 import org.apache.accumulo.core.lock.ServiceLockData;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.zookeeper.ZooCache;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.minicluster.ServerType;
@@ -261,7 +261,7 @@ public class RestartIT extends AccumuloClusterHarness {
       }
       assertNotNull(splitThreshold);
       try {
-        c.tableOperations().setProperty(AccumuloTable.METADATA.tableName(),
+        c.tableOperations().setProperty(AccumuloNamespace.METADATA.tableName(),
             Property.TABLE_SPLIT_THRESHOLD.getKey(), "20K");
         TestIngest.ingest(c, params);
         c.tableOperations().flush(tableName, null, null, false);
@@ -270,7 +270,7 @@ public class RestartIT extends AccumuloClusterHarness {
       } finally {
         if (getClusterType() == ClusterType.STANDALONE) {
           getCluster().start();
-          c.tableOperations().setProperty(AccumuloTable.METADATA.tableName(),
+          c.tableOperations().setProperty(AccumuloNamespace.METADATA.tableName(),
               Property.TABLE_SPLIT_THRESHOLD.getKey(), splitThreshold);
         }
       }

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitIT.java
@@ -66,7 +66,7 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.metadata.schema.TabletMergeabilityMetadata;
@@ -248,7 +248,8 @@ public class SplitIT extends AccumuloClusterHarness {
         Thread.sleep(SECONDS.toMillis(15));
       }
       TableId id = TableId.of(c.tableOperations().tableIdMap().get(table));
-      try (Scanner s = c.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
+      try (Scanner s =
+          c.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY)) {
         KeyExtent extent = new KeyExtent(id, null, null);
         s.setRange(extent.toMetaRange());
         TabletColumnFamily.PREV_ROW_COLUMN.fetch(s);

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitMillionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitMillionIT.java
@@ -45,7 +45,7 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.Filter;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.minicluster.MemoryUnit;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
@@ -92,7 +92,7 @@ public class SplitMillionIT extends ConfigurableMacBase {
         String metaSplit = String.format("%s;%010d", tableId, 100_000_000 / 10 * i);
         metaSplits.add(new Text(metaSplit));
       }
-      c.tableOperations().addSplits(AccumuloTable.METADATA.tableName(), metaSplits);
+      c.tableOperations().addSplits(AccumuloNamespace.METADATA.tableName(), metaSplits);
 
       SortedSet<Text> splits = new TreeSet<>();
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
@@ -47,7 +47,7 @@ import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.FateInstanceType;
 import org.apache.accumulo.core.file.rfile.RFile;
 import org.apache.accumulo.core.lock.ServiceLock;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.TServerInstance;
@@ -178,7 +178,7 @@ public class SplitRecoveryIT extends ConfigurableMacBase {
     // Ample is not used here because it does not recognize some of the old columns that this
     // upgrade code is dealing with.
     try (Scanner scanner =
-        context.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
+        context.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY)) {
       scanner.setRange(extent.toMetaRange());
 
       Map<FateId,List<ReferencedTabletFile>> bulkFiles = new HashMap<>();
@@ -229,7 +229,7 @@ public class SplitRecoveryIT extends ConfigurableMacBase {
       Double persistedSplitRatio = null;
 
       try (var scanner =
-          context.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
+          context.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY)) {
         scanner.setRange(high.toMetaRange());
         for (var entry : scanner) {
           if (SPLIT_RATIO_COLUMN.hasColumns(entry.getKey())) {
@@ -268,7 +268,7 @@ public class SplitRecoveryIT extends ConfigurableMacBase {
   private void ensureTabletHasNoUnexpectedMetadataEntries(ServerContext context, KeyExtent extent,
       SortedMap<StoredTabletFile,DataFileValue> expectedDataFiles) throws Exception {
     try (Scanner scanner =
-        new ScannerImpl(context, AccumuloTable.METADATA.tableId(), Authorizations.EMPTY)) {
+        new ScannerImpl(context, AccumuloNamespace.METADATA.tableId(), Authorizations.EMPTY)) {
       scanner.setRange(extent.toMetaRange());
 
       HashSet<ColumnFQ> expectedColumns = new HashSet<>();
@@ -294,7 +294,7 @@ public class SplitRecoveryIT extends ConfigurableMacBase {
 
         if (!key.getRow().equals(extent.toMetaRow())) {
           throw new Exception("Tablet " + extent + " contained unexpected "
-              + AccumuloTable.METADATA.tableName() + " entry " + key);
+              + AccumuloNamespace.METADATA.tableName() + " entry " + key);
         }
 
         if (TabletColumnFamily.PREV_ROW_COLUMN.hasColumns(key)) {
@@ -313,7 +313,7 @@ public class SplitRecoveryIT extends ConfigurableMacBase {
         }
 
         throw new Exception("Tablet " + extent + " contained unexpected "
-            + AccumuloTable.METADATA.tableName() + " entry " + key);
+            + AccumuloNamespace.METADATA.tableName() + " entry " + key);
       }
 
       // This is not always present

--- a/test/src/main/java/org/apache/accumulo/test/functional/TableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TableIT.java
@@ -36,7 +36,7 @@ import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
@@ -74,7 +74,8 @@ public class TableIT extends AccumuloClusterHarness {
       to.flush(tableName, null, null, true);
       VerifyIngest.verifyIngest(c, params);
       TableId id = TableId.of(to.tableIdMap().get(tableName));
-      try (Scanner s = c.createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
+      try (Scanner s =
+          c.createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY)) {
         s.setRange(new KeyExtent(id, null, null).toMetaRange());
         s.fetchColumnFamily(DataFileColumnFamily.NAME);
         assertTrue(s.stream().findAny().isPresent());

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletAvailabilityIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletAvailabilityIT.java
@@ -43,7 +43,7 @@ import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.client.admin.TabletAvailability;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.Test;
@@ -53,7 +53,7 @@ public class TabletAvailabilityIT extends AccumuloClusterHarness {
   @Test
   public void testSystemFails() throws Exception {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-      for (AccumuloTable t : AccumuloTable.values()) {
+      for (AccumuloNamespace t : AccumuloNamespace.values()) {
         assertThrows(IllegalArgumentException.class, () -> client.tableOperations()
             .setTabletAvailability(t.tableName(), new Range(), UNHOSTED));
       }

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletManagementIteratorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletManagementIteratorIT.java
@@ -73,7 +73,7 @@ import org.apache.accumulo.core.lock.ServiceLockPaths.ServiceLockPath;
 import org.apache.accumulo.core.manager.state.TabletManagement;
 import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.core.manager.thrift.ManagerState;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.schema.Ample;
@@ -149,7 +149,7 @@ public class TabletManagementIteratorIT extends AccumuloClusterHarness {
       var unused = Iterables.size(s); // consume all the data
 
       // examine a clone of the metadata table, so we can manipulate it
-      copyTable(client, AccumuloTable.METADATA.tableName(), metaCopy1);
+      copyTable(client, AccumuloNamespace.METADATA.tableName(), metaCopy1);
 
       var tableId1 = getServerContext().getTableId(t1);
       var tableId3 = getServerContext().getTableId(t3);
@@ -170,7 +170,7 @@ public class TabletManagementIteratorIT extends AccumuloClusterHarness {
       while (!tabletsInFlux.isEmpty()) {
         log.debug("Waiting for {} tablets for {}", tabletsInFlux, metaCopy1);
         UtilWaitThread.sleep(500);
-        copyTable(client, AccumuloTable.METADATA.tableName(), metaCopy1);
+        copyTable(client, AccumuloNamespace.METADATA.tableName(), metaCopy1);
         tabletsInFlux = findTabletsNeedingAttention(client, metaCopy1, tabletMgmtParams);
       }
       expected = Map.of();
@@ -530,7 +530,7 @@ public class TabletManagementIteratorIT extends AccumuloClusterHarness {
     log.debug("Gathered {} rows to create copy {}", mutations.size(), copy);
     assertEquals(10, mutations.size(),
         "Metadata should have 8 rows (2 for each table) + one row for "
-            + AccumuloTable.FATE.tableId().canonical());
+            + AccumuloNamespace.FATE.tableId().canonical());
     client.tableOperations().create(copy);
 
     try (BatchWriter writer = client.createBatchWriter(copy)) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletMergeabilityIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletMergeabilityIT.java
@@ -49,7 +49,7 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.security.Authorizations;
@@ -110,25 +110,25 @@ public class TabletMergeabilityIT extends SharedMiniClusterBase {
       var splitPoint = MetadataSchema.TabletsSection.getRange().getEndKey().getRow();
       // Test merge with new splits added after splitPoint default tablet (which is mergeable)
       // Should keep tablets section tablet on merge
-      testMergeabilityAlways(c, AccumuloTable.METADATA.tableName(), "~",
-          Set.of(new KeyExtent(AccumuloTable.METADATA.tableId(), null, splitPoint),
-              new KeyExtent(AccumuloTable.METADATA.tableId(), splitPoint, null)));
+      testMergeabilityAlways(c, AccumuloNamespace.METADATA.tableName(), "~",
+          Set.of(new KeyExtent(AccumuloNamespace.METADATA.tableId(), null, splitPoint),
+              new KeyExtent(AccumuloNamespace.METADATA.tableId(), splitPoint, null)));
     }
   }
 
   @Test
   public void testMergeabilityFate() throws Exception {
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
-      testMergeabilityAlways(c, AccumuloTable.FATE.tableName(), "",
-          Set.of(new KeyExtent(AccumuloTable.FATE.tableId(), null, null)));
+      testMergeabilityAlways(c, AccumuloNamespace.FATE.tableName(), "",
+          Set.of(new KeyExtent(AccumuloNamespace.FATE.tableId(), null, null)));
     }
   }
 
   @Test
   public void testMergeabilityScanRef() throws Exception {
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
-      testMergeabilityAlways(c, AccumuloTable.SCAN_REF.tableName(), "",
-          Set.of(new KeyExtent(AccumuloTable.SCAN_REF.tableId(), null, null)));
+      testMergeabilityAlways(c, AccumuloNamespace.SCAN_REF.tableName(), "",
+          Set.of(new KeyExtent(AccumuloNamespace.SCAN_REF.tableId(), null, null)));
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletResourceGroupBalanceIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletResourceGroupBalanceIT.java
@@ -47,7 +47,7 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.lock.ServiceLockPaths.AddressSelector;
 import org.apache.accumulo.core.lock.ServiceLockPaths.ServiceLockPath;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
@@ -254,8 +254,8 @@ public class TabletResourceGroupBalanceIT extends SharedMiniClusterBase {
         Accumulo.newClient().from(getCluster().getClientProperties()).build()) {
 
       client.instanceOperations().waitForBalance();
-      testResourceGroupPropertyChange(client, AccumuloTable.METADATA.tableName(),
-          getCountOfHostedTablets(client, AccumuloTable.METADATA.tableName()));
+      testResourceGroupPropertyChange(client, AccumuloNamespace.METADATA.tableName(),
+          getCountOfHostedTablets(client, AccumuloNamespace.METADATA.tableName()));
     }
   }
 
@@ -265,8 +265,8 @@ public class TabletResourceGroupBalanceIT extends SharedMiniClusterBase {
         Accumulo.newClient().from(getCluster().getClientProperties()).build()) {
 
       client.instanceOperations().waitForBalance();
-      testResourceGroupPropertyChange(client, AccumuloTable.ROOT.tableName(),
-          getCountOfHostedTablets(client, AccumuloTable.ROOT.tableName()));
+      testResourceGroupPropertyChange(client, AccumuloNamespace.ROOT.tableName(),
+          getCountOfHostedTablets(client, AccumuloNamespace.ROOT.tableName()));
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/WALSunnyDayBaseIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/WALSunnyDayBaseIT.java
@@ -48,7 +48,7 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LogColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
@@ -118,8 +118,8 @@ public abstract class WALSunnyDayBaseIT extends ConfigurableMacBase {
       assertEquals(3, countInUse(walsAfterRoll.values()), "all WALs should be in use");
 
       // flush the tables
-      for (String table : new String[] {tableName, AccumuloTable.METADATA.tableName(),
-          AccumuloTable.ROOT.tableName(), AccumuloTable.FATE.tableName()}) {
+      for (String table : new String[] {tableName, AccumuloNamespace.METADATA.tableName(),
+          AccumuloNamespace.ROOT.tableName(), AccumuloNamespace.FATE.tableName()}) {
         c.tableOperations().flush(table, null, null, true);
       }
       Thread.sleep(SECONDS.toMillis(1));
@@ -152,11 +152,11 @@ public abstract class WALSunnyDayBaseIT extends ConfigurableMacBase {
           "tableId of the keyExtent should be 1");
       assertTrue(
           markers.keySet().stream()
-              .anyMatch(extent -> extent.tableId().equals(AccumuloTable.FATE.tableId())),
+              .anyMatch(extent -> extent.tableId().equals(AccumuloNamespace.FATE.tableId())),
           "tableId of the Fate table can't be found");
       assertTrue(
           markers.keySet().stream()
-              .anyMatch(extent -> extent.tableId().equals(AccumuloTable.SCAN_REF.tableId())),
+              .anyMatch(extent -> extent.tableId().equals(AccumuloNamespace.SCAN_REF.tableId())),
           "tableId of the ScanRef table can't be found");
 
       // put some data in the WAL
@@ -206,8 +206,8 @@ public abstract class WALSunnyDayBaseIT extends ConfigurableMacBase {
 
   private Map<KeyExtent,List<String>> getRecoveryMarkers(AccumuloClient c) throws Exception {
     Map<KeyExtent,List<String>> result = new HashMap<>();
-    try (Scanner root = c.createScanner(AccumuloTable.ROOT.tableName(), EMPTY);
-        Scanner meta = c.createScanner(AccumuloTable.METADATA.tableName(), EMPTY)) {
+    try (Scanner root = c.createScanner(AccumuloNamespace.ROOT.tableName(), EMPTY);
+        Scanner meta = c.createScanner(AccumuloNamespace.METADATA.tableName(), EMPTY)) {
       root.setRange(TabletsSection.getRange());
       root.fetchColumnFamily(LogColumnFamily.NAME);
       TabletColumnFamily.PREV_ROW_COLUMN.fetch(root);

--- a/test/src/main/java/org/apache/accumulo/test/server/security/SystemCredentialsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/server/security/SystemCredentialsIT.java
@@ -32,7 +32,7 @@ import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.clientImpl.Credentials;
 import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.data.InstanceId;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.security.SystemCredentials;
@@ -83,7 +83,7 @@ public class SystemCredentialsIT extends ConfigurableMacBase {
           .as(creds.getPrincipal(), creds.getToken()).build()) {
         client.securityOperations().authenticateUser(creds.getPrincipal(), creds.getToken());
         try (Scanner scan =
-            client.createScanner(AccumuloTable.ROOT.tableName(), Authorizations.EMPTY)) {
+            client.createScanner(AccumuloNamespace.ROOT.tableName(), Authorizations.EMPTY)) {
           scan.forEach((k, v) -> {});
         } catch (RuntimeException e) {
           e.printStackTrace(System.err);

--- a/test/src/main/java/org/apache/accumulo/test/upgrade/ScanServerUpgrade11to12TestIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/upgrade/ScanServerUpgrade11to12TestIT.java
@@ -43,7 +43,7 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.manager.state.tables.TableState;
-import org.apache.accumulo.core.metadata.AccumuloTable;
+import org.apache.accumulo.core.metadata.AccumuloNamespace;
 import org.apache.accumulo.core.metadata.ScanServerRefTabletFile;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.security.Authorizations;
@@ -68,8 +68,8 @@ import com.google.common.net.HostAndPort;
 public class ScanServerUpgrade11to12TestIT extends SharedMiniClusterBase {
 
   public static final Logger log = LoggerFactory.getLogger(ScanServerUpgrade11to12TestIT.class);
-  private static final Range META_RANGE =
-      new Range(AccumuloTable.SCAN_REF.tableId() + ";", AccumuloTable.SCAN_REF.tableId() + "<");
+  private static final Range META_RANGE = new Range(AccumuloNamespace.SCAN_REF.tableId() + ";",
+      AccumuloNamespace.SCAN_REF.tableId() + "<");
 
   private static class ScanServerUpgradeITConfiguration
       implements MiniClusterConfigurationCallback {
@@ -106,13 +106,13 @@ public class ScanServerUpgrade11to12TestIT extends SharedMiniClusterBase {
     ServerContext ctx = getCluster().getServerContext();
     // Remove the scan server table metadata in zk
     try {
-      ctx.getTableManager().removeTable(AccumuloTable.SCAN_REF.tableId());
+      ctx.getTableManager().removeTable(AccumuloNamespace.SCAN_REF.tableId());
     } catch (KeeperException | InterruptedException e) {
       throw new RuntimeException("Removal of scan ref table failed" + e);
     }
 
     // Read from the metadata table to find any existing scan ref tablets and remove them
-    try (BatchWriter writer = ctx.createBatchWriter(AccumuloTable.METADATA.tableName())) {
+    try (BatchWriter writer = ctx.createBatchWriter(AccumuloNamespace.METADATA.tableName())) {
       var refTablet = checkForScanRefTablets().iterator();
       while (refTablet.hasNext()) {
         var entry = refTablet.next();
@@ -128,7 +128,8 @@ public class ScanServerUpgrade11to12TestIT extends SharedMiniClusterBase {
 
     // Compact the metadata table to remove the tablet file for the scan ref table
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-      client.tableOperations().compact(AccumuloTable.METADATA.tableName(), null, null, true, true);
+      client.tableOperations().compact(AccumuloNamespace.METADATA.tableName(), null, null, true,
+          true);
     } catch (TableNotFoundException | AccumuloException | AccumuloSecurityException e) {
       log.error("Failed to compact metadata table");
       throw new RuntimeException(e);
@@ -197,7 +198,7 @@ public class ScanServerUpgrade11to12TestIT extends SharedMiniClusterBase {
   private Stream<Entry<Key,Value>> checkForScanRefTablets() {
     try {
       Scanner scanner = getCluster().getServerContext()
-          .createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY);
+          .createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY);
       scanner.setRange(META_RANGE);
       return scanner.stream().onClose(scanner::close);
     } catch (TableNotFoundException e) {
@@ -224,7 +225,7 @@ public class ScanServerUpgrade11to12TestIT extends SharedMiniClusterBase {
     var upgrader = new Upgrader11to12();
     upgrader.createScanServerRefTable(ctx);
     assertEquals(TableState.ONLINE,
-        ctx.getTableManager().getTableState(AccumuloTable.SCAN_REF.tableId()));
+        ctx.getTableManager().getTableState(AccumuloNamespace.SCAN_REF.tableId()));
 
     while (checkForScanRefTablets().count() < 4) {
       log.info("Waiting for the table to be hosted");
@@ -233,7 +234,7 @@ public class ScanServerUpgrade11to12TestIT extends SharedMiniClusterBase {
 
     log.info("Reading entries from the metadata table");
     try (Scanner scanner = getCluster().getServerContext()
-        .createScanner(AccumuloTable.METADATA.tableName(), Authorizations.EMPTY)) {
+        .createScanner(AccumuloNamespace.METADATA.tableName(), Authorizations.EMPTY)) {
       var refTablet = scanner.stream().iterator();
       while (refTablet.hasNext()) {
         log.info("Metadata Entry: {}", refTablet.next());
@@ -244,7 +245,7 @@ public class ScanServerUpgrade11to12TestIT extends SharedMiniClusterBase {
 
     log.info("Reading entries from the root table");
     try (Scanner scanner = getCluster().getServerContext()
-        .createScanner(AccumuloTable.ROOT.tableName(), Authorizations.EMPTY)) {
+        .createScanner(AccumuloNamespace.ROOT.tableName(), Authorizations.EMPTY)) {
       var refTablet = scanner.stream().iterator();
       while (refTablet.hasNext()) {
         log.info("Root Entry: {}", refTablet.next());


### PR DESCRIPTION
- Renamed AccumuloTable -> AccumuloNamespace
- Added new convenience methods

The new `containsTable(String tableName)` and `allTableNames()` aren't used but added in case they might be helpful in the future. Can remove if desired.

Suggested in: https://github.com/apache/accumulo/pull/5487#discussion_r2054966995

May look like a lot of changes, but is 99% just the rename done through my IDE