### PR TITLE
allow allocating zero unique names

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/tablets/UniqueNameAllocator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tablets/UniqueNameAllocator.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.server.tablets;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicLong;
@@ -67,7 +68,12 @@ public class UniqueNameAllocator {
    * @return a thread safe iterator that can be called up to the number of names requested
    */
   public synchronized Iterator<String> getNextNames(int needed) {
-    Preconditions.checkArgument(needed > 0, "needed=%s is <=-0", needed);
+    Preconditions.checkArgument(needed >= 0, "needed=%s is <0", needed);
+
+    if (needed == 0) {
+      return Collections.emptyIterator();
+    }
+
     while ((next + needed) > maxAllocated) {
       final int allocate = getAllocation(needed);
       try {

--- a/test/src/main/java/org/apache/accumulo/test/UniqueNameAllocatorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/UniqueNameAllocatorIT.java
@@ -105,7 +105,7 @@ class UniqueNameAllocatorIT extends SharedMiniClusterBase {
     }
 
     assertThrows(IllegalArgumentException.class, () -> allocators[0].getNextNames(-1));
-    assertThrows(IllegalArgumentException.class, () -> allocators[0].getNextNames(0));
+    assertFalse(allocators[0].getNextNames(0).hasNext());
 
     assertTrue(namesSeen.size() >= 1_000_000);
     assertTrue(namesSeen.stream().allMatch(name -> name.matches("[0-9a-z]{7}")));


### PR DESCRIPTION
ImportExportIT.testImportedTableIsOnDemand was failing when its Fate operation tried to allocate zero unique names.  Allocating zero unique names is reasonable for cases like importing a table or tablet with zero files.  Relaxed the restriction to allow zero.