### PR TITLE
WIP add config for max total thrift messages sizes

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -55,8 +55,16 @@ public enum Property {
           + " RPC. See also `instance.ssl.enabled`.",
       "1.6.0"),
   RPC_MAX_MESSAGE_SIZE("rpc.message.size.max", Integer.toString(Integer.MAX_VALUE),
-      PropertyType.BYTES, "The maximum size of a message that can be received by a server.",
+      PropertyType.BYTES,
+      "The maximum size of an individual message that can be received by a server. Messages over this size will be rejected.",
       "2.1.3"),
+  RPC_MAX_TOTAL_READ_SIZE("rpc.messages.total.size.max", Integer.toString(Integer.MAX_VALUE),
+      PropertyType.BYTES,
+      "The maximum size of the sum of all message sizes that a server will hold in memory at once. If a new message comes in "
+          + "and its frame size plus the sum of all frames in memory would exceed this max then reading of that frame is deferred "
+          + "until enough memory is free.  Once over this limit messages are not rejected, they are not read off the network. TODO "
+          + "document which server type support this.",
+      "2.1.4"),
   RPC_BACKLOG("rpc.backlog", "50", PropertyType.COUNT,
       "Configures the TCP backlog for the server side sockets created by Thrift."
           + " This property is not used for SSL type server sockets. A value of zero"

--- a/server/base/src/test/java/org/apache/accumulo/server/rpc/TServerUtilsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/rpc/TServerUtilsTest.java
@@ -306,7 +306,7 @@ public class TServerUtilsTest {
     return TServerUtils.startServer(context, hostname, Property.TSERV_CLIENTPORT, processor,
         "TServerUtilsTest", "TServerUtilsTestThread", Property.TSERV_PORTSEARCH,
         Property.TSERV_MINTHREADS, Property.TSERV_MINTHREADS_TIMEOUT, Property.TSERV_THREADCHECK,
-        Property.RPC_MAX_MESSAGE_SIZE);
+        Property.RPC_MAX_MESSAGE_SIZE, Property.RPC_MAX_TOTAL_READ_SIZE);
 
   }
 }

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
@@ -255,7 +255,8 @@ public class CompactionCoordinator extends AbstractServer implements
         "Thrift Client Server", Property.COMPACTION_COORDINATOR_THRIFTCLIENT_PORTSEARCH,
         Property.COMPACTION_COORDINATOR_MINTHREADS,
         Property.COMPACTION_COORDINATOR_MINTHREADS_TIMEOUT,
-        Property.COMPACTION_COORDINATOR_THREADCHECK, maxMessageSizeProperty);
+        Property.COMPACTION_COORDINATOR_THREADCHECK, maxMessageSizeProperty,
+        Property.RPC_MAX_TOTAL_READ_SIZE);
     LOG.info("address = {}", sp.address);
     return sp;
   }

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -327,7 +327,7 @@ public class Compactor extends AbstractServer
         Property.COMPACTOR_CLIENTPORT, processor, this.getClass().getSimpleName(),
         "Thrift Client Server", Property.COMPACTOR_PORTSEARCH, Property.COMPACTOR_MINTHREADS,
         Property.COMPACTOR_MINTHREADS_TIMEOUT, Property.COMPACTOR_THREADCHECK,
-        maxMessageSizeProperty);
+        maxMessageSizeProperty, Property.RPC_MAX_TOTAL_READ_SIZE);
     LOG.info("address = {}", sp.address);
     return sp;
   }

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -428,10 +428,11 @@ public class SimpleGarbageCollector extends AbstractServer
     var maxMessageSizeProperty = getConfiguration().resolve(Property.RPC_MAX_MESSAGE_SIZE,
         Property.GENERAL_MAX_MESSAGE_SIZE);
     long maxMessageSize = getConfiguration().getAsBytes(maxMessageSizeProperty);
