### PR TITLE
makes shutdown in compactor process to always halt

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ServiceLockSupport.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ServiceLockSupport.java
@@ -53,8 +53,8 @@ public class ServiceLockSupport {
     @Override
     public void lostLock(LockLossReason reason) {
       if (shutdownComplete.get()) {
-        LOG.warn("{} lost lock (reason = {}), not halting because shutdown is complete.",
-            serviceName, reason);
+        Halt.halt(0, serviceName + " lock in zookeeper lost (reason = " + reason
+            + "), exiting cleanly because shutdown is complete.");
       } else {
         Halt.halt(-1, serviceName + " lock in zookeeper lost (reason = " + reason + "), exiting!");
       }
@@ -139,8 +139,10 @@ public class ServiceLockSupport {
     @Override
     public void lostLock(final LockLossReason reason) {
       if (shutdownComplete.get()) {
-        LOG.warn("{} lost lock (reason = {}), not halting because shutdown is complete.",
-            serviceName, reason);
+        Halt.halt(0,
+            serviceName + " lost lock (reason = " + reason
+                + "), exiting cleanly because shutdown is complete.",
+            () -> lostLockAction.accept(serviceName));
       } else {
         Halt.halt(1, serviceName + " lost lock (reason = " + reason + "), exiting.",
             () -> lostLockAction.accept(serviceName));

--- a/server/base/src/main/java/org/apache/accumulo/server/AbstractServer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/AbstractServer.java
@@ -190,9 +190,11 @@ public abstract class AbstractServer
       verificationThread.interrupt();
       verificationThread.join();
     }
-    log.info(getClass().getSimpleName() + " process shut down.");
     Throwable thrown = err.get();
-    if (thrown != null) {
+    if (thrown == null) {
+      log.info("{} process shut down.", getClass().getSimpleName());
+    } else {
+      log.error("{} process failure.", getClass().getSimpleName(), thrown);
       if (thrown instanceof Error) {
         throw (Error) thrown;
       }


### PR DESCRIPTION
Ran into an issue where a compactor process threw an exception that caused it to exit its main servers thread.  This caused it shut down its thrift server and delete its lock in zookeeper.  However the process stayed alive after its lock was deleted.  This may have been due to some non daemon threads in the process.