### PR TITLE
Update Javadoc for wrapped TableNotFoundException in modifyProperties and removeConstraint

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
@@ -528,7 +528,8 @@ public interface TableOperations {
    * @return The map that became Accumulo's new properties for this table. This map is immutable and
    *         contains the snapshot passed to mapMutator and the changes made by mapMutator.
    *
-   * @throws AccumuloException if a general error occurs
+   * @throws AccumuloException if a general error occurs. Wrapped TableNotFoundException if table
+   *         does not exist.
    * @throws AccumuloSecurityException if the user does not have permission
    * @throws IllegalArgumentException if the Consumer alters the map by adding properties that
    *         cannot be stored
@@ -931,6 +932,8 @@ public interface TableOperations {
    *
    * @param tableName the name of the table
    * @param number the unique number assigned to the constraint
+   * @throws AccumuloException if a general error occurs. Wrapped TableNotFoundException if table
+   *         does not exist.
    * @throws AccumuloSecurityException thrown if the user doesn't have permission to remove the
    *         constraint
    * @since 1.5.0


### PR DESCRIPTION
This PR adds a note to `modifyProperties()` and `removeConstraint()` documenting that they wrap TableNotFoundException in AccumuloException.