### PR TITLE
Revert changes from #5514 that added new metadata constraint

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
@@ -301,8 +301,6 @@ public class MetadataConstraints implements Constraint {
         return "Malformed availability value";
       case 4006:
         return "Malformed mergeability value";
-      case 4007:
-        return "Tried to set availability of a system table";
 
     }
     return null;
@@ -378,12 +376,6 @@ public class MetadataConstraints implements Constraint {
       case (TabletColumnFamily.AVAILABILITY_QUAL):
         try {
           TabletAvailabilityUtil.fromValue(new Value(columnUpdate.getValue()));
-          if (!violations.contains((short) 4)) {
-            KeyExtent ke = KeyExtent.fromMetaRow(new Text(mutation.getRow()));
-            if (ke.isSystemTable()) {
-              addViolation(violations, 4007);
-            }
-          }
         } catch (IllegalArgumentException e) {
           addViolation(violations, 4005);
         }

--- a/server/base/src/test/java/org/apache/accumulo/server/constraints/MetadataConstraintsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/constraints/MetadataConstraintsTest.java
@@ -696,20 +696,9 @@ public class MetadataConstraintsTest {
     Mutation m;
     List<Short> violations;
 
-    for (var sysTable : SystemTables.values()) {
-      KeyExtent ke = new KeyExtent(sysTable.tableId(), null, null);
-      m = new Mutation(ke.toMetaRow());
-      TabletColumnFamily.AVAILABILITY_COLUMN.put(m, new Value(TabletAvailability.UNHOSTED.name()));
-      assertViolation(mc, m, (short) 4007);
-    }
-
     m = new Mutation(new Text("0;foo"));
     TabletColumnFamily.AVAILABILITY_COLUMN.put(m, new Value("INVALID"));
     assertViolation(mc, m, (short) 4005);
-
-    m = new Mutation(new Text("foo"));
-    TabletColumnFamily.AVAILABILITY_COLUMN.put(m, new Value(TabletAvailability.UNHOSTED.name()));
-    assertViolation(mc, m, (short) 4);
 
     m = new Mutation(new Text("0;foo"));
     TabletColumnFamily.AVAILABILITY_COLUMN.put(m, new Value(TabletAvailability.UNHOSTED.name()));


### PR DESCRIPTION
reverts a breaking change which prevented setting tablet availability on system tables with a metadata constraint. This broke splits which needs to set the availability of new tablets.

Did not use `git revert` as keeping most of the new test added in this commit is fine