### PR TITLE
Parallelize CreateTableIT.testCreateLotsOfTables() to speed it up

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/CreateTableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/CreateTableIT.java
@@ -21,15 +21,25 @@ package org.apache.accumulo.test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.TableExistsException;
+import org.apache.accumulo.core.util.Timer;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CreateTableIT extends SharedMiniClusterBase {
+  private static final Logger log = LoggerFactory.getLogger(CreateTableIT.class);
+  public static final int NUM_TABLES = 500;
 
   @Override
   protected Duration defaultTimeout() {
@@ -47,20 +57,22 @@ public class CreateTableIT extends SharedMiniClusterBase {
   }
 
   @Test
-  public void testCreateLotsOfTables() throws Exception {
+  public void testCreateLotsOfTables() {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
+      String[] tableNames = getUniqueNames(NUM_TABLES);
 
-      String[] tableNames = getUniqueNames(500);
+      Arrays.stream(tableNames).parallel().forEach(name -> {
+        Timer timer = Timer.startNew();
+        try {
+          client.tableOperations().create(name);
+        } catch (AccumuloException | AccumuloSecurityException | TableExistsException e) {
+          throw new RuntimeException(e);
+        }
+        log.info("Table {} creation took: {} ms", name, timer.elapsed(TimeUnit.MILLISECONDS));
+      });
 
-      for (int i = 0; i < tableNames.length; i++) {
-        // Create waits for the Fate operation to complete
-        long start = System.currentTimeMillis();
-        client.tableOperations().create(tableNames[i]);
-        System.out.println("Table creation took: " + (System.currentTimeMillis() - start) + "ms");
-      }
-      // Confirm all 500 user tables exist in addition to Root, Metadata,
-      // and ScanRef tables
-      assertEquals(503, client.tableOperations().list().size());
+      final int systemTables = 3;
+      assertEquals(NUM_TABLES + systemTables, client.tableOperations().list().size());
     }
   }
 


### PR DESCRIPTION
This test times out pretty consistently when resource constrained. The following improvement was made to speed the test up:
* use `Arrays.stream(tableNames).parallel().forEach()` instead of for loop to parallelize the test

Other improvements that don't necessarily improve runtime:
* use `Timer` objects instead of System.millis for timekeeping
* use `Logger` instead of System.out

I assume this test was not created explicitly to run serially. When run locally this speeds runtime up from ~1 min to ~15 seconds.