### PR TITLE
Schedule cleanup of interrupted scan refs

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
@@ -184,6 +184,20 @@ class DatafileManager {
     }
   }
 
+  /**
+   * Removes any scan‐in‐use metadata entries that were left behind when a scan cleanup was
+   * interrupted. Intended to be called periodically to clear these orphaned scan refs once their
+   * in-memory reference count reaches zero.
+   */
+  public void removeOrphanedScanRefs() {
+    Set<StoredTabletFile> snapshot;
+    synchronized (tablet) {
+      snapshot = new HashSet<>(filesToDeleteAfterScan);
+      filesToDeleteAfterScan.clear();
+    }
+    removeFilesAfterScan(snapshot);
+  }
+
   private TreeSet<StoredTabletFile> waitForScansToFinish(Set<StoredTabletFile> pathsToWaitFor) {
     long maxWait = 10000L;
     long startTime = System.currentTimeMillis();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -2220,6 +2220,10 @@ public class Tablet extends TabletBase {
     return getDatafileManager().getUpdateCount();
   }
 
+  public void removeOrphanedScanRefs() {
+    getDatafileManager().removeOrphanedScanRefs();
+  }
+
   TabletMemory getTabletMemory() {
     return tabletMemory;
   }


### PR DESCRIPTION
Fixes #5650

Adds a scheduled task to the tablet server to attempt to remove any scan refs that may not have been properly cleaned up due to an interruption in the scan or scan cleanup process. 