### PR TITLE
Upgraded spotbugs-maven-plugin to 4.9.3.0

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/data/Column.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Column.java
@@ -110,9 +110,9 @@ public class Column implements WritableComparable<Column> {
     }
   }
 
-  public byte[] columnFamily;
-  public byte[] columnQualifier;
-  public byte[] columnVisibility;
+  private byte[] columnFamily;
+  private byte[] columnQualifier;
+  private byte[] columnVisibility;
 
   /**
    * Creates a new blank column.

--- a/core/src/main/java/org/apache/accumulo/core/data/Range.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Range.java
@@ -577,11 +577,11 @@ public class Range implements WritableComparable<Range> {
       ByteSequence cf = sk.getColumnFamilyData();
       ByteSequence cq = sk.getColumnQualifierData();
 
-      ByteSequence mincf = new ArrayByteSequence(min.columnFamily);
+      ByteSequence mincf = new ArrayByteSequence(min.getColumnFamily());
       ByteSequence mincq;
 
-      if (min.columnQualifier != null) {
-        mincq = new ArrayByteSequence(min.columnQualifier);
+      if (min.getColumnQualifier() != null) {
+        mincq = new ArrayByteSequence(min.getColumnQualifier());
       } else {
         mincq = new ArrayByteSequence(new byte[0]);
       }
@@ -604,10 +604,10 @@ public class Range implements WritableComparable<Range> {
       ByteSequence cq = ek.getColumnQualifierData();
       ByteSequence cv = ek.getColumnVisibilityData();
 
-      ByteSequence maxcf = new ArrayByteSequence(max.columnFamily);
+      ByteSequence maxcf = new ArrayByteSequence(max.getColumnFamily());
       ByteSequence maxcq = null;
-      if (max.columnQualifier != null) {
-        maxcq = new ArrayByteSequence(max.columnQualifier);
+      if (max.getColumnQualifier() != null) {
+        maxcq = new ArrayByteSequence(max.getColumnQualifier());
       }
 
       boolean set = false;

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/CachableBlockFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/CachableBlockFile.java
@@ -50,8 +50,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.cache.Cache;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 /**
  * This is a wrapper class for BCFile that includes a cache for independent caches for datablocks
  * and metadatablocks
@@ -339,8 +337,6 @@ public class CachableBlockFile {
         return Collections.emptyMap();
       }
 
-      @SuppressFBWarnings(value = {"NP_LOAD_OF_KNOWN_NULL_VALUE"},
-          justification = "Spotbugs false positive, see spotbugs issue 2836.")
       @Override
       public byte[] load(int maxSize, Map<String,byte[]> dependencies) {
 

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/ColumnQualifierFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/ColumnQualifierFilter.java
@@ -41,13 +41,13 @@ public class ColumnQualifierFilter extends ServerFilter {
     this.columnsQualifiers = new HashMap<>();
 
     columns.forEach(col -> {
-      if (col.columnQualifier != null) {
+      if (col.getColumnQualifier() != null) {
         this.columnsQualifiers
-            .computeIfAbsent(new ArrayByteSequence(col.columnQualifier), k -> new HashSet<>())
-            .add(new ArrayByteSequence(col.columnFamily));
+            .computeIfAbsent(new ArrayByteSequence(col.getColumnQualifier()), k -> new HashSet<>())
+            .add(new ArrayByteSequence(col.getColumnFamily()));
       } else {
         // this whole column family should pass
-        columnFamilies.add(new ArrayByteSequence(col.columnFamily));
+        columnFamilies.add(new ArrayByteSequence(col.getColumnFamily()));
       }
     });
   }

--- a/core/src/test/java/org/apache/accumulo/core/conf/SiteConfigurationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/SiteConfigurationTest.java
@@ -38,8 +38,6 @@ public class SiteConfigurationTest {
   @Test
   public void testOnlySensitivePropertiesExtractedFromCredentialProvider()
       throws SecurityException {
-    // site-cfg.jceks={'ignored.property'=>'ignored', 'instance.secret'=>'mysecret',
-    // 'general.rpc.timeout'=>'timeout'}
     URL keystore = SiteConfigurationTest.class.getResource("/site-cfg.jceks");
     assertNotNull(keystore);
     String credProvPath = "jceks://file" + new File(keystore.getFile()).getAbsolutePath();
@@ -78,7 +76,7 @@ public class SiteConfigurationTest {
     assertEquals("256M", conf.get(Property.TSERV_WAL_MAX_SIZE));
     assertEquals("org.apache.accumulo.core.spi.crypto.PerTableCryptoServiceFactory",
         conf.get(Property.INSTANCE_CRYPTO_FACTORY));
-    assertEquals(System.getenv("USER"), conf.get("general.test.user.name"));
+    assertEquals(System.getProperty("user.name"), conf.get("general.test.user.name"));
     assertEquals("/tmp/test/dir", conf.get("general.test.user.dir"));
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
@@ -340,7 +340,7 @@ public class RFileTest {
     return String.format(prefix + "%06d", i);
   }
 
-  public AccumuloConfiguration conf = null;
+  private AccumuloConfiguration conf = null;
 
   @Test
   public void test1() throws IOException {

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterClasspathTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterClasspathTest.java
@@ -60,7 +60,7 @@ public class MiniAccumuloClusterClasspathTest extends WithTestNames {
   public static final String ROOT_PASSWORD = "superSecret";
   public static final String ROOT_USER = "root";
 
-  public static File testDir;
+  private static File testDir;
 
   private static MiniAccumuloCluster accumulo;
 

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterTest.java
@@ -64,7 +64,7 @@ public class MiniAccumuloClusterTest extends WithTestNames {
   public static final String ROOT_PASSWORD = "superSecret";
   public static final String ROOT_USER = "root";
 
-  public static File testDir;
+  private static File testDir;
 
   private static MiniAccumuloCluster accumulo;
 

--- a/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImplTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImplTest.java
@@ -51,7 +51,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
 public class MiniAccumuloClusterImplTest {
-  public static File testDir;
+  private static File testDir;
 
   private static MiniAccumuloClusterImpl accumulo;
 

--- a/pom.xml
+++ b/pom.xml
@@ -731,13 +731,14 @@
         <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>4.7.3.6</version>
+          <version>4.9.3.0</version>
           <configuration>
             <xmlOutput>true</xmlOutput>
             <effort>Max</effort>
             <failOnError>true</failOnError>
             <includeTests>true</includeTests>
             <maxRank>16</maxRank>
+            <omitVisitors>ConstructorThrow,SharedVariableAtomicityDetector</omitVisitors>
             <jvmArgs>-Dcom.overstock.findbugs.ignore=com.google.common.util.concurrent.RateLimiter,com.google.common.hash.Hasher,com.google.common.hash.HashCode,com.google.common.hash.HashFunction,com.google.common.hash.Hashing,com.google.common.cache.Cache,com.google.common.io.CountingOutputStream,com.google.common.io.ByteStreams,com.google.common.cache.LoadingCache,com.google.common.base.Stopwatch,com.google.common.cache.RemovalNotification,com.google.common.util.concurrent.Uninterruptibles,com.google.common.reflect.ClassPath,com.google.common.reflect.ClassPath$ClassInfo,com.google.common.base.Throwables,com.google.common.collect.Iterators</jvmArgs>
             <plugins combine.children="append">
               <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1614,7 +1614,7 @@
                 <plugin>
                   <groupId>com.h3xstream.findsecbugs</groupId>
                   <artifactId>findsecbugs-plugin</artifactId>
-                  <version>1.12.0</version>
+                  <version>1.14.0</version>
                 </plugin>
               </plugins>
             </configuration>

--- a/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReports.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReports.java
@@ -73,7 +73,7 @@ public class ProblemReports implements Iterable<ProblemReport> {
 
   private final ServerContext context;
 
-  public ProblemReports(ServerContext context) {
+  private ProblemReports(ServerContext context) {
     this.context = context;
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/replication/proto/Replication.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/replication/proto/Replication.java
@@ -22,6 +22,8 @@
 // Protobuf Java Version: 3.25.6
 package org.apache.accumulo.server.replication.proto;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 @SuppressWarnings("unused") public final class Replication {
   private Replication() {}
   public static void registerAllExtensions(
@@ -135,6 +137,7 @@ package org.apache.accumulo.server.replication.proto;
   /**
    * Protobuf type {@code Status}
    */
