### PR TITLE
Implement estimate overlapping entries for BloomFilterLayer

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
@@ -431,7 +431,7 @@ public class BloomFilterLayer {
 
     @Override
     public long estimateOverlappingEntries(KeyExtent extent) throws IOException {
-      throw new UnsupportedOperationException();
+      return reader.estimateOverlappingEntries(extent);
     }
 
     @Override


### PR DESCRIPTION
Fixes https://github.com/apache/accumulo/issues/5517

Using the same setup as in the linked issue I confirmed that this resolves the problem. But I'm hoping you have some context as to why an UnsupportedOperationException is thrown here, possibly I'm missing something.