### PR TITLE
fixes bug in seeking iterator w/ disjoint range and columns

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/data/Range.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Range.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.accumulo.core.dataImpl.RangeImpl;
 import org.apache.accumulo.core.dataImpl.thrift.TRange;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.WritableComparable;
@@ -562,81 +563,10 @@ public class Range implements WritableComparable<Range> {
    * @param max maximum column
    * @return a column bounded range
    * @throws IllegalArgumentException if the minimum column compares greater than the maximum column
+   *         OR if the columns and the range are disjoint
    */
   public Range bound(Column min, Column max) {
-
-    if (min.compareTo(max) > 0) {
-      throw new IllegalArgumentException("min column > max column " + min + " " + max);
-    }
-
-    Key sk = getStartKey();
-    boolean ski = isStartKeyInclusive();
-
-    if (sk != null) {
-
-      ByteSequence cf = sk.getColumnFamilyData();
-      ByteSequence cq = sk.getColumnQualifierData();
-
-      ByteSequence mincf = new ArrayByteSequence(min.columnFamily);
-      ByteSequence mincq;
-
-      if (min.columnQualifier != null) {
-        mincq = new ArrayByteSequence(min.columnQualifier);
-      } else {
-        mincq = new ArrayByteSequence(new byte[0]);
-      }
-
-      int cmp = cf.compareTo(mincf);
-
-      if (cmp < 0 || (cmp == 0 && cq.compareTo(mincq) < 0)) {
-        ski = true;
-        sk = new Key(sk.getRowData().toArray(), mincf.toArray(), mincq.toArray(), new byte[0],
-            Long.MAX_VALUE, true);
-      }
-    }
-
-    Key ek = getEndKey();
-    boolean eki = isEndKeyInclusive();
-
-    if (ek != null) {
-      ByteSequence row = ek.getRowData();
-      ByteSequence cf = ek.getColumnFamilyData();
-      ByteSequence cq = ek.getColumnQualifierData();
-      ByteSequence cv = ek.getColumnVisibilityData();
-
-      ByteSequence maxcf = new ArrayByteSequence(max.columnFamily);
-      ByteSequence maxcq = null;
-      if (max.columnQualifier != null) {
-        maxcq = new ArrayByteSequence(max.columnQualifier);
-      }
-
-      boolean set = false;
-
-      int comp = cf.compareTo(maxcf);
-
-      if (comp > 0) {
-        set = true;
-      } else if (comp == 0 && maxcq != null && cq.compareTo(maxcq) > 0) {
-        set = true;
-      } else if (!eki && row.length() > 0 && row.byteAt(row.length() - 1) == 0 && cf.length() == 0
-          && cq.length() == 0 && cv.length() == 0 && ek.getTimestamp() == Long.MAX_VALUE) {
-        row = row.subSequence(0, row.length() - 1);
-        set = true;
-      }
-
-      if (set) {
-        eki = false;
-        if (maxcq == null) {
-          ek = new Key(row.toArray(), maxcf.toArray(), new byte[0], new byte[0], 0, false)
-              .followingKey(PartialKey.ROW_COLFAM);
-        } else {
-          ek = new Key(row.toArray(), maxcf.toArray(), maxcq.toArray(), new byte[0], 0, false)
-              .followingKey(PartialKey.ROW_COLFAM_COLQUAL);
-        }
-      }
-    }
-
-    return new Range(sk, ski, ek, eki);
+    return RangeImpl.bound(this, min, max, false);
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/dataImpl/RangeImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/dataImpl/RangeImpl.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.dataImpl;
+
+import org.apache.accumulo.core.data.ArrayByteSequence;
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.data.Column;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.PartialKey;
+import org.apache.accumulo.core.data.Range;
+
+public class RangeImpl {
+  public static Range bound(Range range, Column min, Column max,
+      boolean returnEmptyRangeWhenDisjoint) {
+
+    if (min.compareTo(max) > 0) {
+      throw new IllegalArgumentException("min column > max column " + min + " " + max);
+    }
+
+    Key sk = range.getStartKey();
+    boolean ski = range.isStartKeyInclusive();
+
+    if (sk != null) {
+
+      ByteSequence cf = sk.getColumnFamilyData();
+      ByteSequence cq = sk.getColumnQualifierData();
+
+      ByteSequence mincf = new ArrayByteSequence(min.columnFamily);
+      ByteSequence mincq;
+
+      if (min.columnQualifier != null) {
+        mincq = new ArrayByteSequence(min.columnQualifier);
+      } else {
+        mincq = new ArrayByteSequence(new byte[0]);
+      }
+
+      int cmp = cf.compareTo(mincf);
+
+      if (cmp < 0 || (cmp == 0 && cq.compareTo(mincq) < 0)) {
+        ski = true;
+        sk = new Key(sk.getRowData().toArray(), mincf.toArray(), mincq.toArray(), new byte[0],
+            Long.MAX_VALUE, true);
+      }
+    }
+
+    Key ek = range.getEndKey();
+    boolean eki = range.isEndKeyInclusive();
+
+    if (ek != null) {
+      ByteSequence row = ek.getRowData();
+      ByteSequence cf = ek.getColumnFamilyData();
+      ByteSequence cq = ek.getColumnQualifierData();
+      ByteSequence cv = ek.getColumnVisibilityData();
+
+      ByteSequence maxcf = new ArrayByteSequence(max.columnFamily);
+      ByteSequence maxcq = null;
+      if (max.columnQualifier != null) {
+        maxcq = new ArrayByteSequence(max.columnQualifier);
+      }
+
+      boolean set = false;
+
+      int comp = cf.compareTo(maxcf);
+
+      if (comp > 0) {
+        set = true;
+      } else if (comp == 0 && maxcq != null && cq.compareTo(maxcq) > 0) {
+        set = true;
+      } else if (!eki && row.length() > 0 && row.byteAt(row.length() - 1) == 0 && cf.length() == 0
+          && cq.length() == 0 && cv.length() == 0 && ek.getTimestamp() == Long.MAX_VALUE) {
+        row = row.subSequence(0, row.length() - 1);
+        set = true;
+      }
+
+      if (set) {
+        eki = false;
+        if (maxcq == null) {
+          ek = new Key(row.toArray(), maxcf.toArray(), new byte[0], new byte[0], 0, false)
+              .followingKey(PartialKey.ROW_COLFAM);
+        } else {
+          ek = new Key(row.toArray(), maxcf.toArray(), maxcq.toArray(), new byte[0], 0, false)
+              .followingKey(PartialKey.ROW_COLFAM_COLQUAL);
+        }
+      }
+    }
+
+    if (returnEmptyRangeWhenDisjoint && sk != null && ek != null && sk.compareTo(ek) > 0) {
+      return new Range(sk, true, sk, false);
+    }
+    return new Range(sk, ski, ek, eki);
+  }
+}

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/ColumnFamilySkippingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/ColumnFamilySkippingIterator.java
@@ -31,6 +31,7 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.dataImpl.RangeImpl;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.ServerSkippingIterator;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
@@ -126,8 +127,8 @@ public class ColumnFamilySkippingIterator extends ServerSkippingIterator
         this.range = range;
       } else {
         // Limit the range based on the min and max column families
-        this.range = range.bound(new Column(sortedColFams.first().toArray(), null, null),
-            new Column(sortedColFams.last().toArray(), null, null));
+        this.range = RangeImpl.bound(range, new Column(sortedColFams.first().toArray(), null, null),
+            new Column(sortedColFams.last().toArray(), null, null), true);
       }
     } else {
       sortedColFams = null;

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/ColumnFamilySkippingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/ColumnFamilySkippingIteratorTest.java
@@ -364,5 +364,15 @@ public class ColumnFamilySkippingIteratorTest {
       }
     }
     assertFalse(cfi.hasTop());
+
+    // test the case where the columns and range are disjoint
+    seekRange =
+        new Range(new Key(format(1), format(9)), true, new Key(format(1), format(11)), false);
+    capturedRanges.clear();
+    cfi.seek(seekRange, Set.of(new ArrayByteSequence(format(7))), true);
+    assertFalse(cfi.hasTop());
+    assertEquals(new Range(seekRange.getStartKey(), true, seekRange.getStartKey(), false),
+        capturedRanges.get(0));
+
   }
 }


### PR DESCRIPTION
In #5621 a bug was introduced where if an iterator seeks with range and columns families that are disjoint it will throw an exception.  This was caused by Range.bound() that had this behavior.

To fix this copied the code in Range.bound() into RangeImpl and made a very slight modification.  This was done to preserve the existing behavior of the public API method Range.bound() and reuse 99% of its code and test for a slightly different behavior.  Also documented the behavior of Range.bound(), considered changing its behavior but this subtle change in runtime behavior seemed dicey w/ hard to predict outcomes (like it would change the runtime behavior of Scanner and BatchScanner which currently use Range.bound()).

Now when the range and column families are disjoint ColumnFamilySkippingIterator will seek its underlying iterator with a new empty range.

This bug was found by BigRootTabletIT.  After this change that test passes.