### PR TITLE
moves ShellIT out of simple suite

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellAuthenticatorIT_SimpleSuite.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellAuthenticatorIT_SimpleSuite.java
@@ -26,8 +26,8 @@ import java.util.TimeZone;
 
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.shell.Shell;
-import org.apache.accumulo.test.shell.ShellIT_SimpleSuite.StringInputStream;
-import org.apache.accumulo.test.shell.ShellIT_SimpleSuite.TestOutputStream;
+import org.apache.accumulo.test.shell.ShellIT.StringInputStream;
+import org.apache.accumulo.test.shell.ShellIT.TestOutputStream;
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
 import org.jline.terminal.Size;

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellIT.java
@@ -53,7 +53,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Tag(MINI_CLUSTER_ONLY)
-public class ShellIT_SimpleSuite extends SharedMiniClusterBase {
+public class ShellIT extends SharedMiniClusterBase {
 
   @Override
   protected Duration defaultTimeout() {
@@ -70,7 +70,7 @@ public class ShellIT_SimpleSuite extends SharedMiniClusterBase {
     SharedMiniClusterBase.stopMiniCluster();
   }
 
-  private static final Logger log = LoggerFactory.getLogger(ShellIT_SimpleSuite.class);
+  private static final Logger log = LoggerFactory.getLogger(ShellIT.class);
 
   public static class TestOutputStream extends OutputStream {
     StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
This test was changing all properties back to default values and this would cause other test to fail after it ran.  When tablet group watcher scan time was changed from 5s to the default of 60s it would cause subsequent test to timeout and fail.