### PR TITLE
Minor changes to log4j2-service.properties file

### DIFF
--- a/assemble/conf/log4j2-service.properties
+++ b/assemble/conf/log4j2-service.properties
@@ -34,7 +34,7 @@ appender.console.target = SYSTEM_ERR
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{ISO8601} [%-8c{2}] %-5p: %m%n
 appender.console.filter.threshold.type = ThresholdFilter
-appender.console.filter.threshold.level = info
+appender.console.filter.threshold.level = error
 
 appender.rolling.type = RollingFile
 appender.rolling.name = LogFiles
@@ -51,20 +51,21 @@ appender.rolling.policies.size.size=512MB
 appender.rolling.strategy.type = DefaultRolloverStrategy
 appender.rolling.strategy.max = 10
 
-appender.audit.type = RollingFile
-appender.audit.name = AuditLogFiles
-appender.audit.fileName = ${filename}.audit
-appender.audit.filePattern = ${filename}-%d{yyyy-MM-dd}-%i.audit.gz
-appender.audit.layout.type = PatternLayout
-appender.audit.layout.pattern = %d{ISO8601} [%-8c{2}] %-5p: %m%n
-appender.audit.policies.type = Policies
-appender.audit.policies.time.type = TimeBasedTriggeringPolicy
-appender.audit.policies.time.interval = 1
-appender.audit.policies.time.modulate = true
-appender.audit.policies.size.type = SizeBasedTriggeringPolicy
-appender.audit.policies.size.size=512MB
-appender.audit.strategy.type = DefaultRolloverStrategy
-appender.audit.strategy.max = 10
+# uncomment for separate audit logs
+#appender.audit.type = RollingFile
+#appender.audit.name = AuditLogFiles
+#appender.audit.fileName = ${filename}.audit
+#appender.audit.filePattern = ${filename}-%d{yyyy-MM-dd}-%i.audit.gz
+#appender.audit.layout.type = PatternLayout
+#appender.audit.layout.pattern = %d{ISO8601} [%-8c{2}] %-5p: %m%n
+#appender.audit.policies.type = Policies
+#appender.audit.policies.time.type = TimeBasedTriggeringPolicy
+#appender.audit.policies.time.interval = 1
+#appender.audit.policies.time.modulate = true
+#appender.audit.policies.size.type = SizeBasedTriggeringPolicy
+#appender.audit.policies.size.size=512MB
+#appender.audit.strategy.type = DefaultRolloverStrategy
+#appender.audit.strategy.max = 10
 
 logger.zookeeper.name = org.apache.zookeeper
 logger.zookeeper.level = error


### PR DESCRIPTION
Fully comment out the audit configuration so that an empty audit file is not created. Set the .err file appender to the error level so that info and above messages were not duplicated between the .log and err file.

Closes #5682