### PR TITLE
Bound seek range using families in iter stack

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/ColumnFamilySkippingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/ColumnFamilySkippingIterator.java
@@ -26,6 +26,7 @@ import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.data.Column;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.Range;
@@ -121,13 +122,20 @@ public class ColumnFamilySkippingIterator extends ServerSkippingIterator
 
     if (inclusive) {
       sortedColFams = new TreeSet<>(colFamSet);
+      if (sortedColFams.isEmpty()) {
+        this.range = range;
+      } else {
+        // Limit the range based on the min and max column families
+        this.range = range.bound(new Column(sortedColFams.first().toArray(), null, null),
+            new Column(sortedColFams.last().toArray(), null, null));
+      }
     } else {
       sortedColFams = null;
+      this.range = range;
     }
 
-    this.range = range;
     this.inclusive = inclusive;
-    super.seek(range, colFamSet, inclusive);
+    super.seek(this.range, colFamSet, inclusive);
   }
 
   @Override

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/ColumnFamilySkippingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/ColumnFamilySkippingIteratorTest.java
@@ -22,15 +22,23 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.TreeMap;
+import java.util.function.Consumer;
 
 import org.apache.accumulo.core.data.ArrayByteSequence;
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.accumulo.core.iterators.WrappingIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.ColumnFamilySkippingIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.CountingIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.SortedMapIterator;
@@ -45,9 +53,12 @@ public class ColumnFamilySkippingIteratorTest {
     return new Key(new Text(row), new Text(cf), new Text(cq), time);
   }
 
+  String format(int field) {
+    return String.format("%06d", field);
+  }
+
   Key newKey(int row, int cf, int cq, long time) {
-    return newKey(String.format("%06d", row), String.format("%06d", cf), String.format("%06d", cq),
-        time);
+    return newKey(format(row), format(cf), format(cq), time);
   }
 
   void put(TreeMap<Key,Value> tm, String row, String cf, String cq, long time, Value val) {
@@ -250,5 +261,108 @@ public class ColumnFamilySkippingIteratorTest {
     assertFalse(cfi.hasTop());
 
     // System.out.println(ci.getCount());
+  }
+
+  private static class SeekCaptureIter extends WrappingIterator {
+
+    private final Consumer<Range> rangeConsumer;
+
+    SeekCaptureIter(Consumer<Range> rangeConsumer, SortedKeyValueIterator<Key,Value> source) {
+      this.rangeConsumer = rangeConsumer;
+      setSource(source);
+    }
+
+    @Override
+    public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive)
+        throws IOException {
+      rangeConsumer.accept(range);
+      super.seek(range, columnFamilies, inclusive);
+    }
+  }
+
+  /**
+   * Test to ensure the seek range is bounded using the min and max column families.
+   */
+  @Test
+  public void testBoundedSeek() throws Exception {
+    TreeMap<Key,Value> tm1 = new TreeMap<>();
+
+    for (int r = 0; r < 3; r++) {
+      for (int cf = 4; cf < 1000; cf++) {
+        for (int cq = 0; cq < 1; cq++) {
+          put(tm1, r, cf, cq, 6, r * cf * cq);
+        }
+      }
+    }
+
+    List<Range> capturedRanges = new ArrayList<>();
+    // Add an iterator that captures the seek range that ColumnFamilySkippingIterator passes down
+    SeekCaptureIter seekCaptureIter =
+        new SeekCaptureIter(capturedRanges::add, new SortedMapIterator(tm1));
+    ColumnFamilySkippingIterator cfi = new ColumnFamilySkippingIterator(seekCaptureIter);
+
+    cfi.seek(new Range(format(1)),
+        Set.of(new ArrayByteSequence(format(8)), new ArrayByteSequence(format(10))), true);
+    assertEquals(1, capturedRanges.size());
+    // verify the seek on the underlying iterator was narrowed using the min and max columns
+    var startKey = new Key(format(1), format(8));
+    startKey.setDeleted(true);
+    var endKey = new Key(format(1), format(10)).followingKey(PartialKey.ROW_COLFAM);
+    // check that the seek range was bounded using the columns
+    assertEquals(new Range(startKey, true, endKey, false), capturedRanges.get(0));
+
+    // check the data is correct after the seek
+    for (int cf = 8; cf <= 10; cf += 2) {
+      for (int cq = 0; cq < 1; cq++) {
+        assertTrue(cfi.hasTop());
+        assertEquals(cfi.getTopKey(), newKey(1, cf, cq, 6));
+        cfi.next();
+      }
+    }
+
+    assertFalse(cfi.hasTop());
+
+    // ensure that bounding does not widen the range
+    var seekRange =
+        new Range(new Key(format(1), format(9)), true, new Key(format(2), format(9)), false);
+    capturedRanges.clear();
+    cfi.seek(seekRange, Set.of(new ArrayByteSequence(format(8)), new ArrayByteSequence(format(10))),
+        true);
+    assertEquals(1, capturedRanges.size());
+    // the range is more narrow than what bounding the range by the min and max family would have
+    // produced so nothing should be done to the seek range
+    assertEquals(seekRange, capturedRanges.get(0));
+
+    // with the range supplied should see family 10 for row 1 and family 8 for row 2
+    for (int cq = 0; cq < 1; cq++) {
+      assertTrue(cfi.hasTop());
+      assertEquals(cfi.getTopKey(), newKey(1, 10, cq, 6));
+      cfi.next();
+    }
+    for (int cq = 0; cq < 1; cq++) {
+      assertTrue(cfi.hasTop());
+      assertEquals(cfi.getTopKey(), newKey(2, 8, cq, 6));
+      cfi.next();
+    }
+    assertFalse(cfi.hasTop());
+
+    // test narrowing a range that crosses multiple rows
+    seekRange = new Range(format(1), true, format(2), true);
+    capturedRanges.clear();
+    cfi.seek(seekRange, Set.of(new ArrayByteSequence(format(7))), true);
+    startKey = new Key(format(1), format(7));
+    startKey.setDeleted(true);
+    endKey = new Key(format(2), format(7)).followingKey(PartialKey.ROW_COLFAM);
+    // check that the seek range was bounded using the columns
+    assertEquals(new Range(startKey, true, endKey, false), capturedRanges.get(0));
+
+    for (int r = 1; r <= 2; r++) {
+      for (int cq = 0; cq < 1; cq++) {
+        assertTrue(cfi.hasTop());
+        assertEquals(cfi.getTopKey(), newKey(r, 7, cq, 6));
+        cfi.next();
+      }
+    }
+    assertFalse(cfi.hasTop());
   }
 }


### PR DESCRIPTION
When using scanner or batch scanner and setting a range+column on the scanner Range.bound will be called by the scanner to narrow the range. However when seeking in an iterator on the server side, nothing similar is done.  Added this narrowing to ColumnFamilySkippingIterator which will cause any server side iterator seeks to be narrowed using Range.bound().

Manually did some test to ensure nothing in the code was currently doing this.  Added some prints to the rfile code and had server side iterators seek with a range over an entire row w/ some column families.  Did not see any narrowing happen w/o this change.  Wanted to make sure it was not being done by code somewhere in the iter stack that did not call Range.bound().

Without this change a seek with a range that covers an entire row and a set of column families will always go to the first key in the row and start skipping from there.