### PR TITLE
critical vs non-critical threads

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportPool.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportPool.java
@@ -73,7 +73,8 @@ public class ThriftTransportPool {
 
   private ThriftTransportPool(LongSupplier maxAgeMillis) {
     this.maxAgeMillis = maxAgeMillis;
-    this.checkThread = Threads.createThread("Thrift Connection Pool Checker", () -> {
+    // TODO KEVIN RATHBUN all this does is perform some resource cleanup, so may not be critical.
+    this.checkThread = Threads.createNonCriticalThread("Thrift Connection Pool Checker", () -> {
       try {
         final long minNanos = MILLISECONDS.toNanos(250);
         final long maxNanos = MINUTES.toNanos(1);

--- a/core/src/main/java/org/apache/accumulo/core/util/Halt.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/Halt.java
@@ -51,7 +51,9 @@ public class Halt {
 
     try {
       // give ourselves a little time to try and do something
-      Threads.createThread("Halt Thread", () -> {
+      // TODO KEVIN RATHBUN doesn't matter if this is critical or not, halt() will be called in
+      // this method no matter what
+      Threads.createNonCriticalThread("Halt Thread", () -> {
         sleepUninterruptibly(100, MILLISECONDS);
         Runtime.getRuntime().halt(status);
       }).start();

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/NamedThreadFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/NamedThreadFactory.java
@@ -55,6 +55,11 @@ class NamedThreadFactory implements ThreadFactory {
       threadName =
           String.format(FORMAT, name, r.getClass().getSimpleName(), threadNum.getAndIncrement());
     }
-    return Threads.createThread(threadName, priority, r, handler);
+    // TODO KEVIN RATHBUN I don't believe this needs to be critical (or needs to have a way of
+    // configuring whether or not the thread is critical). This class is used in the ThreadPools
+    // class to create a ThreadPoolExecutor. Tasks submitted to this pool are configured to be
+    // critical or not with watchCriticalScheduledTask, watchCriticalFixedDelay, and
+    // watchNonCriticalScheduledTask
+    return Threads.createNonCriticalThread(threadName, priority, r, handler);
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/Threads.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/Threads.java
@@ -55,15 +55,15 @@ public class Threads {
     return new NamedRunnable(name, r);
   }
 
-  public static Thread createThread(String name, Runnable r) {
-    return createThread(name, OptionalInt.empty(), r, UEH);
+  public static Thread createNonCriticalThread(String name, Runnable r) {
+    return createNonCriticalThread(name, OptionalInt.empty(), r, UEH);
   }
 
-  public static Thread createThread(String name, OptionalInt priority, Runnable r) {
-    return createThread(name, priority, r, UEH);
+  public static Thread createNonCriticalThread(String name, OptionalInt priority, Runnable r) {
+    return createNonCriticalThread(name, priority, r, UEH);
   }
 
-  public static Thread createThread(String name, OptionalInt priority, Runnable r,
+  public static Thread createNonCriticalThread(String name, OptionalInt priority, Runnable r,
       UncaughtExceptionHandler ueh) {
     Thread thread = new AccumuloDaemonThread(TraceUtil.wrap(r), name, ueh);
     priority.ifPresent(thread::setPriority);
@@ -71,6 +71,10 @@ public class Threads {
   }
 
   public static Thread createCriticalThread(String name, Runnable r) {
+    return createCriticalThread(name, OptionalInt.empty(), r);
+  }
+
+  public static Thread createCriticalThread(String name, OptionalInt priority, Runnable r) {
     Runnable wrapped = () -> {
       try {
         r.run();
@@ -81,6 +85,6 @@ public class Threads {
       }
     };
 
-    return createThread(name, wrapped);
+    return createNonCriticalThread(name, priority, wrapped);
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/AbstractServer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/AbstractServer.java
@@ -243,7 +243,9 @@ public abstract class AbstractServer
     final long interval =
         getConfiguration().getTimeInMillis(Property.GENERAL_SERVER_LOCK_VERIFICATION_INTERVAL);
     if (interval > 0) {
-      verificationThread = Threads.createThread("service-lock-verification-thread",
+      // TODO KEVIN RATHBUN verifying the service lock is a critical function of any process
+      // calling this and the thread would not be recreated on failures
+      verificationThread = Threads.createCriticalThread("service-lock-verification-thread",
           OptionalInt.of(Thread.NORM_PRIORITY + 1), () -> {
             while (serverThread.isAlive()) {
               ServiceLock lock = getLock();

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/ServerConfigurationFactory.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/ServerConfigurationFactory.java
@@ -87,8 +87,9 @@ public class ServerConfigurationFactory extends ServerConfiguration {
         Caffeine.newBuilder().expireAfterAccess(CACHE_EXPIRATION_HRS, TimeUnit.HOURS).build();
 
     refresher = new ConfigRefreshRunner();
-    Runtime.getRuntime()
-        .addShutdownHook(Threads.createThread("config-refresh-shutdownHook", refresher::shutdown));
+    // TODO KEVIN RATHBUN JVM already shutting down, no need to be critical
+    Runtime.getRuntime().addShutdownHook(
+        Threads.createNonCriticalThread("config-refresh-shutdownHook", refresher::shutdown));
   }
 
   public ServerContext getServerContext() {

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/TServerUtils.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/TServerUtils.java
@@ -47,7 +47,6 @@ import org.apache.accumulo.core.metrics.MetricsInfo;
 import org.apache.accumulo.core.rpc.SslConnectionParams;
 import org.apache.accumulo.core.rpc.ThriftUtil;
 import org.apache.accumulo.core.rpc.UGIAssumingTransportFactory;
-import org.apache.accumulo.core.util.Halt;
 import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.core.util.UtilWaitThread;
@@ -660,13 +659,8 @@ public class TServerUtils {
 
     final TServer finalServer = serverAddress.server;
 
-    Threads.createThread(threadName, () -> {
-      try {
-        finalServer.serve();
-      } catch (Error e) {
-        Halt.halt("Unexpected error in TThreadPoolServer " + e + ", halting.", 1);
-      }
-    }).start();
+    // TODO KEVIN RATHBUN I can't imagine that the process would be healthy if this is not running
+    Threads.createCriticalThread(threadName, finalServer::serve).start();
 
     while (!finalServer.isServing()) {
       // Wait for the thread to start and for the TServer to start

--- a/server/base/src/main/java/org/apache/accumulo/server/security/SecurityUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/SecurityUtil.java
@@ -63,7 +63,7 @@ public class SecurityUtil {
 
     if (login(principal, keyTab)) {
       try {
-        startTicketRenewalThread(acuConf, UserGroupInformation.getCurrentUser(),
+        startTicketRenewalThread(UserGroupInformation.getCurrentUser(),
             acuConf.getTimeInMillis(Property.GENERAL_KERBEROS_RENEWAL_PERIOD));
         return;
       } catch (IOException e) {
@@ -115,13 +115,14 @@ public class SecurityUtil {
   /**
    * Start a thread that periodically attempts to renew the current Kerberos user's ticket.
    *
-   * @param conf Accumulo configuration
    * @param ugi The current Kerberos user.
    * @param renewalPeriod The amount of time between attempting renewals.
    */
-  static void startTicketRenewalThread(AccumuloConfiguration conf, final UserGroupInformation ugi,
-      final long renewalPeriod) {
-    Threads.createThread("Kerberos Ticket Renewal", () -> {
+  static void startTicketRenewalThread(final UserGroupInformation ugi, final long renewalPeriod) {
+    // TODO KEVIN RATHBUN this renewal seems like a critical task of any process running it, as not
+    // renewing the ticket would probably lead to authentication problems. This thread is also only
+    // created once.
+    Threads.createCriticalThread("Kerberos Ticket Renewal", () -> {
       while (true) {
         try {
           renewalLog.debug("Invoking renewal attempt for Kerberos ticket");

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -736,8 +736,10 @@ public class Compactor extends AbstractServer
           final FileCompactorRunnable fcr =
               createCompactionJob(job, totalInputEntries, totalInputBytes, started, stopped, err);
 
-          final Thread compactionThread =
-              Threads.createThread("Compaction job for tablet " + job.getExtent().toString(), fcr);
+          // TODO KEVIN RATHBUN exists within a while(!shutdown) loop so thread is repeatedly
+          // recreated. No need to be critical. If a single job fails, that's okay.
+          final Thread compactionThread = Threads.createNonCriticalThread(
+              "Compaction job for tablet " + job.getExtent().toString(), fcr);
 
           JOB_HOLDER.set(job, compactionThread, fcr.getFileCompactor());
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -1265,14 +1265,21 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener, 
 
     context.getTableManager().addObserver(this);
 
-    Thread statusThread = Threads.createThread("Status Thread", new StatusThread());
+    // TODO KEVIN RATHBUN updating the Manager state seems like a critical function. However, the
+    // thread already handles, waits, and continues in the case of any Exception, so critical or
+    // non critical doesn't make a difference here.
+    Thread statusThread = Threads.createCriticalThread("Status Thread", new StatusThread());
     statusThread.start();
 
-    Threads.createThread("Migration Cleanup Thread", new MigrationCleanupThread()).start();
+    // TODO KEVIN RATHBUN migration cleanup may be a critical function of the manager, but the
+    // thread will already handle, wait, and continue in the case of any Exception, so critical
+    // or non critical doesn't make a difference here.
+    Threads.createCriticalThread("Migration Cleanup Thread", new MigrationCleanupThread()).start();
 
     tserverSet.startListeningForTabletServerChanges();
 
-    Threads.createThread("ScanServer Cleanup Thread", new ScanServerZKCleaner()).start();
+    // TODO KEVIN RATHBUN Some ZK cleanup doesn't seem like a critical function of manager
+    Threads.createNonCriticalThread("ScanServer Cleanup Thread", new ScanServerZKCleaner()).start();
 
     try {
       blockForTservers();
@@ -1378,8 +1385,10 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener, 
       } catch (KeeperException | InterruptedException e) {
         throw new IllegalStateException("Exception setting up delegation-token key manager", e);
       }
-      authenticationTokenKeyManagerThread =
-          Threads.createThread("Delegation Token Key Manager", authenticationTokenKeyManager);
+      // TODO KEVIN RATHBUN managing delegation tokens seems like a critical function of the
+      // manager and this is not recreated on failures.
+      authenticationTokenKeyManagerThread = Threads
+          .createCriticalThread("Delegation Token Key Manager", authenticationTokenKeyManager);
       authenticationTokenKeyManagerThread.start();
       boolean logged = false;
       while (!authenticationTokenKeyManager.isInitialized()) {
@@ -1616,14 +1625,16 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener, 
         Property.MANAGER_REPLICATION_COORDINATOR_THREADCHECK, maxMessageSizeProperty);
 
     log.info("Started replication coordinator service at " + replAddress.address);
+    // TODO KEVIN RATHBUN this thread creation exists within a task which is labeled non-critical
+    // so assuming these are as well.
     // Start the daemon to scan the replication table and make units of work
-    replicationWorkThread = Threads.createThread("Replication Driver",
+    replicationWorkThread = Threads.createNonCriticalThread("Replication Driver",
         new org.apache.accumulo.manager.replication.ReplicationDriver(this));
     replicationWorkThread.start();
 
     // Start the daemon to assign work to tservers to replicate to our peers
     var wd = new org.apache.accumulo.manager.replication.WorkDriver(this);
-    replicationAssignerThread = Threads.createThread(wd.getName(), wd);
+    replicationAssignerThread = Threads.createNonCriticalThread(wd.getName(), wd);
     replicationAssignerThread.start();
 
     // Advertise that port we used so peers don't have to be told what it is

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -514,7 +514,9 @@ public class Monitor extends AbstractServer implements HighlyAvailableService {
     }
 
     // need to regularly fetch data so plot data is updated
-    Threads.createThread("Data fetcher", () -> {
+    // TODO KEVIN RATHBUN don't think this is a critical function of the Monitor (and the
+    // RuntimeException is already handled here)
+    Threads.createNonCriticalThread("Data fetcher", () -> {
       while (true) {
         try {
           fetchData();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/AssignmentHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/AssignmentHandler.java
@@ -232,7 +232,9 @@ class AssignmentHandler implements Runnable {
               AssignmentHandler handler = new AssignmentHandler(server, extent, retryAttempt + 1);
               if (extent.isMeta()) {
                 if (extent.isRootTablet()) {
-                  Threads.createThread("Root tablet assignment retry", handler).start();
+                  // TODO KEVIN RATHBUN should remain non critical for same reason explained in
+                  // TabletClientHandler
+                  Threads.createNonCriticalThread("Root tablet assignment retry", handler).start();
                 } else {
                   server.resourceManager.addMetaDataAssignment(extent, log, handler);
                 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -1110,7 +1110,9 @@ public class TabletServer extends AbstractServer
 
   private void config() {
     log.info("Tablet server starting on {}", getHostname());
-    Threads.createThread("Split/MajC initiator", new MajorCompactor(context)).start();
+    // TODO KEVIN RATHBUN running major compactions is a critical function of the TabletServer.
+    // also this thread is only created once.
+    Threads.createCriticalThread("Split/MajC initiator", new MajorCompactor(context)).start();
 
     clientAddress = HostAndPort.fromParts(getHostname(), 0);
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionManager.java
@@ -298,7 +298,9 @@ public class CompactionManager {
 
   public void start() {
     log.debug("Started compaction manager");
-    Threads.createThread("Compaction Manager", () -> mainLoop()).start();
+    // TODO KEVIN RATHBUN This is a critical thread for the TabletServer to run properly and is
+    // only called once.
+    Threads.createCriticalThread("Compaction Manager", () -> mainLoop()).start();
   }
 
   public CompactionServices getServices() {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
@@ -475,7 +475,10 @@ public class DfsLogger implements Comparable<DfsLogger> {
       throw new IOException(ex);
     }
 
-    syncThread = Threads.createThread("Accumulo WALog thread " + this, new LogSyncingTask());
+    // TODO KEVIN RATHBUN this seems like a vital thread for TabletServer, but appears that the
+    // thread will continuously be recreated, so probably fine to stay non critical
+    syncThread =
+        Threads.createNonCriticalThread("Accumulo WALog thread " + this, new LogSyncingTask());
     syncThread.start();
     op.await();
     log.debug("Got new write-ahead log: {}", this);

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionMetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionMetricsIT.java
@@ -116,7 +116,7 @@ public class ExternalCompactionMetricsIT extends SharedMiniClusterBase {
       final LinkedBlockingQueue<Metric> queueMetrics = new LinkedBlockingQueue<>();
       final AtomicBoolean shutdownTailer = new AtomicBoolean(false);
 
-      Thread thread = Threads.createThread("metric-tailer", () -> {
+      Thread thread = Threads.createNonCriticalThread("metric-tailer", () -> {
         while (!shutdownTailer.get()) {
           List<String> statsDMetrics = sink.getLines();
           for (String s : statsDMetrics) {

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionProgressIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionProgressIT.java
@@ -270,7 +270,7 @@ public class ExternalCompactionProgressIT extends AccumuloClusterHarness {
    */
   private static Thread getMetricsCheckerThread(AtomicLong totalEntriesRead,
       AtomicLong totalEntriesWritten) {
-    return Threads.createThread("metric-tailer", () -> {
+    return Threads.createNonCriticalThread("metric-tailer", () -> {
       log.info("Starting metric tailer");
 
       sink.getLines().clear();
@@ -408,7 +408,7 @@ public class ExternalCompactionProgressIT extends AccumuloClusterHarness {
   }
 
   public Thread startChecker() {
-    return Threads.createThread("RC checker", () -> {
+    return Threads.createNonCriticalThread("RC checker", () -> {
       try {
         while (!stopCheckerThread.get()) {
           checkRunning();

--- a/test/src/main/java/org/apache/accumulo/test/metrics/TestStatsDSink.java
+++ b/test/src/main/java/org/apache/accumulo/test/metrics/TestStatsDSink.java
@@ -103,7 +103,7 @@ public class TestStatsDSink implements Closeable {
   public TestStatsDSink() throws SocketException {
     sock = new DatagramSocket();
     int len = sock.getReceiveBufferSize();
-    Threads.createThread("test-server-thread", () -> {
+    Threads.createNonCriticalThread("test-server-thread", () -> {
       while (!sock.isClosed()) {
         byte[] buf = new byte[len];
         DatagramPacket packet = new DatagramPacket(buf, len);


### PR DESCRIPTION
- Identified and updated which threads should or shouldn't be critical to the process they are running in (previously, all threads created were non-critical). "Critical" meaning if an (unhandled) `RuntimeException` occurs in the thread, the process should be halted. All threads (i.e., those created through both `createNonCriticalThread` or `createCriticalThread`) already halt the process if an `Error` occurs via the `AccumuloUncaughtExceptionHandler`. So, now we handle all cases of unchecked exceptions (`Error` and `RuntimeException`): all `Error`s will result in `halt()` and we choose whether or not a `RuntimeException` will result in `halt()`.
- Renamed `Threads.createThread()` to `Threads.createNonCriticalThread()` to ensure callers consider which method to use.

I have provided my reasoning for each of the decisions for critical vs non critical, in case they are helpful in review.

Something still left todo for this is to review the threads in 4.0 and determine if there are any new threads there that need to be considered. Will look into this now.

closes #5546