### PR TITLE
new options display option for ServiceStatusCmd

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
@@ -269,11 +269,16 @@ public class Admin implements KeywordExecutable {
 
   @Parameters(commandDescription = "show service status")
   public static class ServiceStatusCmdOpts extends SubCommandOpts {
-    @Parameter(names = "--json", description = "provide output in json format (--noHosts ignored)")
-    boolean json = false;
+    @Parameter(names = "--json",
+        description = "provide output in json format (--noHosts ignored). Options: 'nested' or 'flat'")
+    String json = null;
     @Parameter(names = "--noHosts",
         description = "provide a summary of service counts without host details")
     boolean noHosts = false;
+
+    @Parameter(names = "--csv",
+        description = "provide output in csv format (--json and --noHost ignored)")
+    boolean csv = false;
   }
 
   public static void main(String[] args) {
@@ -438,7 +443,8 @@ public class Admin implements KeywordExecutable {
         executeFateOpsCommand(context, fateOpsCommand);
       } else if (cl.getParsedCommand().equals("serviceStatus")) {
         ServiceStatusCmd ssc = new ServiceStatusCmd();
-        ssc.execute(context, serviceStatusCommandOpts.json, serviceStatusCommandOpts.noHosts);
+        ssc.execute(context, serviceStatusCommandOpts.json, serviceStatusCommandOpts.noHosts,
+            serviceStatusCommandOpts.csv);
       } else if (cl.getParsedCommand().equals("stopManager")
           || cl.getParsedCommand().equals("stopAll")) {
         boolean everything = cl.getParsedCommand().equals("stopAll");

--- a/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
@@ -270,11 +270,11 @@ public class Admin implements KeywordExecutable {
   @Parameters(commandDescription = "show service status")
   public static class ServiceStatusCmdOpts extends SubCommandOpts {
     @Parameter(names = "--json",
-        description = "provide output in json format (--noHosts ignored). Options: 'nested' or 'flat'")
-    String json = null;
-    @Parameter(names = "--noHosts",
-        description = "provide a summary of service counts without host details")
-    boolean noHosts = false;
+        description = "provide output in json format (--showHosts ignored)")
+    boolean json = false;
+    @Parameter(names = "--showHosts",
+        description = "provide a summary of service counts with host details")
+    boolean showHosts = false;
 
     @Parameter(names = "--csv",
         description = "provide output in csv format (--json and --noHost ignored)")
@@ -443,7 +443,7 @@ public class Admin implements KeywordExecutable {
         executeFateOpsCommand(context, fateOpsCommand);
       } else if (cl.getParsedCommand().equals("serviceStatus")) {
         ServiceStatusCmd ssc = new ServiceStatusCmd();
-        ssc.execute(context, serviceStatusCommandOpts.json, serviceStatusCommandOpts.noHosts,
+        ssc.execute(context, serviceStatusCommandOpts.json, serviceStatusCommandOpts.showHosts,
             serviceStatusCommandOpts.csv);
       } else if (cl.getParsedCommand().equals("stopManager")
           || cl.getParsedCommand().equals("stopAll")) {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ServiceStatusCmd.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ServiceStatusCmd.java
@@ -54,7 +54,8 @@ public class ServiceStatusCmd {
    * Read the service statuses from ZooKeeper, build the status report and then output the report to
    * stdout.
    */
-  public void execute(final ServerContext context, final boolean json, final boolean noHosts) {
+  public void execute(final ServerContext context, final String json, final boolean noHosts,
+      final boolean csv) {
 
     ZooReader zooReader = context.getZooReader();
 
@@ -74,7 +75,11 @@ public class ServiceStatusCmd {
 
     ServiceStatusReport report = new ServiceStatusReport(services, noHosts);
 
-    if (json) {
+    if (csv) {
+      System.out.println(report.toCsv());
+    } else if ("flat".equalsIgnoreCase(json)) {
+      System.out.println(report.toFlatJson());
+    } else if (json != null) {
       System.out.println(report.toJson());
     } else {
       StringBuilder sb = new StringBuilder(8192);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ServiceStatusCmd.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ServiceStatusCmd.java
@@ -54,7 +54,7 @@ public class ServiceStatusCmd {
    * Read the service statuses from ZooKeeper, build the status report and then output the report to
    * stdout.
    */
-  public void execute(final ServerContext context, final String json, final boolean noHosts,
+  public void execute(final ServerContext context, final boolean json, final boolean showHosts,
       final boolean csv) {
 
     ZooReader zooReader = context.getZooReader();
@@ -73,13 +73,11 @@ public class ServiceStatusCmd {
     services.put(ServiceStatusReport.ReportKey.COMPACTOR, getCompactorStatus(zooReader, zooRoot));
     services.put(ServiceStatusReport.ReportKey.GC, getGcStatus(zooReader, zooRoot));
 
-    ServiceStatusReport report = new ServiceStatusReport(services, noHosts);
+    ServiceStatusReport report = new ServiceStatusReport(services, showHosts);
 
     if (csv) {
       System.out.println(report.toCsv());
-    } else if ("flat".equalsIgnoreCase(json)) {
-      System.out.println(report.toFlatJson());
-    } else if (json != null) {
+    } else if (json) {
       System.out.println(report.toJson());
     } else {
       StringBuilder sb = new StringBuilder(8192);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/serviceStatus/ServiceStatusReport.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/serviceStatus/ServiceStatusReport.java
@@ -111,44 +111,6 @@ public class ServiceStatusReport {
 
     return sb.toString();
   }
-  //
-  // public String toFlatJson() {
-  // Map<String,Map<String,Object>> flatJson = new LinkedHashMap<>();
-  //
-  // for (Map.Entry<ReportKey,StatusSummary> entry : summaries.entrySet()) {
-  // ReportKey reportKey = entry.getKey();
-  // StatusSummary statusSummary = entry.getValue();
-  //
-  // if (statusSummary.getServiceByGroups() == null) {
-  // continue;
-  // }
-  //
-  // Map<String,Object> groupData = getGroupData(statusSummary);
-  // flatJson.put(reportKey.name(), groupData);
-  // }
-  //
-  // Map<String,Object> wrapper = new LinkedHashMap<>();
-  // wrapper.put("summaries", flatJson);
-  //
-  // return gson.toJson(wrapper);
-  // }
-  //
-  // private static Map<String,Object> getGroupData(StatusSummary statusSummary) {
-  // Map<String,Object> groupData = new LinkedHashMap<>();
-  // for (Map.Entry<String,Set<String>> groupEntry : statusSummary.getServiceByGroups().entrySet())
-  // {
-  // String group = groupEntry.getKey();
-  // Set<String> hosts = groupEntry.getValue();
-  //
-  // Map<String,Object> details = new LinkedHashMap<>();
-  // details.put("HostCount", hosts.size());
-  // details.put("hosts", hosts);
-  // details.put("errorCount", statusSummary.getErrorCount());
-  //
-  // groupData.put(group, details);
-  // }
-  // return groupData;
-  // }
 
   public String report(final StringBuilder sb) {
     sb.append("Report time: ").append(rptTimeFmt.format(ZonedDateTime.now(ZoneId.of("UTC"))))

--- a/server/base/src/main/java/org/apache/accumulo/server/util/serviceStatus/ServiceStatusReport.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/serviceStatus/ServiceStatusReport.java
@@ -87,7 +87,7 @@ public class ServiceStatusReport {
 
   public String toCsv() {
     StringBuilder sb = new StringBuilder();
-    sb.append("Service, Resource Group, Host Count, Hosts, Error Count\n");
+    sb.append("Service,Resource Group,Host Count,Hosts,Error Count\n");
 
     for (Map.Entry<ReportKey,StatusSummary> entry : summaries.entrySet()) {
       ReportKey reportKey = entry.getKey();

--- a/server/base/src/main/java/org/apache/accumulo/server/util/serviceStatus/StatusSummary.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/serviceStatus/StatusSummary.java
@@ -18,9 +18,11 @@
  */
 package org.apache.accumulo.server.util.serviceStatus;
 
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeMap;
 
 public class StatusSummary {
 
@@ -62,6 +64,26 @@ public class StatusSummary {
 
   public int getErrorCount() {
     return errorCount;
+  }
+
+  public StatusSummary withoutHosts() {
+    Map<String,Set<String>> tmpHosts = new TreeMap<>();
+
+    for (Map.Entry<String,Set<String>> entry : this.serviceByGroups.entrySet()) {
+
+      String group = entry.getKey();
+      int size = entry.getValue().size();
+      ;
+
+      Set<String> hosts = new HashSet<>();
+      for (int i = 0; i < size; i++) {
+        hosts.add("");
+      }
+
+      tmpHosts.put(group, hosts);
+    }
+
+    return new StatusSummary(this.serviceType, this.resourceGroups, tmpHosts, this.errorCount);
   }
 
   @Override

--- a/server/base/src/test/java/org/apache/accumulo/server/util/ServiceStatusCmdTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/ServiceStatusCmdTest.java
@@ -28,7 +28,6 @@ import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.List;
 import java.util.Map;
@@ -400,8 +399,8 @@ public class ServiceStatusCmdTest {
   public void testServiceStatusCommandOpts() {
     replay(zooReader); // needed for @AfterAll verify
     Admin.ServiceStatusCmdOpts opts = new Admin.ServiceStatusCmdOpts();
-    assertNull(opts.json);
-    assertFalse(opts.noHosts);
+    assertFalse(opts.json);
+    assertFalse(opts.showHosts);
     assertFalse(opts.csv);
   }
 

--- a/server/base/src/test/java/org/apache/accumulo/server/util/ServiceStatusCmdTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/ServiceStatusCmdTest.java
@@ -28,6 +28,7 @@ import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.List;
 import java.util.Map;
@@ -399,8 +400,9 @@ public class ServiceStatusCmdTest {
   public void testServiceStatusCommandOpts() {
     replay(zooReader); // needed for @AfterAll verify
     Admin.ServiceStatusCmdOpts opts = new Admin.ServiceStatusCmdOpts();
-    assertFalse(opts.json);
+    assertNull(opts.json);
     assertFalse(opts.noHosts);
+    assertFalse(opts.csv);
   }
 
 }


### PR DESCRIPTION
Closes [issue #5051 ](https://github.com/apache/accumulo/issues/5051)

I changed ServiceStatusCmd option json from a boolean to a sting to allow for the option from having the full summary of the system (the current output) and condense version of it ( new desired output). I also went a head and added a new option for ServiceStatusCmd to output in csv format as well.  