### PR TITLE
Modified TableMapping.update to only check root and meta exist

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/util/tables/TableMapping.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/tables/TableMapping.java
@@ -144,9 +144,11 @@ public class TableMapping {
       }
       Map<String,String> idToName = deserializeMap(data);
       if (namespaceId.equals(Namespace.ACCUMULO.id())) {
-        if (!idToName.equals(SystemTables.tableIdToSimpleNameMap())) {
-          throw new IllegalStateException("Accumulo namespace expected to contain tables "
-              + SystemTables.tableIdToSimpleNameMap() + ", but saw " + idToName);
+        if (!(idToName.containsKey(SystemTables.ROOT.tableId().canonical())
+            && idToName.containsKey(SystemTables.METADATA.tableId().canonical()))) {
+          throw new IllegalStateException("Accumulo namespace expected to at least contain tables "
+              + SystemTables.ROOT.tableId().canonical() + " and "
+              + SystemTables.METADATA.tableId().canonical() + ", but saw " + idToName);
         }
       }
       var converted = ImmutableSortedMap.<TableId,String>naturalOrder();


### PR DESCRIPTION
TableMapping.update was added as part of #5451 and it validated that the accumulo namespace contained all of the system tables. This is technically correct, except when upgrading. Since this is used as part of the client, there is not a good way to determine whether or not the instance is upgrading to implement an alternate check. This change modifies the check in TableMapping.update to only check that root and meta tables exist to allow the upgrade code to run.

Closes #5640