### PR TITLE
Fixed compaction planning search bug

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
@@ -392,13 +392,18 @@ public class DefaultCompactionPlanner implements CompactionPlanner {
         for (int i = 1; i < filesInWindow.size(); i++) {
           long size = filesInWindow.get(i).getEstimatedSize();
           sum += size;
-          // This is the compaction ratio needed to compact these files
-          double neededCompactionRatio = sum / (double) size;
-          log.trace("neededCompactionRatio:{} files:{}", neededCompactionRatio,
-              filesInWindow.subList(0, i + 1));
-          if (neededCompactionRatio >= largestRatioSeen) {
-            largestRatioSeen = neededCompactionRatio;
-            found = filesInWindow.subList(0, i + 1);
+          if (size > 0) {
+            // This is the compaction ratio needed to compact these files
+            double neededCompactionRatio = sum / (double) size;
+            log.trace("neededCompactionRatio:{} files:{}", neededCompactionRatio,
+                filesInWindow.subList(0, i + 1));
+            if (neededCompactionRatio >= largestRatioSeen) {
+              largestRatioSeen = neededCompactionRatio;
+              found = filesInWindow.subList(0, i + 1);
+            }
+          } else {
+            log.warn("Unexpected size seen for file {} {} {}", params.getTabletId(),
+                filesInWindow.get(i).getFileName(), size);
           }
         }
 

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
@@ -125,7 +125,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * For example, given a tablet with 20 files, and table.file.max is 15 and no compactions are
  * planned. If the compaction ratio is set to 3, then this plugin will find the largest compaction
  * ratio less than 3 that results in a compaction. The lowest compaction ratio that will be
- * considered in this search defaults to 1.1. Starting in 2.1.4, thw lower bound for the search can
+ * considered in this search defaults to 1.1. Starting in 2.1.4, the lower bound for the search can
  * be set using {@code tserver.compaction.major.service.<service>.opts.lowestRatio}
  *
  * @since 2.1.0


### PR DESCRIPTION
When a tablet has too many files and its not compacting with the configured compaction ratio the planner would search for the highest ratio that would cause a compaction.  Encountered a problem with this search were two constraints in the code would cause nothing to be found. One constraint was a check to only accept compactions that satisfied `filesToCompact.size() < goalCompactionSize`.  The other constraint was that `DefaultCompactionPlanner.findDataFilesToCompact()` would find the largest set of small files to compact. Putting these two together in some cases `findDataFilesToCompact()` would keep finding a set of files smaller than `goalCompactionSize` and log a warning that it could not find anything.  However the set it did find would have been good to compact.

Looking into fixing this came to the conclusion that the behavior of `findDataFilesToCompact()` where it finds the largest set of small files to compact is probably not optimal when varying the compaction ratio. Also its probably best to not set a minimum size to compact, its ok if it takes multiple compactions to resolve the issue.  Changed the code to find the files with highest ratio and dropped those two other constraints.

Added a test that causes the two constraints to conflict and this new test will not pass with the old code.  Adjusted some of the existing test because of the change in behavior.

Added a new config option to limit the minimum compaction ratio of the search. Defaulted this to 1.1 which may be extreme, not sure.  Files with a difference in size of 10x will have a ratio of 1.1.  This is roughly the minimum ratio that the old code would search.