### PR TITLE
fixes bug where external compaction never starts

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/ExternalCompactionExecutor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/ExternalCompactionExecutor.java
@@ -174,6 +174,11 @@ public class ExternalCompactionExecutor implements CompactionExecutor {
           var ecj = extJob.compactable.reserveExternalCompaction(extJob.csid, extJob.getJob(),
               compactorId, externalCompactionId);
           if (ecj == null) {
+            // No job could be reserved. This class will no longer have a reference to extJob
+            // however CompactionService may in its submittedJobs set. Mark the job as something
+            // other than RUNNING so that CompactionService will eventually discard it from the
+            // submitted jobs it is tracking.
+            extJob.status.compareAndSet(Status.RUNNING, Status.FAILED);
             break;
           } else {
             extJob.ecid = ecj.getExternalCompactionId();


### PR DESCRIPTION
Ran into an issue when running random walk bulk test where a compaction that needed to happen was never running.  The code fixed in this PR used to change the state to running and then forget about it in some cases. However [this code][1] would still remember it.  That would cause this [this code][2] to filter out planned jobs when there were running compactions in submitted jobs. Hopefully this change will cause [this code][3] to filter this from submitted jobs.

Ran all Compaction ITs w/ this change and they passed.

[1]:https://github.com/apache/accumulo/blob/5bba2f3cf36717d0e2fabbf4abb93c3455c0619e/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionService.java#L84 [2]:https://github.com/apache/accumulo/blob/5bba2f3cf36717d0e2fabbf4abb93c3455c0619e/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionService.java#L186 [3]:https://github.com/apache/accumulo/blob/5bba2f3cf36717d0e2fabbf4abb93c3455c0619e/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionService.java#L359-L365