### PR TITLE
Created bind addr property, add help for -o options

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/cli/ConfigOpts.java
+++ b/core/src/main/java/org/apache/accumulo/core/cli/ConfigOpts.java
@@ -22,14 +22,18 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.conf.PropertyType;
 import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.converters.IParameterSplitter;
 
@@ -106,4 +110,95 @@ public class ConfigOpts extends Help {
       }
     }
   }
+
+  @Override
+  public void printUsage(JCommander commander, String programName) {
+
+    final String indent = "    ";
+    final Set<String> validPrefixes = new HashSet<>();
+
+    switch (programName) {
+      case "compactor":
+        validPrefixes.add(Property.COMPACTOR_PREFIX.getKey());
+        break;
+      case "compaction-coordinator":
+        validPrefixes.add(Property.COMPACTION_COORDINATOR_PREFIX.getKey());
+        break;
+      case "gc":
+        validPrefixes.add(Property.GC_PREFIX.getKey());
+        break;
+      case "manager":
+        validPrefixes.add(Property.MANAGER_PREFIX.getKey());
+        break;
+      case "monitor":
+        validPrefixes.add(Property.MONITOR_PREFIX.getKey());
+        break;
+      case "sserver":
+        validPrefixes.add(Property.SSERV_PREFIX.getKey());
+        break;
+      case "tserver":
+        validPrefixes.add(Property.TSERV_PREFIX.getKey());
+        break;
+      default:
+        break;
+    }
+
+    super.printUsage(commander, programName);
+    // If the program name is a server process, then print out
+    // possible property overrides for the -o argument.
+    if (!validPrefixes.isEmpty()) {
+      validPrefixes.add(Property.GENERAL_PREFIX.getKey());
+      validPrefixes.add(Property.GENERAL_ARBITRARY_PROP_PREFIX.getKey());
+      validPrefixes.add(Property.RPC_PREFIX.getKey());
+
+      int maxPropLength = 0;
+      int maxDefaultLength = 0;
+
+      for (Property prop : Property.values()) {
+        if (prop.getKey().length() > maxPropLength) {
+          maxPropLength = prop.getKey().length();
+        }
+        if (prop.getDefaultValue() != null && prop.getDefaultValue().length() > maxDefaultLength) {
+          maxDefaultLength = prop.getDefaultValue().length();
+        }
+      }
+
+      final String propOnlyFormat =
+          "%1$" + maxPropLength + "s %2$" + Math.min(52, maxDefaultLength) + "s";
+      final String deprecatedOnlyFormat = propOnlyFormat + " (deprecated)";
+      final String replacedFormat = propOnlyFormat + " (deprecated - replaced by %3$s)";
+
+      StringBuilder sb = new StringBuilder();
+      sb.append(indent).append(
+          "Below are the properties, and their default values, that can be used with the '-o' (overrides) option.\n");
+      sb.append(indent).append(" Long default values will be truncated.\n");
+      sb.append(indent).append(
+          " See the user guide at https://accumulo.apache.org/ for more information about each property.\n");
+      sb.append("\n");
+      for (Property prop : Property.values()) {
+        if (prop.getType() == PropertyType.PREFIX) {
+          continue;
+        }
+        for (String prefix : validPrefixes) {
+          String key = prop.getKey();
+          if (key.startsWith(prefix)) {
+            String value = prop.getDefaultValue();
+            if (value.length() > 40) {
+              value = value.substring(0, 40) + " (truncated)";
+            }
+            if (!prop.isDeprecated() && !prop.isReplaced()) {
+              sb.append(String.format(propOnlyFormat, key, value));
+            } else if (prop.isDeprecated() && !prop.isReplaced()) {
+              sb.append(String.format(deprecatedOnlyFormat, key, value));
+            } else {
+              sb.append(String.format(replacedFormat, key, value, prop.replacedBy().getKey()));
+            }
+            sb.append("\n");
+          }
+        }
+      }
+      commander.getConsole().println(sb.toString());
+    }
+  }
+
 }

--- a/core/src/main/java/org/apache/accumulo/core/cli/Help.java
+++ b/core/src/main/java/org/apache/accumulo/core/cli/Help.java
@@ -40,9 +40,13 @@ public class Help {
       exitWithError(ex.getMessage(), 1);
     }
     if (help) {
-      commander.usage();
+      printUsage(commander, programName);
       exit(0);
     }
