### PR TITLE
Created hashCode JUnit tests for data classes

### DIFF
--- a/core/src/test/java/org/apache/accumulo/core/data/AbstractIdTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/AbstractIdTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.data;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+class AbstractIdTest {
+
+  @Test
+  void testHashCode() {
+    // Testing consistency
+    TestAbstractId abstractId = new TestAbstractId("value");
+    int hashOne = abstractId.hashCode();
+    int hashTwo = abstractId.hashCode();
+    assertEquals(hashOne, hashTwo);
+
+    // Testing equality
+    TestAbstractId abstractOne = new TestAbstractId("value") {};
+    TestAbstractId abstractTwo = new TestAbstractId("value") {};
+    assertEquals(abstractOne.hashCode(), abstractTwo.hashCode());
+
+    // Testing even distribution
+    List<TestAbstractId> idList = new ArrayList<>();
+    for (int i = 0; i < 1000; i++) {
+      idList.add(new TestAbstractId("value" + i) {});
+    }
+    Set<Integer> hashCodes = new HashSet<>();
+    for (TestAbstractId id : idList) {
+      hashCodes.add(id.hashCode());
+    }
+    assertEquals(idList.size(), hashCodes.size(), 10);
+  }
+
+  private static class TestAbstractId extends AbstractId<TestAbstractId> {
+    private static final long serialVersionUID = 1L;
+
+    protected TestAbstractId(String canonical) {
+      super(canonical);
+    }
+  }
+}

--- a/core/src/test/java/org/apache/accumulo/core/data/ByteSequenceTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/ByteSequenceTest.java
@@ -18,7 +18,13 @@
  */
 package org.apache.accumulo.core.data;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -38,6 +44,31 @@ public class ByteSequenceTest {
   private void assertLessThan(ByteSequence lhs, ByteSequence rhs) {
     int result = ByteSequence.compareBytes(lhs, rhs);
     assertTrue(result < 0);
+  }
+
+  @Test
+  public void testHashCode() {
+    // Testing consistency
+    ByteSequence byteSeq = new ArrayByteSequence("value");
+    int hashCode1 = byteSeq.hashCode();
+    int hashCode2 = byteSeq.hashCode();
+    assertEquals(hashCode1, hashCode2);
+
+    // Testing equality
+    ByteSequence byteOne = new ArrayByteSequence("value");
+    ByteSequence byteTwo = new ArrayByteSequence("value");
+    assertEquals(byteOne.hashCode(), byteTwo.hashCode());
+
+    // Testing even distribution
+    List<ByteSequence> byteSequences = new ArrayList<>();
+    for (int i = 0; i < 1000; i++) {
+      byteSequences.add(new ArrayByteSequence("value" + i));
+    }
+    Set<Integer> hashCodes = new HashSet<>();
+    for (ByteSequence bytes : byteSequences) {
+      hashCodes.add(bytes.hashCode());
+    }
+    assertEquals(byteSequences.size(), hashCodes.size(), 10);
   }
 
 }

--- a/core/src/test/java/org/apache/accumulo/core/data/ColumnTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/ColumnTest.java
@@ -29,6 +29,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.apache.accumulo.core.dataImpl.thrift.TColumn;
 import org.junit.jupiter.api.BeforeAll;
@@ -102,4 +106,40 @@ public class ColumnTest {
       assertEquals(c, new Column(tc));
     }
   }
+
+  @Test
+  public void testHashCode() {
+    // Testing consistency
+    for (Column c : col) {
+      assertEquals(c.hashCode(), c.hashCode());
+    }
+
+    // Testing equality
+    Column[] colCopy = new Column[5];
+    colCopy[0] =
+        new Column("colfam".getBytes(UTF_8), "colq".getBytes(UTF_8), "colv".getBytes(UTF_8));
+    colCopy[1] =
+        new Column("colfam".getBytes(UTF_8), "colq".getBytes(UTF_8), "colv".getBytes(UTF_8));
+    colCopy[2] = new Column(new byte[0], new byte[0], new byte[0]);
+    colCopy[3] = new Column(null, null, null);
+    colCopy[4] = new Column("colfam".getBytes(UTF_8), "cq".getBytes(UTF_8), "cv".getBytes(UTF_8));
+
+    for (int i = 0; i < col.length; i++) {
+      assertEquals(col[i].hashCode(), colCopy[i].hashCode());
+    }
+
+    // Testing even distribution
+    List<Column> columns = new ArrayList<>();
+    for (int i = 0; i < 1000; i++) {
+      columns.add(new Column(("colfam" + i).getBytes(UTF_8), ("colq" + i).getBytes(UTF_8),
+          ("colv" + i).getBytes(UTF_8)));
+    }
+    Set<Integer> hashCodes = new HashSet<>();
+    for (Column c : columns) {
+      hashCodes.add(c.hashCode());
+    }
+    assertEquals(columns.size(), hashCodes.size(), 10);
+
+  }
+
 }

