### PR TITLE
avoid creating thread pool metrics per batch writer

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchWriter.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchWriter.java
@@ -212,7 +212,7 @@ public class TabletServerBatchWriter implements AutoCloseable {
   public TabletServerBatchWriter(ClientContext context, BatchWriterConfig config) {
     this.context = context;
     this.executor = context.threadPools().createScheduledExecutorService(2,
-        "BatchWriterThreads-" + numWritersCreated.incrementAndGet(), true);
+        "BatchWriterThreads-" + numWritersCreated.incrementAndGet(), false);
     this.failedMutations = new FailedMutations();
     this.maxMem = config.getMaxMemory();
     this.maxLatency = config.getMaxLatency(MILLISECONDS) <= 0 ? Long.MAX_VALUE


### PR DESCRIPTION
Each batch writer created was creating a thread pool intrumented with metrics.  This would cause Meters to continually be added to the global registry which could eventually cause memory problems.  Disabled metrics instrumentation on these thread pools.