### PR TITLE
Fix race condition in Manager.partitionMigrations

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/upgrade/ScanServerUpgrade11to12TestIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/upgrade/ScanServerUpgrade11to12TestIT.java
@@ -56,6 +56,7 @@ import org.apache.accumulo.manager.upgrade.Upgrader11to12;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.hadoop.fs.RawLocalFileSystem;
 import org.apache.hadoop.io.Text;
 import org.apache.zookeeper.KeeperException;
 import org.junit.jupiter.api.AfterAll;
@@ -79,6 +80,7 @@ public class ScanServerUpgrade11to12TestIT extends SharedMiniClusterBase {
     @Override
     public void configureMiniCluster(MiniAccumuloConfigImpl cfg,
         org.apache.hadoop.conf.Configuration coreSite) {
+      coreSite.set("fs.file.impl", RawLocalFileSystem.class.getName());
       cfg.getClusterServerConfiguration().setNumDefaultScanServers(0);
     }
   }


### PR DESCRIPTION
in the Manager to new columns in the root and metadata tables. The Manager.partitionMigrations method was changed to scan the root and metadata tables migration column to gather the current migrations. However, if the root and metadata tables are not hosted, then this scan will hang until the tablet locations can be resolved.

ScanServerUpgrade11to12TestIT.testScanRefTableCreation has been failing since #5416 was merged. The test deletes the scanref table, shuts down the TabletServers and Manager, then restarts them. This leaves the root tablet in a state where it needs to perform recovery. The Manager.partitionMigrations method is called via the StatusThread, and it appears that the Manager starts up and the StatusThread gets hung trying to scan the root tablet (it's waiting for a location). Meanwhile, the root tablet can't be assigned a location because the Manager.tserverStatus map is not populated, which is done from the StatusThread as well.

Also modified the IT to set the filesystem to the RawLocalFileSystem so that warnings about missing checksum files were not in the logs.