--- a/core/src/test/java/org/apache/accumulo/core/data/ColumnUpdateTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/ColumnUpdateTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.data;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+class ColumnUpdateTest {
+  /*
+   * byte[] columnFamily = cf; byte[] columnQualifier = cq; byte[] columnVisibility = cv; boolean
+   * hasTimestamp = hasts; long timestamp = ts; boolean deleted = deleted; byte[] val = val;
+   */
+  @Test
+  void testHashCode() {
+    // Testing consistency
+    ColumnUpdate colUpdate = new ColumnUpdate("colfam".getBytes(UTF_8), "colq".getBytes(UTF_8),
+        "colv".getBytes(UTF_8), true, 1L, false, "val".getBytes(UTF_8));
+
+    int hashCode1 = colUpdate.hashCode();
+    int hashCode2 = colUpdate.hashCode();
+    assertEquals(hashCode1, hashCode2);
+
+    // Testing equality
+    ColumnUpdate col1 = new ColumnUpdate("colfam".getBytes(UTF_8), "colq".getBytes(UTF_8),
+        "colv".getBytes(UTF_8), true, 1L, false, "val".getBytes(UTF_8));
+    ColumnUpdate col2 = new ColumnUpdate("colfam".getBytes(UTF_8), "colq".getBytes(UTF_8),
+        "colv".getBytes(UTF_8), true, 1L, false, "val".getBytes(UTF_8));
+    assertEquals(col1.hashCode(), col2.hashCode());
+
+    // Testing even distribution
+    List<ColumnUpdate> columns = new ArrayList<>();
+    for (int i = 0; i < 1000; i++) {
+      columns.add(new ColumnUpdate(("colfam" + i).getBytes(UTF_8), ("colq" + i).getBytes(UTF_8),
+          ("colv" + i).getBytes(UTF_8), true, 1L, false, ("val" + i).getBytes(UTF_8)));
+    }
+    Set<Integer> hashCodes = new HashSet<>();
+    for (ColumnUpdate c : columns) {
+      hashCodes.add(c.hashCode());
+    }
+    assertEquals(columns.size(), hashCodes.size(), 10);
+
+  }
+}

