### PR TITLE
Fixed advertise address check for metrics rpc

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/AbstractServer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/AbstractServer.java
@@ -334,8 +334,7 @@ public abstract class AbstractServer
     final FlatBufferBuilder builder = new FlatBufferBuilder(1024);
     final MetricResponseWrapper response = new MetricResponseWrapper(builder);
 
-    if (getAdvertiseAddress().toString()
-        .startsWith(Property.RPC_PROCESS_BIND_ADDRESS.getDefaultValue())) {
+    if (getAdvertiseAddress() == null) {
       log.error(
           "Advertise address is not set, this should have been done after starting the Thrift service.");
       return response;


### PR DESCRIPTION
The default value of the bind address changed
recently and this was not updated.