### PR TITLE
Modified TabletsMetadata to run filters on root tablet

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/RootTabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/RootTabletMetadata.java
@@ -194,9 +194,10 @@ public class RootTabletMetadata {
    * Convert this class to a {@link TabletMetadata}
    */
   public TabletMetadata toTabletMetadata() {
-    // use a stream so we don't have to re-sort in a new TreeMap<Key,Value> structure
+    // Create a tablet metadata object from the RootTabletMetadata
+    // Keep the key/values in case they are needed
     return TabletMetadata.convertRow(getKeyValues().iterator(),
-        EnumSet.allOf(TabletMetadata.ColumnType.class), false, false);
+        EnumSet.allOf(TabletMetadata.ColumnType.class), true, false);
   }
 
   public static boolean needsUpgrade(final String json) {

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
@@ -55,6 +55,7 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.iterators.user.WholeRowIterator;
+import org.apache.accumulo.core.iteratorsImpl.ClientIteratorEnvironment;
 import org.apache.accumulo.core.iteratorsImpl.system.SortedMapIterator;
 import org.apache.accumulo.core.metadata.SystemTables;
 import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
@@ -153,6 +154,8 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
         final SortedMapIterator iter = new SortedMapIterator(rtm.toKeyValues());
         iter.seek(new Range(), null, true);
         for (var filter : tabletMetadataFilters) {
+          filter.init(iter, filter.getServerSideOptions(),
+              new ClientIteratorEnvironment.Builder().withClient(client).build());
           if (!filter.acceptRow(iter)) {
             LOG.trace("Not returning root metadata as it does not pass filter: {}",
                 filter.getClass().getSimpleName());

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/filters/HasColumnFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/filters/HasColumnFilter.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.metadata.schema.filters;
+
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
+import org.apache.accumulo.core.util.ColumnFQ;
+import org.apache.hadoop.io.Text;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * If the TabletMetadata contains the supplied key, then return the TabletMetadata
+ */
+public class HasColumnFilter extends TabletMetadataFilter {
+
+  public static final String COLUMN_OPT = "HasColumnFilter_Column";
+  public static final String INCLUDE_OPT = "HasColumnFilter_Include";
+
+  private Map<String,String> options = null;
+
+  private Predicate<TabletMetadata> pred;
+
+  public HasColumnFilter() {}
+
+  public HasColumnFilter(ColumnType type, boolean include) {
+    Objects.requireNonNull(type, "Type must be supplied");
+    options = Map.of(COLUMN_OPT, type.name(), INCLUDE_OPT, Boolean.toString(include));
+  }
+
+  public HasColumnFilter(Key key, boolean include) {
+    Objects.requireNonNull(key, "Key must be supplied");
+    ColumnType type = findMatchingColumn(key);
+    Objects.requireNonNull(type, "Key did not match any known column");
+    options = Map.of(COLUMN_OPT, type.name(), INCLUDE_OPT, Boolean.toString(include));
+  }
+
+  private ColumnType findMatchingColumn(Key key) {
+    ColumnType result = null;
+    for (Entry<ColumnType,ColumnFQ> e : ColumnType.COLUMNS_TO_QUALIFIERS.entrySet()) {
+      if (e.getValue().hasColumns(key)) {
+        result = e.getKey();
+        break;
+      }
+    }
+    if (result == null) {
+      // Did not matching on colf:colq, check to see if colf matches
+      for (Entry<ColumnType,Set<Text>> e : ColumnType.COLUMNS_TO_FAMILIES.entrySet()) {
+        if (e.getValue().contains(key.getColumnFamily())) {
+          result = e.getKey();
+          break;
+        }
+      }
+    }
+    return result;
+  }
+
+  @Override
+  public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options,
+      IteratorEnvironment env) throws IOException {
+    super.init(source, options, env);
+    String colOpt = options.get(COLUMN_OPT);
+    String includeOpt = options.get(INCLUDE_OPT);
+    Objects.requireNonNull(colOpt, "Setting COLUMN_OPT is required");
+    Objects.requireNonNull(includeOpt, "Setting INCLUDE_OPT is required");
+    ColumnType type = ColumnType.valueOf(colOpt);
+    Boolean include = Boolean.parseBoolean(includeOpt);
+    pred = (tm) -> {
+      boolean columnFound = false;
+      for (Entry<Key,Value> e : tm.getKeyValues()) {
+        ColumnType ct = findMatchingColumn(e.getKey());
+        if (ct != null && ct == type) {
+          columnFound = true;
+        }
+      }
+      return include && columnFound;
+    };
+  }
+
+  @Override
+  public Map<String,String> getServerSideOptions() {
+    Preconditions.checkState(options != null);
+    return options;
+  }
+
+  @Override
+  public Set<ColumnType> getColumns() {
+    return EnumSet.allOf(ColumnType.class);
+  }
+
+  @Override
+  protected Predicate<TabletMetadata> acceptTablet() {
+    return pred;
+  }
+
+}

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/filters/TabletMetadataFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/filters/TabletMetadataFilter.java
@@ -36,7 +36,11 @@ public abstract class TabletMetadataFilter extends RowFilter {
   public boolean acceptRow(SortedKeyValueIterator<Key,Value> rowIterator) {
     TabletMetadata tm = TabletMetadata.convertRow(new IteratorAdapter(rowIterator),
         EnumSet.copyOf(getColumns()), true, false);
-    return acceptTablet().test(tm);
+    Predicate<TabletMetadata> predicate = acceptTablet();
+    if (predicate == null) {
+      return false;
+    }
+    return predicate.test(tm);
   }
 
   public abstract Set<TabletMetadata.ColumnType> getColumns();

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/filters/TabletMetadataFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/filters/TabletMetadataFilter.java
@@ -29,8 +29,12 @@ import org.apache.accumulo.core.iterators.IteratorAdapter;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iterators.user.RowFilter;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class TabletMetadataFilter extends RowFilter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TabletMetadataFilter.class);
 
   @Override
   public boolean acceptRow(SortedKeyValueIterator<Key,Value> rowIterator) {
@@ -40,7 +44,10 @@ public abstract class TabletMetadataFilter extends RowFilter {
     if (predicate == null) {
       return false;
     }
-    return predicate.test(tm);
+    boolean result = predicate.test(tm);
+    LOG.trace("Filter {} returned {} for tablet metadata: {}", this.getClass().getSimpleName(),
+        result, tm.getKeyValues());
+    return result;
   }
 
   public abstract Set<TabletMetadata.ColumnType> getColumns();

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletsMetadataIT_SimpleSuite.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletsMetadataIT_SimpleSuite.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test.functional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.EnumSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import org.apache.accumulo.core.client.Accumulo;
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.clientImpl.ClientContext;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.PartialKey;
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.metadata.SystemTables;
+import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
+import org.apache.accumulo.core.metadata.schema.RootTabletMetadata;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
+import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
+import org.apache.accumulo.core.metadata.schema.filters.TabletMetadataFilter;
+import org.apache.accumulo.harness.SharedMiniClusterBase;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class TabletsMetadataIT_SimpleSuite extends SharedMiniClusterBase {
+
+  private static class TestBuilder extends TabletsMetadata.Builder {
+
+    private final RootTabletMetadata rtm;
+
+    TestBuilder(AccumuloClient client, Function<DataLevel,String> tableMapper,
+        RootTabletMetadata rtm) {
+      super(client, tableMapper);
+      this.rtm = rtm;
+    }
+
+    @Override
+    protected RootTabletMetadata getRootMetadata(AccumuloClient client) {
+      return rtm;
+    }
+
+  }
+
+  /**
+   * If the TabletMetadata contains the supplied key, then return the TabletMetadata
+   */
+  public static class HasColumnFilter extends TabletMetadataFilter {
+
+    Predicate<TabletMetadata> pred;
+
+    public HasColumnFilter() {}
+
+    public HasColumnFilter(ColumnType type, boolean include) {
+      pred = (tm) -> {
+        Stream<Key> stream = tm.getKeyValues().stream().map(e -> e.getKey());
+        if (include) {
+          return stream.anyMatch(k -> ColumnType.COLUMNS_TO_QUALIFIERS.get(type).hasColumns(k));
+        } else {
+          return stream.noneMatch(k -> !ColumnType.COLUMNS_TO_QUALIFIERS.get(type).hasColumns(k));
+        }
+      };
+    }
+
+    public HasColumnFilter(Key key, boolean include) {
+      pred = (tm) -> {
+        Stream<Key> stream = tm.getKeyValues().stream().map(e -> e.getKey());
+        if (include) {
+          return stream.anyMatch(k -> k.equals(key, PartialKey.ROW_COLFAM_COLQUAL_COLVIS_TIME_DEL));
+        } else {
+          return stream
+              .noneMatch(k -> k.equals(key, PartialKey.ROW_COLFAM_COLQUAL_COLVIS_TIME_DEL));
+        }
+      };
+    }
+
+    @Override
+    public Set<ColumnType> getColumns() {
+      return EnumSet.allOf(ColumnType.class);
+    }
+
+    @Override
+    protected Predicate<TabletMetadata> acceptTablet() {
+      return pred;
+    }
+  }
+
+  @BeforeAll
+  public static void setup() throws Exception {
+    SharedMiniClusterBase.startMiniCluster();
+  }
+
+  @AfterAll
+  public static void teardown() {
+    SharedMiniClusterBase.stopMiniCluster();
+  }
+
+  @Override
+  protected Duration defaultTimeout() {
+    return Duration.ofMinutes(2);
+  }
+
+  @Test
+  public void testTabletsMetadataRoot() throws Exception {
+    try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
+      c.instanceOperations().waitForBalance();
+      final RootTabletMetadata rtm = RootTabletMetadata.read((ClientContext) c);
+      TestBuilder builder = new TestBuilder(c, DataLevel::metaTable, rtm);
+      TabletsMetadata tms = builder.forLevel(DataLevel.ROOT).saveKeyValues().build();
+      Iterator<TabletMetadata> iter = tms.iterator();
+      assertTrue(iter.hasNext());
+      final TabletMetadata tm = iter.next();
+      assertFalse(iter.hasNext());
+
+      Map<Key,Value> fromTM = new TreeMap<>();
+      tm.getKeyValues().forEach(e -> fromTM.put(e.getKey(), e.getValue()));
+
+      Map<Key,Value> fromZK = new TreeMap<>();
+      rtm.getKeyValues().forEach(e -> fromZK.put(e.getKey(), e.getValue()));
+
+      assertEquals(fromTM, fromZK);
+    }
+  }
+
+  @Test
+  public void testTabletsMetadataRootFilter() throws Exception {
+    try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
+      c.instanceOperations().waitForBalance();
+      final RootTabletMetadata rtm = RootTabletMetadata.read((ClientContext) c);
+      for (Entry<Key,Value> e : rtm.toKeyValues().entrySet()) {
+        TestBuilder builder = new TestBuilder(c, DataLevel::metaTable, rtm);
+        TabletsMetadata tms =
+            builder.forLevel(DataLevel.ROOT).filter(new HasColumnFilter(e.getKey(), true)).build();
+        assertTrue(tms.iterator().hasNext());
+        TestBuilder builder2 = new TestBuilder(c, DataLevel::metaTable, rtm);
+        TabletsMetadata tms2 = builder2.forLevel(DataLevel.ROOT)
+            .filter(new HasColumnFilter(e.getKey(), false)).build();
+        assertFalse(tms2.iterator().hasNext());
+      }
+    }
+  }
+
+  @Test
+  public void testTabletsMetadataMetadata() throws Exception {
+    try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
+      c.instanceOperations().waitForBalance();
+      TabletsMetadata tms =
+          TabletsMetadata.builder(c).forLevel(DataLevel.METADATA).saveKeyValues().build();
+      Iterator<TabletMetadata> iter = tms.iterator();
+      assertTrue(iter.hasNext());
+      TabletMetadata tm = iter.next();
+      assertEquals(SystemTables.METADATA.tableId(), tm.getExtent().tableId());
+      assertTrue(iter.hasNext());
+      tm = iter.next();
+      assertEquals(SystemTables.METADATA.tableId(), tm.getExtent().tableId());
+      assertFalse(iter.hasNext());
+    }
+  }
+
+  @Test
+  public void testTabletsMetadataMetadataFilter() throws Exception {
+    try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
+      c.instanceOperations().waitForBalance();
+      TabletsMetadata tms =
+          TabletsMetadata.builder(c).forLevel(DataLevel.METADATA).fetch(ColumnType.values())
+              .filter(new HasColumnFilter(ColumnType.PREV_ROW, true)).build();
+      Iterator<TabletMetadata> iter = tms.iterator();
+      assertTrue(iter.hasNext());
+      TabletMetadata tm = iter.next();
+      assertEquals(SystemTables.METADATA.tableId(), tm.getExtent().tableId());
+      assertTrue(iter.hasNext());
+      tm = iter.next();
+      assertEquals(SystemTables.METADATA.tableId(), tm.getExtent().tableId());
+      assertFalse(iter.hasNext());
+      TabletsMetadata tms2 =
+          TabletsMetadata.builder(c).forLevel(DataLevel.METADATA).fetch(ColumnType.values())
+              .filter(new HasColumnFilter(ColumnType.PREV_ROW, false)).build();
+      Iterator<TabletMetadata> iter2 = tms2.iterator();
+      assertFalse(iter2.hasNext());
+    }
+  }
+
+  @Test
+  public void testTabletsMetadataUserFilter() throws Exception {
+    try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
+
+      String table = getUniqueNames(1)[0];
+      c.tableOperations().create(table);
+      ReadWriteIT.ingest(c, 100, 10, 10, 0, table);
+      c.tableOperations().flush(table);
+      TableId tid = TableId.of(c.tableOperations().tableIdMap().get(table));
+      c.instanceOperations().waitForBalance();
+
+      TabletsMetadata tms =
+          TabletsMetadata.builder(c).forLevel(DataLevel.USER).fetch(ColumnType.values())
+              .filter(new HasColumnFilter(ColumnType.PREV_ROW, true)).build();
+      Iterator<TabletMetadata> iter = tms.iterator();
+      assertTrue(iter.hasNext());
+      TabletMetadata tm = iter.next();
+      assertEquals(tid, tm.getExtent().tableId());
+      assertTrue(iter.hasNext());
+      tm = iter.next();
+      assertEquals(tid, tm.getExtent().tableId());
+      assertFalse(iter.hasNext());
+      TabletsMetadata tms2 =
+          TabletsMetadata.builder(c).forLevel(DataLevel.USER).fetch(ColumnType.values())
+              .filter(new HasColumnFilter(ColumnType.PREV_ROW, false)).build();
+      Iterator<TabletMetadata> iter2 = tms2.iterator();
+      assertFalse(iter2.hasNext());
+    }
+  }
+
+}


### PR DESCRIPTION
Filters on TabletMetadata were not being applied to the root tablet metadata causing an exception in in Manager.shouldCleanupMigration. The code was applying a filter to only return tablet metadata that contained a migration, then checking that the migration was not null. Because the filter was not being applied to the root tablet, it was being returned as matching the filter but with no migration.

Applying the fix in TabletsMetadata to run the filter on the root tablet metadata caused a subsequent issue in the GcWalsFilter where acceptTablet() would return null. Modified TabletMetadataFilter to protect against this condition.

Closes #5643