+    // TODO duplicated maxMessageSize
     ServerAddress server = TServerUtils.startTServer(getConfiguration(),
         getContext().getThriftServerType(), processor, this.getClass().getSimpleName(),
         "GC Monitor Service", 2, ThreadPools.DEFAULT_TIMEOUT_MILLISECS, 1000, maxMessageSize,
-        getContext().getServerSslParams(), getContext().getSaslParams(), 0,
+        maxMessageSize, getContext().getServerSslParams(), getContext().getSaslParams(), 0,
         getConfiguration().getCount(Property.RPC_BACKLOG), getContext().getMetricsInfo(), false,
         addresses);
     log.debug("Starting garbage collector listening on " + server.address);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -1238,8 +1238,8 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener, 
           Property.GENERAL_MAX_MESSAGE_SIZE);
       sa = TServerUtils.startServer(context, getHostname(), Property.MANAGER_CLIENTPORT, processor,
           "Manager", "Manager Client Service Handler", null, Property.MANAGER_MINTHREADS,
-          Property.MANAGER_MINTHREADS_TIMEOUT, Property.MANAGER_THREADCHECK,
-          maxMessageSizeProperty);
+          Property.MANAGER_MINTHREADS_TIMEOUT, Property.MANAGER_THREADCHECK, maxMessageSizeProperty,
+          Property.RPC_MAX_TOTAL_READ_SIZE);
     } catch (UnknownHostException e) {
       throw new IllegalStateException("Unable to start server on host " + getHostname(), e);
     }
@@ -1613,7 +1613,8 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener, 
     ServerAddress replAddress = TServerUtils.startServer(context, getHostname(),
         Property.MANAGER_REPLICATION_COORDINATOR_PORT, processor, "Manager Replication Coordinator",
         "Replication Coordinator", null, Property.MANAGER_REPLICATION_COORDINATOR_MINTHREADS, null,
-        Property.MANAGER_REPLICATION_COORDINATOR_THREADCHECK, maxMessageSizeProperty);
+        Property.MANAGER_REPLICATION_COORDINATOR_THREADCHECK, maxMessageSizeProperty,
+        Property.RPC_MAX_TOTAL_READ_SIZE);
 
     log.info("Started replication coordinator service at " + replAddress.address);
     // Start the daemon to scan the replication table and make units of work

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -311,10 +311,11 @@ public class ScanServer extends AbstractServer
     @SuppressWarnings("deprecation")
     var maxMessageSizeProperty = getConfiguration().resolve(Property.RPC_MAX_MESSAGE_SIZE,
         Property.GENERAL_MAX_MESSAGE_SIZE);
-    ServerAddress sp = TServerUtils.startServer(getContext(), getHostname(),
-        Property.SSERV_CLIENTPORT, processor, this.getClass().getSimpleName(),
-        "Thrift Client Server", Property.SSERV_PORTSEARCH, Property.SSERV_MINTHREADS,
-        Property.SSERV_MINTHREADS_TIMEOUT, Property.SSERV_THREADCHECK, maxMessageSizeProperty);
+    ServerAddress sp =
+        TServerUtils.startServer(getContext(), getHostname(), Property.SSERV_CLIENTPORT, processor,
+            this.getClass().getSimpleName(), "Thrift Client Server", Property.SSERV_PORTSEARCH,
+            Property.SSERV_MINTHREADS, Property.SSERV_MINTHREADS_TIMEOUT,
+            Property.SSERV_THREADCHECK, maxMessageSizeProperty, Property.RPC_MAX_TOTAL_READ_SIZE);
 
     LOG.info("address = {}", sp.address);
     return sp;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -558,7 +558,7 @@ public class TabletServer extends AbstractServer
     ServerAddress sp = TServerUtils.startServer(getContext(), address, Property.TSERV_CLIENTPORT,
         processor, this.getClass().getSimpleName(), "Thrift Client Server",
         Property.TSERV_PORTSEARCH, Property.TSERV_MINTHREADS, Property.TSERV_MINTHREADS_TIMEOUT,
-        Property.TSERV_THREADCHECK, maxMessageSizeProperty);
+        Property.TSERV_THREADCHECK, maxMessageSizeProperty, Property.RPC_MAX_TOTAL_READ_SIZE);
     this.server = sp.server;
     return sp.address;
   }
