### PR TITLE
fixes external compaction race condition

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/OpeningAndOnlineCompactables.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/OpeningAndOnlineCompactables.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.tserver;
+
+import java.util.Set;
+
+import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.tserver.compactions.Compactable;
+
+public class OpeningAndOnlineCompactables {
+  public final Set<KeyExtent> opening;
+  public final Iterable<Compactable> open;
+
+  public OpeningAndOnlineCompactables(Set<KeyExtent> openingSnapshot,
+      Iterable<Compactable> openSnapshot) {
+    this.opening = openingSnapshot;
+    this.open = openSnapshot;
+  }
+}

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
@@ -1429,7 +1429,6 @@ public class CompactableImpl implements Compactable {
       ExternalCompactionInfo ecInfo = externalCompactions.get(extCompactionId);
 
       if (ecInfo != null) {
-        log.debug("Attempting to commit external compaction {}", extCompactionId);
         Optional<StoredTabletFile> metaFile = Optional.empty();
         boolean successful = false;
         try {
@@ -1448,11 +1447,11 @@ public class CompactableImpl implements Compactable {
         } finally {
           completeCompaction(ecInfo.job, ecInfo.meta.getJobFiles(), metaFile, successful);
           externalCompactions.remove(extCompactionId);
-          log.debug("Completed commit of external compaction {}", extCompactionId);
+          log.debug("Completed commit of external compaction {} {}", extCompactionId, getExtent());
         }
       } else {
-        log.debug("Ignoring request to commit external compaction that is unknown {}",
-            extCompactionId);
+        log.debug("Ignoring request to commit external compaction that is unknown {} {}",
+            extCompactionId, getExtent());
       }
 
       tablet.getContext().getAmple().deleteExternalCompactionFinalStates(List.of(extCompactionId));
@@ -1487,7 +1486,8 @@ public class CompactableImpl implements Compactable {
         externalCompactions.remove(ecid);
         log.debug("Processed external compaction failure: id: {}, extent: {}", ecid, getExtent());
       } else {
-        log.debug("Ignoring request to fail external compaction that is unknown {}", ecid);
+        log.debug("Ignoring request to fail external compaction that is unknown {} {}", ecid,
+            getExtent());
       }
 
       tablet.getContext().getAmple().deleteExternalCompactionFinalStates(List.of(ecid));


### PR DESCRIPTION
In there tablet server there was a race condition between the set of online tablets and set of external compactions.  When a tablet loaded w/ existing external compaction it would add to the external compaction set first and the online tablet set second. This order could cause cause code that cleans up external compactions to remove something it saw in  one set and not the other.  Considered opening tablets to avoid this race.  Also adjusted rpc code to avoid the race.