### PR TITLE
Trivial - improve table property setting in tests

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/functional/ConcurrencyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ConcurrencyIT.java
@@ -28,6 +28,7 @@ import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
@@ -98,12 +99,12 @@ public class ConcurrencyIT extends AccumuloClusterHarness {
   }
 
   static void runTest(AccumuloClient c, String tableName) throws Exception {
-    c.tableOperations().create(tableName);
+    NewTableConfiguration ntc = new NewTableConfiguration();
+    ntc.setProperties(Map.of(Property.TABLE_MAJC_RATIO.getKey(), "1.0"));
     IteratorSetting is = new IteratorSetting(10, SlowIterator.class);
     SlowIterator.setSleepTime(is, 50);
-    c.tableOperations().attachIterator(tableName, is,
-        EnumSet.of(IteratorScope.minc, IteratorScope.majc));
-    c.tableOperations().setProperty(tableName, Property.TABLE_MAJC_RATIO.getKey(), "1.0");
+    ntc.attachIterator(is, EnumSet.of(IteratorScope.minc, IteratorScope.majc));
+    c.tableOperations().create(tableName, ntc);
 
     BatchWriter bw = c.createBatchWriter(tableName);
     for (int i = 0; i < 50; i++) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/MergeTabletsBaseIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MergeTabletsBaseIT.java
@@ -308,8 +308,6 @@ public abstract class MergeTabletsBaseIT extends SharedMiniClusterBase {
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
       String tableName = getUniqueNames(1)[0];
       createTableAndDisableCompactions(c, tableName, new NewTableConfiguration());
-      // disable compactions
-      c.tableOperations().setProperty(tableName, Property.TABLE_MAJC_RATIO.getKey(), "9999");
       final TableId tableId = TableId.of(c.tableOperations().tableIdMap().get(tableName));
 
       // First write 1000 rows to a file in the default tablet


### PR DESCRIPTION
* Use NewTableConfiguration in two test cases instead of setProperty() calls after the table was already created
* removed  a duplicate call to set TABLE_MAJC_RATIO in MergeTabletsBaseIT.noChopMergeDeleteAcrossTablets()