@@ -634,7 +634,7 @@ public class TabletServer extends AbstractServer
     ServerAddress sp = TServerUtils.startServer(getContext(), clientAddress.getHost(),
         Property.REPLICATION_RECEIPT_SERVICE_PORT, processor, "ReplicationServicerHandler",
         "Replication Servicer", Property.TSERV_PORTSEARCH, Property.REPLICATION_MIN_THREADS, null,
-        Property.REPLICATION_THREADCHECK, maxMessageSizeProperty);
+        Property.REPLICATION_THREADCHECK, maxMessageSizeProperty, Property.RPC_MAX_TOTAL_READ_SIZE);
     this.replServer = sp.server;
     log.info("Started replication service on {}", sp.address);
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/ThriftMaxFrameSize2IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ThriftMaxFrameSize2IT.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test.functional;
+
+import static org.apache.accumulo.harness.AccumuloITBase.MINI_CLUSTER_ONLY;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.apache.accumulo.core.client.Accumulo;
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(MINI_CLUSTER_ONLY)
+public class ThriftMaxFrameSize2IT extends ConfigurableMacBase {
+
+  @Override
+  public void configure(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
+    cfg.setNumTservers(1);
+    cfg.setProperty(Property.RPC_MAX_MESSAGE_SIZE, "256K");
+    cfg.setProperty(Property.RPC_MAX_TOTAL_READ_SIZE, "1M");
+  }
+
+  @Test
+  public void testMaxTotalMaxMessages() throws Exception {
+    String table = getUniqueNames(1)[0];
+    var executor = Executors.newCachedThreadPool();
+    try (var client = Accumulo.newClient().from(getClientProperties()).build()) {
+      client.tableOperations().create(table);
+
+      List<Future<?>> futures = new ArrayList<>();
+
+      for (int i = 0; i < 500; i++) {
+        String row = "bigvalue" + i;
+        var future = executor.submit(() -> {
+          try (var writer = client.createBatchWriter(table)) {
+            Mutation m = new Mutation("bigvalue");
+            m.at().family("data").qualifier("1").put(new byte[128_000]);
+            writer.addMutation(m);
+          }
+
+          return null;
+        });
+        futures.add(future);
+      }
+
+      for (var future : futures) {
+        future.get();
+      }
+      /*
+       * try(var writer = client.createBatchWriter(table)) { Mutation m = new Mutation("bigvalue");
+       * m.at().family("data").qualifier("1").put(new byte[512_000]); // TODO this write will fail
+       * and retry forever because it exceeds the size of individual message, can we detect this and
+       * percolate an exception back up? writer.addMutation(m); }
+       */
+    }
+  }
+
+}

--- a/test/src/main/java/org/apache/accumulo/test/functional/ZombieTServer.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ZombieTServer.java
@@ -124,9 +124,9 @@ public class ZombieTServer {
 
     ServerAddress serverPort = TServerUtils.startTServer(context.getConfiguration(),
         ThriftServerType.CUSTOM_HS_HA, muxProcessor, "ZombieTServer", "walking dead", 2,
-        ThreadPools.DEFAULT_TIMEOUT_MILLISECS, 1000, 10 * 1024 * 1024, null, null, -1,
-        context.getConfiguration().getCount(Property.RPC_BACKLOG), context.getMetricsInfo(), false,
-        HostAndPort.fromParts("0.0.0.0", port));
+        ThreadPools.DEFAULT_TIMEOUT_MILLISECS, 1000, 10 * 1024 * 1024, 10 * 1024 * 1024, null, null,
+        -1, context.getConfiguration().getCount(Property.RPC_BACKLOG), context.getMetricsInfo(),
+        false, HostAndPort.fromParts("0.0.0.0", port));
 
     String addressString = serverPort.address.toString();
     var zLockPath =

