### PR TITLE
Avoids creating a batch writer per completed ext compaction

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -1932,7 +1932,8 @@ public enum Property {
       COMPACTOR_MINTHREADS_TIMEOUT,
 
       // others
-      TSERV_NATIVEMAP_ENABLED, TSERV_SCAN_MAX_OPENFILES, MANAGER_RECOVERY_WAL_EXISTENCE_CACHE_TIME);
+      TSERV_NATIVEMAP_ENABLED, TSERV_SCAN_MAX_OPENFILES, MANAGER_RECOVERY_WAL_EXISTENCE_CACHE_TIME,
+      COMPACTION_COORDINATOR_FINALIZER_QUEUE_SIZE);
 
   /**
    * Checks if the given property may be changed via Zookeeper, but not recognized until the restart

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -1584,6 +1584,10 @@ public enum Property {
       "The interval at which to check for external compaction final state markers in the metadata table.",
       "2.1.0"),
   @Experimental
+  COMPACTION_COORDINATOR_FINALIZER_QUEUE_SIZE(
+      "compaction.coordinator.compaction.finalizer.queue.size", "16384", PropertyType.COUNT,
+      "The number of completed compactions to buffer in memory before blocking.", "2.1.4"),
+  @Experimental
   COMPACTION_COORDINATOR_TSERVER_COMPACTION_CHECK_INTERVAL(
       "compaction.coordinator.tserver.check.interval", "1m", PropertyType.TIMEDURATION,
       "The interval at which to check the tservers for external compactions.", "2.1.0"),

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
@@ -224,11 +224,6 @@ public interface Ample {
     throw new UnsupportedOperationException();
   }
 
-  default void
-      putExternalCompactionFinalStates(Collection<ExternalCompactionFinalState> finalStates) {
-    throw new UnsupportedOperationException();
-  }
-
   default Stream<ExternalCompactionFinalState> getExternalCompactionFinalStates() {
     throw new UnsupportedOperationException();
   }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/ExternalCompactionFinalState.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/ExternalCompactionFinalState.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.core.metadata.schema;
 
 import java.util.Base64;
 
+import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.util.TextUtil;
@@ -135,5 +136,12 @@ public class ExternalCompactionFinalState {
   @Override
   public String toString() {
     return toJson();
+  }
+
+  public Mutation toMutation() {
+    String prefix = MetadataSchema.ExternalCompactionSection.getRowPrefix();
+    Mutation m = new Mutation(prefix + getExternalCompactionId().canonical());
+    m.put("", "", toJson());
+    return m;
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/Threads.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/Threads.java
@@ -22,8 +22,13 @@ import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.OptionalInt;
 
 import org.apache.accumulo.core.trace.TraceUtil;
+import org.apache.accumulo.core.util.Halt;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Threads {
+
+  private static final Logger log = LoggerFactory.getLogger(Threads.class);
 
   public static final UncaughtExceptionHandler UEH = new AccumuloUncaughtExceptionHandler();
 
@@ -66,4 +71,17 @@ public class Threads {
     return thread;
   }
 
+  public static Thread createCriticalThread(String name, Runnable r) {
+    Runnable wrapped = () -> {
+      try {
+        r.run();
+      } catch (RuntimeException e) {
+        String msg = "Critical thread " + name + " died";
+        log.error(msg, e);
+        Halt.halt(msg);
+      }
+    };
+
+    return createThread(name, wrapped);
+  }
 }

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/Threads.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/Threads.java
@@ -22,7 +22,6 @@ import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.OptionalInt;
 
 import org.apache.accumulo.core.trace.TraceUtil;
-import org.apache.accumulo.core.util.Halt;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,9 +75,9 @@ public class Threads {
       try {
         r.run();
       } catch (RuntimeException e) {
-        String msg = "Critical thread " + name + " died";
-        log.error(msg, e);
-        Halt.halt(msg);
+        System.err.println("Critical thread " + name + " died");
+        e.printStackTrace();
+        Runtime.getRuntime().halt(-1);
       }
     };
 

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
@@ -298,11 +298,8 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
   public void
       putExternalCompactionFinalStates(Collection<ExternalCompactionFinalState> finalStates) {
     try (BatchWriter writer = context.createBatchWriter(DataLevel.USER.metaTable())) {
-      String prefix = ExternalCompactionSection.getRowPrefix();
       for (ExternalCompactionFinalState finalState : finalStates) {
-        Mutation m = new Mutation(prefix + finalState.getExternalCompactionId().canonical());
-        m.put("", "", finalState.toJson());
-        writer.addMutation(m);
+        writer.addMutation(finalState.toMutation());
       }
     } catch (MutationsRejectedException | TableNotFoundException e) {
       throw new RuntimeException(e);

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
@@ -295,18 +295,6 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
   }
 
   @Override
-  public void
-      putExternalCompactionFinalStates(Collection<ExternalCompactionFinalState> finalStates) {
-    try (BatchWriter writer = context.createBatchWriter(DataLevel.USER.metaTable())) {
-      for (ExternalCompactionFinalState finalState : finalStates) {
-        writer.addMutation(finalState.toMutation());
-      }
-    } catch (MutationsRejectedException | TableNotFoundException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  @Override
   public Stream<ExternalCompactionFinalState> getExternalCompactionFinalStates() {
     Scanner scanner;
     try {

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/SharedBatchWriter.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/SharedBatchWriter.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.coordinator;
+
+import java.util.ArrayList;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.accumulo.core.client.BatchWriterConfig;
+import org.apache.accumulo.core.client.MutationsRejectedException;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.util.Timer;
+import org.apache.accumulo.core.util.threads.Threads;
+import org.apache.accumulo.server.ServerContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SharedBatchWriter {
+  private static final Logger log = LoggerFactory.getLogger(SharedBatchWriter.class);
+
+  private static class Work {
+    private final Mutation mutation;
+    private final CompletableFuture<Void> future;
+
+    private Work(Mutation mutation) {
+      this.mutation = mutation;
+      this.future = new CompletableFuture<>();
+    }
+  }
+
+  private final BlockingQueue<Work> mutations;
+  private final String table;
+  private final ServerContext context;
+
+  public SharedBatchWriter(String table, ServerContext context, int queueSize) {
+    this.table = table;
+    this.context = context;
+    this.mutations = new ArrayBlockingQueue<>(queueSize);
+    var thread =
+        Threads.createCriticalThread("shared batch writer for " + table, this::processMutations);
+    thread.start();
+  }
+
+  public void write(Mutation m) {
+    try {
+      var work = new Work(m);
+      mutations.put(work);
+      work.future.join();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private void processMutations() {
+    Timer timer = Timer.startNew();
+    while (true) {
+      ArrayList<Work> batch = new ArrayList<>();
+      try {
+        batch.add(mutations.take());
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IllegalStateException(e);
+      }
+
+      var config = new BatchWriterConfig().setMaxWriteThreads(16);
+      try (var writer = context.createBatchWriter(table, config)) {
+        mutations.drainTo(batch);
+        timer.restart();
+        for (var work : batch) {
+          writer.addMutation(work.mutation);
+        }
+        writer.flush();
+        log.trace("Wrote {} mutations in {}ms", batch.size(), timer.elapsed(TimeUnit.MILLISECONDS));
+        batch.forEach(work -> work.future.complete(null));
+      } catch (TableNotFoundException | MutationsRejectedException e) {
+        batch.forEach(work -> work.future.completeExceptionally(e));
+      }
+    }
+  }
+}


### PR DESCRIPTION
The compaction coordinator was creating a batch writer per a completed external compaction.  The batch writer was used to write a single small mutation.  This caused a lot of thread creation and RPCs in the coordinator.  Changed the coordinator to use a single batch writer for these mutations.  Also update some logging in the coordinator to lower levels to trace and add some timing information.