### PR TITLE
Create all vars before sourcing accumulo-env.sh

### DIFF
--- a/assemble/bin/accumulo-service
+++ b/assemble/bin/accumulo-service
@@ -268,16 +268,6 @@ function main() {
   group=$(get_group "$@")
   export ACCUMULO_RESOURCE_GROUP="$group"
 
-  if [[ -f "${conf}/accumulo-env.sh" ]]; then
-    #shellcheck source=../conf/accumulo-env.sh
-    source "${conf}/accumulo-env.sh"
-  fi
-  ACCUMULO_LOG_DIR="${ACCUMULO_LOG_DIR:-${basedir}/logs}"
-  ACCUMULO_PID_DIR="${ACCUMULO_PID_DIR:-${basedir}/run}"
-
-  mkdir -p "$ACCUMULO_LOG_DIR" 2>/dev/null
-  mkdir -p "$ACCUMULO_PID_DIR" 2>/dev/null
-
   HOST="$(hostname)"
   if [[ -z $HOST ]]; then
     HOST=$(ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
@@ -293,6 +283,16 @@ function main() {
     echo "WARN : Use of 'master' service name is deprecated; use 'manager' instead."
     service_type="manager"
   fi
+
+  if [[ -f "${conf}/accumulo-env.sh" ]]; then
+    #shellcheck source=../conf/accumulo-env.sh
+    source "${conf}/accumulo-env.sh"
+  fi
+  ACCUMULO_LOG_DIR="${ACCUMULO_LOG_DIR:-${basedir}/logs}"
+  ACCUMULO_PID_DIR="${ACCUMULO_PID_DIR:-${basedir}/run}"
+
+  mkdir -p "$ACCUMULO_LOG_DIR" 2>/dev/null
+  mkdir -p "$ACCUMULO_PID_DIR" 2>/dev/null
 
   # Check and see if accumulo-cluster is calling this script
   if [[ -z $ACCUMULO_CLUSTER_ARG ]]; then


### PR DESCRIPTION
Moves the sourcing of accumulo-env.sh to after all of the variables are defined for accumulo-service.

This allows for better handling of specific processes and actions in accumulo-env.sh