### PR TITLE
Add ability to filter out metric by id name

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -362,6 +362,8 @@ public enum Property {
       "A comma separated list of tags to emit with all metrics from the process. Example:"
           + "\"tag1=value1,tag2=value2\".",
       "4.0.0"),
+  GENERAL_MICROMETER_ID_FILTERS("general.micrometer.id.filters", "", PropertyType.STRING,
+          "A comma separated list of patterns to deny meters with matching id names. Example: \"foo.*,bar\".", "4.0"),
   GENERAL_PROCESS_BIND_ADDRESS("general.process.bind.addr", "0.0.0.0", PropertyType.STRING,
       "The local IP address to which this server should bind for sending and receiving network traffic.",
       "3.0.0"),

--- a/core/src/test/java/org/apache/accumulo/core/spi/metrics/MeterRegistryFactoryTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/metrics/MeterRegistryFactoryTest.java
@@ -1,0 +1,101 @@
+package org.apache.accumulo.core.spi.metrics;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.config.MeterFilterReply;
+import org.junit.Test;
+
+import java.util.regex.PatternSyntaxException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class MeterRegistryFactoryTest {
+
+    /**
+     * Verify that when a Null pattern is supplied to {@link MeterRegistryFactory#getMeterFilter(String)}, that we
+     * catch a NullPointerException and receive the errorMessage: "patternList must not be null"
+     */
+    @Test
+    public void testNullPatternList () {
+        Throwable exception = assertThrows(NullPointerException.class,
+                () -> MeterRegistryFactory.getMeterFilter(null), "Expected an NPE");
+        assertEquals("patternList must not be null", exception.getMessage());
+    }
+
+    /**
+     * Verify that when an empty pattern is supplied to {@link MeterRegistryFactory#getMeterFilter(String)}, that we
+     * catch an IllegalArgumentException and receive the errorMessage: "patternList must not be empty"
+     */
+    @Test
+    public void testIfEmptyPattern() {
+        Throwable exception = assertThrows(IllegalArgumentException.class,
+                () -> MeterRegistryFactory.getMeterFilter(""), "Expected an IllegalArgumentException");
+        assertEquals("patternList must not be empty", exception.getMessage());
+
+    }
+
+    /**
+     * Verify that when an invalid regex pattern is supplied to {@link MeterRegistryFactory#getMeterFilter(String)},
+     * that a PatternSyntaxException is thrown.
+     */
+    @Test
+    public void testIfPatternListInvalid() {
+        assertThrows(PatternSyntaxException.class,
+                () -> MeterRegistryFactory.getMeterFilter("[\\]"), "Expected an PatternSyntaxException");
+
+    }
+
+    /**
+     * Verify that when only one pattern is supplied to {@link MeterRegistryFactory#getMeterFilter(String)} and the
+     * resulting filter is given an id whose name matches that pattern, that we get a reply of
+     * {@link MeterFilterReply#DENY}.
+     */
+    @Test
+    public void testIfSinglePatternMatchesId() {
+        MeterFilter filter = MeterRegistryFactory.getMeterFilter("aaa.*");
+        Meter.Id id = new Meter.Id("aaaName", Tags.of("tag", "tag"), null, null, Meter.Type.OTHER);
+        MeterFilterReply reply = filter.accept(id);
+        assertEquals(MeterFilterReply.DENY, reply, "Expected a reply of DENY");
+    }
+
+    /**
+     * Verify that when only one pattern is supplied to {@link MeterRegistryFactory#getMeterFilter(String)}, and the
+     * resulting filter is given an id whose name does not match that patten, that we get a reply of
+     * {@link MeterFilterReply#NEUTRAL}.
+     */
+    @Test
+    public void testIfSinglePatternDoesNotMatch(){
+        MeterFilter filter = MeterRegistryFactory.getMeterFilter(("aaa.*"));
+        Meter.Id id = new Meter.Id("Wrong", Tags.of("tag", "tag"), null, null, Meter.Type.OTHER);
+        MeterFilterReply reply = filter.accept(id);
+        assertEquals(MeterFilterReply.NEUTRAL, reply, "Expected a reply of NEUTRAL");
+    }
+
+    /**
+     * Verify that when multiple patterns are supplied to {@link MeterRegistryFactory#getMeterFilter(String)}, and the
+     * resulting filter is given an id whose name matches at least one of the patterns, that we get a reply of
+     * {@link MeterFilterReply#DENY}.
+     */
+    @Test
+    public void testIfMultiplePatternsMatches() {
+        MeterFilter filter = MeterRegistryFactory.getMeterFilter(("aaa.*,bbb.*,ccc.*"));
+        Meter.Id id = new Meter.Id("aaaRight", Tags.of("tag", "tag"), null, null, Meter.Type.OTHER);
+        MeterFilterReply reply = filter.accept(id);
+        assertEquals(MeterFilterReply.DENY, reply, "Expected a reply of DENY");
+    }
+
+    /**
+     * Verify that when multiple patterns are supplied to {@link MeterRegistryFactory#getMeterFilter(String)}, and the
+     * resulting filter is given an id whose name matches none of the patterns, that we get a reply of
+     * {@link MeterFilterReply#NEUTRAL}.
+     */
+    @Test
+    public void testMultiplePatternsWithNoMatch() {
+        MeterFilter filter = MeterRegistryFactory.getMeterFilter(("aaa.*,bbb.*,ccc.*"));
+        Meter.Id id = new Meter.Id("Wrong", Tags.of("tag", "tag"), null, null, Meter.Type.OTHER);
+        MeterFilterReply reply = filter.accept(id);
+        assertEquals(MeterFilterReply.NEUTRAL, reply, "Expected a reply of NEUTRAL");
+    }
+}


### PR DESCRIPTION
Users might want to the ability to filter out metrics that are not necessary for them to view. Created a static getMeterFilter function in MeterRegistryFactory to filter out metrics user does not want to see. Created new Property GENERAL_MICROMETER_ID_FILTERS, and filters specified via this property will be added to meter registries created in MeterInfoImpl

Closes issue #4599