### PR TITLE
fixes NPE in coordinator

### DIFF
--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
@@ -425,12 +425,16 @@ public class CompactionCoordinator extends AbstractServer implements
         LOG.trace("Contacting tablet server {} to get external compaction summaries",
             tsi.getHostPort());
         client = getTabletServerConnection(tsi);
-        List<TCompactionQueueSummary> summaries =
-            client.getCompactionQueueInfo(TraceUtil.traceInfo(), getContext().rpcCreds());
-        QUEUE_SUMMARIES.update(tsi, summaries);
-        summaries.forEach(summary -> {
-          queuesSeen.add(summary.getQueue());
-        });
+        if (client != null) {
+          List<TCompactionQueueSummary> summaries =
+              client.getCompactionQueueInfo(TraceUtil.traceInfo(), getContext().rpcCreds());
+          QUEUE_SUMMARIES.update(tsi, summaries);
+          summaries.forEach(summary -> {
+            queuesSeen.add(summary.getQueue());
+          });
+        } else {
+          QUEUE_SUMMARIES.remove(Set.of(tsi));
+        }
       } finally {
         ThriftUtil.returnClient(client, getContext());
       }
@@ -506,13 +510,20 @@ public class CompactionCoordinator extends AbstractServer implements
       TabletClientService.Client client = null;
       try {
         client = getTabletServerConnection(tserver);
+        if (client == null) {
+          LOG.trace("No connection established for queue {} on tserver {}, trying next tserver",
+              queue, tserver.getHostAndPort());
+          QUEUE_SUMMARIES.removeSummary(tserver, queue, prioTserver.prio);
+          prioTserver = QUEUE_SUMMARIES.getNextTserver(queue);
+          continue;
+        }
+
         TExternalCompactionJob job =
             client.reserveCompactionJob(TraceUtil.traceInfo(), getContext().rpcCreds(), queue,
                 prioTserver.prio, compactorAddress, externalCompactionId);
         if (null == job.getExternalCompactionId()) {
           LOG.trace("No compactions found for queue {} on tserver {}, trying next tserver", queue,
               tserver.getHostAndPort());
-
           QUEUE_SUMMARIES.removeSummary(tserver, queue, prioTserver.prio);
           prioTserver = QUEUE_SUMMARIES.getNextTserver(queue);
           continue;
@@ -555,6 +566,9 @@ public class CompactionCoordinator extends AbstractServer implements
   protected TabletClientService.Client getTabletServerConnection(TServerInstance tserver)
       throws TTransportException {
     TServerConnection connection = tserverSet.getConnection(tserver);
+    if (connection == null) {
+      return null;
+    }
     ServerContext serverContext = getContext();
     TTransport transport = serverContext.getTransportPool().getTransport(
         ThriftClientTypes.TABLET_SERVER, connection.getAddress(), 0, serverContext, true);

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
@@ -428,11 +428,14 @@ public class CompactionCoordinator extends AbstractServer implements
         if (client != null) {
           List<TCompactionQueueSummary> summaries =
               client.getCompactionQueueInfo(TraceUtil.traceInfo(), getContext().rpcCreds());
+          LOG.trace("Got summaries {} {} ", tsi.getHostAndPort(), summaries);
           QUEUE_SUMMARIES.update(tsi, summaries);
           summaries.forEach(summary -> {
             queuesSeen.add(summary.getQueue());
           });
         } else {
+          LOG.trace("Connection to get summaries could not be established {} ",
+              tsi.getHostAndPort());
           QUEUE_SUMMARIES.remove(Set.of(tsi));
         }
       } finally {

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
@@ -428,7 +428,6 @@ public class CompactionCoordinator extends AbstractServer implements
         if (client != null) {
           List<TCompactionQueueSummary> summaries =
               client.getCompactionQueueInfo(TraceUtil.traceInfo(), getContext().rpcCreds());
-          LOG.trace("Got summaries {} {} ", tsi.getHostAndPort(), summaries);
           QUEUE_SUMMARIES.update(tsi, summaries);
           summaries.forEach(summary -> {
             queuesSeen.add(summary.getQueue());


### PR DESCRIPTION
When the compaction coordinator requested a connection to a tserver from LiveTserverSet it could return null. If this happened an NPE would be thrown.  Modified the coordinator to handle null for these cases.