### PR TITLE
fixes chaotic balancer IT

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/ChaoticLoadBalancer.java
+++ b/test/src/main/java/org/apache/accumulo/test/ChaoticLoadBalancer.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.test;
 import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -66,37 +67,23 @@ public class ChaoticLoadBalancer implements TabletBalancer {
 
   @Override
   public void getAssignments(AssignmentParameters params) {
-    long total = params.unassignedTablets().size();
-    long avg = (long) Math.ceil(((double) total) / params.currentStatus().size());
-    Map<TabletServerId,Long> toAssign = new HashMap<>();
-    List<TabletServerId> tServerArray = new ArrayList<>();
-    for (Entry<TabletServerId,TServerStatus> e : params.currentStatus().entrySet()) {
-      long numTablets = 0;
-      for (TableStatistics ti : e.getValue().getTableMap().values()) {
-        numTablets += ti.getTabletCount();
-      }
-      if (numTablets <= avg) {
-        tServerArray.add(e.getKey());
-        toAssign.put(e.getKey(), avg - numTablets);
-      }
+
+    List<TabletId> tabletsToAssign = new ArrayList<>(params.unassignedTablets().keySet());
+    if (tabletsToAssign.size() > 1) {
+      Collections.shuffle(tabletsToAssign);
+      int index = RANDOM.get().nextInt(tabletsToAssign.size()) + 1;
+      tabletsToAssign = tabletsToAssign.subList(0, index);
     }
 
+    List<TabletServerId> tServerArray = new ArrayList<>(params.currentStatus().keySet());
+
     if (tServerArray.isEmpty()) {
-      // No tservers to assign to
       return;
     }
 
-    for (TabletId tabletId : params.unassignedTablets().keySet()) {
+    for (TabletId tabletId : tabletsToAssign) {
       int index = RANDOM.get().nextInt(tServerArray.size());
-      TabletServerId dest = tServerArray.get(index);
-      params.addAssignment(tabletId, dest);
-      long remaining = toAssign.get(dest) - 1;
-      if (remaining == 0) {
-        tServerArray.remove(index);
-        toAssign.remove(dest);
-      } else {
-        toAssign.put(dest, remaining);
-      }
+      params.addAssignment(tabletId, tServerArray.get(index));
     }
   }
 

--- a/test/src/test/java/org/apache/accumulo/test/ChaoticLoadBalancerTest.java
+++ b/test/src/test/java/org/apache/accumulo/test/ChaoticLoadBalancerTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -117,11 +117,19 @@ public class ChaoticLoadBalancerTest {
     TestChaoticLoadBalancer balancer = new TestChaoticLoadBalancer();
 
     Map<TabletId,TabletServerId> assignments = new HashMap<>();
-    balancer.getAssignments(new AssignmentParamsImpl(getAssignments(servers),
-        Map.of(Constants.DEFAULT_RESOURCE_GROUP_NAME, servers.keySet()), metadataTable,
-        assignments));
+    Map<TabletId,TabletServerId> unassigned = new HashMap<>(metadataTable);
 
-    assertEquals(assignments.size(), metadataTable.size());
+    while (!unassigned.isEmpty()) {
+      balancer.getAssignments(new AssignmentParamsImpl(getAssignments(servers),
+          Map.of(Constants.DEFAULT_RESOURCE_GROUP_NAME, servers.keySet()), unassigned,
+          assignments));
+      assignments.forEach((tablet, tserver) -> {
+        servers.get(tserver).tablets.add(tablet);
+        assertTrue(unassigned.containsKey(tablet));
+        unassigned.remove(tablet);
+      });
+      assignments.clear();
+    }
   }
 
   SortedMap<TabletServerId,TServerStatus> getAssignments(Map<TabletServerId,FakeTServer> servers) {


### PR DESCRIPTION
When assigning the root tablet after other tablets were assigned, the getAssignment function in ChaoticLoadBalancer would never return an assignment. This would cause the test to hang until it timed out.  Not sure what the intention of the code was, but made it do something different that would always eventually yield an assignment.