### PR TITLE
Adds support for getting batches of names

### DIFF
--- a/server/base/src/test/java/org/apache/accumulo/server/tablets/UniqueNameAllocatorTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/tablets/UniqueNameAllocatorTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.tablets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.TreeSet;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.apache.accumulo.server.tablets.UniqueNameAllocator.NameIterator;
+import org.junit.jupiter.api.Test;
+
+public class UniqueNameAllocatorTest {
+  @Test
+  public void testErrors() {
+    assertThrows(IllegalArgumentException.class, () -> new NameIterator(0, 0));
+    assertThrows(IllegalArgumentException.class, () -> new NameIterator(1, 0));
+  }
+
+  @Test
+  public void testNameIterator() {
+    testRange(0, 1);
+    testRange(0, 2);
+    testRange(0, 10);
+    testRange(10, 11);
+    testRange(10, 12);
+    testRange(10, 20);
+  }
+
+  private void testRange(long start, long end) {
+    NameIterator iter = new NameIterator(start, end);
+    for (long i = start; i < end; i++) {
+      assertTrue(iter.hasNext());
+      assertEquals(i, Long.parseLong(iter.next(), 36));
+    }
+    assertFalse(iter.hasNext());
+    assertThrows(NoSuchElementException.class, iter::next);
+  }
+
+  @Test
+  public void testConcurrent() throws Exception {
+    NameIterator iter = new NameIterator(0, 10_000);
+    var executor = Executors.newCachedThreadPool();
+
+    // start 100 threads each consuming 100 names
+    List<Future<String[]>> futures = new ArrayList<>(100);
+    for (int i = 0; i < 100; i++) {
+      var future = executor.submit(() -> {
+        String[] names = new String[100];
+        for (int j = 0; j < 100; j++) {
+          assertTrue(iter.hasNext());
+          names[j] = iter.next();
+        }
+        return names;
+      });
+      futures.add(future);
+    }
+
+    // verify 10_000 unique names were generated
+    TreeSet<String> allNames = new TreeSet<>();
+    for (var future : futures) {
+      String[] names = future.get();
+      for (String name : names) {
+        assertTrue(allNames.add(name));
+      }
+    }
+
+    // everything should be consumed from the iterator
+    assertFalse(iter.hasNext());
+
+    // verify order of names
+    long expected = 0;
+    for (String name : allNames) {
+      assertEquals(expected++, Long.parseLong(name, 36));
+    }
+  }
+}

--- a/server/base/src/test/java/org/apache/accumulo/server/tablets/UniqueNameAllocatorTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/tablets/UniqueNameAllocatorTest.java
@@ -18,7 +18,10 @@
  */
 package org.apache.accumulo.server.tablets;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/PrepBulkImport.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/PrepBulkImport.java
@@ -291,10 +291,12 @@ public class PrepBulkImport extends ManagerRepo {
 
     Map<String,String> oldToNewNameMap = new HashMap<>();
 
+    Iterator<String> names = namer.getNextNames(files.size());
+
     for (FileStatus file : files) {
       // since these are only valid files we know it has an extension
       String newName = FilePrefix.BULK_IMPORT.createFileName(
-          namer.getNextName() + "." + FilenameUtils.getExtension(file.getPath().getName()));
+          names.next() + "." + FilenameUtils.getExtension(file.getPath().getName()));
       oldToNewNameMap.put(file.getPath().getName(), new Path(bulkDir, newName).getName());
     }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/ChooseDir.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/ChooseDir.java
@@ -21,8 +21,8 @@ package org.apache.accumulo.manager.tableOps.create;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.IOException;
-import java.util.SortedMap;
 import java.util.Iterator;
+import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeSet;
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/ChooseDir.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/ChooseDir.java
@@ -22,6 +22,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.IOException;
 import java.util.SortedMap;
