### PR TITLE
fixes ChaoticLoadBalancerIT

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/ChaoticLoadBalancer.java
+++ b/test/src/main/java/org/apache/accumulo/test/ChaoticLoadBalancer.java
@@ -57,6 +57,8 @@ public class ChaoticLoadBalancer implements TabletBalancer {
 
   public ChaoticLoadBalancer() {}
 
+  public ChaoticLoadBalancer(TableId tableId) {}
+
   @Override
   public void init(BalancerEnvironment balancerEnvironment) {
     this.environment = balancerEnvironment;


### PR DESCRIPTION
The changes in #5530 exposed an existing problem in ChaoticLoadBalancerIT.  It seems the test was configuring a balancer that could not be constructed and then accumulo would fall back to the simple balancer and the test would pass.