### PR TITLE
Bump Zookeeper from 3.9.2 -> 3.9.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
     <version.powermock>2.0.9</version.powermock>
     <version.slf4j>2.0.17</version.slf4j>
     <version.thrift>0.17.0</version.thrift>
-    <version.zookeeper>3.9.2</version.zookeeper>
+    <version.zookeeper>3.9.3</version.zookeeper>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
Ran `Psunny` and all of those tests passed. Looks like there are no mentioned compatibility issues between 3.9.2 and 3.9.3.