### PR TITLE
Configure WebViewsIT to use a random free port.

### DIFF
--- a/server/monitor/src/test/java/org/apache/accumulo/monitor/it/WebViewsIT.java
+++ b/server/monitor/src/test/java/org/apache/accumulo/monitor/it/WebViewsIT.java
@@ -84,6 +84,8 @@ public class WebViewsIT extends JerseyTest {
 
   @BeforeAll
   public static void createMocks() throws TableNotFoundException {
+    System.setProperty(TestProperties.CONTAINER_PORT, "0");
+
     ServerContext contextMock = createMock(ServerContext.class);
     expect(contextMock.getConfiguration()).andReturn(DefaultConfiguration.getInstance()).anyTimes();
     expect(contextMock.getInstanceID()).andReturn(InstanceId.of("foo")).atLeastOnce();


### PR DESCRIPTION
If not configure, the WebViewsIT parent class will always use port 9998. This could conflict with other running tests. Setting the property to zero enables the port selected to be a random free port.