### PR TITLE
Avoid unnecessarily accessing snapshot repositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -564,6 +564,11 @@
         <version>${version.bouncycastle}</version>
       </dependency>
       <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcutil-jdk18on</artifactId>
+        <version>${version.bouncycastle}</version>
+      </dependency>
+      <dependency>
         <groupId>org.checkerframework</groupId>
         <artifactId>checker-qual</artifactId>
         <version>3.49.2</version>
@@ -1037,6 +1042,12 @@
                 <reactorModuleConvergence />
                 <banDuplicatePomDependencyVersions />
                 <dependencyConvergence />
+                <banDynamicVersions>
+                  <ignores>
+                    <!-- ignore our own SNAPSHOT versions during development -->
+                    <ignore>org.apache.accumulo:*:${project.version}</ignore>
+                  </ignores>
+                </banDynamicVersions>
                 <bannedDependencies>
                   <excludes>
                     <!-- we redirect logging to log4j2, so we should have those bridges instead -->


### PR DESCRIPTION
This change avoids unnecessarily accessing the configured repository.apache.org/snapshots snapshot repository. To do this, it affixes a specific version from the range in one of the transitive dependencies (in this case, bouncycastle), so Maven does not query all of the configured repositories for the versions they contain. The apparent behavior of Maven's dependency resolution is to query all repositories, whether they are configured for snapshots or releases, in order to resolve dependency ranges. However, this [may be a bug in Maven](https://github.com/apache/maven/issues/2558)

It is important to avoid unnecessary accesses to
repository.apache.org/snapshots, because Apache's INFRA team blocks network clients for too many accesses to repository.apache.org that result in 404s. Any attempt to resolve bouncycastle dependencies from repository.apache.org is certainly going to fail with 404 responses, because bouncycastle is not an Apache project that publishes anything to this server. So, the version range in that dependency, is likely to contribute to getting Apache projects blocked who use the Apache parent POM, because the Apache parent POM adds the
repository.apache.org/snapshots as a snapshot repository by default.

The workaround in this commit sets a specific version that is *not* a SNAPSHOT version, so the snapshot repository should not be used. Unfortunately, it appears this will need to be done for *any* version ranges anywhere in our project's dependency tree.

This commit also adds an enforcer rule to detect new version ranges showing up in the dependency tree.