### PR TITLE
Allow system user to create namespaces

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/SetupNamespacePermissions.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/SetupNamespacePermissions.java
@@ -39,13 +39,15 @@ class SetupNamespacePermissions extends ManagerRepo {
   public Repo<Manager> call(long tid, Manager env) throws Exception {
     // give all namespace permissions to the creator
     var security = env.getContext().getSecurityOperation();
-    for (var permission : NamespacePermission.values()) {
-      try {
-        security.grantNamespacePermission(env.getContext().rpcCreds(), namespaceInfo.user,
-            namespaceInfo.namespaceId, permission);
-      } catch (ThriftSecurityException e) {
-        LoggerFactory.getLogger(SetupNamespacePermissions.class).error("{}", e.getMessage(), e);
-        throw e;
+    if (!namespaceInfo.user.equals(env.getContext().getCredentials().getPrincipal())) {
+      for (var permission : NamespacePermission.values()) {
+        try {
+          security.grantNamespacePermission(env.getContext().rpcCreds(), namespaceInfo.user,
+              namespaceInfo.namespaceId, permission);
+        } catch (ThriftSecurityException e) {
+          LoggerFactory.getLogger(SetupNamespacePermissions.class).error("{}", e.getMessage(), e);
+          throw e;
+        }
       }
     }
 

--- a/test/src/main/java/org/apache/accumulo/test/NamespacesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/NamespacesIT.java
@@ -216,6 +216,13 @@ public class NamespacesIT extends SharedMiniClusterBase {
   }
 
   @Test
+  public void createNamespaceWithSystemUser() throws Exception {
+    String testNamespace = "ns_" + getUniqueNames(1)[0];
+    AccumuloClient client = getCluster().getServerContext();
+    client.namespaceOperations().create(testNamespace);
+  }
+
+  @Test
   public void createAndDeleteNamespace() throws Exception {
     String t1 = namespace + ".1";
     String t2 = namespace + ".2";

--- a/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
@@ -191,6 +191,18 @@ public class TableOperationsIT extends AccumuloClusterHarness {
   }
 
   @Test
+  public void createTableWithSystemUser() throws TableExistsException, AccumuloException,
+      AccumuloSecurityException, TableNotFoundException {
+    String tableName = getUniqueNames(1)[0];
+    AccumuloClient client = getServerContext();
+    client.tableOperations().create(tableName);
+    Map<String,String> props = client.tableOperations().getConfiguration(tableName);
+    assertEquals(DefaultKeySizeConstraint.class.getName(),
+        props.get(Property.TABLE_CONSTRAINT_PREFIX + "1"));
+    client.tableOperations().delete(tableName);
+  }
+
+  @Test
   public void createTableWithTableNameLengthLimit()
       throws AccumuloException, AccumuloSecurityException, TableExistsException {
     TableOperations tableOps = accumuloClient.tableOperations();


### PR DESCRIPTION
Added the system user check logic that is defined in SetupPermissions for CreateTable.
https://github.com/apache/accumulo/blob/3af3fde6232bd11bd1cb05731d667723aaa2984a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/SetupPermissions.java#L43 

This fixes the "USER_DOESNT_EXIST" error that was being reported when the system user was attempting to create a namespace