### PR TITLE
TableManager.getTableState no longer returns null

### DIFF
--- a/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
@@ -342,7 +342,7 @@ public class GCRun implements GarbageCollectionEnvironment {
                 TableId tableId = TableId.of(parts[1]);
                 String tabletDir = parts[2];
                 TableState tableState = context.getTableManager().getTableState(tableId);
-                if (tableState != null && tableState != TableState.DELETING) {
+                if (tableState != TableState.UNKNOWN && tableState != TableState.DELETING) {
                   // clone directories don't always exist
                   if (!tabletDir.startsWith(Constants.CLONE_PREFIX)) {
                     log.debug("{} File doesn't exist: {}", fileActionPrefix, pathToDel);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
@@ -60,6 +60,7 @@ import org.apache.accumulo.core.logging.ConditionalLogger.EscalatingLogger;
 import org.apache.accumulo.core.logging.TabletLogger;
 import org.apache.accumulo.core.manager.state.TabletManagement;
 import org.apache.accumulo.core.manager.state.TabletManagement.ManagementAction;
+import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.core.manager.thrift.ManagerGoalState;
 import org.apache.accumulo.core.manager.thrift.ManagerState;
 import org.apache.accumulo.core.manager.thrift.TabletServerStatus;
@@ -484,7 +485,7 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
 
       final TableId tableId = tm.getTableId();
       // ignore entries for tables that do not exist in zookeeper
-      if (manager.getTableManager().getTableState(tableId) == null) {
+      if (manager.getTableManager().getTableState(tableId) == TableState.UNKNOWN) {
         continue;
       }
 


### PR DESCRIPTION
The change in #5422 to return TableState.UNKNOWN
instead of null when the TableId does not exist
or the state is not a valid value. Calling code
in GCRun and TabletGroupWatcher need to be updated to account for this change.

Closes #5564