### PR TITLE
fixes an issue with upgrade 12 to 13

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader12to13.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader12to13.java
@@ -138,12 +138,6 @@ public class Upgrader12to13 implements Upgrader {
   }
 
   private void createFateTable(ServerContext context) {
-
-    if (context.tableOperations().exists(SystemTables.FATE.tableName())) {
-      LOG.info("Fate table already exists");
-      return;
-    }
-
     try {
       FileSystemInitializer initializer = new FileSystemInitializer(
           new InitialConfiguration(context.getHadoopConf(), context.getSiteConfiguration()));


### PR DESCRIPTION
On upgrading to 4.0 (13), the fate table would exist on listing the tables with something like `tables -ls` but there were no entries in the metadata table for the fate table. This left accumulo in a broken state where table operations could not be handled.

Listing the tables is done through scanning ZooKeeper for the table info. Upgrading ZooKeeper is done first then upgrading the metadata is done. The ZooKeeper step completed fine, which is why the fate table would show up on listing the tables. But the upgrade metadata step would check if the fate table already exists (via TableOperations.exists()) before populating the metadata with the fate table data. The problem is that TableOperations.exists() always returns true for system tables so the metadata table would never get populated.

Fix: remove the check if the fate table already exists. The fate table cannot exist before 13, so there is no need to check this.

closes #5657