### PR TITLE
Fix to some shared mini cluster ITs

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_1_IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_1_IT.java
@@ -101,6 +101,7 @@ import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.test.functional.SlowIterator;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -124,6 +125,11 @@ public class ExternalCompaction_1_IT extends SharedMiniClusterBase {
   @BeforeAll
   public static void beforeTests() throws Exception {
     startMiniClusterWithConfig(new ExternalCompaction1Config());
+  }
+
+  @AfterAll
+  public static void afterTests() {
+    stopMiniCluster();
   }
 
   @AfterEach

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_2_IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_2_IT.java
@@ -66,6 +66,7 @@ import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.test.functional.SlowIterator;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -86,6 +87,11 @@ public class ExternalCompaction_2_IT extends SharedMiniClusterBase {
   @BeforeAll
   public static void beforeTests() throws Exception {
     startMiniClusterWithConfig(new ExternalCompaction2Config());
+  }
+
+  @AfterAll
+  public static void afterTests() {
+    stopMiniCluster();
   }
 
   @AfterEach

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_3_IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_3_IT.java
@@ -54,6 +54,7 @@ import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -70,6 +71,11 @@ public class ExternalCompaction_3_IT extends SharedMiniClusterBase {
   @BeforeAll
   public static void beforeTests() throws Exception {
     startMiniClusterWithConfig(new ExternalCompaction3Config());
+  }
+
+  @AfterAll
+  public static void afterTests() {
+    stopMiniCluster();
   }
 
   @AfterEach


### PR DESCRIPTION
Some mini cluster ITs were missing a
`SharedMiniClusterBase.stopMiniCluster()` in a JUnit AfterAll. Added to those that were missing.

This has already been fixed in main by #5555

Mini cluster needs to be started in a `BeforeAll` with `SharedMiniClusterBase.startMiniCluster()` or `SharedMiniClusterBase.startMiniClusterWithConfig(...)` and stopped in an `AfterAll` with `SharedMiniClusterBase.stopMiniCluster()`, so used:
```
$ grep -rl --include *.java "startMiniCluster" . | xargs grep -L "stopMiniCluster"
```
To identify tests not adhering to this