### PR TITLE
Created CompactionFinalizer SPI

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -1573,20 +1573,29 @@ public enum Property {
       "compaction.coordinator.compactor.dead.check.interval", "5m", PropertyType.TIMEDURATION,
       "The interval at which to check for dead compactors.", "2.1.0"),
   @Experimental
+  COMPACTION_COORDINATOR_FINALIZER_IMPL("compaction.coordinator.compaction.finalizer.impl",
+      "org.apache.accumulo.coordinator.DefaultCompactionFinalizer", PropertyType.CLASSNAME,
+      "Fully qualified name of CompactionFinalizer implementation to use in the Coordinator.",
+      "2.1.4"),
+  @Experimental
   COMPACTION_COORDINATOR_FINALIZER_TSERVER_NOTIFIER_MAXTHREADS(
       "compaction.coordinator.compaction.finalizer.threads.maximum", "5", PropertyType.COUNT,
-      "The maximum number of threads to use for notifying tablet servers that an external compaction has completed.",
+      "The maximum number of threads to use for notifying tablet servers that an external compaction has completed."
+          + " May only be used in the DefaultCompactionFinalizer.",
       "2.1.0"),
   @Experimental
   COMPACTION_COORDINATOR_FINALIZER_COMPLETION_CHECK_INTERVAL(
       "compaction.coordinator.compaction.finalizer.check.interval", "60s",
       PropertyType.TIMEDURATION,
-      "The interval at which to check for external compaction final state markers in the metadata table.",
+      "The interval at which to check for external compaction final state markers in the metadata table."
+          + " May only be used in the DefaultCompactionFinalizer.",
       "2.1.0"),
   @Experimental
   COMPACTION_COORDINATOR_FINALIZER_QUEUE_SIZE(
       "compaction.coordinator.compaction.finalizer.queue.size", "16384", PropertyType.COUNT,
-      "The number of completed compactions to buffer in memory before blocking.", "2.1.4"),
+      "The number of completed compactions to buffer in memory before blocking."
+          + " May only be used in the DefaultCompactionFinalizer.",
+      "2.1.4"),
   @Experimental
   COMPACTION_COORDINATOR_TSERVER_COMPACTION_CHECK_INTERVAL(
       "compaction.coordinator.tserver.check.interval", "1m", PropertyType.TIMEDURATION,

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionFinalizer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionFinalizer.java
@@ -21,8 +21,8 @@ package org.apache.accumulo.core.spi.compaction;
 import java.util.Map;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
-import org.apache.accumulo.core.clientImpl.ClientContext;
-import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.data.TabletId;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
 
 /**
@@ -39,7 +39,7 @@ public interface CompactionFinalizer {
    * @param context ClientContext
    * @param schedExecutor general scheduled executor for any needed tasks
    */
-  void initialize(ClientContext context, ScheduledThreadPoolExecutor schedExecutor);
+  void initialize(AccumuloClient client, ScheduledThreadPoolExecutor schedExecutor);
 
   /**
    * Called by the CompactionCoordinator when the compaction has completed successfully.
@@ -51,7 +51,7 @@ public interface CompactionFinalizer {
    * @param fileSize size of newly compacted file
    * @param fileEntries number of entries in the newly compacted file
    */
-  void commitCompaction(ExternalCompactionId ecid, KeyExtent extent, long fileSize,
+  void commitCompaction(ExternalCompactionId ecid, TabletId extent, long fileSize,
       long fileEntries);
 
   /**
@@ -62,6 +62,6 @@ public interface CompactionFinalizer {
    *
    * @param compactionsToFail map of ExternalCompactionId to KeyExtent
    */
-  void failCompactions(Map<ExternalCompactionId,KeyExtent> compactionsToFail);
+  void failCompactions(Map<ExternalCompactionId,TabletId> compactionsToFail);
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionFinalizer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionFinalizer.java
@@ -21,9 +21,8 @@ package org.apache.accumulo.core.spi.compaction;
 import java.util.Map;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
-import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.data.TabletId;
-import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
+import org.apache.accumulo.core.spi.common.ServiceEnvironment;
 
 /**
  * A CompactionFinalizer is used by the CompactionCoordinator to update the state of a compaction
@@ -34,12 +33,24 @@ import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
 public interface CompactionFinalizer {
 
   /**
+   * This interface exists so the API can evolve and additional parameters can be passed to the
+   * method in the future.
+   *
+   * @since 2.1.4
+   */
+  public interface InitParameters {
+
+    ServiceEnvironment getServiceEnvironment();
+
+    ScheduledThreadPoolExecutor getScheduledThreadPoolExecutor();
+  }
+
+  /**
    * Initialize the CompactionFinalizer
    *
-   * @param context ClientContext
-   * @param schedExecutor general scheduled executor for any needed tasks
+   * @param params initialization parameters
    */
-  void initialize(AccumuloClient client, ScheduledThreadPoolExecutor schedExecutor);
+  void init(InitParameters params);
 
   /**
    * Called by the CompactionCoordinator when the compaction has completed successfully.
@@ -51,8 +62,7 @@ public interface CompactionFinalizer {
    * @param fileSize size of newly compacted file
    * @param fileEntries number of entries in the newly compacted file
    */
-  void commitCompaction(ExternalCompactionId ecid, TabletId extent, long fileSize,
-      long fileEntries);
+  void commitCompaction(String ecid, TabletId extent, long fileSize, long fileEntries);
 
   /**
    * Called by the CompactionCoordinator when compactions have failed. Implementations will create
@@ -62,6 +72,6 @@ public interface CompactionFinalizer {
    *
    * @param compactionsToFail map of ExternalCompactionId to KeyExtent
    */
-  void failCompactions(Map<ExternalCompactionId,TabletId> compactionsToFail);
+  void failCompactions(Map<String,TabletId> compactionsToFail);
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionFinalizer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionFinalizer.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.spi.compaction;
+
+import java.util.Map;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+import org.apache.accumulo.core.clientImpl.ClientContext;
+import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
+
+/**
+ * A CompactionFinalizer is used by the CompactionCoordinator to update the state of a compaction
+ * running on a Compactor.
+ *
+ * @since 2.1.4
+ */
+public interface CompactionFinalizer {
+
+  /**
+   * Initialize the CompactionFinalizer
+   *
+   * @param context ClientContext
+   * @param schedExecutor general scheduled executor for any needed tasks
+   */
+  void initialize(ClientContext context, ScheduledThreadPoolExecutor schedExecutor);
+
+  /**
+   * Called by the CompactionCoordinator when the compaction has completed successfully.
+   * Implementations will create an ExternalCompactionFinalState object from the input arguments
+   * with a FinalState of FINISHED, and insert it into the metadata table.
+   *
+   * @param ecid ExternalCompactionId
+   * @param extent KeyExtent
+   * @param fileSize size of newly compacted file
+   * @param fileEntries number of entries in the newly compacted file
+   */
+  void commitCompaction(ExternalCompactionId ecid, KeyExtent extent, long fileSize,
+      long fileEntries);
+
+  /**
+   * Called by the CompactionCoordinator when compactions have failed. Implementations will create
+   * ExternalCompactionFinalState objects from the input arguments with a FinalState of FAILED and
+   * zero for the file size and number of entries. The implementation will insert the
+   * ExternalCompactionFinalState objects into the metadata table.
+   *
+   * @param compactionsToFail map of ExternalCompactionId to KeyExtent
+   */
+  void failCompactions(Map<ExternalCompactionId,KeyExtent> compactionsToFail);
+
+}

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
@@ -69,6 +69,7 @@ import org.apache.accumulo.core.process.thrift.ServerProcessService;
 import org.apache.accumulo.core.rpc.ThriftUtil;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
 import org.apache.accumulo.core.securityImpl.thrift.TCredentials;
+import org.apache.accumulo.core.spi.compaction.CompactionFinalizer;
 import org.apache.accumulo.core.tabletserver.thrift.TCompactionQueueSummary;
 import org.apache.accumulo.core.tabletserver.thrift.TCompactionStats;
 import org.apache.accumulo.core.tabletserver.thrift.TExternalCompactionJob;
@@ -168,7 +169,12 @@ public class CompactionCoordinator extends AbstractServer implements
 
   protected CompactionFinalizer
       createCompactionFinalizer(ScheduledThreadPoolExecutor schedExecutor) {
-    return new CompactionFinalizer(getContext(), schedExecutor);
+
+    CompactionFinalizer finalizer = Property.createInstanceFromPropertyName(getConfiguration(),
+        Property.MANAGER_TABLET_BALANCER, CompactionFinalizer.class,
+        new DefaultCompactionFinalizer());
+    finalizer.initialize(getContext(), schedExecutor);
+    return finalizer;
   }
 
   protected LiveTServerSet createLiveTServerSet() {

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/DeadCompactionDetector.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/DeadCompactionDetector.java
@@ -140,10 +140,12 @@ public class DeadCompactionDetector {
         this.deadCompactions.entrySet().stream().filter(e -> e.getValue() > 2).map(e -> e.getKey())
             .collect(Collectors.toCollection(TreeSet::new));
     tabletCompactions.keySet().retainAll(toFail);
+    Map<String,TabletId> failedCompactions = new HashMap<>();
     tabletCompactions.forEach((ecid, extent) -> {
+      failedCompactions.put(ecid.canonical(), extent);
       log.warn("Compaction believed to be dead, failing it: id: {}, extent: {}", ecid, extent);
     });
-    coordinator.compactionFailed(tabletCompactions);
+    coordinator.compactionFailed(failedCompactions);
     this.deadCompactions.keySet().removeAll(toFail);
   }
 

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/DeadCompactionDetector.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/DeadCompactionDetector.java
@@ -29,7 +29,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.conf.Property;
-import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.core.data.TabletId;
+import org.apache.accumulo.core.dataImpl.TabletIdImpl;
 import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionFinalState;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
@@ -63,13 +64,13 @@ public class DeadCompactionDetector {
 
     log.trace("Starting to look for dead compactions");
 
-    Map<ExternalCompactionId,KeyExtent> tabletCompactions = new HashMap<>();
+    Map<ExternalCompactionId,TabletId> tabletCompactions = new HashMap<>();
 
     // find what external compactions tablets think are running
     context.getAmple().readTablets().forLevel(DataLevel.USER)
         .fetch(ColumnType.ECOMP, ColumnType.PREV_ROW).build().forEach(tm -> {
           tm.getExternalCompactions().keySet().forEach(ecid -> {
-            tabletCompactions.put(ecid, tm.getExtent());
+            tabletCompactions.put(ecid, new TabletIdImpl(tm.getExtent()));
           });
         });
 

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/SharedBatchWriter.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/SharedBatchWriter.java
@@ -27,10 +27,10 @@ import java.util.concurrent.TimeUnit;
 import org.apache.accumulo.core.client.BatchWriterConfig;
 import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.util.Timer;
 import org.apache.accumulo.core.util.threads.Threads;
-import org.apache.accumulo.server.ServerContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,9 +54,9 @@ public class SharedBatchWriter {
 
   private final BlockingQueue<Work> mutations;
   private final String table;
-  private final ServerContext context;
+  private final ClientContext context;
 
-  public SharedBatchWriter(String table, ServerContext context, int queueSize) {
+  public SharedBatchWriter(String table, ClientContext context, int queueSize) {
     this.table = table;
     this.context = context;
     this.mutations = new ArrayBlockingQueue<>(queueSize);

--- a/server/compaction-coordinator/src/test/java/org/apache/accumulo/coordinator/CompactionCoordinatorTest.java
+++ b/server/compaction-coordinator/src/test/java/org/apache/accumulo/coordinator/CompactionCoordinatorTest.java
@@ -103,7 +103,7 @@ public class CompactionCoordinatorTest {
 
     private Set<ExternalCompactionId> metadataCompactionIds = null;
 
-    protected TestCoordinator(CompactionFinalizer finalizer, LiveTServerSet tservers,
+    protected TestCoordinator(DefaultCompactionFinalizer finalizer, LiveTServerSet tservers,
         ServerAddress client, TabletClientService.Client tabletServerClient, ServerContext context,
         AuditedSecurityOperation security) {
       super(new ServerOpts(), new String[] {}, context.getConfiguration());
@@ -142,7 +142,8 @@ public class CompactionCoordinatorTest {
     protected void startCompactionCleaner(ScheduledThreadPoolExecutor schedExecutor) {}
 
     @Override
-    protected CompactionFinalizer createCompactionFinalizer(ScheduledThreadPoolExecutor stpe) {
+    protected DefaultCompactionFinalizer
+        createCompactionFinalizer(ScheduledThreadPoolExecutor stpe) {
       return null;
     }
 
@@ -268,7 +269,8 @@ public class CompactionCoordinatorTest {
         .andReturn(runningCompactions);
     expect(ExternalCompactionUtil.getCompactorAddrs(context)).andReturn(Map.of()).anyTimes();
 
-    CompactionFinalizer finalizer = PowerMock.createNiceMock(CompactionFinalizer.class);
+    DefaultCompactionFinalizer finalizer =
+        PowerMock.createNiceMock(DefaultCompactionFinalizer.class);
     LiveTServerSet tservers = PowerMock.createNiceMock(LiveTServerSet.class);
     expect(tservers.getCurrentServers()).andReturn(Collections.emptySet()).anyTimes();
 
@@ -324,7 +326,8 @@ public class CompactionCoordinatorTest {
         .andReturn(runningCompactions);
     expect(ExternalCompactionUtil.getCompactorAddrs(context)).andReturn(Map.of()).anyTimes();
 
-    CompactionFinalizer finalizer = PowerMock.createNiceMock(CompactionFinalizer.class);
+    DefaultCompactionFinalizer finalizer =
+        PowerMock.createNiceMock(DefaultCompactionFinalizer.class);
     LiveTServerSet tservers = PowerMock.createNiceMock(LiveTServerSet.class);
     TServerInstance instance = PowerMock.createNiceMock(TServerInstance.class);
     expect(tservers.getCurrentServers()).andReturn(Collections.singleton(instance)).once();
@@ -392,7 +395,8 @@ public class CompactionCoordinatorTest {
     TCredentials creds = PowerMock.createNiceMock(TCredentials.class);
     expect(context.rpcCreds()).andReturn(creds);
 
-    CompactionFinalizer finalizer = PowerMock.createNiceMock(CompactionFinalizer.class);
+    DefaultCompactionFinalizer finalizer =
+        PowerMock.createNiceMock(DefaultCompactionFinalizer.class);
     LiveTServerSet tservers = PowerMock.createNiceMock(LiveTServerSet.class);
     TServerInstance instance = PowerMock.createNiceMock(TServerInstance.class);
     HostAndPort tserverAddress = HostAndPort.fromString("localhost:9997");
@@ -469,7 +473,8 @@ public class CompactionCoordinatorTest {
     TCredentials creds = PowerMock.createNiceMock(TCredentials.class);
     expect(context.rpcCreds()).andReturn(creds);
 
-    CompactionFinalizer finalizer = PowerMock.createNiceMock(CompactionFinalizer.class);
+    DefaultCompactionFinalizer finalizer =
+        PowerMock.createNiceMock(DefaultCompactionFinalizer.class);
     LiveTServerSet tservers = PowerMock.createNiceMock(LiveTServerSet.class);
     TServerInstance instance = PowerMock.createNiceMock(TServerInstance.class);
     HostAndPort tserverAddress = HostAndPort.fromString("localhost:9997");
@@ -558,7 +563,8 @@ public class CompactionCoordinatorTest {
     expect(ExternalCompactionUtil.getCompactorAddrs(context)).andReturn(Map.of()).anyTimes();
     expect(ExternalCompactionUtil.countCompactors("R2DQ", context)).andReturn(3).anyTimes();
 
-    CompactionFinalizer finalizer = PowerMock.createNiceMock(CompactionFinalizer.class);
+    DefaultCompactionFinalizer finalizer =
+        PowerMock.createNiceMock(DefaultCompactionFinalizer.class);
     LiveTServerSet tservers = PowerMock.createNiceMock(LiveTServerSet.class);
     TServerInstance instance = PowerMock.createNiceMock(TServerInstance.class);
     expect(tservers.getCurrentServers()).andReturn(Collections.singleton(instance)).once();
@@ -650,7 +656,8 @@ public class CompactionCoordinatorTest {
 
     TCredentials creds = PowerMock.createNiceMock(TCredentials.class);
 
-    CompactionFinalizer finalizer = PowerMock.createNiceMock(CompactionFinalizer.class);
+    DefaultCompactionFinalizer finalizer =
+        PowerMock.createNiceMock(DefaultCompactionFinalizer.class);
     LiveTServerSet tservers = PowerMock.createNiceMock(LiveTServerSet.class);
 
     ServerAddress client = PowerMock.createNiceMock(ServerAddress.class);
@@ -690,7 +697,8 @@ public class CompactionCoordinatorTest {
 
     TCredentials creds = PowerMock.createNiceMock(TCredentials.class);
 
-    CompactionFinalizer finalizer = PowerMock.createNiceMock(CompactionFinalizer.class);
+    DefaultCompactionFinalizer finalizer =
+        PowerMock.createNiceMock(DefaultCompactionFinalizer.class);
     LiveTServerSet tservers = PowerMock.createNiceMock(LiveTServerSet.class);
 
     ServerAddress client = PowerMock.createNiceMock(ServerAddress.class);

--- a/test/src/main/java/org/apache/accumulo/test/compaction/TestCompactionCoordinatorForOfflineTable.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/TestCompactionCoordinatorForOfflineTable.java
@@ -22,12 +22,13 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 import org.apache.accumulo.coordinator.CompactionCoordinator;
 import org.apache.accumulo.coordinator.DefaultCompactionFinalizer;
+import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.client.TableNotFoundException;
-import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.compaction.thrift.CompactionCoordinatorService;
-import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.core.data.TabletId;
+import org.apache.accumulo.core.dataImpl.TabletIdImpl;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionFinalState;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionFinalState.FinalState;
@@ -47,17 +48,17 @@ public class TestCompactionCoordinatorForOfflineTable extends CompactionCoordina
         LoggerFactory.getLogger(NonNotifyingCompactionFinalizer.class);
 
     @Override
-    public void initialize(ClientContext context, ScheduledThreadPoolExecutor stpe) {
+    public void initialize(AccumuloClient context, ScheduledThreadPoolExecutor stpe) {
       // TODO Auto-generated method stub
       super.initialize(context, stpe);
     }
 
     @Override
-    public void commitCompaction(ExternalCompactionId ecid, KeyExtent extent, long fileSize,
+    public void commitCompaction(ExternalCompactionId ecid, TabletId extent, long fileSize,
         long fileEntries) {
 
-      var ecfs = new ExternalCompactionFinalState(ecid, extent, FinalState.FINISHED, fileSize,
-          fileEntries);
+      var ecfs = new ExternalCompactionFinalState(ecid, ((TabletIdImpl) extent).toKeyExtent(),
+          FinalState.FINISHED, fileSize, fileEntries);
 
       // write metadata entry
       LOG.info("Writing completed external compaction to metadata table: {}", ecfs);

--- a/test/src/main/java/org/apache/accumulo/test/compaction/TestCompactionCoordinatorForOfflineTable.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/TestCompactionCoordinatorForOfflineTable.java
@@ -21,10 +21,11 @@ package org.apache.accumulo.test.compaction;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 import org.apache.accumulo.coordinator.CompactionCoordinator;
-import org.apache.accumulo.coordinator.CompactionFinalizer;
+import org.apache.accumulo.coordinator.DefaultCompactionFinalizer;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.compaction.thrift.CompactionCoordinatorService;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.schema.Ample;
@@ -32,7 +33,7 @@ import org.apache.accumulo.core.metadata.schema.ExternalCompactionFinalState;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionFinalState.FinalState;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
 import org.apache.accumulo.core.process.thrift.ServerProcessService;
-import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.core.spi.compaction.CompactionFinalizer;
 import org.apache.accumulo.server.ServerOpts;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,13 +41,15 @@ import org.slf4j.LoggerFactory;
 public class TestCompactionCoordinatorForOfflineTable extends CompactionCoordinator
     implements CompactionCoordinatorService.Iface, ServerProcessService.Iface {
 
-  public static class NonNotifyingCompactionFinalizer extends CompactionFinalizer {
+  public static class NonNotifyingCompactionFinalizer extends DefaultCompactionFinalizer {
 
     private static final Logger LOG =
         LoggerFactory.getLogger(NonNotifyingCompactionFinalizer.class);
 
-    NonNotifyingCompactionFinalizer(ServerContext context, ScheduledThreadPoolExecutor stpe) {
-      super(context, stpe);
+    @Override
+    public void initialize(ClientContext context, ScheduledThreadPoolExecutor stpe) {
+      // TODO Auto-generated method stub
+      super.initialize(context, stpe);
     }
 
     @Override
@@ -76,7 +79,9 @@ public class TestCompactionCoordinatorForOfflineTable extends CompactionCoordina
 
   @Override
   protected CompactionFinalizer createCompactionFinalizer(ScheduledThreadPoolExecutor stpe) {
-    return new NonNotifyingCompactionFinalizer(getContext(), stpe);
+    CompactionFinalizer finalizer = new NonNotifyingCompactionFinalizer();
+    finalizer.initialize(getContext(), stpe);
+    return finalizer;
   }
 
   public static void main(String[] args) throws Exception {


### PR DESCRIPTION
Created a SPI for the CompactionFinalizer with the current implementation being the DefaultCompactionFinalizer. This change will allow for different CompactionFinalizer implementations for 2.1 and 3.1. The CompactionFinalizer was removed in 4.0 as it has a different implementation for compactions.