### PR TITLE
disallows cloning fate and scanref tables

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/util/Validators.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/Validators.java
@@ -205,7 +205,7 @@ public class Validators {
     }
     if (SystemTables.containsTableId(id)) {
       return Optional.of("Cloning " + SystemTables.tableIdToSimpleNameMap().get(id.canonical())
-          + " is not supported," + " see https://github.com/apache/accumulo/issues/1309.");
+          + " is not supported, see https://github.com/apache/accumulo/issues/1309.");
     }
 
     return Validator.OK;

--- a/core/src/main/java/org/apache/accumulo/core/util/Validators.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/Validators.java
@@ -203,14 +203,11 @@ public class Validators {
     if (id == null) {
       return Optional.of("Table id must not be null");
     }
-    if (id.equals(SystemTables.METADATA.tableId())) {
-      return Optional.of(
-          "Cloning " + SystemTables.METADATA.tableName() + " is dangerous and no longer supported,"
-              + " see https://github.com/apache/accumulo/issues/1309.");
+    if (SystemTables.containsTableId(id)) {
+      return Optional.of("Cloning " + SystemTables.tableIdToSimpleNameMap().get(id.canonical())
+          + " is not supported," + " see https://github.com/apache/accumulo/issues/1309.");
     }
-    if (id.equals(SystemTables.ROOT.tableId())) {
-      return Optional.of("Unable to clone " + SystemTables.ROOT.tableName());
-    }
+
     return Validator.OK;
   });
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/CloneTestIT_SimpleSuite.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CloneTestIT_SimpleSuite.java
@@ -368,7 +368,7 @@ public class CloneTestIT_SimpleSuite extends SharedMiniClusterBase {
         var sysTable = sysTables[i];
         var cloneTableName = tableNames[i];
         assertThrows(Exception.class, () -> client.tableOperations().clone(sysTable.tableName(),
-            cloneTableName, CloneConfiguration.empty()));
+            cloneTableName, CloneConfiguration.empty()), () -> "Table:" + sysTable.tableName());
         assertFalse(client.tableOperations().exists(cloneTableName));
       }
     }


### PR DESCRIPTION
CloneTestIT_SimpleSuite.testCloneSystemTables() was failing because it was possible to clone the scanref and fate tables.  It seems like it would be safe to allow cloning those tables, but decided to disallow for now for consistency.  Can relax the restriction in the future if needed.