### PR TITLE
Support configuring compactions by tablet and output path

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/admin/compaction/CompactionConfigurer.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/compaction/CompactionConfigurer.java
@@ -62,8 +62,8 @@ public interface CompactionConfigurer {
     TabletId getTabletId();
 
     /**
-     * Returns the path that the compaction will write to, one use of this is to know the
-     * output volume.
+     * Returns the path that the compaction will write to, one use of this is to know the output
+     * volume.
      *
      * @since 2.1.4
      */

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/compaction/CompactionConfigurer.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/compaction/CompactionConfigurer.java
@@ -18,11 +18,13 @@
  */
 package org.apache.accumulo.core.client.admin.compaction;
 
+import java.net.URI;
 import java.util.Collection;
 import java.util.Map;
 
 import org.apache.accumulo.core.client.PluginEnvironment;
 import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.data.TabletId;
 
 /**
  * Enables dynamically overriding of per table properties used to create the output file for a
@@ -34,7 +36,7 @@ public interface CompactionConfigurer {
   /**
    * @since 2.1.0
    */
-  public interface InitParameters {
+  interface InitParameters {
     TableId getTableId();
 
     Map<String,String> getOptions();
@@ -47,10 +49,25 @@ public interface CompactionConfigurer {
   /**
    * @since 2.1.0
    */
-  public interface InputParameters {
+  interface InputParameters {
     TableId getTableId();
 
-    public Collection<CompactableFile> getInputFiles();
+    Collection<CompactableFile> getInputFiles();
+
+    /**
+     * Returns the tablet that is compacting.
+     *
+     * @since 2.1.4
+     */
+    TabletId getTabletId();
+
+    /**
+     * Returns the path that the compaction will write to, one use of this is to know the
+     * output volume.
+     *
+     * @since 2.1.4
+     */
+    URI getOutputFile();
 
     PluginEnvironment getEnvironment();
   }
@@ -60,7 +77,7 @@ public interface CompactionConfigurer {
    *
    * @since 2.1.0
    */
-  public class Overrides {
+  class Overrides {
     private final Map<String,String> tablePropertyOverrides;
 
     public Overrides(Map<String,String> tablePropertyOverrides) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
@@ -146,7 +146,7 @@ public class CompactableImpl implements Compactable {
 
     Set<StoredTabletFile> getFilesToDrop();
 
-    Map<String,String> getConfigOverrides(Set<CompactableFile> files);
+    Map<String,String> getConfigOverrides(Set<CompactableFile> files, TabletFile tmpFile);
 
   }
 
@@ -1373,10 +1373,10 @@ public class CompactableImpl implements Compactable {
     var cInfo = ocInfo.orElseThrow();
 
     try {
-      Map<String,String> overrides =
-          CompactableUtils.getOverrides(job.getKind(), tablet, cInfo.localHelper, job.getFiles());
-
       TabletFile compactTmpName = tablet.getNextMapFilenameForMajc(cInfo.propagateDeletes);
+
+      Map<String,String> overrides = CompactableUtils.getOverrides(job.getKind(), tablet,
+          cInfo.localHelper, job.getFiles(), compactTmpName);
 
       ExternalCompactionInfo ecInfo = new ExternalCompactionInfo();
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/strategies/ConfigurableCompactionStrategyTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/strategies/ConfigurableCompactionStrategyTest.java
@@ -36,6 +36,7 @@ import org.apache.accumulo.core.client.admin.compaction.CompactionConfigurer.Ove
 import org.apache.accumulo.core.compaction.CompactionSettings;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.data.TabletId;
 import org.junit.jupiter.api.Test;
 
 public class ConfigurableCompactionStrategyTest {
@@ -83,6 +84,16 @@ public class ConfigurableCompactionStrategyTest {
       @Override
       public Collection<CompactableFile> getInputFiles() {
         return files;
+      }
+
+      @Override
+      public TabletId getTabletId() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public URI getOutputFile() {
+        throw new UnsupportedOperationException();
       }
 
       @Override


### PR DESCRIPTION
Adds two methods to compaction configurer that provide the tablet and output path for the compaction.  This allows different configuration to be generated based on the tablet or volume.