--- a/test/src/main/java/org/apache/accumulo/test/performance/NullTserver.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/NullTserver.java
@@ -348,8 +348,9 @@ public class NullTserver {
 
     TServerUtils.startTServer(context.getConfiguration(), ThriftServerType.CUSTOM_HS_HA,
         muxProcessor, "NullTServer", "null tserver", 2, ThreadPools.DEFAULT_TIMEOUT_MILLISECS, 1000,
-        10 * 1024 * 1024, null, null, -1, context.getConfiguration().getCount(Property.RPC_BACKLOG),
-        context.getMetricsInfo(), false, HostAndPort.fromParts("0.0.0.0", opts.port));
+        10 * 1024 * 1024, 10 * 1024 * 1024, null, null, -1,
+        context.getConfiguration().getCount(Property.RPC_BACKLOG), context.getMetricsInfo(), false,
+        HostAndPort.fromParts("0.0.0.0", opts.port));
 
     HostAndPort addr = HostAndPort.fromParts(InetAddress.getLocalHost().getHostName(), opts.port);
 

--- a/test/src/main/resources/log4j2-test.properties
+++ b/test/src/main/resources/log4j2-test.properties
@@ -155,6 +155,9 @@ logger.39.level = trace
 logger.40.name = org.apache.accumulo.manager.tableOps.bulkVer2.LoadFiles
 logger.40.level = trace
 
+logger.41.name = org.apache.accumulo.server.rpc.CustomNonBlockingServer
+logger.41.level = trace
+
 rootLogger.level = debug
 rootLogger.appenderRef.console.ref = STDOUT
 


### PR DESCRIPTION
Thrift supports the following two configurations related to incoming framed messages sizes.

 1. A max size for individual message.  When a message is over this size thrift will close the connection and not read the message. Accumulo configure that setting [here](https://github.com/apache/accumulo/blob/1e4b7924a13f1fe1883c7de3c8faca7fdb4791ce/server/base/src/main/java/org/apache/accumulo/server/rpc/TServerUtils.java#L273)
 2. A max size for all messages across all connections that will be held in memory.  If a message on a connection would exceed this limit, then thrift delays reading the data off the connection until there is enough memory.  Accumulo configures that setting [here](https://github.com/apache/accumulo/blob/1e4b7924a13f1fe1883c7de3c8faca7fdb4791ce/server/base/src/main/java/org/apache/accumulo/server/rpc/TServerUtils.java#L280)

The thrift code implementing to these two configurations can be seen [here](https://github.com/apache/thrift/blob/df626d768a87fe07fef215b4dde831185e6929d7/lib/java/src/main/java/org/apache/thrift/server/AbstractNonblockingServer.java#L342-L356). 

Accumulo configures both thrift settings to the same value.  Experimented with adding a seperate setting for the total across all configurations in this PR.  Also added a ton of logging and a test to convince myself this is actually working, and it is working will see thrift deferring reading from a connection when there is too much already in memory.  Can not think of a way to actaully test this feature because it will eventually work, there is just an indeterminate delay.

One uncertainty I have about adding this new property is the way it changes behavior.  The existing accumulo property used to configure two thrift settings in code.  After this change the existing accumulo property only configures one thrift setting code and the new accumulo property configures the other thrift setting. This changes seem tricky for the case where the existing property is already set.  That uncertainty about the new property and not having an ability to test this new property are the reasons why I am opening this as draft for now.   The test that was added was used to cause activity that would allow me to look in the logs and verify this is working, it does not actually test the new property is working. 

Another reason this draft is that only supported this new property in the default thrift server type, do not look at the other thrift server types to see if the new property would be applicable.

