### PR TITLE
Log more information about why compaction can not be planned

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionPlanner.java
@@ -96,7 +96,7 @@ public interface CompactionPlanner {
     TableId getTableId();
 
     /**
-     * @teturn the tablet for which a compaction is being planned
+     * @return the tablet for which a compaction is being planned
      * @since 2.1.4
      */
     TabletId getTabletId();

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionPlanner.java
@@ -26,6 +26,7 @@ import org.apache.accumulo.core.client.admin.CompactionConfig;
 import org.apache.accumulo.core.client.admin.compaction.CompactableFile;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.data.TabletId;
 import org.apache.accumulo.core.spi.common.ServiceEnvironment;
 
 /**
@@ -93,6 +94,12 @@ public interface CompactionPlanner {
      * @see ServiceEnvironment#getTableName(TableId)
      */
     TableId getTableId();
+
+    /**
+     * @teturn the tablet for which a compaction is being planned
+     * @since 2.1.4
+     */
+    TabletId getTabletId();
 
     ServiceEnvironment getServiceEnvironment();
 

--- a/core/src/test/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlannerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlannerTest.java
@@ -45,6 +45,9 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.data.TabletId;
+import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.core.dataImpl.TabletIdImpl;
 import org.apache.accumulo.core.spi.common.ServiceEnvironment;
 import org.apache.accumulo.core.spi.common.ServiceEnvironment.Configuration;
 import org.apache.accumulo.core.spi.compaction.CompactionPlan.Builder;
@@ -752,6 +755,11 @@ public class DefaultCompactionPlannerTest {
       @Override
       public TableId getTableId() {
         return TableId.of("42");
+      }
+
+      @Override
+      public TabletId getTabletId() {
+        return new TabletIdImpl(new KeyExtent(getTableId(), null, null));
       }
 
       @Override

--- a/core/src/test/java/org/apache/accumulo/core/util/NumUtilTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/NumUtilTest.java
@@ -27,7 +27,6 @@ import java.util.Locale;
 import org.junit.jupiter.api.Test;
 
 public class NumUtilTest {
-
   @Test
   public void testBigNumberForSize() {
     Locale.setDefault(Locale.US);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionService.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionService.java
@@ -47,7 +47,9 @@ import org.apache.accumulo.core.conf.ConfigurationTypeHelper;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.data.TabletId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.core.dataImpl.TabletIdImpl;
 import org.apache.accumulo.core.spi.common.ServiceEnvironment;
 import org.apache.accumulo.core.spi.compaction.CompactionExecutorId;
 import org.apache.accumulo.core.spi.compaction.CompactionJob;
@@ -245,6 +247,11 @@ public class CompactionService {
     @Override
     public TableId getTableId() {
       return comp.getTableId();
+    }
+
+    @Override
+    public TabletId getTabletId() {
+      return new TabletIdImpl(comp.getExtent());
     }
 
     @Override


### PR DESCRIPTION
For the case when a tablet has more than tablet.file.max files and a compaction can not be planned, log more information about what went into the planning process.