### PR TITLE
avoid abstract classes ending in 'IT'

### DIFF
--- a/src/build/ci/find-unapproved-junit.sh
+++ b/src/build/ci/find-unapproved-junit.sh
@@ -35,7 +35,7 @@ function findalljunitproblems() {
     opts='-PRlH'
   fi
   # find any new classes using something other than the jupiter API, except those allowed
-  grep "$opts" --include='*.java' 'org[.]junit[.](?!(jupiter|platform[.]suite)' | grep -Pv "^(${ALLOWED_PIPE_SEP//./[.]})\$"
+  grep "$opts" --include='*.java' 'org[.]junit[.](?!(jupiter|platform[.]suite))' | grep -Pv "^(${ALLOWED_PIPE_SEP//./[.]})\$"
   if ((${#ALLOWED[@]} != 0)); then
     # find any uses of the jupiter API in the allowed vintage classes
     grep "$opts" 'org[.]junit[.]jupiter' "${ALLOWED[@]}"

--- a/test/src/main/java/org/apache/accumulo/test/ComprehensiveFlakyAmpleIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ComprehensiveFlakyAmpleIT.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.BeforeAll;
  * {@link org.apache.accumulo.test.ample.FlakyAmpleServerContext} because it will make a lot of
  * metadata updates using Ample.
  */
-public class ComprehensiveFlakyAmpleIT extends ComprehensiveBaseIT {
+public class ComprehensiveFlakyAmpleIT extends ComprehensiveITBase {
   @BeforeAll
   public static void setup() throws Exception {
     SharedMiniClusterBase.startMiniClusterWithConfig((cfg, coreSite) -> {

--- a/test/src/main/java/org/apache/accumulo/test/ComprehensiveFlakyFateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ComprehensiveFlakyFateIT.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.BeforeAll;
  * This test touches a lot of the Accumulo API, so it's a good candidate to run using
  * {@link org.apache.accumulo.test.fate.FlakyFate} because it will run a lot of FATE operations.
  */
-public class ComprehensiveFlakyFateIT extends ComprehensiveBaseIT {
+public class ComprehensiveFlakyFateIT extends ComprehensiveITBase {
   @BeforeAll
   public static void setup() throws Exception {
     SharedMiniClusterBase.startMiniClusterWithConfig(

--- a/test/src/main/java/org/apache/accumulo/test/ComprehensiveITBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/ComprehensiveITBase.java
@@ -114,7 +114,7 @@ import com.google.common.collect.Sets;
  * It provides a quick test that verifies a lot of functionality is working for basic use. This test
  * does not provide deep coverage of the features it tests.
  */
-public abstract class ComprehensiveBaseIT extends SharedMiniClusterBase {
+public abstract class ComprehensiveITBase extends SharedMiniClusterBase {
 
   public static final String DOG_AND_CAT = "DOG&CAT";
   static final Authorizations AUTHORIZATIONS = new Authorizations("CAT", "DOG");

--- a/test/src/main/java/org/apache/accumulo/test/ComprehensiveIT_SimpleSuite.java
+++ b/test/src/main/java/org/apache/accumulo/test/ComprehensiveIT_SimpleSuite.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 
 @Tag(SUNNY_DAY)
-public class ComprehensiveIT_SimpleSuite extends ComprehensiveBaseIT {
+public class ComprehensiveIT_SimpleSuite extends ComprehensiveITBase {
   @BeforeAll
   public static void setup() throws Exception {
     SharedMiniClusterBase.startMiniCluster();

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction2ITBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction2ITBase.java
@@ -70,7 +70,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
-public abstract class ExternalCompaction2BaseIT extends SharedMiniClusterBase {
+public abstract class ExternalCompaction2ITBase extends SharedMiniClusterBase {
 
   static class ExternalCompaction2Config implements MiniClusterConfigurationCallback {
     @Override

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_2_IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_2_IT.java
@@ -20,7 +20,7 @@ package org.apache.accumulo.test.compaction;
 
 import org.junit.jupiter.api.BeforeAll;
 
-public class ExternalCompaction_2_IT extends ExternalCompaction2BaseIT {
+public class ExternalCompaction_2_IT extends ExternalCompaction2ITBase {
 
   @BeforeAll
   public static void beforeTests() throws Exception {

--- a/test/src/main/java/org/apache/accumulo/test/compaction/FlakyExternalCompaction2IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/FlakyExternalCompaction2IT.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.BeforeAll;
  * that rejection handlers such as the handler used for
  * CompactionCoordinator.compactionFailedForLevel work.
  */
-public class FlakyExternalCompaction2IT extends ExternalCompaction2BaseIT {
+public class FlakyExternalCompaction2IT extends ExternalCompaction2ITBase {
 
   static class FlakyExternalCompaction2Config extends ExternalCompaction2Config {
     @Override

--- a/test/src/main/java/org/apache/accumulo/test/fate/FateExecutionOrderITBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FateExecutionOrderITBase.java
@@ -65,8 +65,8 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Iterators;
 
-public abstract class FateExecutionOrderIT extends SharedMiniClusterBase
-    implements FateTestRunner<FateExecutionOrderIT.FeoTestEnv> {
+public abstract class FateExecutionOrderITBase extends SharedMiniClusterBase
+    implements FateTestRunner<FateExecutionOrderITBase.FeoTestEnv> {
 
   public static class FeoTestEnv extends FateTestRunner.TestEnv {
     private final AccumuloClient client;
@@ -80,7 +80,7 @@ public abstract class FateExecutionOrderIT extends SharedMiniClusterBase
     }
   }
 
-  public static class FirstOp implements Repo<FateExecutionOrderIT.FeoTestEnv> {
+  public static class FirstOp implements Repo<FateExecutionOrderITBase.FeoTestEnv> {
 
     private static final long serialVersionUID = 1L;
 
@@ -245,7 +245,7 @@ public abstract class FateExecutionOrderIT extends SharedMiniClusterBase
       }
 
       Scanner scanner = client.createScanner(FATE_TRACKING_TABLE);
-      var iter = scanner.stream().map(FateExecutionOrderIT::toIdStep).iterator();
+      var iter = scanner.stream().map(FateExecutionOrderITBase::toIdStep).iterator();
 
       // we should see the following execution order for all fate ids:
       // FirstOp::isReady1, FirstOp::isReady2, FirstOp::call,

--- a/test/src/main/java/org/apache/accumulo/test/fate/FateITBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FateITBase.java
@@ -60,9 +60,9 @@ import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public abstract class FateIT extends SharedMiniClusterBase implements FateTestRunner<TestEnv> {
+public abstract class FateITBase extends SharedMiniClusterBase implements FateTestRunner<TestEnv> {
 
-  private static final Logger LOG = LoggerFactory.getLogger(FateIT.class);
+  private static final Logger LOG = LoggerFactory.getLogger(FateITBase.class);
 
   private static CountDownLatch callStarted;
   private static CountDownLatch finishCall;
@@ -99,7 +99,7 @@ public abstract class FateIT extends SharedMiniClusterBase implements FateTestRu
     public Repo<TestEnv> call(FateId fateId, TestEnv environment) throws Exception {
       LOG.debug("Entering call {}", fateId);
       try {
-        FateIT.inCall();
+        FateITBase.inCall();
         return null;
       } finally {
         LOG.debug("Leaving call {}", fateId);

--- a/test/src/main/java/org/apache/accumulo/test/fate/FateOpsCommandsITBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FateOpsCommandsITBase.java
@@ -72,8 +72,8 @@ import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.util.Admin;
 import org.apache.accumulo.server.util.fateCommand.FateSummaryReport;
 import org.apache.accumulo.server.util.fateCommand.FateTxnDetails;
-import org.apache.accumulo.test.fate.MultipleStoresIT.LatchTestEnv;
-import org.apache.accumulo.test.fate.MultipleStoresIT.LatchTestRepo;
+import org.apache.accumulo.test.fate.MultipleStoresITBase.LatchTestEnv;
+import org.apache.accumulo.test.fate.MultipleStoresITBase.LatchTestRepo;
 import org.apache.accumulo.test.functional.ConfigurableMacBase;
 import org.apache.accumulo.test.functional.ReadWriteIT;
 import org.apache.accumulo.test.functional.SlowIterator;
@@ -82,7 +82,7 @@ import org.easymock.EasyMock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public abstract class FateOpsCommandsIT extends ConfigurableMacBase
+public abstract class FateOpsCommandsITBase extends ConfigurableMacBase
     implements FateTestRunner<LatchTestEnv> {
 
   @Override

--- a/test/src/main/java/org/apache/accumulo/test/fate/FatePoolsWatcherITBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FatePoolsWatcherITBase.java
@@ -44,8 +44,8 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests the functionality of the FATE pools watcher task
  */
-public abstract class FatePoolsWatcherIT extends SharedMiniClusterBase
-    implements FateTestRunner<FatePoolsWatcherIT.PoolResizeTestEnv> {
+public abstract class FatePoolsWatcherITBase extends SharedMiniClusterBase
+    implements FateTestRunner<FatePoolsWatcherITBase.PoolResizeTestEnv> {
 
   private static final Set<Fate.FateOperation> ALL_USER_FATE_OPS =
       Fate.FateOperation.getAllUserFateOps();

--- a/test/src/main/java/org/apache/accumulo/test/fate/FateStatusEnforcementITBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FateStatusEnforcementITBase.java
@@ -32,16 +32,16 @@ import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
-public abstract class FateStatusEnforcementIT extends SharedMiniClusterBase {
+public abstract class FateStatusEnforcementITBase extends SharedMiniClusterBase {
 
   protected FateId fateId;
   protected FateStore<FateTestRunner.TestEnv> store;
-  protected FateStore.FateTxStore<FateIT.TestEnv> txStore;
+  protected FateStore.FateTxStore<FateITBase.TestEnv> txStore;
 
   @Test
   public void push() throws Exception {
     testOperationWithStatuses(() -> {}, // No special setup needed for push
-        () -> txStore.push(new FateIT.TestRepo("testOp")), AbstractFateStore.REQ_PUSH_STATUS);
+        () -> txStore.push(new FateITBase.TestRepo("testOp")), AbstractFateStore.REQ_PUSH_STATUS);
   }
 
   @Test
@@ -50,7 +50,7 @@ public abstract class FateStatusEnforcementIT extends SharedMiniClusterBase {
       // Setup for pop: Ensure there something to pop by first pushing
       try {
         txStore.setStatus(ReadOnlyFateStore.TStatus.NEW);
-        txStore.push(new FateIT.TestRepo("testOp"));
+        txStore.push(new FateITBase.TestRepo("testOp"));
       } catch (Exception e) {
         throw new RuntimeException("Failed to setup for pop", e);
       }

--- a/test/src/main/java/org/apache/accumulo/test/fate/FateStoreITBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FateStoreITBase.java
@@ -63,7 +63,7 @@ import org.apache.accumulo.core.fate.StackOverflowException;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.server.ServerContext;
-import org.apache.accumulo.test.fate.FateIT.TestRepo;
+import org.apache.accumulo.test.fate.FateITBase.TestRepo;
 import org.apache.accumulo.test.fate.FateTestRunner.TestEnv;
 import org.apache.accumulo.test.util.Wait;
 import org.apache.hadoop.io.Text;
@@ -71,7 +71,8 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Sets;
 
-public abstract class FateStoreIT extends SharedMiniClusterBase implements FateTestRunner<TestEnv> {
+public abstract class FateStoreITBase extends SharedMiniClusterBase
+    implements FateTestRunner<TestEnv> {
 
   @Override
   protected Duration defaultTimeout() {

--- a/test/src/main/java/org/apache/accumulo/test/fate/FateTestRunner.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FateTestRunner.java
@@ -34,8 +34,8 @@ public interface FateTestRunner<T extends TestEnv> {
         AbstractFateStore.DEFAULT_FATE_ID_GENERATOR);
   }
 
-  default void stopManagerAndExecuteTest(FateTestExecutor<MultipleStoresIT.LatchTestEnv> testMethod)
-      throws Exception {
+  default void stopManagerAndExecuteTest(
+      FateTestExecutor<MultipleStoresITBase.LatchTestEnv> testMethod) throws Exception {
     throw new UnsupportedOperationException("Not implemented");
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/fate/MultipleStoresITBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/MultipleStoresITBase.java
@@ -55,9 +55,9 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Sets;
 
-public abstract class MultipleStoresIT extends SharedMiniClusterBase {
+public abstract class MultipleStoresITBase extends SharedMiniClusterBase {
 
-  private static final Logger LOG = LoggerFactory.getLogger(MultipleStoresIT.class);
+  private static final Logger LOG = LoggerFactory.getLogger(MultipleStoresITBase.class);
 
   @Test
   public void testReserveUnreserve() throws Exception {

--- a/test/src/main/java/org/apache/accumulo/test/fate/meta/MetaFateExecutionOrderIT_SimpleSuite.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/meta/MetaFateExecutionOrderIT_SimpleSuite.java
@@ -28,9 +28,9 @@ import org.apache.accumulo.core.fate.AbstractFateStore;
 import org.apache.accumulo.core.fate.zookeeper.MetaFateStore;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.core.zookeeper.ZooSession;
-import org.apache.accumulo.test.fate.FateExecutionOrderIT;
+import org.apache.accumulo.test.fate.FateExecutionOrderITBase;
 
-public class MetaFateExecutionOrderIT_SimpleSuite extends FateExecutionOrderIT {
+public class MetaFateExecutionOrderIT_SimpleSuite extends FateExecutionOrderITBase {
 
   // put the fate data for the test in a different location than what accumulo is using
   private static final InstanceId IID = InstanceId.of(UUID.randomUUID());

--- a/test/src/main/java/org/apache/accumulo/test/fate/meta/MetaFateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/meta/MetaFateIT.java
@@ -34,7 +34,7 @@ import org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus;
 import org.apache.accumulo.core.fate.zookeeper.MetaFateStore;
 import org.apache.accumulo.core.zookeeper.ZooSession;
 import org.apache.accumulo.server.ServerContext;
-import org.apache.accumulo.test.fate.FateIT;
+import org.apache.accumulo.test.fate.FateITBase;
 import org.apache.accumulo.test.fate.FateTestUtil;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.zookeeper.KeeperException;
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.io.TempDir;
 
-public class MetaFateIT extends FateIT {
+public class MetaFateIT extends FateITBase {
   @TempDir
   private static File tempDir;
 

--- a/test/src/main/java/org/apache/accumulo/test/fate/meta/MetaFateOpsCommandsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/meta/MetaFateOpsCommandsIT.java
@@ -26,15 +26,15 @@ import org.apache.accumulo.core.fate.zookeeper.MetaFateStore;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.core.lock.ServiceLock;
 import org.apache.accumulo.server.ServerContext;
-import org.apache.accumulo.test.fate.FateOpsCommandsIT;
-import org.apache.accumulo.test.fate.MultipleStoresIT.LatchTestEnv;
+import org.apache.accumulo.test.fate.FateOpsCommandsITBase;
+import org.apache.accumulo.test.fate.MultipleStoresITBase.LatchTestEnv;
 import org.apache.accumulo.test.fate.TestLock;
 
-public class MetaFateOpsCommandsIT extends FateOpsCommandsIT {
+public class MetaFateOpsCommandsIT extends FateOpsCommandsITBase {
   /**
    * This should be used for tests that will not seed a txn with work/reserve a txn. Note that this
    * should be used in conjunction with
-   * {@link FateOpsCommandsIT#initFateNoDeadResCleaner(FateStore)}
+   * {@link FateOpsCommandsITBase#initFateNoDeadResCleaner(FateStore)}
    */
   @Override
   public void executeTest(FateTestExecutor<LatchTestEnv> testMethod, int maxDeferred,
@@ -48,7 +48,7 @@ public class MetaFateOpsCommandsIT extends FateOpsCommandsIT {
   /**
    * This should be used for tests that will seed a txn with work/reserve a txn. Note that this
    * should be used in conjunction with
-   * {@link FateOpsCommandsIT#initFateWithDeadResCleaner(FateStore, LatchTestEnv)}
+   * {@link FateOpsCommandsITBase#initFateWithDeadResCleaner(FateStore, LatchTestEnv)}
    */
   @Override
   public void stopManagerAndExecuteTest(FateTestExecutor<LatchTestEnv> testMethod)

--- a/test/src/main/java/org/apache/accumulo/test/fate/meta/MetaFatePoolsWatcherIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/meta/MetaFatePoolsWatcherIT.java
@@ -28,13 +28,13 @@ import java.io.File;
 import org.apache.accumulo.core.fate.AbstractFateStore;
 import org.apache.accumulo.core.fate.zookeeper.MetaFateStore;
 import org.apache.accumulo.server.ServerContext;
-import org.apache.accumulo.test.fate.FatePoolsWatcherIT;
+import org.apache.accumulo.test.fate.FatePoolsWatcherITBase;
 import org.apache.accumulo.test.fate.FateTestUtil;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.io.TempDir;
 
-public class MetaFatePoolsWatcherIT extends FatePoolsWatcherIT {
+public class MetaFatePoolsWatcherIT extends FatePoolsWatcherITBase {
   @TempDir
   private static File tempDir;
 

--- a/test/src/main/java/org/apache/accumulo/test/fate/meta/MetaFateStatusEnforcementIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/meta/MetaFateStatusEnforcementIT.java
@@ -23,14 +23,14 @@ import static org.apache.accumulo.test.fate.TestLock.createDummyLockID;
 import java.io.File;
 
 import org.apache.accumulo.core.fate.zookeeper.MetaFateStore;
-import org.apache.accumulo.test.fate.FateStatusEnforcementIT;
+import org.apache.accumulo.test.fate.FateStatusEnforcementITBase;
 import org.apache.accumulo.test.fate.FateTestUtil;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 
-public class MetaFateStatusEnforcementIT extends FateStatusEnforcementIT {
+public class MetaFateStatusEnforcementIT extends FateStatusEnforcementITBase {
   @TempDir
   private static File tempDir;
 

--- a/test/src/main/java/org/apache/accumulo/test/fate/meta/MetaFateStoreFateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/meta/MetaFateStoreFateIT.java
@@ -45,7 +45,7 @@ import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.MetaFateStore;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.accumulo.server.ServerContext;
-import org.apache.accumulo.test.fate.FateStoreIT;
+import org.apache.accumulo.test.fate.FateStoreITBase;
 import org.apache.accumulo.test.fate.FateTestUtil;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -53,7 +53,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.io.TempDir;
 
 @Tag(ZOOKEEPER_TESTING_SERVER)
-public class MetaFateStoreFateIT extends FateStoreIT {
+public class MetaFateStoreFateIT extends FateStoreITBase {
   @TempDir
   private static File tempDir;
 

--- a/test/src/main/java/org/apache/accumulo/test/fate/meta/MetaMultipleStoresIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/meta/MetaMultipleStoresIT.java
@@ -25,13 +25,13 @@ import org.apache.accumulo.core.fate.FateStore;
 import org.apache.accumulo.core.fate.zookeeper.MetaFateStore;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.test.fate.FateTestUtil;
-import org.apache.accumulo.test.fate.MultipleStoresIT;
+import org.apache.accumulo.test.fate.MultipleStoresITBase;
 import org.apache.zookeeper.KeeperException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.io.TempDir;
 
-public class MetaMultipleStoresIT extends MultipleStoresIT {
+public class MetaMultipleStoresIT extends MultipleStoresITBase {
   @TempDir
   private static File tempDir;
 

--- a/test/src/main/java/org/apache/accumulo/test/fate/user/FateMutatorImplIT_SimpleSuite.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/user/FateMutatorImplIT_SimpleSuite.java
@@ -39,7 +39,7 @@ import org.apache.accumulo.core.fate.user.FateMutator;
 import org.apache.accumulo.core.fate.user.FateMutatorImpl;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
-import org.apache.accumulo.test.fate.FateIT;
+import org.apache.accumulo.test.fate.FateITBase;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -79,21 +79,26 @@ public class FateMutatorImplIT_SimpleSuite extends SharedMiniClusterBase {
           FateId.from(FateInstanceType.fromNamespaceOrTableName(table), UUID.randomUUID());
 
       // add some repos in order
-      FateMutatorImpl<FateIT.TestEnv> fateMutator = new FateMutatorImpl<>(context, table, fateId);
-      fateMutator.putRepo(100, new FateIT.TestRepo("test")).mutate();
-      FateMutatorImpl<FateIT.TestEnv> fateMutator1 = new FateMutatorImpl<>(context, table, fateId);
-      fateMutator1.putRepo(99, new FateIT.TestRepo("test")).mutate();
-      FateMutatorImpl<FateIT.TestEnv> fateMutator2 = new FateMutatorImpl<>(context, table, fateId);
-      fateMutator2.putRepo(98, new FateIT.TestRepo("test")).mutate();
+      FateMutatorImpl<FateITBase.TestEnv> fateMutator =
+          new FateMutatorImpl<>(context, table, fateId);
+      fateMutator.putRepo(100, new FateITBase.TestRepo("test")).mutate();
+      FateMutatorImpl<FateITBase.TestEnv> fateMutator1 =
+          new FateMutatorImpl<>(context, table, fateId);
+      fateMutator1.putRepo(99, new FateITBase.TestRepo("test")).mutate();
+      FateMutatorImpl<FateITBase.TestEnv> fateMutator2 =
+          new FateMutatorImpl<>(context, table, fateId);
+      fateMutator2.putRepo(98, new FateITBase.TestRepo("test")).mutate();
 
       // make sure we cant add a repo that has already been added
-      FateMutatorImpl<FateIT.TestEnv> fateMutator3 = new FateMutatorImpl<>(context, table, fateId);
+      FateMutatorImpl<FateITBase.TestEnv> fateMutator3 =
+          new FateMutatorImpl<>(context, table, fateId);
       assertThrows(IllegalStateException.class,
-          () -> fateMutator3.putRepo(98, new FateIT.TestRepo("test")).mutate(),
+          () -> fateMutator3.putRepo(98, new FateITBase.TestRepo("test")).mutate(),
           "Repo in position 98 already exists. Expected to not be able to add it again.");
-      FateMutatorImpl<FateIT.TestEnv> fateMutator4 = new FateMutatorImpl<>(context, table, fateId);
+      FateMutatorImpl<FateITBase.TestEnv> fateMutator4 =
+          new FateMutatorImpl<>(context, table, fateId);
       assertThrows(IllegalStateException.class,
-          () -> fateMutator4.putRepo(99, new FateIT.TestRepo("test")).mutate(),
+          () -> fateMutator4.putRepo(99, new FateITBase.TestRepo("test")).mutate(),
           "Repo in position 99 already exists. Expected to not be able to add it again.");
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/fate/user/FateMutatorImplIT_SimpleSuite.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/user/FateMutatorImplIT_SimpleSuite.java
@@ -33,13 +33,13 @@ import org.apache.accumulo.core.client.admin.TabletAvailability;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.FateInstanceType;
-import org.apache.accumulo.core.fate.FateStore;
+import org.apache.accumulo.core.fate.FateStore.FateReservation;
 import org.apache.accumulo.core.fate.ReadOnlyFateStore;
-import org.apache.accumulo.core.fate.user.FateMutator;
 import org.apache.accumulo.core.fate.user.FateMutatorImpl;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
-import org.apache.accumulo.test.fate.FateITBase;
+import org.apache.accumulo.test.fate.FateITBase.TestRepo;
+import org.apache.accumulo.test.fate.FateTestRunner.TestEnv;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -75,30 +75,24 @@ public class FateMutatorImplIT_SimpleSuite extends SharedMiniClusterBase {
 
       ClientContext context = (ClientContext) client;
 
-      FateId fateId =
-          FateId.from(FateInstanceType.fromNamespaceOrTableName(table), UUID.randomUUID());
+      var fateId = FateId.from(FateInstanceType.USER, UUID.randomUUID());
 
       // add some repos in order
-      FateMutatorImpl<FateITBase.TestEnv> fateMutator =
-          new FateMutatorImpl<>(context, table, fateId);
-      fateMutator.putRepo(100, new FateITBase.TestRepo("test")).mutate();
-      FateMutatorImpl<FateITBase.TestEnv> fateMutator1 =
-          new FateMutatorImpl<>(context, table, fateId);
-      fateMutator1.putRepo(99, new FateITBase.TestRepo("test")).mutate();
-      FateMutatorImpl<FateITBase.TestEnv> fateMutator2 =
-          new FateMutatorImpl<>(context, table, fateId);
-      fateMutator2.putRepo(98, new FateITBase.TestRepo("test")).mutate();
+      var fateMutator = new FateMutatorImpl<TestEnv>(context, table, fateId);
+      fateMutator.putRepo(100, new TestRepo("test")).mutate();
+      var fateMutator1 = new FateMutatorImpl<TestEnv>(context, table, fateId);
+      fateMutator1.putRepo(99, new TestRepo("test")).mutate();
+      var fateMutator2 = new FateMutatorImpl<TestEnv>(context, table, fateId);
+      fateMutator2.putRepo(98, new TestRepo("test")).mutate();
 
       // make sure we cant add a repo that has already been added
-      FateMutatorImpl<FateITBase.TestEnv> fateMutator3 =
-          new FateMutatorImpl<>(context, table, fateId);
+      var fateMutator3 = new FateMutatorImpl<TestEnv>(context, table, fateId);
       assertThrows(IllegalStateException.class,
-          () -> fateMutator3.putRepo(98, new FateITBase.TestRepo("test")).mutate(),
+          () -> fateMutator3.putRepo(98, new TestRepo("test")).mutate(),
           "Repo in position 98 already exists. Expected to not be able to add it again.");
-      FateMutatorImpl<FateITBase.TestEnv> fateMutator4 =
-          new FateMutatorImpl<>(context, table, fateId);
+      var fateMutator4 = new FateMutatorImpl<TestEnv>(context, table, fateId);
       assertThrows(IllegalStateException.class,
-          () -> fateMutator4.putRepo(99, new FateITBase.TestRepo("test")).mutate(),
+          () -> fateMutator4.putRepo(99, new TestRepo("test")).mutate(),
           "Repo in position 99 already exists. Expected to not be able to add it again.");
     }
   }
@@ -111,8 +105,7 @@ public class FateMutatorImplIT_SimpleSuite extends SharedMiniClusterBase {
 
       ClientContext context = (ClientContext) client;
 
-      FateId fateId =
-          FateId.from(FateInstanceType.fromNamespaceOrTableName(table), UUID.randomUUID());
+      var fateId = FateId.from(FateInstanceType.USER, UUID.randomUUID());
 
       // use require status passing all statuses. without the status column present this should fail
       assertThrows(IllegalStateException.class,
@@ -185,15 +178,13 @@ public class FateMutatorImplIT_SimpleSuite extends SharedMiniClusterBase {
 
       ClientContext context = (ClientContext) client;
 
-      FateId fateId = FateId.from(FateInstanceType.USER, UUID.randomUUID());
-      ZooUtil.LockID lockID = new ZooUtil.LockID("/locks", "L1", 50);
-      FateStore.FateReservation reservation =
-          FateStore.FateReservation.from(lockID, UUID.randomUUID());
-      FateStore.FateReservation wrongReservation =
-          FateStore.FateReservation.from(lockID, UUID.randomUUID());
+      var fateId = FateId.from(FateInstanceType.USER, UUID.randomUUID());
+      var lockID = new ZooUtil.LockID("/locks", "L1", 50);
+      var reservation = FateReservation.from(lockID, UUID.randomUUID());
+      var wrongReservation = FateReservation.from(lockID, UUID.randomUUID());
 
       // Ensure that reserving is the only thing we can do
-      FateMutator.Status status =
+      var status =
           new FateMutatorImpl<>(context, table, fateId).putUnreserveTx(reservation).tryMutate();
       assertEquals(REJECTED, status);
       status = new FateMutatorImpl<>(context, table, fateId).putReservedTx(reservation).tryMutate();

--- a/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateExecutionOrderIT_SimpleSuite.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateExecutionOrderIT_SimpleSuite.java
@@ -25,9 +25,9 @@ import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.fate.AbstractFateStore;
 import org.apache.accumulo.core.fate.user.UserFateStore;
-import org.apache.accumulo.test.fate.FateExecutionOrderIT;
+import org.apache.accumulo.test.fate.FateExecutionOrderITBase;
 
-public class UserFateExecutionOrderIT_SimpleSuite extends FateExecutionOrderIT {
+public class UserFateExecutionOrderIT_SimpleSuite extends FateExecutionOrderITBase {
   @Override
   public void executeTest(FateTestExecutor<FeoTestEnv> testMethod, int maxDeferred,
       AbstractFateStore.FateIdGenerator fateIdGenerator) throws Exception {

--- a/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateIT_SimpleSuite.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateIT_SimpleSuite.java
@@ -42,12 +42,12 @@ import org.apache.accumulo.core.metadata.SystemTables;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.server.ServerContext;
-import org.apache.accumulo.test.fate.FateIT;
+import org.apache.accumulo.test.fate.FateITBase;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class UserFateIT_SimpleSuite extends FateIT {
+public class UserFateIT_SimpleSuite extends FateITBase {
 
   private String table;
 

--- a/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateOpsCommandsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateOpsCommandsIT.java
@@ -26,15 +26,15 @@ import org.apache.accumulo.core.fate.user.UserFateStore;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.core.lock.ServiceLock;
 import org.apache.accumulo.core.metadata.SystemTables;
-import org.apache.accumulo.test.fate.FateOpsCommandsIT;
-import org.apache.accumulo.test.fate.MultipleStoresIT.LatchTestEnv;
+import org.apache.accumulo.test.fate.FateOpsCommandsITBase;
+import org.apache.accumulo.test.fate.MultipleStoresITBase.LatchTestEnv;
 import org.apache.accumulo.test.fate.TestLock;
 
-public class UserFateOpsCommandsIT extends FateOpsCommandsIT {
+public class UserFateOpsCommandsIT extends FateOpsCommandsITBase {
   /**
    * This should be used for tests that will not seed a txn with work/reserve a txn. Note that this
    * should be used in conjunction with
-   * {@link FateOpsCommandsIT#initFateNoDeadResCleaner(FateStore)}
+   * {@link FateOpsCommandsITBase#initFateNoDeadResCleaner(FateStore)}
    */
   @Override
   public void executeTest(FateTestExecutor<LatchTestEnv> testMethod, int maxDeferred,
@@ -48,7 +48,7 @@ public class UserFateOpsCommandsIT extends FateOpsCommandsIT {
   /**
    * This should be used for tests that will seed a txn with work/reserve a txn. Note that this
    * should be used in conjunction with
-   * {@link FateOpsCommandsIT#initFateWithDeadResCleaner(FateStore, LatchTestEnv)}
+   * {@link FateOpsCommandsITBase#initFateWithDeadResCleaner(FateStore, LatchTestEnv)}
    */
   @Override
   public void stopManagerAndExecuteTest(FateTestExecutor<LatchTestEnv> testMethod)

--- a/test/src/main/java/org/apache/accumulo/test/fate/user/UserFatePoolsWatcherIT_SimpleSuite.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/user/UserFatePoolsWatcherIT_SimpleSuite.java
@@ -26,11 +26,11 @@ import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.fate.AbstractFateStore;
 import org.apache.accumulo.core.fate.user.UserFateStore;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
-import org.apache.accumulo.test.fate.FatePoolsWatcherIT;
+import org.apache.accumulo.test.fate.FatePoolsWatcherITBase;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 
-public class UserFatePoolsWatcherIT_SimpleSuite extends FatePoolsWatcherIT {
+public class UserFatePoolsWatcherIT_SimpleSuite extends FatePoolsWatcherITBase {
 
   private String table;
 

--- a/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateStatusEnforcementIT_SimpleSuite.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateStatusEnforcementIT_SimpleSuite.java
@@ -25,13 +25,13 @@ import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.fate.user.UserFateStore;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
-import org.apache.accumulo.test.fate.FateStatusEnforcementIT;
+import org.apache.accumulo.test.fate.FateStatusEnforcementITBase;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 
-public class UserFateStatusEnforcementIT_SimpleSuite extends FateStatusEnforcementIT {
+public class UserFateStatusEnforcementIT_SimpleSuite extends FateStatusEnforcementITBase {
   private ClientContext client;
   private String table;
 

--- a/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateStoreFateIT_SimpleSuite.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateStoreFateIT_SimpleSuite.java
@@ -34,11 +34,11 @@ import org.apache.accumulo.core.fate.user.UserFateStore;
 import org.apache.accumulo.core.fate.user.schema.FateSchema.TxColumnFamily;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.server.ServerContext;
-import org.apache.accumulo.test.fate.FateStoreIT;
+import org.apache.accumulo.test.fate.FateStoreITBase;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 
-public class UserFateStoreFateIT_SimpleSuite extends FateStoreIT {
+public class UserFateStoreFateIT_SimpleSuite extends FateStoreITBase {
 
   @BeforeAll
   public static void setup() throws Exception {

--- a/test/src/main/java/org/apache/accumulo/test/fate/user/UserMultipleStoresIT_SimpleSuite.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/user/UserMultipleStoresIT_SimpleSuite.java
@@ -31,13 +31,13 @@ import org.apache.accumulo.core.fate.FateStore;
 import org.apache.accumulo.core.fate.user.UserFateStore;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
-import org.apache.accumulo.test.fate.MultipleStoresIT;
+import org.apache.accumulo.test.fate.MultipleStoresITBase;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 
-public class UserMultipleStoresIT_SimpleSuite extends MultipleStoresIT {
+public class UserMultipleStoresIT_SimpleSuite extends MultipleStoresITBase {
   private ClientContext client;
   private String tableName;
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/CompactionFlakyAmpleIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CompactionFlakyAmpleIT.java
@@ -24,7 +24,7 @@ import org.apache.accumulo.test.ample.FlakyAmpleManager;
 import org.apache.accumulo.test.ample.FlakyAmpleTserver;
 import org.apache.hadoop.conf.Configuration;
 
-public class CompactionFlakyAmpleIT extends CompactionBaseIT {
+public class CompactionFlakyAmpleIT extends CompactionITBase {
   @Override
   public void configureMiniCluster(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
     super.configureMiniCluster(cfg, hadoopCoreSite);

--- a/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
@@ -120,7 +120,7 @@ import com.google.common.base.Supplier;
 import com.google.common.collect.Iterators;
 import com.google.common.net.HostAndPort;
 
-public class CompactionIT extends CompactionBaseIT {
+public class CompactionIT extends CompactionITBase {
 
   public static class TestFilter extends Filter {
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/CompactionITBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CompactionITBase.java
@@ -48,12 +48,12 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public abstract class CompactionBaseIT extends AccumuloClusterHarness {
+public abstract class CompactionITBase extends AccumuloClusterHarness {
 
   public static final String COMPACTOR_GROUP_1 = "cg1";
   public static final String COMPACTOR_GROUP_2 = "cg2";
   protected static final int MAX_DATA = 1000;
-  private static final Logger log = LoggerFactory.getLogger(CompactionBaseIT.class);
+  private static final Logger log = LoggerFactory.getLogger(CompactionITBase.class);
 
   @Override
   public void configureMiniCluster(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
@@ -65,9 +65,9 @@ public abstract class CompactionBaseIT extends AccumuloClusterHarness {
     hadoopCoreSite.set("fs.file.impl", RawLocalFileSystem.class.getName());
 
     cfg.getClusterServerConfiguration()
-        .addCompactorResourceGroup(CompactionBaseIT.COMPACTOR_GROUP_1, 1);
+        .addCompactorResourceGroup(CompactionITBase.COMPACTOR_GROUP_1, 1);
     cfg.getClusterServerConfiguration()
-        .addCompactorResourceGroup(CompactionBaseIT.COMPACTOR_GROUP_2, 1);
+        .addCompactorResourceGroup(CompactionITBase.COMPACTOR_GROUP_2, 1);
   }
 
   @Test

--- a/test/src/main/java/org/apache/accumulo/test/functional/MergeTabletsFlakyFateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MergeTabletsFlakyFateIT.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.BeforeAll;
  * Run all of the merge test using a flaky Fate impl that will run merge fate steps multiple times
  * to ensure idempotent.
  */
-public class MergeTabletsFlakyFateIT extends MergeTabletsBaseIT {
+public class MergeTabletsFlakyFateIT extends MergeTabletsITBase {
 
   @BeforeAll
   public static void setup() throws Exception {

--- a/test/src/main/java/org/apache/accumulo/test/functional/MergeTabletsITBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MergeTabletsITBase.java
@@ -84,9 +84,9 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public abstract class MergeTabletsBaseIT extends SharedMiniClusterBase {
+public abstract class MergeTabletsITBase extends SharedMiniClusterBase {
 
-  private static final Logger log = LoggerFactory.getLogger(MergeTabletsBaseIT.class);
+  private static final Logger log = LoggerFactory.getLogger(MergeTabletsITBase.class);
 
   SortedSet<Text> splits(String[] points) {
     SortedSet<Text> result = new TreeSet<>();

--- a/test/src/main/java/org/apache/accumulo/test/functional/MergeTabletsIT_SimpleSuite.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MergeTabletsIT_SimpleSuite.java
@@ -22,7 +22,7 @@ import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 
-public class MergeTabletsIT_SimpleSuite extends MergeTabletsBaseIT {
+public class MergeTabletsIT_SimpleSuite extends MergeTabletsITBase {
 
   @BeforeAll
   public static void setup() throws Exception {

--- a/test/src/main/java/org/apache/accumulo/test/functional/WALFlakyAmpleIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/WALFlakyAmpleIT.java
@@ -24,7 +24,7 @@ import org.apache.accumulo.test.ample.FlakyAmpleManager;
 import org.apache.accumulo.test.ample.FlakyAmpleTserver;
 import org.apache.hadoop.conf.Configuration;
 
-public class WALFlakyAmpleIT extends WALSunnyDayBaseIT {
+public class WALFlakyAmpleIT extends WALSunnyDayITBase {
   @Override
   protected void configure(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
     super.configure(cfg, hadoopCoreSite);

--- a/test/src/main/java/org/apache/accumulo/test/functional/WALSunnyDayIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/WALSunnyDayIT.java
@@ -29,6 +29,6 @@ import org.junit.jupiter.api.Tag;
  * the SUNNY_DAY tag which is not desirable.
  */
 @Tag(SUNNY_DAY)
-public class WALSunnyDayIT extends WALSunnyDayBaseIT {
+public class WALSunnyDayIT extends WALSunnyDayITBase {
 
 }

--- a/test/src/main/java/org/apache/accumulo/test/functional/WALSunnyDayITBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/WALSunnyDayITBase.java
@@ -70,7 +70,7 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Iterators;
 
-public abstract class WALSunnyDayBaseIT extends ConfigurableMacBase {
+public abstract class WALSunnyDayITBase extends ConfigurableMacBase {
 
   private static final Text CF = new Text(new byte[0]);
 


### PR DESCRIPTION
Re: https://github.com/apache/accumulo/pull/5581#discussion_r2110570716

Targeting 4.0 since 2.1 does not have this issue.

These are abstract classes, so they can't be run, so they shouldn't end in IT.

Did want to keep IT in the class name, as this is useful for grepping, so just made them all end in `ITBase` now.
