### PR TITLE
Modified SystemIteratorEnvironmentImpl to implement isRunningLowOnMemory

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/iterators/SystemIteratorEnvironment.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/iterators/SystemIteratorEnvironment.java
@@ -30,9 +30,4 @@ public interface SystemIteratorEnvironment extends IteratorEnvironment {
 
   SortedKeyValueIterator<Key,Value> getTopLevelIterator(SortedKeyValueIterator<Key,Value> iter);
 
-  @Override
-  default boolean isRunningLowOnMemory() {
-    return getServerContext().getLowMemoryDetector().isRunningLowOnMemory();
-  }
-
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/iterators/SystemIteratorEnvironmentImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/iterators/SystemIteratorEnvironmentImpl.java
@@ -128,4 +128,9 @@ public class SystemIteratorEnvironmentImpl extends ClientIteratorEnvironment
     return new MultiIterator(allIters, false);
   }
 
+  @Override
+  public boolean isRunningLowOnMemory() {
+    return getServerContext().getLowMemoryDetector().isRunningLowOnMemory();
+  }
+
 }


### PR DESCRIPTION
SystemIteratorEnvironmentImpl was added in #5587, but did not implement the isRunningLowOnMemory method. It deferred to its parent class implementation, ClientIteratorEnvironment.isRunningLowOnMemory, which just returns false.