--- a/core/src/test/java/org/apache/accumulo/core/data/ConditionTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/ConditionTest.java
@@ -25,6 +25,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.hadoop.io.Text;
@@ -240,13 +245,17 @@ public class ConditionTest {
 
   @Test
   public void testHashCode() {
+    // Testing consistency
     ColumnVisibility cvis = new ColumnVisibility(VISIBILITY);
     c.setVisibility(cvis);
     c.setValue(VALUE);
     c.setTimestamp(1234L);
     c.setIterators(ITERATORS);
     int hc1 = c.hashCode();
+    int hc2 = c.hashCode();
+    assertEquals(hc1, hc2);
 
+    // Testing equality
     Condition c2 = new Condition(FAMILY, QUALIFIER);
     c2.setVisibility(cvis);
     c2.setValue(VALUE);
@@ -254,5 +263,22 @@ public class ConditionTest {
     c2.setIterators(ITERATORS);
     assertEquals(c, c2);
     assertEquals(hc1, c2.hashCode());
+
+    // Testing even distribution
+    List<Condition> conditions = new ArrayList<>();
+    for (int i = 0; i < 1000; i++) {
+      Condition con = new Condition("colfam" + i, "colq" + i);
+      con.setVisibility(cvis);
+      con.setValue(VALUE + i);
+      con.setTimestamp(1234L);
+      con.setIterators(ITERATORS);
+      conditions.add(con);
+    }
+    Set<Integer> hashCodes = new HashSet<>();
+    for (Condition c : conditions) {
+      hashCodes.add(c.hashCode());
+    }
+    assertEquals(conditions.size(), hashCodes.size(), 10);
+
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/data/ConditionalMutationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/ConditionalMutationTest.java
@@ -25,8 +25,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.iterators.user.SummingCombiner;
@@ -238,8 +241,26 @@ public class ConditionalMutationTest {
 
   @Test
   public void testHashcode() {
+    // Testing consistency
+    int hashCode1 = cm.hashCode();
+    int hashCode2 = cm.hashCode();
+    assertEquals(hashCode1, hashCode2);
+
+    // Testing equality
     ConditionalMutation cm2 = new ConditionalMutation(ROW, c1, c2);
     assertTrue(cm.equals(cm2));
     assertEquals(cm2.hashCode(), cm.hashCode());
+
+    // Testing even distribution
+    List<ConditionalMutation> cmList = new ArrayList<>();
+    for (int i = 0; i < 1000; i++) {
+      cmList.add(new ConditionalMutation(("row" + i).getBytes(UTF_8),
+          new Condition("family" + i, "qualifier" + i)));
+    }
+    Set<Integer> hashCodes = new HashSet<>();
+    for (ConditionalMutation c : cmList) {
+      hashCodes.add(c.hashCode());
+    }
+    assertEquals(cmList.size(), hashCodes.size(), 10);
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/data/KeyExtentTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/KeyExtentTest.java
@@ -29,6 +29,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
@@ -222,6 +226,31 @@ public class KeyExtentTest {
     assertThrows(IllegalArgumentException.class,
         () -> ke.clip(new Range(new Key("r_0004").followingKey(PartialKey.ROW), true,
             new Key("").followingKey(PartialKey.ROW), false)));
+  }
+
+  @Test
+  public void testHashCode() {
+    // Testing consistency
+    KeyExtent key = new KeyExtent(TableId.of("r1"), new Text("b"), new Text("a"));
+    int hashCode1 = key.hashCode();
+    int hashCode2 = key.hashCode();
+    assertEquals(hashCode1, hashCode2);
+
+    // Testing equality
+    KeyExtent k1 = new KeyExtent(TableId.of("r1"), new Text("b"), new Text("a"));
+    KeyExtent k2 = new KeyExtent(TableId.of("r1"), new Text("b"), new Text("a"));
+    assertEquals(k1.hashCode(), k2.hashCode());
+
+    // Testing even distribution
+    List<KeyExtent> keys = new ArrayList<>();
+    for (int i = 0; i < 1000; i++) {
+      keys.add(new KeyExtent(TableId.of("r1" + i), new Text("b" + i), new Text("a" + i)));
+    }
+    Set<Integer> hashCodes = new HashSet<>();
+    for (KeyExtent k : keys) {
+      hashCodes.add(k.hashCode());
+    }
+    assertEquals(keys.size(), hashCodes.size(), 10);
   }
 
 }

--- a/core/src/test/java/org/apache/accumulo/core/data/KeyTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/KeyTest.java
@@ -27,8 +27,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.accumulo.core.dataImpl.thrift.TKey;
 import org.apache.accumulo.core.dataImpl.thrift.TKeyValue;
@@ -377,5 +379,34 @@ public class KeyTest {
       }
     }
 
+  }
+
+  @Test
+  public void testHashCode() {
+    // Test consistency
+    Key key = new Key("r1".getBytes(UTF_8), "cf".getBytes(UTF_8), "cq".getBytes(UTF_8),
+        "cv".getBytes(UTF_8), 0, false);
+    int hashCode1 = key.hashCode();
+    int hashCode2 = key.hashCode();
+    assertEquals(hashCode1, hashCode2);
+
+    // Testing equality
+    Key k1 = new Key("r1".getBytes(UTF_8), "cf".getBytes(UTF_8), "cq".getBytes(UTF_8),
+        "cv".getBytes(UTF_8), 0, false);
+    Key k2 = new Key("r1".getBytes(UTF_8), "cf".getBytes(UTF_8), "cq".getBytes(UTF_8),
+        "cv".getBytes(UTF_8), 0, false);
+    assertEquals(k1.hashCode(), k2.hashCode());
+
+    // Testing even distribution
+    List<Key> keys = new ArrayList<>();
+    for (int i = 0; i < 1000; i++) {
+      keys.add(new Key(("r1" + i).getBytes(UTF_8), ("cf" + i).getBytes(UTF_8),
+          ("cq" + i).getBytes(UTF_8), ("cv" + i).getBytes(UTF_8), 0, false));
+    }
+    Set<Integer> hashCodes = new HashSet<>();
+    for (Key k : keys) {
+      hashCodes.add(k.hashCode());
+    }
+    assertEquals(keys.size(), hashCodes.size(), 10);
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/data/LoadPlanTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/LoadPlanTest.java
@@ -194,4 +194,30 @@ public class LoadPlanTest {
   public static Set<String> toString(Collection<Destination> destinations) {
     return destinations.stream().map(d -> toString(d)).collect(Collectors.toSet());
   }
+
+  @Test
+  public void testHashCode() {
+    // Testing consistency
+    LoadPlan.TableSplits tableSplits =
+        new LoadPlan.TableSplits(new Text("text1"), new Text("text2"));
+    int hashCode1 = tableSplits.hashCode();
+    int hashCode2 = tableSplits.hashCode();
+    assertEquals(hashCode1, hashCode2);
+
+    // Testing equality
+    LoadPlan.TableSplits tableOne = new LoadPlan.TableSplits(new Text("text1"), new Text("text2"));
+    LoadPlan.TableSplits tableTwo = new LoadPlan.TableSplits(new Text("text1"), new Text("text2"));
+    assertEquals(tableOne.hashCode(), tableTwo.hashCode());
+
+    // Testing even distribution
+    List<LoadPlan.TableSplits> tables = new ArrayList<>();
+    for (int i = 0; i < 1000; i++) {
+      tables.add(new LoadPlan.TableSplits(new Text("text1" + i), new Text("text2" + i)));
+    }
+    Set<Integer> hashCodes = new HashSet<>();
+    for (LoadPlan.TableSplits tabs : tables) {
+      hashCodes.add(tabs.hashCode());
+    }
+    assertEquals(tables.size(), hashCodes.size(), 10);
+  }
 }

--- a/core/src/test/java/org/apache/accumulo/core/data/RangeTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/RangeTest.java
@@ -30,9 +30,11 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.InvalidObjectException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.dataImpl.RangeImpl;
@@ -943,5 +945,30 @@ public class RangeTest {
     TRange tr = r.toThrift();
     assertThrows(IllegalArgumentException.class, () -> new Range(tr),
         "Thrift constructor allowed invalid range");
+  }
+
+  @Test
+  public void testHashCode() {
+    // Testing consistency
+    Range range = new Range("a", "b");
+    int hashCode1 = range.hashCode();
+    int hashCode2 = range.hashCode();
+    assertEquals(hashCode1, hashCode2);
+
+    // Testing equality
+    Range r1 = new Range("a", "b");
+    Range r2 = new Range("a", "b");
+    assertEquals(r1.hashCode(), r2.hashCode());
+
+    // Testing even distribution
+    List<Range> ranges = new ArrayList<>();
+    for (int i = 0; i < 1000; i++) {
+      ranges.add(new Range("a" + i, "b" + i));
+    }
+    Set<Integer> hashCodes = new HashSet<>();
+    for (Range r : ranges) {
+      hashCodes.add(r.hashCode());
+    }
+    assertEquals(ranges.size(), hashCodes.size(), 10);
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/data/ValueTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/ValueTest.java
@@ -35,6 +35,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.BeforeEach;
@@ -164,9 +168,28 @@ public class ValueTest {
 
   @Test
   public void testHashCode() {
+    // Testing consistency
+    Value value = new Value(DATA);
+    int hashCode1 = value.hashCode();
+    int hashCode2 = value.hashCode();
+    assertEquals(hashCode1, hashCode2);
+
+    // Testing equality
     Value v1 = new Value(DATA);
     Value v2 = new Value(DATA);
     assertEquals(v1.hashCode(), v2.hashCode());
+
+    // Testing even distribution
+    List<Value> values = new ArrayList<>();
+    for (int i = 0; i < 1000; i++) {
+      values.add(new Value(("data" + i).getBytes(UTF_8)));
+    }
+    Set<Integer> hashCodes = new HashSet<>();
+    for (Value v : values) {
+      hashCodes.add(v.hashCode());
+    }
+
+    assertEquals(values.size(), hashCodes.size(), 10);
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/dataImpl/TabletIdImplTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/dataImpl/TabletIdImplTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.dataImpl;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.accumulo.core.data.TableId;
+import org.apache.hadoop.io.Text;
+import org.junit.jupiter.api.Test;
+
+class TabletIdImplTest {
+
+  @Test
+  void testHashCode() {
+    // Testing consistency
+    TabletIdImpl tabletId =
+        new TabletIdImpl(new KeyExtent(TableId.of("r1"), new Text("b"), new Text("a")));
+    int hashCode1 = tabletId.hashCode();
+    int hashCode2 = tabletId.hashCode();
+    assertEquals(hashCode1, hashCode2);
+
+    // Testing equality
+    TabletIdImpl tabletOne =
+        new TabletIdImpl(new KeyExtent(TableId.of("r1"), new Text("b"), new Text("a")));
+    TabletIdImpl tabletTwo =
+        new TabletIdImpl(new KeyExtent(TableId.of("r1"), new Text("b"), new Text("a")));
+    assertEquals(tabletOne.hashCode(), tabletTwo.hashCode());
+
+    // Testing even distribution
+    List<TabletIdImpl> tablets = new ArrayList<>();
+    for (int i = 0; i < 1000; i++) {
+      tablets.add(new TabletIdImpl(
+          new KeyExtent(TableId.of("r1" + i), new Text("b" + i), new Text("a" + i))));
+    }
+    Set<Integer> hashCodes = new HashSet<>();
+    for (TabletIdImpl tabs : tablets) {
+      hashCodes.add(tabs.hashCode());
+    }
+    assertEquals(tablets.size(), hashCodes.size(), 10);
+  }
+}


### PR DESCRIPTION
Created JUnit tests for all data and dataImpl classes that have their own hashCode method. Testing the hashCode method for consistency, equality, and even distribution.

Closes #5704