### PR TITLE
Made AbstractServer.hostname volatile

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/AbstractServer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/AbstractServer.java
@@ -71,7 +71,7 @@ public abstract class AbstractServer
   private final MetricSource metricSource;
   private final ServerContext context;
   protected final String applicationName;
-  private String hostname;
+  private volatile String hostname;
   private final String resourceGroup;
   private final Logger log;
   private final ProcessMetrics processMetrics;


### PR DESCRIPTION
The Monitor calls `getMetrics` on each server to get their information, and `getMetrics` logs an a message if the hostname is `0.0.0.0` and returns an empty response. Saw these messages in the gc server log, but SimpleGarbageCollector sets the hostname immediately after starting the Thrift service in `startStatsService`.