### PR TITLE
Replace status logger property with system property

### DIFF
--- a/assemble/conf/accumulo-env.sh
+++ b/assemble/conf/accumulo-env.sh
@@ -114,6 +114,7 @@ esac
 JAVA_OPTS=("-Daccumulo.log.dir=${ACCUMULO_LOG_DIR}"
   "-Daccumulo.application=${ACCUMULO_SERVICE_INSTANCE}_$(hostname)"
   "-Daccumulo.metrics.service.instance=${ACCUMULO_SERVICE_INSTANCE}"
+  "-Dlog4j2.statusLoggerLevel=ERROR"
   "-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector"
   "-Dotel.service.name=${ACCUMULO_SERVICE_INSTANCE}"
   "${JAVA_OPTS[@]}"

--- a/assemble/conf/log4j2-service.properties
+++ b/assemble/conf/log4j2-service.properties
@@ -20,7 +20,6 @@
 ## Log4j2 file that configures logging for all Accumulo services
 ## The system properties referenced below are configured by accumulo-env.sh
 
-status = warn
 dest = err
 name = AccumuloServiceLoggingProperties
 monitorInterval = 30

--- a/assemble/conf/log4j2.properties
+++ b/assemble/conf/log4j2.properties
@@ -19,7 +19,6 @@
 
 ## Log4j2 file that configures logging for processes other than Accumulo services
 
-status = warn
 dest = err
 name = AccumuloDefaultLoggingProperties
 monitorInterval = 30

--- a/core/src/test/resources/log4j2-test.properties
+++ b/core/src/test/resources/log4j2-test.properties
@@ -17,7 +17,6 @@
 # under the License.
 #
 
-status = warn
 dest = err
 name = AccumuloCoreTestLoggingProperties
 

--- a/hadoop-mapreduce/src/test/resources/log4j2-test.properties
+++ b/hadoop-mapreduce/src/test/resources/log4j2-test.properties
@@ -17,7 +17,6 @@
 # under the License.
 #
 
-status = warn
 dest = err
 name = AccumuloHadoopMapReduceTestLoggingProperties
 

--- a/iterator-test-harness/src/test/resources/log4j2-test.properties
+++ b/iterator-test-harness/src/test/resources/log4j2-test.properties
@@ -17,7 +17,6 @@
 # under the License.
 #
 
-status = warn
 dest = err
 name = AccumuloIteratorTestHarnessTestLoggingProperties
 

--- a/minicluster/src/test/resources/log4j2-test.properties
+++ b/minicluster/src/test/resources/log4j2-test.properties
@@ -17,7 +17,6 @@
 # under the License.
 #
 
-status = warn
 dest = err
 name = AccumuloMiniclusterTestLoggingProperties
 

--- a/server/base/src/test/resources/log4j2-test.properties
+++ b/server/base/src/test/resources/log4j2-test.properties
@@ -17,7 +17,6 @@
 # under the License.
 #
 
-status = warn
 dest = err
 name = AccumuloServerBaseTestLoggingProperties
 

--- a/server/compaction-coordinator/src/test/resources/log4j2-test.properties
+++ b/server/compaction-coordinator/src/test/resources/log4j2-test.properties
@@ -17,7 +17,6 @@
 # under the License.
 #
 
-status = info
 dest = err
 name = AccumuloCoreTestLoggingProperties
 

--- a/server/compactor/src/test/resources/log4j2-test.properties
+++ b/server/compactor/src/test/resources/log4j2-test.properties
@@ -17,7 +17,6 @@
 # under the License.
 #
 
-status = info
 dest = err
 name = AccumuloCoreTestLoggingProperties
 

--- a/server/gc/src/test/resources/log4j2-test.properties
+++ b/server/gc/src/test/resources/log4j2-test.properties
@@ -17,7 +17,6 @@
 # under the License.
 #
 
-status = warn
 dest = err
 name = AccumuloGcTestLoggingProperties
 

--- a/server/manager/src/test/resources/log4j2-test.properties
+++ b/server/manager/src/test/resources/log4j2-test.properties
@@ -17,7 +17,6 @@
 # under the License.
 #
 
-status = warn
 dest = err
 name = AccumuloManagerTestLoggingProperties
 

--- a/server/monitor/src/test/resources/log4j2-test.properties
+++ b/server/monitor/src/test/resources/log4j2-test.properties
@@ -17,7 +17,6 @@
 # under the License.
 #
 
-status = warn
 dest = err
 name = AccumuloMonitorTestLoggingProperties
 

--- a/server/tserver/src/test/resources/log4j2-test.properties
+++ b/server/tserver/src/test/resources/log4j2-test.properties
@@ -17,7 +17,6 @@
 # under the License.
 #
 
-status = warn
 dest = err
 name = AccumuloTserverTestLoggingProperties
 

--- a/shell/src/test/resources/log4j2-test.properties
+++ b/shell/src/test/resources/log4j2-test.properties
@@ -17,7 +17,6 @@
 # under the License.
 #
 
-status = warn
 dest = err
 name = AccumuloShellTestLoggingProperties
 

--- a/start/src/test/resources/log4j2-test.properties
+++ b/start/src/test/resources/log4j2-test.properties
@@ -17,7 +17,6 @@
 # under the License.
 #
 
-status = warn
 dest = err
 name = AccumuloStartTestLoggingProperties
 

--- a/test/src/main/resources/log4j2-test.properties
+++ b/test/src/main/resources/log4j2-test.properties
@@ -17,7 +17,6 @@
 # under the License.
 #
 
-status = warn
 dest = err
 name = AccumuloITLoggingProperties
 


### PR DESCRIPTION
The log4j2 status property was deprecated from the properties file in log4j2 version 2.24.0 and
replaced by a System property. This change removes property from all log4j2 properties files and adds the system property with default value to accumulo-env.sh

Closes #5482