+  }
+
+  public void printUsage(JCommander commander, String programName) {
+    commander.usage();
   }
 
   public void exit(int status) {

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -54,6 +54,9 @@ public enum Property {
       "Properties in this category related to the configuration of SSL keys for"
           + " RPC. See also `instance.ssl.enabled`.",
       "1.6.0"),
+  RPC_PROCESS_BIND_ADDRESS("rpc.bind.addr", "", PropertyType.STRING,
+      "The local IP address to which this server should bind for sending and receiving network traffic.",
+      "2.1.4"),
   RPC_MAX_MESSAGE_SIZE("rpc.message.size.max", Integer.toString(Integer.MAX_VALUE),
       PropertyType.BYTES, "The maximum size of a message that can be received by a server.",
       "2.1.3"),

--- a/core/src/test/java/org/apache/accumulo/core/cli/ConfigOptsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/cli/ConfigOptsTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.conf.DefaultConfiguration;
+import org.apache.accumulo.core.conf.Property;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ConfigOptsTest {
+  private ConfigOpts opts;
+
+  @BeforeEach
+  public void setUp() {
+    opts = new ConfigOpts();
+  }
+
+  @Test
+  public void testGetAddress() {
+    opts.parseArgs(ConfigOptsTest.class.getName(),
+        new String[] {"-o", Property.RPC_PROCESS_BIND_ADDRESS.getKey() + "=1.2.3.4"});
+    assertEquals("1.2.3.4", opts.getSiteConfiguration().get(Property.RPC_PROCESS_BIND_ADDRESS));
+  }
+
+  @Test
+  public void testGetAddress_None() {
+    opts.parseArgs(ConfigOptsTest.class.getName(), new String[] {});
+    assertEquals("", opts.getSiteConfiguration().get(Property.RPC_PROCESS_BIND_ADDRESS));
+  }
+
+  @Test
+  public void testOverrideConfig() {
+    AccumuloConfiguration defaults = DefaultConfiguration.getInstance();
+    assertEquals("localhost:2181", defaults.get(Property.INSTANCE_ZK_HOST));
+    opts.parseArgs(ConfigOptsTest.class.getName(),
+        new String[] {"-o", "instance.zookeeper.host=test:123"});
+    assertEquals("test:123", opts.getSiteConfiguration().get(Property.INSTANCE_ZK_HOST));
+  }
+
+  @Test
+  public void testOverrideMultiple() {
+    opts.parseArgs(ConfigOptsTest.class.getName(),
+        new String[] {"-o", Property.RPC_PROCESS_BIND_ADDRESS.getKey() + "=1.2.3.4", "-o",
+            Property.SSERV_CLIENTPORT.getKey() + "=8888"});
+    assertEquals("1.2.3.4", opts.getSiteConfiguration().get(Property.RPC_PROCESS_BIND_ADDRESS));
+    assertEquals("8888", opts.getSiteConfiguration().get(Property.SSERV_CLIENTPORT));
+  }
+
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerOpts.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerOpts.java
@@ -24,7 +24,8 @@ import com.beust.jcommander.Parameter;
 
 public class ServerOpts extends ConfigOpts {
 
-  @Parameter(names = {"-a", "--address"}, description = "address to bind to")
+  @Parameter(names = {"-a", "--address"},
+      description = "address to bind to (deprecated - use rpc.bind.addr instead)")
   private String address = null;
 
   public String getAddress() {


### PR DESCRIPTION
This change includes a new property, rpc.bind.addr, which was included in 3.0 as general.process.bind.addr in #3192, backports ConfigOptsTest from #3192, and changes to AbstractServer to use either the '-a' or '-o rpc.bind.addr' bind address as the hostname.

This change also includes changes to ConfigOpts such that when the '-h' option is used **and** the command is a server name, then it prints out possible property overrides to use with the '-o' option.

For example, 'accumulo rfile-info -h' and 'accumulo tserver -x' just print the normal usage information. However, 'accumulo tserver -?' or 'accumulo tserver -h' will print an expanded usage information that includes properties that the user can override on the command line for that server.

Related to #4976
Closes #5430