### PR TITLE
Bump Apache Parent POM from version 31 to 34

### DIFF
--- a/.github/workflows/maven-full-its.yaml
+++ b/.github/workflows/maven-full-its.yaml
@@ -60,7 +60,7 @@ jobs:
       timeout-minutes: 20
       run: mvn -B -V -e -ntp "-Dstyle.color=always" clean package dependency:resolve -DskipTests -DskipFormat -DverifyFormat
       env:
-        MAVEN_OPTS: -Djansi.force=true
+        MAVEN_OPTS: -Djansi.force=true -Dapache.snapshots=true
   creatematrix:
     needs: fastbuild
     timeout-minutes: 5
@@ -110,7 +110,7 @@ jobs:
       timeout-minutes: 60
       run: mvn -B -V -e -ntp "-Dstyle.color=always" verify -PskipQA -DskipTests=false -DskipITs=false -Dtest=nomatchingtest -Dit.test="${{ matrix.profile.its }}"
       env:
-        MAVEN_OPTS: -Djansi.force=true
+        MAVEN_OPTS: -Djansi.force=true -Dapache.snapshots=true
     - name: Upload unit test results
       if: ${{ failure() }}
       uses: actions/upload-artifact@v4

--- a/.github/workflows/maven-on-demand.yaml
+++ b/.github/workflows/maven-on-demand.yaml
@@ -92,7 +92,7 @@ jobs:
       timeout-minutes: 345
       run: mvn -B -V -e -ntp "-Dstyle.color=always" ${{ github.event.inputs.mvnOpts }} ${{ github.event.inputs.goals }} ${{ github.event.inputs.utOpts }} ${{ github.event.inputs.itOpts }} ${{ github.event.inputs.addOpts }}
       env:
-        MAVEN_OPTS: -Djansi.force=true
+        MAVEN_OPTS: -Djansi.force=true -Dapache.snapshots=true
     - name: Upload unit test results
       if: ${{ failure() }}
       uses: actions/upload-artifact@v4

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -54,7 +54,7 @@ jobs:
       timeout-minutes: 20
       run: mvn -B -V -e -ntp "-Dstyle.color=always" clean package dependency:resolve -DskipTests -DskipFormat -DverifyFormat
       env:
-        MAVEN_OPTS: -Djansi.force=true
+        MAVEN_OPTS: -Djansi.force=true -Dapache.snapshots=true
   # more complete builds with tests
   mvn:
     needs: fastbuild
@@ -94,7 +94,7 @@ jobs:
       timeout-minutes: 60
       run: mvn -B -V -e -ntp "-Dstyle.color=always" -DskipFormat ${{ matrix.profile.args }}
       env:
-        MAVEN_OPTS: -Djansi.force=true
+        MAVEN_OPTS: -Djansi.force=true -Dapache.snapshots=true
     - name: Upload unit test results
       if: ${{ failure() }}
       uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ waiting for the tests to run.
 
 This command produces `assemble/target/accumulo-<version>-bin.tar.gz`
 
+If building a non-release version of Accumulo then you may need to add
+`-Dapache.snapshots=true` to the MAVEN_OPTS environment variable so that
+Maven can resolve snapshot dependencies.
+
 ## Contributing
 
 Contributions are welcome to all Apache Accumulo repositories.

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,7 @@
   <properties>
     <!-- used for filtering the java source with the current version -->
     <accumulo.release.version>${project.version}</accumulo.release.version>
+    <apache.snapshots>true</apache.snapshots>
     <!-- avoid error shutting down built-in ForkJoinPool.commonPool() during exec:java tasks -->
     <exec.cleanupDaemonThreads>false</exec.cleanupDaemonThreads>
     <extraTestArgs>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.management/java.lang.management=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens java.base/java.time=ALL-UNNAMED</extraTestArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,6 @@
   <properties>
     <!-- used for filtering the java source with the current version -->
     <accumulo.release.version>${project.version}</accumulo.release.version>
-    <apache.snapshots>true</apache.snapshots>
     <!-- avoid error shutting down built-in ForkJoinPool.commonPool() during exec:java tasks -->
     <exec.cleanupDaemonThreads>false</exec.cleanupDaemonThreads>
     <extraTestArgs>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.management/java.lang.management=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens java.base/java.time=ALL-UNNAMED</extraTestArgs>
@@ -899,6 +898,26 @@
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>properties-maven-plugin</artifactId>
+        <version>1.2.1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>set-system-properties</goal>
+            </goals>
+            <configuration>
+              <properties>
+                <property>
+                  <name>apache.snapshots</name>
+                  <value>true</value>
+                </property>
+              </properties>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>31</version>
+    <version>34</version>
   </parent>
   <groupId>org.apache.accumulo</groupId>
   <artifactId>accumulo-project</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -899,26 +899,6 @@
     </pluginManagement>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
-        <version>1.2.1</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>set-system-properties</goal>
-            </goals>
-            <configuration>
-              <properties>
-                <property>
-                  <name>apache.snapshots</name>
-                  <value>true</value>
-                </property>
-              </properties>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>


### PR DESCRIPTION
Bumps the parent pom version from 31 to 34 and adds
the apache.snapshots property that was included in
https://github.com/apache/maven-apache-parent/pull/183
to enable pulling of snapshots from the apache snapshot
repository during the build.