### PR TITLE
WIP makes balancing a noop when balancer setup fails.

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/DerelictBalancer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/DerelictBalancer.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.spi.balancer;
+
+import org.apache.accumulo.core.data.TableId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A balancer that will do nothing and warn about doing nothing. This purpose of this balancer is as
+ * a fallback when attempts to create a balancer fail.
+ *
+ * @since 2.1.4
+ */
+public class DerelictBalancer implements TabletBalancer {
+
+  private static final Logger log = LoggerFactory.getLogger(DerelictBalancer.class);
+
+  private final TableId tableId;
+
+  public DerelictBalancer() {
+    this.tableId = null;
+  }
+
+  public DerelictBalancer(TableId tableId) {
+    this.tableId = tableId;
+  }
+
+  @Override
+  public void init(BalancerEnvironment balancerEnvironment) {}
+
+  @Override
+  public void getAssignments(AssignmentParameters params) {
+    if (tableId != null) {
+      log.warn("Ignoring {} assignment request for tableId {}", params.unassignedTablets().size(),
+          tableId);
+    } else {
+      log.warn("Ignoring {} assignment request ", params.unassignedTablets().size());
+    }
+  }
+
+  @Override
+  public long balance(BalanceParameters params) {
+    if (tableId != null) {
+      log.warn("Ignoring request to balance tablets for tableId:{}", tableId);
+    } else {
+      log.warn("Ignoring request to balance tablets");
+    }
+    return 30_000;
+  }
+}

--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/TableLoadBalancer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/TableLoadBalancer.java
@@ -98,8 +98,8 @@ public class TableLoadBalancer implements TabletBalancer {
 
       if (balancer == null) {
         log.info("Creating balancer {} limited to balancing table {}",
-            SimpleLoadBalancer.class.getName(), tableId);
-        balancer = new SimpleLoadBalancer(tableId);
+            DerelictBalancer.class.getName(), tableId);
+        balancer = new DerelictBalancer(tableId);
       }
       perTableBalancers.put(tableId, balancer);
       balancer.init(environment);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -98,7 +98,7 @@ import org.apache.accumulo.core.metrics.MetricsProducer;
 import org.apache.accumulo.core.process.thrift.ServerProcessService;
 import org.apache.accumulo.core.replication.thrift.ReplicationCoordinator;
 import org.apache.accumulo.core.spi.balancer.BalancerEnvironment;
-import org.apache.accumulo.core.spi.balancer.TableLoadBalancer;
+import org.apache.accumulo.core.spi.balancer.DerelictBalancer;
 import org.apache.accumulo.core.spi.balancer.TabletBalancer;
 import org.apache.accumulo.core.spi.balancer.data.TServerStatus;
 import org.apache.accumulo.core.spi.balancer.data.TabletMigration;
@@ -1919,7 +1919,7 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener, 
 
   void initializeBalancer() {
     var localTabletBalancer = Property.createInstanceFromPropertyName(getConfiguration(),
-        Property.MANAGER_TABLET_BALANCER, TabletBalancer.class, new TableLoadBalancer());
+        Property.MANAGER_TABLET_BALANCER, TabletBalancer.class, new DerelictBalancer());
     localTabletBalancer.init(balancerEnvironment);
     tabletBalancer = localTabletBalancer;
   }


### PR DESCRIPTION
In the case where setting up a balancer fails the manager currently falls back to using the SimpleLoadBalancer.  This fallback behavior could be very unhelpful and turn one problem (bad balancer config) into multiple problems as the simple load balancer may start assigning tablets in a way that is detrimental.

The reason this is a draft is to get feedback on the approach. New test are needed, but those will be a lot more work than this simple change. Did not want to write test if we settle on a different approach. Need to test the following for system balancer and per table balancers.

 * Configuring a balancer class name that does not exists
 * Configuring a balancer class that is not of the correct type
 * Configuring a balancer class that throws an exception in it constructor
 * Configuring a balancer class that throws an exception when init is called