### PR TITLE
Use existing table name collection in list tablets command

### DIFF
--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ListTabletsCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ListTabletsCommand.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
@@ -52,7 +53,7 @@ import com.google.common.annotations.VisibleForTesting;
 
 /**
  * Utility that generates single line tablet info. The output of this could be fed to sort, awk,
- * grep, etc inorder to answer questions like which tablets have the most files.
+ * grep, etc. to answer questions like which tablets have the most files.
  */
 public class ListTabletsCommand extends Command {
 
@@ -120,13 +121,13 @@ public class ListTabletsCommand extends Command {
       throws NamespaceNotFoundException {
 
     final TableOperations tableOps = shellState.getAccumuloClient().tableOperations();
-    var tableIdMap = tableOps.tableIdMap();
+    final Map<String, String> tableIdMap = tableOps.tableIdMap();
 
     Set<TableInfo> tableSet = new TreeSet<>();
 
     if (cl.hasOption(optTablePattern.getOpt())) {
       Pattern tablePattern = Pattern.compile(cl.getOptionValue(optTablePattern.getOpt()));
-      for (String table : tableOps.list()) {
+      for (String table : tableIdMap.keySet()) {
         if (tablePattern.matcher(table).matches()) {
           TableId id = TableId.of(tableIdMap.get(table));
           tableSet.add(new TableInfo(table, id));


### PR DESCRIPTION
Fixes #5617 

Avoids making another tableOps call to `tableOps.list()` and just uses the existing `tableIdMap` to iterate through the tablenames.