### PR TITLE
Send error back from TabletManagementIterator on invalid metadata

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementIterator.java
@@ -237,10 +237,17 @@ public class TabletManagementIterator extends WholeRowIterator {
 
     Exception error = null;
     try {
-      LOG.trace("Evaluating extent: {}", tm);
-      computeTabletManagementActions(tm, actions);
-    } catch (Exception e) {
-      LOG.error("Error computing tablet management actions for extent: {}", tm.getExtent(), e);
+      // Validate that a minimum set of keys were seen to create a valid tablet
+      tm.getPrevEndRow();
+      try {
+        LOG.trace("Evaluating extent: {}", tm);
+        computeTabletManagementActions(tm, actions);
+      } catch (Exception e) {
+        LOG.error("Error computing tablet management actions for extent: {}", tm.getExtent(), e);
+        error = e;
+      }
+    } catch (IllegalStateException e) {
+      LOG.error("Irregular tablet metadata encountered: {}", tm, e);
       error = e;
     }
 


### PR DESCRIPTION
Modified the TabletManagementIterator to invoke getPrevEndRow() on the constructed TabletMetadata object to catch a the raised IllegalStateException and return it to the Manager. The existing try/catch around computeTabletManagementActions would likely throw the IllegalStateException when tm.getExtent is called when trying to log an error, preventing the error from being retured to the Manager.

There is an existing test case, TabletMetadataTest.testAbsentPrevRow, which demonstrates that an IllegalStateException is raised when TabletMetadata.convertRow is called on a set of keys that don't contain a prevEndRow.

Closes #5658