### PR TITLE
fixes non overlapping file and tablet range on CloneIT

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/CloneIT_SimpleSuite.java
+++ b/test/src/main/java/org/apache/accumulo/test/CloneIT_SimpleSuite.java
@@ -452,8 +452,8 @@ public class CloneIT_SimpleSuite extends SharedMiniClusterBase {
           // Pass in up to 3 arguments of infinite ranges to test non-ranged files
           Arguments.of(new Range(), new Range(), new Range()),
           // For second run pass in up to 3 arguments with the first two non-infinite ranges
-          Arguments.of(new Range(null, false, "row_0", true),
-              new Range("row_0", false, "row_1", true), new Range()));
+          Arguments.of(new Range(null, false, "row_0", true), new Range("row_0", false, null, true),
+              new Range()));
     }
   }
 


### PR DESCRIPTION
CloneIT was directly inserting metadata table file entries with row ranges that did not overlap the tablet range.  After the changes in  #5340 this caused the metadata reads to fail.  Modfied the test to insert file w/ ranges that overlap.