### PR TITLE
Returned false from Manager.shouldCleanupMigration vs exception

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -582,10 +582,11 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener {
   }
 
   private boolean shouldCleanupMigration(TabletMetadata tabletMetadata) {
+    if (!tabletMetadata.hasMigration()) {
+      return false;
+    }
     var tableState = getContext().getTableManager().getTableState(tabletMetadata.getTableId());
     var migration = tabletMetadata.getMigration();
-    Preconditions.checkState(migration != null,
-        "This method should only be called if there is a migration");
     return tableState == TableState.OFFLINE || !onlineTabletServers().contains(migration)
         || (tabletMetadata.getLocation() != null
             && tabletMetadata.getLocation().getServerInstance().equals(migration));


### PR DESCRIPTION
Re-check that the tablet metadata has a migration and return false if not instead of throwing an exception.

Closes #5643