### PR TITLE
Created TabletMetadataFilter for tablet metadata with migration

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -511,6 +511,11 @@ public class TabletMetadata {
     return location != null && location.getType() == LocationType.CURRENT;
   }
 
+  public boolean hasMigration() {
+    ensureFetched(ColumnType.MIGRATION);
+    return migration != null;
+  }
+
   public Map<StoredTabletFile,FateId> getLoaded() {
     ensureFetched(ColumnType.LOADED);
     return loadedFiles;

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/filters/HasMigrationFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/filters/HasMigrationFilter.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.metadata.schema.filters;
+
+import java.util.Set;
+import java.util.function.Predicate;
+
+import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
+
+import com.google.common.collect.Sets;
+
+public class HasMigrationFilter extends TabletMetadataFilter {
+
+  private static final Set<ColumnType> COLUMNS =
+      Sets.immutableEnumSet(TabletMetadata.ColumnType.MIGRATION);
+  private static final Predicate<TabletMetadata> FILTER = TabletMetadata::hasMigration;
+
+  @Override
+  public Set<ColumnType> getColumns() {
+    return COLUMNS;
+  }
+
+  @Override
+  protected Predicate<TabletMetadata> acceptTablet() {
+    return FILTER;
+  }
+
+}

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -104,6 +104,7 @@ import org.apache.accumulo.core.metadata.SystemTables;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.metadata.schema.filters.HasMigrationFilter;
 import org.apache.accumulo.core.metrics.MetricsInfo;
 import org.apache.accumulo.core.metrics.MetricsProducer;
 import org.apache.accumulo.core.spi.balancer.BalancerEnvironment;
@@ -641,11 +642,10 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener {
     for (DataLevel dl : DataLevel.values()) {
       Set<KeyExtent> extents = new HashSet<>();
       // prev row needed for the extent
-      try (
-          var tabletsMetadata = getContext()
-              .getAmple().readTablets().forLevel(dl).fetch(TabletMetadata.ColumnType.PREV_ROW,
-                  TabletMetadata.ColumnType.MIGRATION, TabletMetadata.ColumnType.LOCATION)
-              .build()) {
+      try (var tabletsMetadata = getContext()
+          .getAmple().readTablets().forLevel(dl).fetch(TabletMetadata.ColumnType.PREV_ROW,
+              TabletMetadata.ColumnType.MIGRATION, TabletMetadata.ColumnType.LOCATION)
+          .filter(new HasMigrationFilter()).build()) {
         // filter out migrations that are awaiting cleanup
         tabletsMetadata.stream()
             .filter(tm -> tm.getMigration() != null && !shouldCleanupMigration(tm))


### PR DESCRIPTION
New HasMigrationFilter is used in the Manager to filter out tablet metadata that does not have a migration column or an empty one. Server side filtering on this condition should speed up Manager.partitionMigrations by only returning tablet metadata with a migration to the Manager for partitioning.

Related to #5520