### PR TITLE
fixes incorrect file range clipping in deleterows

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/DeleteRows.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/DeleteRows.java
@@ -287,6 +287,8 @@ public class DeleteRows extends ManagerRepo {
     final List<Range> ranges = new ArrayList<>();
 
     if (deleteRange.overlaps(tabletExtent)) {
+      // Following checks that deleteRange.prevEndRow() is > tabletExtent.prevEndRow() and falls
+      // within tabletExtent.
       if (deleteRange.prevEndRow() != null
           && tabletExtent.contains(followingRow(deleteRange.prevEndRow()))
           && !Objects.equals(tabletExtent.prevEndRow(), deleteRange.prevEndRow())) {
@@ -296,7 +298,8 @@ public class DeleteRows extends ManagerRepo {
       }
 
       // This covers the case of when a deletion range overlaps the last tablet. We need to create a
-      // range that excludes the deletion.
+      // range that excludes the deletion. Following checks that deleteRange.endRow() is <
+      // tabletExtent.endRow() and falls within tabletExtent.
       if (deleteRange.endRow() != null && tabletMetadata.getExtent().contains(deleteRange.endRow())
           && !Objects.equals(deleteRange.endRow(), tabletExtent.endRow())) {
         log.trace("{} Fencing tablet {} files to ({},{}]", fateId, tabletExtent,

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/UpdateTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/UpdateTablets.java
@@ -107,7 +107,7 @@ public class UpdateTablets extends ManagerRepo {
 
     var newTablets = splitInfo.getTablets();
 
-    var newTabletsFiles = getNewTabletFiles(newTablets, tabletMetadata,
+    var newTabletsFiles = getNewTabletFiles(fateId, newTablets, tabletMetadata,
         file -> manager.getSplitter().getCachedFileInfo(splitInfo.getOriginal().tableId(), file));
 
     addNewTablets(fateId, manager, tabletMetadata, opid, newTablets, newTabletsFiles);
@@ -123,7 +123,7 @@ public class UpdateTablets extends ManagerRepo {
    * Determine which files from the original tablet go to each new tablet being created by the
    * split.
    */
-  static Map<KeyExtent,Map<StoredTabletFile,DataFileValue>> getNewTabletFiles(
+  static Map<KeyExtent,Map<StoredTabletFile,DataFileValue>> getNewTabletFiles(FateId fateId,
       SortedMap<KeyExtent,TabletMergeability> newTablets, TabletMetadata tabletMetadata,
       Function<StoredTabletFile,Splitter.FileInfo> fileInfoProvider) {
 
@@ -179,14 +179,14 @@ public class UpdateTablets extends ManagerRepo {
 
     if (log.isTraceEnabled()) {
       tabletMetadata.getFilesMap().forEach((f, v) -> {
-        log.trace("{} original file {} {} {}", tabletMetadata.getExtent(), f.getFileName(),
-            v.getSize(), v.getNumEntries());
+        log.trace("{} {} original file {} {} {} {}", fateId, tabletMetadata.getExtent(),
+            f.getFileName(), f.getRange(), v.getSize(), v.getNumEntries());
       });
 
       tabletsFiles.forEach((extent, files) -> {
         files.forEach((f, v) -> {
-          log.trace("{} split file {} {} {}", extent, f.getFileName(), v.getSize(),
-              v.getNumEntries());
+          log.trace("{} {} split file {} {} {} {}", fateId, extent, f.getFileName(), f.getRange(),
+              v.getSize(), v.getNumEntries());
         });
       });
     }

--- a/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/split/UpdateTabletsTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/split/UpdateTabletsTest.java
@@ -152,8 +152,9 @@ public class UpdateTabletsTest {
     EasyMock.expect(tabletMeta.getFilesMap()).andReturn(tabletFiles).anyTimes();
     EasyMock.replay(tabletMeta);
 
+    var fid = FateId.from(FateInstanceType.USER, UUID.randomUUID());
     Map<KeyExtent,Map<StoredTabletFile,DataFileValue>> results =
-        UpdateTablets.getNewTabletFiles(newExtents, tabletMeta, firstAndLastKeys::get);
+        UpdateTablets.getNewTabletFiles(fid, newExtents, tabletMeta, firstAndLastKeys::get);
 
     assertEquals(expected.keySet(), results.keySet());
     expected.forEach(((extent, files) -> {
@@ -174,7 +175,7 @@ public class UpdateTabletsTest {
     EasyMock.replay(tabletMeta);
 
     Map<KeyExtent,Map<StoredTabletFile,DataFileValue>> results2 =
-        UpdateTablets.getNewTabletFiles(newExtents, tabletMeta, firstAndLastKeys::get);
+        UpdateTablets.getNewTabletFiles(fid, newExtents, tabletMeta, firstAndLastKeys::get);
     assertEquals(expected.keySet(), results2.keySet());
     expected.forEach(((extent, files) -> {
       assertEquals(files, results2.get(extent));


### PR DESCRIPTION
The delete rows table operation was clipping a file to a row range like (f,f] and adding this to tablet with a row range of (f,g].  The files row range did not overlap the tablets row range causing reads of the tablet to fail with the changes in #5340.  This was causing DeleteRowsIT to fail, modified the code to avoid adding the non overlapping row range and now DeleteRowsIT passes.

Made a lot of logging changes while tracking this down, kept those in this commit.