+  @SuppressFBWarnings(value = "SING_SINGLETON_IMPLEMENTS_SERIALIZABLE", justification = "generated code")
   public static final class Status extends
       com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:Status)

--- a/server/base/src/main/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenSecretManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenSecretManager.java
@@ -45,6 +45,8 @@ import org.slf4j.LoggerFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Manages an internal list of secret keys used to sign new authentication tokens as they are
  * generated, and to validate existing tokens used for authentication.
@@ -282,6 +284,7 @@ public class AuthenticationTokenSecretManager extends SecretManager<Authenticati
     return super.generateSecret();
   }
 
+  @SuppressFBWarnings(value = "HSM_HIDING_METHOD", justification = "")
   public static SecretKey createSecretKey(byte[] raw) {
     return SecretManager.createSecretKey(raw);
   }

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tservers/TabletServerInformation.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tservers/TabletServerInformation.java
@@ -32,11 +32,15 @@ import org.apache.accumulo.monitor.rest.tables.CompactionsTypes;
 import org.apache.accumulo.monitor.rest.trace.RecoveryStatusInformation;
 import org.apache.accumulo.server.util.TableInfoUtil;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Generates tserver information
  *
  * @since 2.0.0
  */
+@SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE",
+    justification = "public member variables only referenced from tests, class used for serialization")
 public class TabletServerInformation {
 
   // Variable names become JSON keys

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tservers/TabletServers.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tservers/TabletServers.java
@@ -23,11 +23,15 @@ import java.util.List;
 
 import org.apache.accumulo.monitor.rest.manager.ManagerInformation;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Generates a list of servers, bad servers, and dead servers
  *
  * @since 2.0.0
  */
+@SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE",
+    justification = "class used for serialization")
 public class TabletServers {
 
   // Variable names become JSON keys

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
@@ -462,9 +462,9 @@ public class DfsLogger implements Comparable<DfsLogger> {
       }
 
       LogFileKey key = new LogFileKey();
-      key.event = OPEN;
-      key.tserverSession = filename;
-      key.filename = filename;
+      key.setEvent(OPEN);
+      key.setTserverSession(filename);
+      key.setFilename(filename);
       op = logKeyData(key, Durability.SYNC);
     } catch (Exception ex) {
       if (logFile != null) {
@@ -567,10 +567,10 @@ public class DfsLogger implements Comparable<DfsLogger> {
   public LoggerOperation defineTablet(CommitSession cs) throws IOException {
     // write this log to the METADATA table
     final LogFileKey key = new LogFileKey();
-    key.event = DEFINE_TABLET;
-    key.seq = cs.getWALogSeq();
-    key.tabletId = cs.getLogId();
-    key.tablet = cs.getExtent();
+    key.setEvent(DEFINE_TABLET);
+    key.setSeq(cs.getWALogSeq());
+    key.setTabletId(cs.getLogId());
+    key.setTablet(cs.getExtent());
     return logKeyData(key, Durability.LOG);
   }
 
@@ -622,11 +622,11 @@ public class DfsLogger implements Comparable<DfsLogger> {
     List<Pair<LogFileKey,LogFileValue>> data = new ArrayList<>();
     for (TabletMutations tabletMutations : mutations) {
       LogFileKey key = new LogFileKey();
-      key.event = MANY_MUTATIONS;
-      key.seq = tabletMutations.getSeq();
-      key.tabletId = tabletMutations.getTid();
+      key.setEvent(MANY_MUTATIONS);
+      key.setSeq(tabletMutations.getSeq());
+      key.setTabletId(tabletMutations.getTid());
       LogFileValue value = new LogFileValue();
-      value.mutations = tabletMutations.getMutations();
+      value.setMutations(tabletMutations.getMutations());
       data.add(new Pair<>(key, value));
       durability = maxDurability(tabletMutations.getDurability(), durability);
     }
@@ -635,11 +635,11 @@ public class DfsLogger implements Comparable<DfsLogger> {
 
   public LoggerOperation log(CommitSession cs, Mutation m, Durability d) throws IOException {
     LogFileKey key = new LogFileKey();
-    key.event = MUTATION;
-    key.seq = cs.getWALogSeq();
-    key.tabletId = cs.getLogId();
+    key.setEvent(MUTATION);
+    key.setSeq(cs.getWALogSeq());
+    key.setTabletId(cs.getLogId());
     LogFileValue value = new LogFileValue();
-    value.mutations = singletonList(m);
+    value.setMutations(singletonList(m));
     return logFileData(singletonList(new Pair<>(key, value)), d);
   }
 
@@ -657,19 +657,19 @@ public class DfsLogger implements Comparable<DfsLogger> {
   public LoggerOperation minorCompactionFinished(long seq, int tid, Durability durability)
       throws IOException {
     LogFileKey key = new LogFileKey();
-    key.event = COMPACTION_FINISH;
-    key.seq = seq;
-    key.tabletId = tid;
+    key.setEvent(COMPACTION_FINISH);
+    key.setSeq(seq);
+    key.setTabletId(tid);
     return logKeyData(key, durability);
   }
 
   public LoggerOperation minorCompactionStarted(long seq, int tid, String fqfn,
       Durability durability) throws IOException {
     LogFileKey key = new LogFileKey();
-    key.event = COMPACTION_START;
-    key.seq = seq;
-    key.tabletId = tid;
-    key.filename = fqfn;
+    key.setEvent(COMPACTION_START);
+    key.setSeq(seq);
+    key.setTabletId(tid);
+    key.setFilename(fqfn);
     return logKeyData(key, durability);
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
@@ -274,7 +274,7 @@ public class LogSorter {
       var logFileKey = pair.getFirst();
       var logFileValue = pair.getSecond();
       Key k = logFileKey.toKey();
-      keyListMap.computeIfAbsent(k, (key) -> new ArrayList<>()).addAll(logFileValue.mutations);
+      keyListMap.computeIfAbsent(k, (key) -> new ArrayList<>()).addAll(logFileValue.getMutations());
     }
 
     try (var writer = FileOperations.getInstance().newWriterBuilder()
@@ -283,7 +283,7 @@ public class LogSorter {
       writer.startDefaultLocalityGroup();
       for (var entry : keyListMap.entrySet()) {
         LogFileValue val = new LogFileValue();
-        val.mutations = entry.getValue();
+        val.setMutations(entry.getValue());
         writer.append(entry.getKey(), val.toValue());
       }
     }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/RecoveryLogsIterator.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/RecoveryLogsIterator.java
@@ -178,7 +178,7 @@ public class RecoveryLogsIterator
       if (iterator.hasNext()) {
         Key firstKey = iterator.next().getKey();
         LogFileKey key = LogFileKey.fromKey(firstKey);
-        if (key.event != LogEvents.OPEN) {
+        if (key.getEvent() != LogEvents.OPEN) {
           throw new IllegalStateException("First log entry is not OPEN " + fullLogPath);
         }
       }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
@@ -45,13 +45,62 @@ import com.google.common.base.Preconditions;
 public class LogFileKey implements WritableComparable<LogFileKey> {
   private static final Logger log = LoggerFactory.getLogger(LogFileKey.class);
 
-  public LogEvents event;
-  public String filename = null;
-  public KeyExtent tablet = null;
-  public long seq = -1;
-  public int tabletId = -1;
   public static final int VERSION = 2;
-  public String tserverSession;
+
+  private LogEvents event;
+  private String filename = null;
+  private KeyExtent tablet = null;
+  private long seq = -1;
+  private int tabletId = -1;
+  private String tserverSession;
+
+  public LogEvents getEvent() {
+    return event;
+  }
+
+  public String getFilename() {
+    return filename;
+  }
+
+  public KeyExtent getTablet() {
+    return tablet;
+  }
+
+  public long getSeq() {
+    return seq;
+  }
+
+  public int getTabletId() {
+    return tabletId;
+  }
+
+  public String getTserverSession() {
+    return tserverSession;
+  }
+
+  public void setEvent(LogEvents event) {
+    this.event = event;
+  }
+
+  public void setFilename(String filename) {
+    this.filename = filename;
+  }
+
+  public void setTablet(KeyExtent tablet) {
+    this.tablet = tablet;
+  }
+
+  public void setSeq(long seq) {
+    this.seq = seq;
+  }
+
+  public void setTabletId(int tabletId) {
+    this.tabletId = tabletId;
+  }
+
+  public void setTserverSession(String tserverSession) {
+    this.tserverSession = tserverSession;
+  }
 
   @Override
   public void readFields(DataInput in) throws IOException {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileValue.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileValue.java
@@ -42,7 +42,15 @@ public class LogFileValue implements Writable {
 
   private static final List<Mutation> empty = Collections.emptyList();
 
-  public List<Mutation> mutations = empty;
+  private List<Mutation> mutations = empty;
+
+  public List<Mutation> getMutations() {
+    return mutations;
+  }
+
+  public void setMutations(List<Mutation> mutations) {
+    this.mutations = mutations;
+  }
 
   @Override
   public void readFields(DataInput in) throws IOException {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogReader.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogReader.java
@@ -230,21 +230,21 @@ public class LogReader implements KeywordExecutable {
       KeyExtent ke, Set<Integer> tabletIds, int maxMutations) {
 
     if (ke != null) {
-      if (key.event == LogEvents.DEFINE_TABLET) {
-        if (key.tablet.equals(ke)) {
-          tabletIds.add(key.tabletId);
+      if (key.getEvent() == LogEvents.DEFINE_TABLET) {
+        if (key.getTablet().equals(ke)) {
+          tabletIds.add(key.getTabletId());
         } else {
           return;
         }
-      } else if (!tabletIds.contains(key.tabletId)) {
+      } else if (!tabletIds.contains(key.getTabletId())) {
         return;
       }
     }
 
     if (row != null || rowMatcher != null) {
-      if (key.event == LogEvents.MUTATION || key.event == LogEvents.MANY_MUTATIONS) {
+      if (key.getEvent() == LogEvents.MUTATION || key.getEvent() == LogEvents.MANY_MUTATIONS) {
         boolean found = false;
-        for (Mutation m : value.mutations) {
+        for (Mutation m : value.getMutations()) {
           if (row != null && new Text(m.getRow()).equals(row)) {
             found = true;
             break;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/AccumuloReplicaSystem.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/AccumuloReplicaSystem.java
@@ -589,10 +589,10 @@ public class AccumuloReplicaSystem implements ReplicaSystem {
       key.readFields(wal);
       value.readFields(wal);
 
-      switch (key.event) {
+      switch (key.getEvent()) {
         case DEFINE_TABLET:
-          if (target.getSourceTableId().equals(key.tablet.tableId())) {
-            desiredTids.add(key.tabletId);
+          if (target.getSourceTableId().equals(key.getTablet().tableId())) {
+            desiredTids.add(key.getTabletId());
           }
           break;
         default:
@@ -648,17 +648,17 @@ public class AccumuloReplicaSystem implements ReplicaSystem {
 
       entriesConsumed++;
 
-      switch (key.event) {
+      switch (key.getEvent()) {
         case DEFINE_TABLET:
           // For new DEFINE_TABLETs, we also need to record the new tids we see
-          if (target.getSourceTableId().equals(key.tablet.tableId())) {
-            desiredTids.add(key.tabletId);
+          if (target.getSourceTableId().equals(key.getTablet().tableId())) {
+            desiredTids.add(key.getTabletId());
           }
           break;
         case MUTATION:
         case MANY_MUTATIONS:
           // Only write out mutations for tids that are for the desired tablet
-          if (desiredTids.contains(key.tabletId)) {
+          if (desiredTids.contains(key.getTabletId())) {
 
             byte[] data;
             try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -701,13 +701,13 @@ public class AccumuloReplicaSystem implements ReplicaSystem {
     // see matching TODO in BatchWriterReplicationReplayer
 
     int mutationsToSend = 0;
-    for (Mutation m : value.mutations) {
+    for (Mutation m : value.getMutations()) {
       if (!m.getReplicationSources().contains(target.getPeerName())) {
         mutationsToSend++;
       }
     }
 
-    int mutationsRemoved = value.mutations.size() - mutationsToSend;
+    int mutationsRemoved = value.getMutations().size() - mutationsToSend;
     if (mutationsRemoved > 0) {
       log.debug("Removing {} mutations from WAL entry as they have already been replicated to {}",
           mutationsRemoved, target.getPeerName());
@@ -720,7 +720,7 @@ public class AccumuloReplicaSystem implements ReplicaSystem {
     }
 
     out.writeInt(mutationsToSend);
-    for (Mutation m : value.mutations) {
+    for (Mutation m : value.getMutations()) {
       // If we haven't yet replicated to this peer
       if (!m.getReplicationSources().contains(target.getPeerName())) {
         m.addReplicationSource(name);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/BatchWriterReplicationReplayer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/BatchWriterReplicationReplayer.java
@@ -90,15 +90,15 @@ public class BatchWriterReplicationReplayer implements AccumuloReplicationReplay
           }
         }
 
-        log.info("Applying {} mutations to table {} as part of batch", value.mutations.size(),
+        log.info("Applying {} mutations to table {} as part of batch", value.getMutations().size(),
             tableName);
 
         // If we got a ServerMutation, we have to make sure that we preserve the systemTimestamp
         // otherwise
         // the local system will assign a new timestamp.
-        List<Mutation> mutationsCopy = new ArrayList<>(value.mutations.size());
+        List<Mutation> mutationsCopy = new ArrayList<>(value.getMutations().size());
         long mutationsCopied = 0L;
-        for (Mutation orig : value.mutations) {
+        for (Mutation orig : value.getMutations()) {
           if (orig instanceof ServerMutation) {
             mutationsCopied++;
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/LogFileKeyTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/LogFileKeyTest.java
@@ -38,9 +38,9 @@ public class LogFileKeyTest {
 
   private static LogFileKey nk(LogEvents e, int tabletId, long seq) {
     LogFileKey k = new LogFileKey();
-    k.event = e;
-    k.tabletId = tabletId;
-    k.seq = seq;
+    k.setEvent(e);
+    k.setTabletId(tabletId);
+    k.setSeq(seq);
     return k;
   }
 
@@ -107,7 +107,7 @@ public class LogFileKeyTest {
 
   private void testToFromKey(int tabletId, long seq) throws IOException {
     var logFileKey = nk(LogEvents.DEFINE_TABLET, tabletId, seq);
-    logFileKey.tablet = new KeyExtent(TableId.of("5"), new Text("b"), null);
+    logFileKey.setTablet(new KeyExtent(TableId.of("5"), new Text("b"), null));
     Key k = logFileKey.toKey();
 
     var converted = LogFileKey.fromKey(k);

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/RecoveryLogsIteratorTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/RecoveryLogsIteratorTest.java
@@ -118,10 +118,10 @@ public class RecoveryLogsIteratorTest extends WithTestNames {
   @Test
   public void testSimpleRLI() throws IOException {
     KeyValue keyValue = new KeyValue();
-    keyValue.key.event = DEFINE_TABLET;
-    keyValue.key.seq = 0;
-    keyValue.key.tabletId = 1;
-    keyValue.key.tablet = extent;
+    keyValue.key.setEvent(DEFINE_TABLET);
+    keyValue.key.setSeq(0);
+    keyValue.key.setTabletId(1);
+    keyValue.key.setTablet(extent);
 
     KeyValue[] keyValues = {keyValue};
 
@@ -135,8 +135,8 @@ public class RecoveryLogsIteratorTest extends WithTestNames {
     try (RecoveryLogsIterator rli = new RecoveryLogsIterator(context, dirs, null, null, false)) {
       while (rli.hasNext()) {
         Entry<LogFileKey,LogFileValue> entry = rli.next();
-        assertEquals(1, entry.getKey().tabletId, "TabletId does not match");
-        assertEquals(DEFINE_TABLET, entry.getKey().event, "Event does not match");
+        assertEquals(1, entry.getKey().getTabletId(), "TabletId does not match");
+        assertEquals(DEFINE_TABLET, entry.getKey().getEvent(), "Event does not match");
       }
     }
   }
@@ -144,10 +144,10 @@ public class RecoveryLogsIteratorTest extends WithTestNames {
   @Test
   public void testFinishMarker() throws IOException {
     KeyValue keyValue = new KeyValue();
-    keyValue.key.event = DEFINE_TABLET;
-    keyValue.key.seq = 0;
-    keyValue.key.tabletId = 1;
-    keyValue.key.tablet = extent;
+    keyValue.key.setEvent(DEFINE_TABLET);
+    keyValue.key.setSeq(0);
+    keyValue.key.setTabletId(1);
+    keyValue.key.setTablet(extent);
 
     KeyValue[] keyValues = {keyValue};
 
@@ -177,10 +177,10 @@ public class RecoveryLogsIteratorTest extends WithTestNames {
   @Test
   public void testCheckFirstKeyFailed() throws IOException {
     KeyValue keyValue = new KeyValue();
-    keyValue.key.event = DEFINE_TABLET;
-    keyValue.key.seq = 0;
-    keyValue.key.tabletId = 1;
-    keyValue.key.tablet = extent;
+    keyValue.key.setEvent(DEFINE_TABLET);
+    keyValue.key.setSeq(0);
+    keyValue.key.setTabletId(1);
+    keyValue.key.setTablet(extent);
 
     KeyValue[] keyValues = {keyValue};
 
@@ -199,16 +199,16 @@ public class RecoveryLogsIteratorTest extends WithTestNames {
   @Test
   public void testCheckFirstKeyPass() throws IOException {
     KeyValue keyValue1 = new KeyValue();
-    keyValue1.key.event = OPEN;
-    keyValue1.key.seq = 0;
-    keyValue1.key.tabletId = -1;
-    keyValue1.key.tserverSession = "1";
+    keyValue1.key.setEvent(OPEN);
+    keyValue1.key.setSeq(0);
+    keyValue1.key.setTabletId(-1);
+    keyValue1.key.setTserverSession("1");
 
     KeyValue keyValue2 = new KeyValue();
-    keyValue2.key.event = DEFINE_TABLET;
-    keyValue2.key.seq = 0;
-    keyValue2.key.tabletId = 1;
-    keyValue2.key.tablet = extent;
+    keyValue2.key.setEvent(DEFINE_TABLET);
+    keyValue2.key.setSeq(0);
+    keyValue2.key.setTabletId(1);
+    keyValue2.key.setTablet(extent);
 
     KeyValue[] keyValues = {keyValue1, keyValue2};
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/SortedLogRecoveryTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/SortedLogRecoveryTest.java
@@ -124,26 +124,26 @@ public class SortedLogRecoveryTest extends WithTestNames {
   private static KeyValue createKeyValue(LogEvents type, long seq, int tid,
       Object fileExtentMutation) {
     KeyValue result = new KeyValue();
-    result.key.event = type;
-    result.key.seq = seq;
-    result.key.tabletId = tid;
+    result.key.setEvent(type);
+    result.key.setSeq(seq);
+    result.key.setTabletId(tid);
     switch (type) {
       case OPEN:
-        result.key.tserverSession = (String) fileExtentMutation;
+        result.key.setTserverSession((String) fileExtentMutation);
         break;
       case COMPACTION_FINISH:
         break;
       case COMPACTION_START:
-        result.key.filename = (String) fileExtentMutation;
+        result.key.setFilename((String) fileExtentMutation);
         break;
       case DEFINE_TABLET:
-        result.key.tablet = (KeyExtent) fileExtentMutation;
+        result.key.setTablet((KeyExtent) fileExtentMutation);
         break;
       case MUTATION:
-        result.value.mutations = List.of((Mutation) fileExtentMutation);
+        result.value.setMutations(List.of((Mutation) fileExtentMutation));
         break;
       case MANY_MUTATIONS:
-        result.value.mutations = Arrays.asList((Mutation[]) fileExtentMutation);
+        result.value.setMutations(Arrays.asList((Mutation[]) fileExtentMutation));
     }
     return result;
   }

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/logger/LogFileTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/logger/LogFileTest.java
@@ -47,14 +47,14 @@ public class LogFileTest {
       KeyExtent tablet, Mutation[] mutations, LogFileKey keyResult, LogFileValue valueResult)
       throws IOException {
     LogFileKey key = new LogFileKey();
-    key.event = event;
-    key.seq = seq;
-    key.tabletId = tid;
-    key.filename = filename;
-    key.tablet = tablet;
-    key.tserverSession = keyResult.tserverSession;
+    key.setEvent(event);
+    key.setSeq(seq);
+    key.setTabletId(tid);
+    key.setFilename(filename);
+    key.setTablet(tablet);
+    key.setTserverSession(keyResult.getTserverSession());
     LogFileValue value = new LogFileValue();
-    value.mutations = Arrays.asList(mutations != null ? mutations : new Mutation[0]);
+    value.setMutations(Arrays.asList(mutations != null ? mutations : new Mutation[0]));
     DataOutputBuffer out = new DataOutputBuffer();
     key.write(out);
     value.write(out);
@@ -64,7 +64,7 @@ public class LogFileTest {
     keyResult.readFields(in);
     valueResult.readFields(in);
     assertEquals(0, key.compareTo(keyResult));
-    assertEquals(value.mutations, valueResult.mutations);
+    assertEquals(value.getMutations(), valueResult.getMutations());
     assertEquals(in.read(), -1);
   }
 
@@ -72,45 +72,45 @@ public class LogFileTest {
   public void testReadFields() throws IOException {
     LogFileKey key = new LogFileKey();
     LogFileValue value = new LogFileValue();
-    key.tserverSession = "";
+    key.setTserverSession("");
     readWrite(OPEN, -1, -1, null, null, null, key, value);
-    assertEquals(key.event, OPEN);
+    assertEquals(key.getEvent(), OPEN);
     readWrite(COMPACTION_FINISH, 1, 2, null, null, null, key, value);
-    assertEquals(key.event, COMPACTION_FINISH);
-    assertEquals(key.seq, 1);
-    assertEquals(key.tabletId, 2);
+    assertEquals(key.getEvent(), COMPACTION_FINISH);
+    assertEquals(key.getSeq(), 1);
+    assertEquals(key.getTabletId(), 2);
     readWrite(COMPACTION_START, 3, 4, "some file", null, null, key, value);
-    assertEquals(key.event, COMPACTION_START);
-    assertEquals(key.seq, 3);
-    assertEquals(key.tabletId, 4);
-    assertEquals(key.filename, "some file");
+    assertEquals(key.getEvent(), COMPACTION_START);
+    assertEquals(key.getSeq(), 3);
+    assertEquals(key.getTabletId(), 4);
+    assertEquals(key.getFilename(), "some file");
     KeyExtent tablet = new KeyExtent(TableId.of("table"), new Text("bbbb"), new Text("aaaa"));
     readWrite(DEFINE_TABLET, 5, 6, null, tablet, null, key, value);
-    assertEquals(key.event, DEFINE_TABLET);
-    assertEquals(key.seq, 5);
-    assertEquals(key.tabletId, 6);
-    assertEquals(key.tablet, tablet);
+    assertEquals(key.getEvent(), DEFINE_TABLET);
+    assertEquals(key.getSeq(), 5);
+    assertEquals(key.getTabletId(), 6);
+    assertEquals(key.getTablet(), tablet);
     Mutation m = new ServerMutation(new Text("row"));
     m.put("cf", "cq", "value");
     readWrite(MUTATION, 7, 8, null, null, new Mutation[] {m}, key, value);
-    assertEquals(key.event, MUTATION);
-    assertEquals(key.seq, 7);
-    assertEquals(key.tabletId, 8);
-    assertEquals(value.mutations, Arrays.asList(m));
+    assertEquals(key.getEvent(), MUTATION);
+    assertEquals(key.getSeq(), 7);
+    assertEquals(key.getTabletId(), 8);
+    assertEquals(value.getMutations(), Arrays.asList(m));
     m = new ServerMutation(new Text("row"));
     m.put(new Text("cf"), new Text("cq"), new ColumnVisibility("vis"), 12345, new Value("value"));
     m.put(new Text("cf"), new Text("cq"), new ColumnVisibility("vis2"), new Value("value"));
     m.putDelete(new Text("cf"), new Text("cq"), new ColumnVisibility("vis2"));
     readWrite(MUTATION, 8, 9, null, null, new Mutation[] {m}, key, value);
-    assertEquals(key.event, MUTATION);
-    assertEquals(key.seq, 8);
-    assertEquals(key.tabletId, 9);
-    assertEquals(value.mutations, Arrays.asList(m));
+    assertEquals(key.getEvent(), MUTATION);
+    assertEquals(key.getSeq(), 8);
+    assertEquals(key.getTabletId(), 9);
+    assertEquals(value.getMutations(), Arrays.asList(m));
     readWrite(MANY_MUTATIONS, 9, 10, null, null, new Mutation[] {m, m}, key, value);
-    assertEquals(key.event, MANY_MUTATIONS);
-    assertEquals(key.seq, 9);
-    assertEquals(key.tabletId, 10);
-    assertEquals(value.mutations, Arrays.asList(m, m));
+    assertEquals(key.getEvent(), MANY_MUTATIONS);
+    assertEquals(key.getSeq(), 9);
+    assertEquals(key.getTabletId(), 10);
+    assertEquals(value.getMutations(), Arrays.asList(m, m));
   }
 
   @Test

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/replication/AccumuloReplicaSystemTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/replication/AccumuloReplicaSystemTest.java
@@ -71,78 +71,78 @@ public class AccumuloReplicaSystemTest {
     LogFileValue value = new LogFileValue();
 
     // What is seq used for?
-    key.seq = 1L;
+    key.setSeq(1L);
 
     /*
      * Disclaimer: the following series of LogFileKey and LogFileValue pairs have *no* bearing
      * whatsoever in reality regarding what these entries would actually look like in a WAL. They
      * are solely for testing that each LogEvents is handled, order is not important.
      */
-    key.event = LogEvents.DEFINE_TABLET;
-    key.tablet = new KeyExtent(TableId.of("1"), null, null);
-    key.tabletId = 1;
+    key.setEvent(LogEvents.DEFINE_TABLET);
+    key.setTablet(new KeyExtent(TableId.of("1"), null, null));
+    key.setTabletId(1);
     key.write(dos);
     value.write(dos);
 
-    key.tablet = null;
-    key.event = LogEvents.MUTATION;
-    key.filename = "/accumulo/wals/tserver+port/" + UUID.randomUUID();
-    value.mutations = Arrays.asList(new ServerMutation(new Text("row")));
-
-    key.write(dos);
-    value.write(dos);
-
-    key.event = LogEvents.DEFINE_TABLET;
-    key.tablet = new KeyExtent(TableId.of("2"), null, null);
-    key.tabletId = 2;
-    value.mutations = Collections.emptyList();
+    key.setTablet(null);
+    key.setEvent(LogEvents.MUTATION);
+    key.setFilename("/accumulo/wals/tserver+port/" + UUID.randomUUID());
+    value.setMutations(Arrays.asList(new ServerMutation(new Text("row"))));
 
     key.write(dos);
     value.write(dos);
 
-    key.event = LogEvents.OPEN;
-    key.tabletId = LogFileKey.VERSION;
-    key.tserverSession = "foobar";
+    key.setEvent(LogEvents.DEFINE_TABLET);
+    key.setTablet(new KeyExtent(TableId.of("2"), null, null));
+    key.setTabletId(2);
+    value.setMutations(Collections.emptyList());
 
     key.write(dos);
     value.write(dos);
 
-    key.tablet = null;
-    key.event = LogEvents.MUTATION;
-    key.filename = "/accumulo/wals/tserver+port/" + UUID.randomUUID();
-    value.mutations = Arrays.asList(new ServerMutation(new Text("badrow")));
+    key.setEvent(LogEvents.OPEN);
+    key.setTabletId(LogFileKey.VERSION);
+    key.setTserverSession("foobar");
 
     key.write(dos);
     value.write(dos);
 
-    key.event = LogEvents.COMPACTION_START;
-    key.tabletId = 2;
-    key.filename = "/accumulo/tables/1/t-000001/A000001.rf";
-    value.mutations = Collections.emptyList();
+    key.setTablet(null);
+    key.setEvent(LogEvents.MUTATION);
+    key.setFilename("/accumulo/wals/tserver+port/" + UUID.randomUUID());
+    value.setMutations(Arrays.asList(new ServerMutation(new Text("badrow"))));
 
     key.write(dos);
     value.write(dos);
 
-    key.event = LogEvents.DEFINE_TABLET;
-    key.tablet = new KeyExtent(TableId.of("1"), null, null);
-    key.tabletId = 3;
-    value.mutations = Collections.emptyList();
+    key.setEvent(LogEvents.COMPACTION_START);
+    key.setTabletId(2);
+    key.setFilename("/accumulo/tables/1/t-000001/A000001.rf");
+    value.setMutations(Collections.emptyList());
 
     key.write(dos);
     value.write(dos);
 
-    key.event = LogEvents.COMPACTION_FINISH;
-    key.tabletId = 6;
-    value.mutations = Collections.emptyList();
+    key.setEvent(LogEvents.DEFINE_TABLET);
+    key.setTablet(new KeyExtent(TableId.of("1"), null, null));
+    key.setTabletId(3);
+    value.setMutations(Collections.emptyList());
 
     key.write(dos);
     value.write(dos);
 
-    key.tablet = null;
-    key.event = LogEvents.MUTATION;
-    key.tabletId = 3;
-    key.filename = "/accumulo/wals/tserver+port/" + UUID.randomUUID();
-    value.mutations = Arrays.asList(new ServerMutation(new Text("row")));
+    key.setEvent(LogEvents.COMPACTION_FINISH);
+    key.setTabletId(6);
+    value.setMutations(Collections.emptyList());
+
+    key.write(dos);
+    value.write(dos);
+
+    key.setTablet(null);
+    key.setEvent(LogEvents.MUTATION);
+    key.setTabletId(3);
+    key.setFilename("/accumulo/wals/tserver+port/" + UUID.randomUUID());
+    value.setMutations(Arrays.asList(new ServerMutation(new Text("row"))));
 
     key.write(dos);
     value.write(dos);
@@ -178,79 +178,79 @@ public class AccumuloReplicaSystemTest {
     LogFileValue value = new LogFileValue();
 
     // What is seq used for?
-    key.seq = 1L;
+    key.setSeq(1L);
 
     /*
      * Disclaimer: the following series of LogFileKey and LogFileValue pairs have *no* bearing
      * whatsoever in reality regarding what these entries would actually look like in a WAL. They
      * are solely for testing that each LogEvents is handled, order is not important.
      */
-    key.event = LogEvents.DEFINE_TABLET;
-    key.tablet = new KeyExtent(TableId.of("1"), null, null);
-    key.tabletId = 1;
+    key.setEvent(LogEvents.DEFINE_TABLET);
+    key.setTablet(new KeyExtent(TableId.of("1"), null, null));
+    key.setTabletId(1);
 
     key.write(dos);
     value.write(dos);
 
-    key.tablet = null;
-    key.event = LogEvents.MUTATION;
-    key.filename = "/accumulo/wals/tserver+port/" + UUID.randomUUID();
-    value.mutations = Arrays.asList(new ServerMutation(new Text("row")));
+    key.setTablet(null);
+    key.setEvent(LogEvents.MUTATION);
+    key.setFilename("/accumulo/wals/tserver+port/" + UUID.randomUUID());
+    value.setMutations(Arrays.asList(new ServerMutation(new Text("row"))));
 
     key.write(dos);
     value.write(dos);
 
-    key.event = LogEvents.DEFINE_TABLET;
-    key.tablet = new KeyExtent(TableId.of("2"), null, null);
-    key.tabletId = 2;
-    value.mutations = Collections.emptyList();
+    key.setEvent(LogEvents.DEFINE_TABLET);
+    key.setTablet(new KeyExtent(TableId.of("2"), null, null));
+    key.setTabletId(2);
+    value.setMutations(Collections.emptyList());
 
     key.write(dos);
     value.write(dos);
 
-    key.event = LogEvents.OPEN;
-    key.tabletId = LogFileKey.VERSION;
-    key.tserverSession = "foobar";
+    key.setEvent(LogEvents.OPEN);
+    key.setTabletId(LogFileKey.VERSION);
+    key.setTserverSession("foobar");
 
     key.write(dos);
     value.write(dos);
 
-    key.tablet = null;
-    key.event = LogEvents.MUTATION;
-    key.filename = "/accumulo/wals/tserver+port/" + UUID.randomUUID();
-    value.mutations = Arrays.asList(new ServerMutation(new Text("badrow")));
+    key.setTablet(null);
+    key.setEvent(LogEvents.MUTATION);
+    key.setFilename("/accumulo/wals/tserver+port/" + UUID.randomUUID());
+    value.setMutations(Arrays.asList(new ServerMutation(new Text("badrow"))));
 
     key.write(dos);
     value.write(dos);
 
-    key.event = LogEvents.COMPACTION_START;
-    key.tabletId = 2;
-    key.filename = "/accumulo/tables/1/t-000001/A000001.rf";
-    value.mutations = Collections.emptyList();
+    key.setEvent(LogEvents.COMPACTION_START);
+    key.setTabletId(2);
+    key.setFilename("/accumulo/tables/1/t-000001/A000001.rf");
+    value.setMutations(Collections.emptyList());
 
     key.write(dos);
     value.write(dos);
 
-    key.event = LogEvents.DEFINE_TABLET;
-    key.tablet = new KeyExtent(TableId.of("1"), null, null);
-    key.tabletId = 3;
-    value.mutations = Collections.emptyList();
+    key.setEvent(LogEvents.DEFINE_TABLET);
+    key.setTablet(new KeyExtent(TableId.of("1"), null, null));
+    key.setTabletId(3);
+    value.setMutations(Collections.emptyList());
 
     key.write(dos);
     value.write(dos);
 
-    key.event = LogEvents.COMPACTION_FINISH;
-    key.tabletId = 6;
-    value.mutations = Collections.emptyList();
+    key.setEvent(LogEvents.COMPACTION_FINISH);
+    key.setTabletId(6);
+    value.setMutations(Collections.emptyList());
 
     key.write(dos);
     value.write(dos);
 
-    key.tablet = null;
-    key.event = LogEvents.MUTATION;
-    key.tabletId = 3;
-    key.filename = "/accumulo/wals/tserver+port/" + UUID.randomUUID();
-    value.mutations = Arrays.asList(new ServerMutation(new Text("row")));
+    key.setTablet(null);
+    key.setEvent(LogEvents.MUTATION);
+    key.setTabletId(3);
+    key.setFilename("/accumulo/wals/tserver+port/" + UUID.randomUUID());
+    value.setMutations(Arrays.asList(new ServerMutation(new Text("row"))));
 
     key.write(dos);
     value.write(dos);
@@ -290,16 +290,16 @@ public class AccumuloReplicaSystemTest {
     ars.setConf(conf);
 
     LogFileValue value = new LogFileValue();
-    value.mutations = new ArrayList<>();
+    value.setMutations(new ArrayList<>());
 
     Mutation m = new Mutation("row");
     m.put("", "", new Value());
-    value.mutations.add(m);
+    value.getMutations().add(m);
 
     m = new Mutation("row2");
     m.put("", "", new Value());
     m.addReplicationSource("peer");
-    value.mutations.add(m);
+    value.getMutations().add(m);
 
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     DataOutputStream out = new DataOutputStream(baos);
@@ -384,33 +384,33 @@ public class AccumuloReplicaSystemTest {
     LogFileValue value = new LogFileValue();
 
     // What is seq used for?
-    key.seq = 1L;
+    key.setSeq(1L);
 
     /*
      * Disclaimer: the following series of LogFileKey and LogFileValue pairs have *no* bearing
      * whatsoever in reality regarding what these entries would actually look like in a WAL. They
      * are solely for testing that each LogEvents is handled, order is not important.
      */
-    key.event = LogEvents.DEFINE_TABLET;
-    key.tablet = new KeyExtent(TableId.of("1"), null, null);
-    key.tabletId = 1;
+    key.setEvent(LogEvents.DEFINE_TABLET);
+    key.setTablet(new KeyExtent(TableId.of("1"), null, null));
+    key.setTabletId(1);
 
     key.write(dos);
     value.write(dos);
 
-    key.tablet = null;
-    key.event = LogEvents.MUTATION;
-    key.filename = "/accumulo/wals/tserver+port/" + UUID.randomUUID();
-    value.mutations = Arrays.asList(new ServerMutation(new Text("row")));
+    key.setTablet(null);
+    key.setEvent(LogEvents.MUTATION);
+    key.setFilename("/accumulo/wals/tserver+port/" + UUID.randomUUID());
+    value.setMutations(Arrays.asList(new ServerMutation(new Text("row"))));
 
     key.write(dos);
     value.write(dos);
 
-    key.tablet = null;
-    key.event = LogEvents.MUTATION;
-    key.tabletId = 1;
-    key.filename = "/accumulo/wals/tserver+port/" + UUID.randomUUID();
-    value.mutations = Arrays.asList(new ServerMutation(new Text("row")));
+    key.setTablet(null);
+    key.setEvent(LogEvents.MUTATION);
+    key.setTabletId(1);
+    key.setFilename("/accumulo/wals/tserver+port/" + UUID.randomUUID());
+    value.setMutations(Arrays.asList(new ServerMutation(new Text("row"))));
 
     key.write(dos);
     value.write(dos);

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/replication/BatchWriterReplicationReplayerTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/replication/BatchWriterReplicationReplayerTest.java
@@ -74,9 +74,9 @@ public class BatchWriterReplicationReplayerTest {
     bwCfg.setMaxMemory(1L);
 
     LogFileKey key = new LogFileKey();
-    key.event = LogEvents.MANY_MUTATIONS;
-    key.seq = 1;
-    key.tabletId = 1;
+    key.setEvent(LogEvents.MANY_MUTATIONS);
+    key.setSeq(1);
+    key.setTabletId(1);
 
     WalEdits edits = new WalEdits();
 
@@ -140,9 +140,9 @@ public class BatchWriterReplicationReplayerTest {
     bwCfg.setMaxMemory(1L);
 
     LogFileKey key = new LogFileKey();
-    key.event = LogEvents.MANY_MUTATIONS;
-    key.seq = 1;
-    key.tabletId = 1;
+    key.setEvent(LogEvents.MANY_MUTATIONS);
+    key.setSeq(1);
+    key.setTabletId(1);
 
     WalEdits edits = new WalEdits();
 

--- a/shell/src/main/java/org/apache/accumulo/shell/Shell.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/Shell.java
@@ -567,7 +567,7 @@ public class Shell extends ShellOptions implements KeywordExecutable {
 
     String home = System.getProperty("HOME");
     if (home == null) {
-      home = System.getenv("HOME");
+      home = System.getProperty("user.home");
     }
     String configDir = home + "/" + HISTORY_DIR_NAME;
     String historyPath = configDir + "/" + HISTORY_FILE_NAME;

--- a/test/src/main/java/org/apache/accumulo/test/TestRandomDeletes.java
+++ b/test/src/main/java/org/apache/accumulo/test/TestRandomDeletes.java
@@ -110,7 +110,7 @@ public class TestRandomDeletes {
       for (int i = 0; i < (entries.size() + 1) / 2; i++) {
         RowColumn rc = entries.get(i);
         Mutation m = new Mutation(rc.row);
-        m.putDelete(new Text(rc.column.columnFamily), new Text(rc.column.columnQualifier),
+        m.putDelete(new Text(rc.column.getColumnFamily()), new Text(rc.column.getColumnQualifier()),
             new ColumnVisibility(rc.column.getColumnVisibility()), rc.timestamp + 1);
         bw.addMutation(m);
         rows.remove(rc);

--- a/test/src/main/java/org/apache/accumulo/test/replication/UnusedWalDoesntCloseReplicationStatusIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/UnusedWalDoesntCloseReplicationStatusIT.java
@@ -119,38 +119,38 @@ public class UnusedWalDoesntCloseReplicationStatusIT extends ConfigurableMacBase
     LogFileKey key = new LogFileKey();
     LogFileValue value = new LogFileValue();
 
-    key.event = OPEN;
-    key.tserverSession = tserverWal.getAbsolutePath();
-    key.filename = tserverWal.getAbsolutePath();
+    key.setEvent(OPEN);
+    key.setTserverSession(tserverWal.getAbsolutePath());
+    key.setFilename(tserverWal.getAbsolutePath());
     key.write(out);
     value.write(out);
 
-    key.event = LogEvents.DEFINE_TABLET;
-    key.tablet = new KeyExtent(TableId.of(Integer.toString(fakeTableId)), null, null);
-    key.seq = 1L;
-    key.tabletId = 1;
+    key.setEvent(LogEvents.DEFINE_TABLET);
+    key.setTablet(new KeyExtent(TableId.of(Integer.toString(fakeTableId)), null, null));
+    key.setSeq(1L);
+    key.setTabletId(1);
 
     key.write(dos);
     value.write(dos);
 
-    key.tablet = null;
-    key.event = LogEvents.MUTATION;
-    key.filename = tserverWal.getAbsolutePath();
-    value.mutations = Arrays.asList(new ServerMutation(new Text("row")));
+    key.setTablet(null);
+    key.setEvent(LogEvents.MUTATION);
+    key.setFilename(tserverWal.getAbsolutePath());
+    value.setMutations(Arrays.asList(new ServerMutation(new Text("row"))));
 
     key.write(dos);
     value.write(dos);
 
-    key.event = LogEvents.COMPACTION_START;
-    key.filename =
-        accumuloDir.getAbsolutePath() + "/tables/" + fakeTableId + "/t-000001/A000001.rf";
-    value.mutations = Collections.emptyList();
+    key.setEvent(LogEvents.COMPACTION_START);
+    key.setFilename(
+        accumuloDir.getAbsolutePath() + "/tables/" + fakeTableId + "/t-000001/A000001.rf");
+    value.setMutations(Collections.emptyList());
 
     key.write(dos);
     value.write(dos);
 
-    key.event = LogEvents.COMPACTION_FINISH;
-    value.mutations = Collections.emptyList();
+    key.setEvent(LogEvents.COMPACTION_FINISH);
+    value.setMutations(Collections.emptyList());
 
     key.write(dos);
     value.write(dos);

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellAuthenticatorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellAuthenticatorIT.java
@@ -54,8 +54,8 @@ public class ShellAuthenticatorIT extends SharedMiniClusterBase {
   private StringInputStream input;
   private TestOutputStream output;
   private Shell shell;
-  public LineReader reader;
-  public Terminal terminal;
+  private LineReader reader;
+  private Terminal terminal;
 
   @BeforeEach
   public void setupShell() throws IOException {

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellIT.java
@@ -117,8 +117,8 @@ public class ShellIT extends SharedMiniClusterBase {
   private TestOutputStream output;
   private Shell shell;
   private File config;
-  public LineReader reader;
-  public Terminal terminal;
+  private LineReader reader;
+  private Terminal terminal;
 
   void execExpectList(String cmd, boolean expecteGoodExit, List<String> expectedStrings)
       throws IOException {


### PR DESCRIPTION
Upgraded plugin which required changes to existing classes as spotbugs was complaining about encapsulation issues. Modified existing configuration to ignore two new bug detectors, ConstructorThrow and SharedVariableAtomicityDetector.

Fixing the code to enable the ConstructorThrow detector would require a lot of refactoring of objects that throw exceptions from their constructor. The SharedVariableAtomicityDetector was complaining about a lot of non-atomic variable manipulation and access to variables from different threads that might require synchronization. Each occurrence likely needs to evaluated to determine if it's an issue or not. For example, it was suggesting that hasTop needs to be marked as volatile in an iterator class because it's set and read in different methods. However, iterators don't support multi-threaded access.

Removed the spotbugs suppression to CachableBlockFile that was added in #5381.

Closes #5382