### PR TITLE
Improvements to scan ref removal in DatafileManager

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -314,7 +314,7 @@ public class TabletServer extends AbstractServer
         context.getScheduledExecutor().scheduleWithFixedDelay(Threads.createNamedRunnable(
             "ScanRefCleanupTask", () -> getOnlineTablets().values().forEach(tablet -> {
               try {
-                tablet.removeOrphanedScanRefs();
+                tablet.removeBatchedScanRefs();
               } catch (Exception e) {
                 log.error("Error cleaning up stale scan references for tablet {}",
                     tablet.getExtent(), e);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -2220,8 +2220,22 @@ public class Tablet extends TabletBase {
     return getDatafileManager().getUpdateCount();
   }
 
-  public void removeOrphanedScanRefs() {
-    getDatafileManager().removeOrphanedScanRefs();
+  public void removeBatchedScanRefs() {
+    synchronized (this) {
+      if (isClosed() || isClosing()) {
+        return;
+      }
+      // TODO if a check is done here to see if there are orphaned scans and none are found could
+      // return and not do the increment.
+      // this would cut down on the number of times the lock is acquired, but not sure how clean
+      // this would be.
+      incrementWritesInProgress();
+    }
+    try {
+      getDatafileManager().removeBatchedScanRefs();
+    } finally {
+      decrementWritesInProgress();
+    }
   }
 
   TabletMemory getTabletMemory() {


### PR DESCRIPTION
Closes #5650 

In #5652, a periodic task was added to remove any scan refs that were not properly removed after a scan due to an interruption. In this PR, we change things so that we don't even try to remove these refs (was being done in `returnFilesForScan()`) and instead just add them to a collection (`filesToDeleteAfterScan`) to be batch removed periodically. I renamed the methods from `removeOrphanedScanRefs()` to `removeBatchedScanRefs()` to more closely align with this behavior. 

Additional changes were made in the Tablet code to properly mark things as a potential write in progress.

These changes were suggested in https://github.com/apache/accumulo/pull/5652#pullrequestreview-2940263926 and  https://github.com/apache/accumulo/pull/5652#discussion_r2155382782.

