### PR TITLE
fixes ScanServer_NoServersIT to fallback to tablet servers

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/ScanServer_NoServersIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ScanServer_NoServersIT.java
@@ -187,7 +187,19 @@ public class ScanServer_NoServersIT extends SharedMiniClusterBase {
 
   @Test
   public void testScanWithTabletAvailabilityMix() throws Exception {
-    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
+
+    // create client config that sets timeToWaitForScanServers to zero so that tserver fallback is
+    // immediate when no scan servers are present.
+    var clientProps = new Properties();
+    clientProps.putAll(getClientProps());
+    String scanServerSelectorProfiles = "[{'isDefault':true,'maxBusyTimeout':'5m',"
+        + "'busyTimeoutMultiplier':8, 'scanTypeActivations':[], 'timeToWaitForScanServers':'0s',"
+        + "'attemptPlans':[{'servers':'3', 'busyTimeout':'1s'}]}]";
+    clientProps.put("scan.server.selector.impl", ConfigurableScanServerSelector.class.getName());
+    clientProps.put("scan.server.selector.opts.profiles",
+        scanServerSelectorProfiles.replace("'", "\""));
+
+    try (AccumuloClient client = Accumulo.newClient().from(clientProps).build()) {
       String tableName = getUniqueNames(1)[0];
 
       setupTableWithTabletAvailabilityMix(client, tableName);
@@ -215,7 +227,19 @@ public class ScanServer_NoServersIT extends SharedMiniClusterBase {
 
   @Test
   public void testBatchScanWithTabletAvailabilityMix() throws Exception {
-    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
+
+    // create client config that sets timeToWaitForScanServers to zero so that tserver fallback is
+    // immediate when no scan servers are present.
+    var clientProps = new Properties();
+    clientProps.putAll(getClientProps());
+    String scanServerSelectorProfiles = "[{'isDefault':true,'maxBusyTimeout':'5m',"
+        + "'busyTimeoutMultiplier':8, 'scanTypeActivations':[], 'timeToWaitForScanServers':'0s',"
+        + "'attemptPlans':[{'servers':'3', 'busyTimeout':'1s'}]}]";
+    clientProps.put("scan.server.selector.impl", ConfigurableScanServerSelector.class.getName());
+    clientProps.put("scan.server.selector.opts.profiles",
+        scanServerSelectorProfiles.replace("'", "\""));
+
+    try (AccumuloClient client = Accumulo.newClient().from(clientProps).build()) {
       final String tableName = getUniqueNames(1)[0];
 
       setupTableWithTabletAvailabilityMix(client, tableName);


### PR DESCRIPTION
Two test in ScanServer_NoServersIT expected scans to fallback to tablet servers when no scan servers were present.  However the configuration was not correct.  Modified the test to use correct config to cause expected behavior.