+import java.util.Iterator;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
@@ -99,8 +100,9 @@ class ChooseDir extends ManagerRepo {
     String tabletDir;
     UniqueNameAllocator namer = manager.getContext().getUniqueNameAllocator();
     SortedSet<Text> splitDirs = new TreeSet<>();
+    Iterator<String> names = namer.getNextNames(num);
     for (int i = 0; i < num; i++) {
-      tabletDir = Constants.GENERATED_TABLET_DIRECTORY_PREFIX + namer.getNextName();
+      tabletDir = Constants.GENERATED_TABLET_DIRECTORY_PREFIX + names.next();
       splitDirs.add(new Text(tabletDir));
     }
     return splitDirs;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/CreateImportDir.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/CreateImportDir.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.manager.tableOps.tableImport;
 
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.Set;
 
 import org.apache.accumulo.core.Constants;
@@ -63,6 +64,7 @@ class CreateImportDir extends ManagerRepo {
    */
   void create(Set<String> tableDirs, Manager manager) throws IOException {
     UniqueNameAllocator namer = manager.getContext().getUniqueNameAllocator();
+    Iterator<String> names = namer.getNextNames(tableInfo.directories.size());
 
     for (ImportedTableInfo.DirectoryMapping dm : tableInfo.directories) {
       Path exportDir = new Path(dm.exportDir);
@@ -76,7 +78,7 @@ class CreateImportDir extends ManagerRepo {
       log.info("Chose base table directory of {}", base);
       Path directory = new Path(base, tableInfo.tableId.canonical());
 
-      Path newBulkDir = new Path(directory, Constants.BULK_PREFIX + namer.getNextName());
+      Path newBulkDir = new Path(directory, Constants.BULK_PREFIX + names.next());
 
       dm.importDir = newBulkDir.toString();
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/MapImportFileNames.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/MapImportFileNames.java
@@ -71,6 +71,7 @@ class MapImportFileNames extends ManagerRepo {
 
         mappingsWriter = new BufferedWriter(new OutputStreamWriter(fs.create(path), UTF_8));
 
+        var names = namer.getNextNames(files.length);
         for (FileStatus fileStatus : files) {
           String fileName = fileStatus.getPath().getName();
           log.info("filename " + fileStatus.getPath());
@@ -88,8 +89,7 @@ class MapImportFileNames extends ManagerRepo {
             continue;
           }
 
-          String newName =
-              FilePrefix.BULK_IMPORT.createFileName(namer.getNextName() + "." + extension);
+          String newName = FilePrefix.BULK_IMPORT.createFileName(names.next() + "." + extension);
 
           mappingsWriter.append(fileName);
           mappingsWriter.append(':');

--- a/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/tableImport/ImportTableTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/tableImport/ImportTableTest.java
@@ -99,7 +99,8 @@ public class ImportTableTest {
         EasyMock.eq(tableDirSet))).andReturn(new Path(tableDirs[1]));
     EasyMock.expect(volumeManager.matchingFileSystem(EasyMock.eq(new Path(expDirs[2])),
         EasyMock.eq(tableDirSet))).andReturn(new Path(tableDirs[2]));
-    EasyMock.expect(uniqueNameAllocator.getNextName()).andReturn(dirName).times(3);
+    EasyMock.expect(uniqueNameAllocator.getNextNames(EasyMock.anyInt()))
+        .andReturn(List.of("abcd", "abcd", "abcd").iterator()).times(1);
 
     ImportedTableInfo ti = new ImportedTableInfo();
     ti.tableId = TableId.of("5b");

--- a/test/src/main/java/org/apache/accumulo/test/UniqueNameAllocatorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/UniqueNameAllocatorIT.java
@@ -106,7 +106,6 @@ class UniqueNameAllocatorIT extends SharedMiniClusterBase {
 
     assertThrows(IllegalArgumentException.class, () -> allocators[0].getNextNames(-1));
     assertThrows(IllegalArgumentException.class, () -> allocators[0].getNextNames(0));
-    allocators[0].getNextNames(0);
 
     assertTrue(namesSeen.size() >= 1_000_000);
     assertTrue(namesSeen.stream().allMatch(name -> name.matches("[0-9a-z]{7}")));

--- a/test/src/main/java/org/apache/accumulo/test/UniqueNameAllocatorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/UniqueNameAllocatorIT.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.apache.accumulo.harness.SharedMiniClusterBase;
+import org.apache.accumulo.server.tablets.UniqueNameAllocator;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+class UniqueNameAllocatorIT extends SharedMiniClusterBase {
+  @BeforeAll
+  public static void setup() throws Exception {
+    SharedMiniClusterBase.startMiniCluster();
+  }
+
+  @AfterAll
+  public static void teardown() {
+    SharedMiniClusterBase.stopMiniCluster();
+  }
+
+  @SuppressFBWarnings(value = {"PREDICTABLE_RANDOM", "DMI_RANDOM_USED_ONLY_ONCE"},
+      justification = "predictable random is ok for testing")
+  @Test
+  void testConcurrentNameGeneration() throws Exception {
+    var srvCtx = getCluster().getServerContext();
+
+    // create multiple namers, each will be interact with zookeeper independently and should see
+    // updates from others.
+    var allocators = new UniqueNameAllocator[10];
+    for (int i = 0; i < 10; i++) {
+      allocators[i] = new UniqueNameAllocator(srvCtx);
+    }
+    Random random = new Random();
+    Set<String> namesSeen = ConcurrentHashMap.newKeySet();
+
+    var executorService = Executors.newCachedThreadPool();
+    List<Future<Integer>> futures = new ArrayList<>();
+
+    // create threads that are allocating large random chunks
+    for (int i = 0; i < 64; i++) {
+      var future = executorService.submit(() -> {
+        int added = 0;
+        while (namesSeen.size() < 1_000_000) {
+          var allocator = allocators[random.nextInt(allocators.length)];
+          int needed = Math.max(1, random.nextInt(999));
+          allocate(allocator, needed, namesSeen);
+          added += needed;
+        }
+        return added;
+      });
+      futures.add(future);
+    }
+
+    // create threads that are always allocating a small amount
+    for (int i = 1; i <= 10; i++) {
+      int needed = i;
+      var future = executorService.submit(() -> {
+        int added = 0;
+        while (namesSeen.size() < 1_000_000) {
+          var allocator = allocators[random.nextInt(allocators.length)];
+          allocate(allocator, needed, namesSeen);
+          added += needed;
+        }
+        return added;
+      });
+      futures.add(future);
+    }
+
+    for (var future : futures) {
+      // expect all threads to add some names
+      assertTrue(future.get() > 0);
+    }
+
+    assertTrue(namesSeen.size() >= 1_000_000);
+    assertTrue(namesSeen.stream().allMatch(name -> name.matches("[0-9a-z]{7}")));
+  }
+
+  private static void allocate(UniqueNameAllocator allocator, int needed, Set<String> namesSeen) {
+    Iterator<String> names = allocator.getNextNames(needed);
+    for (int n = 0; n < needed; n++) {
+      assertTrue(names.hasNext());
+      String nextName = names.next();
+      // set should never contain a name already
+      assertTrue(namesSeen.add(nextName));
+    }
+    assertFalse(names.hasNext());
+    // the iterator should be exhausted
+    assertThrows(NoSuchElementException.class, names::next);
+  }
+}

--- a/test/src/main/java/org/apache/accumulo/test/UniqueNameAllocatorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/UniqueNameAllocatorIT.java
@@ -104,6 +104,10 @@ class UniqueNameAllocatorIT extends SharedMiniClusterBase {
       assertTrue(future.get() > 0);
     }
 
+    assertThrows(IllegalArgumentException.class, () -> allocators[0].getNextNames(-1));
+    assertThrows(IllegalArgumentException.class, () -> allocators[0].getNextNames(0));
+    allocators[0].getNextNames(0);
+
     assertTrue(namesSeen.size() >= 1_000_000);
     assertTrue(namesSeen.stream().allMatch(name -> name.matches("[0-9a-z]{7}")));
   }


### PR DESCRIPTION
Bulk import and other operations would repeatedly request new unique file names one at a time, possibly making multiple trips to zookeeper. For the case of bulk import and some other places in the code, the number of unique names needed is known ahead of time.  Changed name allocation to support requesting a batch of names.  For bulk import this means that bulk import would go to zookeeper at most once.