### PR TITLE
Fixed issue with balancer property updates

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -1932,6 +1932,7 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener, 
             Property.MANAGER_TABLET_BALANCER, TabletBalancer.class, new DoNothingBalancer());
         localTabletBalancer.init(balancerEnvironment);
         tabletBalancer = localTabletBalancer;
+        log.info("tablet balancer changed to {}", localTabletBalancer.getClass().getName());
       }
     } catch (Exception e) {
       log.warn("Failed to create balancer {} using {} instead", configuredBalancerClass,
@@ -1940,10 +1941,6 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener, 
       localTabletBalancer.init(balancerEnvironment);
       tabletBalancer = localTabletBalancer;
     }
-  }
-
-  Class<?> getBalancerClass() {
-    return tabletBalancer.getClass();
   }
 
   void getAssignments(SortedMap<TServerInstance,TabletServerStatus> currentStatus,

--- a/server/manager/src/main/java/org/apache/accumulo/manager/ManagerClientServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/ManagerClientServiceHandler.java
@@ -52,8 +52,6 @@ import org.apache.accumulo.core.clientImpl.thrift.ThriftConcurrentModificationEx
 import org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException;
 import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException;
-import org.apache.accumulo.core.conf.DeprecatedPropertyUtil;
-import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.Range;
@@ -431,7 +429,6 @@ public class ManagerClientServiceHandler implements ManagerClientService.Iface {
 
     try {
       SystemPropUtil.removeSystemProperty(manager.getContext(), property);
-      updatePlugins(property);
     } catch (Exception e) {
       Manager.log.error("Problem removing config property in zookeeper", e);
       throw new RuntimeException(e.getMessage());
@@ -447,7 +444,6 @@ public class ManagerClientServiceHandler implements ManagerClientService.Iface {
 
     try {
       SystemPropUtil.setSystemProperty(manager.getContext(), property, value);
-      updatePlugins(property);
     } catch (IllegalArgumentException iae) {
       Manager.log.error("Problem setting invalid property", iae);
       throw new ThriftPropertyException(property, value, "Property is invalid");
@@ -467,9 +463,6 @@ public class ManagerClientServiceHandler implements ManagerClientService.Iface {
     try {
       SystemPropUtil.modifyProperties(manager.getContext(), properties.getVersion(),
           properties.getProperties());
-      for (Map.Entry<String,String> entry : properties.getProperties().entrySet()) {
-        updatePlugins(entry.getKey());
-      }
     } catch (IllegalArgumentException iae) {
       Manager.log.error("Problem setting invalid property", iae);
       throw new ThriftPropertyException("Modify properties", "failed", iae.getMessage());
@@ -588,15 +581,6 @@ public class ManagerClientServiceHandler implements ManagerClientService.Iface {
               + tableId.canonical() + " to: " + property + "=" + value);
     } catch (IllegalArgumentException iae) {
       throw new ThriftPropertyException(property, value, iae.getMessage());
-    }
-  }
-
-  private void updatePlugins(String property) {
-    // resolve without warning; any warnings should have already occurred
-    String resolved = DeprecatedPropertyUtil.getReplacementName(property, (log, replacement) -> {});
-    if (resolved.equals(Property.MANAGER_TABLET_BALANCER.getKey())) {
-      manager.initializeBalancer();
-      log.info("tablet balancer changed to {}", manager.getBalancerClass().getName());
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/BrokenBalancerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/BrokenBalancerIT.java
@@ -123,7 +123,9 @@ public class BrokenBalancerIT extends ConfigurableMacBase {
       Wait.waitFor(() -> c.instanceOperations().getSystemConfiguration()
           .get(Property.MANAGER_TABLET_BALANCER.getKey()).equals(balancerClass));
       c.instanceOperations().waitForBalance();
-      UtilWaitThread.sleep(5000);
+
+      // Give enough time for property change and Status Thread in Manager
+      UtilWaitThread.sleep(30000);
 
       // should not have balanced across the two new tservers
       assertEquals(2, BalanceIT.countLocations(c, tableName).size());
@@ -134,7 +136,7 @@ public class BrokenBalancerIT extends ConfigurableMacBase {
           TableLoadBalancer.class.getName());
 
       // should eventually balance across all 5 tabletsevers
-      Wait.waitFor(() -> 5 == BalanceIT.countLocations(c, tableName).size());
+      Wait.waitFor(() -> 5 == BalanceIT.countLocations(c, tableName).size(), 60_000);
     }
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/BrokenBalancerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/BrokenBalancerIT.java
@@ -119,6 +119,10 @@ public class BrokenBalancerIT extends ConfigurableMacBase {
       getCluster().getConfig().setNumTservers(5);
       getCluster().getClusterControl().start(ServerType.TABLET_SERVER);
 
+      Wait.waitFor(() -> c.instanceOperations().getTabletServers().size() == 5);
+      Wait.waitFor(() -> c.instanceOperations().getSystemConfiguration()
+          .get(Property.MANAGER_TABLET_BALANCER.getKey()).equals(balancerClass));
+      c.instanceOperations().waitForBalance();
       UtilWaitThread.sleep(5000);
 
       // should not have balanced across the two new tservers


### PR DESCRIPTION
The change in #5530 added code to clear the
property cache in initializeBalancer because
the property change was not immediately seen.
BrokenBalancerIT was changing the property
then checking the balance to see if the new
balancer had taken effect.

This commit changes BrokenBalancerIT to give
it more time in the test thread for the
property change to take effect in the Manager
and changes how the Manager responds to system
property changes so that the property cache
invalidation can be removed.

Related to #5530