### PR TITLE
Add Maveniverse Heimdall to build

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.njord</groupId>
+        <artifactId>extension3</artifactId>
+        <version>0.8.0</version>
+    </extension>
+</extensions>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -21,8 +21,8 @@
 -->
 <extensions>
     <extension>
-        <groupId>eu.maveniverse.maven.njord</groupId>
+        <groupId>eu.maveniverse.maven.heimdall</groupId>
         <artifactId>extension3</artifactId>
-        <version>0.8.0</version>
+        <version>0.1.2</version>
     </extension>
 </extensions>


### PR DESCRIPTION
This extension automatically fetches prefix
files from remote repositories, making Maven
to not ask for things known to not be there.

Thus, prevents being banned from ASF due
excessive amount of 404s on RAO.