### PR TITLE
Add thrift logging to SimpleThriftServiceRunner

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/rpc/SimpleThriftServiceHandler.java
+++ b/test/src/main/java/org/apache/accumulo/test/rpc/SimpleThriftServiceHandler.java
@@ -46,6 +46,11 @@ public class SimpleThriftServiceHandler implements SimpleThriftService.Iface {
   }
 
   @Override
+  public void echoPassVoid(String value) throws TException {
+    setProp("echoPassVoid", value);
+  }
+
+  @Override
   public void onewayFail(String value) throws TException {
     setProp("onewayFail", value);
     throw new TException(new UnsupportedOperationException(value));

--- a/test/src/main/java/org/apache/accumulo/test/rpc/ThriftBehaviorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/rpc/ThriftBehaviorIT.java
@@ -108,6 +108,16 @@ public class ThriftBehaviorIT extends WithTestNames {
   }
 
   @Test
+  public void echoPassVoidHandler() throws TException {
+    handler.echoPassVoid(KITTY_MSG);
+  }
+
+  @Test
+  public void echoPassVoid() throws TException {
+    client.echoPassVoid(KITTY_MSG);
+  }
+
+  @Test
   public void onewayFailHandler() throws TException {
     var e = assertThrows(TException.class, () -> handler.onewayFail(KITTY_MSG));
     assertTrue(e.getCause() instanceof UnsupportedOperationException);

--- a/test/src/main/resources/log4j2-test.properties
+++ b/test/src/main/resources/log4j2-test.properties
@@ -154,6 +154,10 @@ logger.39.level = trace
 logger.40.name = org.apache.accumulo.manager.tableOps.bulkVer2.LoadFiles
 logger.40.level = trace
 
+# TSimpleServer is too noisy at DEBUG when clients disconnect; only used for ThriftBehaviorIT
+logger.41.name = org.apache.thrift.server.TSimpleServer
+logger.41.level = info
+
 rootLogger.level = debug
 rootLogger.appenderRef.console.ref = STDOUT
 

--- a/test/src/main/thrift-gen-java/org/apache/accumulo/test/rpc/thrift/SimpleThriftService.java
+++ b/test/src/main/thrift-gen-java/org/apache/accumulo/test/rpc/thrift/SimpleThriftService.java
@@ -41,6 +41,8 @@ public class SimpleThriftService {
 
     public void onewayRuntimeFail(java.lang.String value) throws org.apache.thrift.TException;
 
+    public void echoPassVoid(java.lang.String value) throws org.apache.thrift.TException;
+
   }
 
   public interface AsyncIface {
@@ -56,6 +58,8 @@ public class SimpleThriftService {
     public void echoRuntimeFail(java.lang.String value, org.apache.thrift.async.AsyncMethodCallback<java.lang.String> resultHandler) throws org.apache.thrift.TException;
 
     public void onewayRuntimeFail(java.lang.String value, org.apache.thrift.async.AsyncMethodCallback<Void> resultHandler) throws org.apache.thrift.TException;
+
+    public void echoPassVoid(java.lang.String value, org.apache.thrift.async.AsyncMethodCallback<Void> resultHandler) throws org.apache.thrift.TException;
 
   }
 
@@ -190,6 +194,27 @@ public class SimpleThriftService {
       onewayRuntimeFail_args args = new onewayRuntimeFail_args();
       args.setValue(value);
       sendBaseOneway("onewayRuntimeFail", args);
+    }
+
+    @Override
+    public void echoPassVoid(java.lang.String value) throws org.apache.thrift.TException
+    {
+      send_echoPassVoid(value);
+      recv_echoPassVoid();
+    }
+
+    public void send_echoPassVoid(java.lang.String value) throws org.apache.thrift.TException
+    {
+      echoPassVoid_args args = new echoPassVoid_args();
+      args.setValue(value);
+      sendBase("echoPassVoid", args);
+    }
+
+    public void recv_echoPassVoid() throws org.apache.thrift.TException
+    {
+      echoPassVoid_result result = new echoPassVoid_result();
+      receiveBase(result, "echoPassVoid");
+      return;
     }
 
   }
@@ -421,6 +446,42 @@ public class SimpleThriftService {
       }
     }
 
+    @Override
+    public void echoPassVoid(java.lang.String value, org.apache.thrift.async.AsyncMethodCallback<Void> resultHandler) throws org.apache.thrift.TException {
+      checkReady();
+      echoPassVoid_call method_call = new echoPassVoid_call(value, resultHandler, this, ___protocolFactory, ___transport);
+      this.___currentMethod = method_call;
+      ___manager.call(method_call);
+    }
+
+    public static class echoPassVoid_call extends org.apache.thrift.async.TAsyncMethodCall<Void> {
+      private java.lang.String value;
+      public echoPassVoid_call(java.lang.String value, org.apache.thrift.async.AsyncMethodCallback<Void> resultHandler, org.apache.thrift.async.TAsyncClient client, org.apache.thrift.protocol.TProtocolFactory protocolFactory, org.apache.thrift.transport.TNonblockingTransport transport) throws org.apache.thrift.TException {
+        super(client, protocolFactory, transport, resultHandler, false);
+        this.value = value;
+      }
+
+      @Override
+      public void write_args(org.apache.thrift.protocol.TProtocol prot) throws org.apache.thrift.TException {
+        prot.writeMessageBegin(new org.apache.thrift.protocol.TMessage("echoPassVoid", org.apache.thrift.protocol.TMessageType.CALL, 0));
+        echoPassVoid_args args = new echoPassVoid_args();
+        args.setValue(value);
+        args.write(prot);
+        prot.writeMessageEnd();
+      }
+
+      @Override
+      public Void getResult() throws org.apache.thrift.TException {
+        if (getState() != org.apache.thrift.async.TAsyncMethodCall.State.RESPONSE_READ) {
+          throw new java.lang.IllegalStateException("Method call not finished!");
+        }
+        org.apache.thrift.transport.TMemoryInputTransport memoryTransport = new org.apache.thrift.transport.TMemoryInputTransport(getFrameBuffer().array());
+        org.apache.thrift.protocol.TProtocol prot = client.getProtocolFactory().getProtocol(memoryTransport);
+        (new Client(prot)).recv_echoPassVoid();
+        return null;
+      }
+    }
+
   }
 
   public static class Processor<I extends Iface> extends org.apache.thrift.TBaseProcessor<I> implements org.apache.thrift.TProcessor {
@@ -440,6 +501,7 @@ public class SimpleThriftService {
       processMap.put("onewayFail", new onewayFail());
       processMap.put("echoRuntimeFail", new echoRuntimeFail());
       processMap.put("onewayRuntimeFail", new onewayRuntimeFail());
+      processMap.put("echoPassVoid", new echoPassVoid());
       return processMap;
     }
 
@@ -608,6 +670,34 @@ public class SimpleThriftService {
       }
     }
 
+    public static class echoPassVoid<I extends Iface> extends org.apache.thrift.ProcessFunction<I, echoPassVoid_args> {
+      public echoPassVoid() {
+        super("echoPassVoid");
+      }
+
+      @Override
+      public echoPassVoid_args getEmptyArgsInstance() {
+        return new echoPassVoid_args();
+      }
+
+      @Override
+      protected boolean isOneway() {
+        return false;
+      }
+
+      @Override
+      protected boolean rethrowUnhandledExceptions() {
+        return false;
+      }
+
+      @Override
+      public echoPassVoid_result getResult(I iface, echoPassVoid_args args) throws org.apache.thrift.TException {
+        echoPassVoid_result result = new echoPassVoid_result();
+        iface.echoPassVoid(args.value);
+        return result;
+      }
+    }
+
   }
 
   public static class AsyncProcessor<I extends AsyncIface> extends org.apache.thrift.TBaseAsyncProcessor<I> {
@@ -627,6 +717,7 @@ public class SimpleThriftService {
       processMap.put("onewayFail", new onewayFail());
       processMap.put("echoRuntimeFail", new echoRuntimeFail());
       processMap.put("onewayRuntimeFail", new onewayRuntimeFail());
+      processMap.put("echoPassVoid", new echoPassVoid());
       return processMap;
     }
 
@@ -948,6 +1039,72 @@ public class SimpleThriftService {
       @Override
       public void start(I iface, onewayRuntimeFail_args args, org.apache.thrift.async.AsyncMethodCallback<Void> resultHandler) throws org.apache.thrift.TException {
         iface.onewayRuntimeFail(args.value,resultHandler);
+      }
+    }
+
+    public static class echoPassVoid<I extends AsyncIface> extends org.apache.thrift.AsyncProcessFunction<I, echoPassVoid_args, Void> {
+      public echoPassVoid() {
+        super("echoPassVoid");
+      }
+
+      @Override
+      public echoPassVoid_args getEmptyArgsInstance() {
+        return new echoPassVoid_args();
+      }
+
+      @Override
+      public org.apache.thrift.async.AsyncMethodCallback<Void> getResultHandler(final org.apache.thrift.server.AbstractNonblockingServer.AsyncFrameBuffer fb, final int seqid) {
+        final org.apache.thrift.AsyncProcessFunction fcall = this;
+        return new org.apache.thrift.async.AsyncMethodCallback<Void>() { 
+          @Override
+          public void onComplete(Void o) {
+            echoPassVoid_result result = new echoPassVoid_result();
+            try {
+              fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
+            } catch (org.apache.thrift.transport.TTransportException e) {
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              fb.close();
+            } catch (java.lang.Exception e) {
+              _LOGGER.error("Exception writing to internal frame buffer", e);
+              onError(e);
+            }
+          }
+          @Override
+          public void onError(java.lang.Exception e) {
+            byte msgType = org.apache.thrift.protocol.TMessageType.REPLY;
+            org.apache.thrift.TSerializable msg;
+            echoPassVoid_result result = new echoPassVoid_result();
+            if (e instanceof org.apache.thrift.transport.TTransportException) {
+              _LOGGER.error("TTransportException inside handler", e);
+              fb.close();
+              return;
+            } else if (e instanceof org.apache.thrift.TApplicationException) {
+              _LOGGER.error("TApplicationException inside handler", e);
+              msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
+              msg = (org.apache.thrift.TApplicationException)e;
+            } else {
+              _LOGGER.error("Exception inside handler", e);
+              msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
+              msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
+            }
+            try {
+              fcall.sendResponse(fb,msg,msgType,seqid);
+            } catch (java.lang.Exception ex) {
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              fb.close();
+            }
+          }
+        };
+      }
+
+      @Override
+      protected boolean isOneway() {
+        return false;
+      }
+
+      @Override
+      public void start(I iface, echoPassVoid_args args, org.apache.thrift.async.AsyncMethodCallback<Void> resultHandler) throws org.apache.thrift.TException {
+        iface.echoPassVoid(args.value,resultHandler);
       }
     }
 
@@ -4353,6 +4510,650 @@ public class SimpleThriftService {
           struct.value = iprot.readString();
           struct.setValueIsSet(true);
         }
+      }
+    }
+
+    private static <S extends org.apache.thrift.scheme.IScheme> S scheme(org.apache.thrift.protocol.TProtocol proto) {
+      return (org.apache.thrift.scheme.StandardScheme.class.equals(proto.getScheme()) ? STANDARD_SCHEME_FACTORY : TUPLE_SCHEME_FACTORY).getScheme();
+    }
+  }
+
+  @SuppressWarnings({"cast", "rawtypes", "serial", "unchecked", "unused"})
+  public static class echoPassVoid_args implements org.apache.thrift.TBase<echoPassVoid_args, echoPassVoid_args._Fields>, java.io.Serializable, Cloneable, Comparable<echoPassVoid_args>   {
+    private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("echoPassVoid_args");
+
+    private static final org.apache.thrift.protocol.TField VALUE_FIELD_DESC = new org.apache.thrift.protocol.TField("value", org.apache.thrift.protocol.TType.STRING, (short)1);
+
+    private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new echoPassVoid_argsStandardSchemeFactory();
+    private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new echoPassVoid_argsTupleSchemeFactory();
+
+    public @org.apache.thrift.annotation.Nullable java.lang.String value; // required
+
+    /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
+    public enum _Fields implements org.apache.thrift.TFieldIdEnum {
+      VALUE((short)1, "value");
+
+      private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
+
+      static {
+        for (_Fields field : java.util.EnumSet.allOf(_Fields.class)) {
+          byName.put(field.getFieldName(), field);
+        }
+      }
+
+      /**
+       * Find the _Fields constant that matches fieldId, or null if its not found.
+       */
+      @org.apache.thrift.annotation.Nullable
+      public static _Fields findByThriftId(int fieldId) {
+        switch(fieldId) {
+          case 1: // VALUE
+            return VALUE;
+          default:
+            return null;
+        }
+      }
+
+      /**
+       * Find the _Fields constant that matches fieldId, throwing an exception
+       * if it is not found.
+       */
+      public static _Fields findByThriftIdOrThrow(int fieldId) {
+        _Fields fields = findByThriftId(fieldId);
+        if (fields == null) throw new java.lang.IllegalArgumentException("Field " + fieldId + " doesn't exist!");
+        return fields;
+      }
+
+      /**
+       * Find the _Fields constant that matches name, or null if its not found.
+       */
+      @org.apache.thrift.annotation.Nullable
+      public static _Fields findByName(java.lang.String name) {
+        return byName.get(name);
+      }
+
+      private final short _thriftId;
+      private final java.lang.String _fieldName;
+
+      _Fields(short thriftId, java.lang.String fieldName) {
+        _thriftId = thriftId;
+        _fieldName = fieldName;
+      }
+
+      @Override
+      public short getThriftFieldId() {
+        return _thriftId;
+      }
+
+      @Override
+      public java.lang.String getFieldName() {
+        return _fieldName;
+      }
+    }
+
+    // isset id assignments
+    public static final java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
+    static {
+      java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+      tmpMap.put(_Fields.VALUE, new org.apache.thrift.meta_data.FieldMetaData("value", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
+      metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
+      org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(echoPassVoid_args.class, metaDataMap);
+    }
+
+    public echoPassVoid_args() {
+    }
+
+    public echoPassVoid_args(
+      java.lang.String value)
+    {
+      this();
+      this.value = value;
+    }
+
+    /**
+     * Performs a deep copy on <i>other</i>.
+     */
+    public echoPassVoid_args(echoPassVoid_args other) {
+      if (other.isSetValue()) {
+        this.value = other.value;
+      }
+    }
+
+    @Override
+    public echoPassVoid_args deepCopy() {
+      return new echoPassVoid_args(this);
+    }
+
+    @Override
+    public void clear() {
+      this.value = null;
+    }
+
+    @org.apache.thrift.annotation.Nullable
+    public java.lang.String getValue() {
+      return this.value;
+    }
+
+    public echoPassVoid_args setValue(@org.apache.thrift.annotation.Nullable java.lang.String value) {
+      this.value = value;
+      return this;
+    }
+
+    public void unsetValue() {
+      this.value = null;
+    }
+
+    /** Returns true if field value is set (has been assigned a value) and false otherwise */
+    public boolean isSetValue() {
+      return this.value != null;
+    }
+
+    public void setValueIsSet(boolean value) {
+      if (!value) {
+        this.value = null;
+      }
+    }
+
+    @Override
+    public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
+      switch (field) {
+      case VALUE:
+        if (value == null) {
+          unsetValue();
+        } else {
+          setValue((java.lang.String)value);
+        }
+        break;
+
+      }
+    }
+
+    @org.apache.thrift.annotation.Nullable
+    @Override
+    public java.lang.Object getFieldValue(_Fields field) {
+      switch (field) {
+      case VALUE:
+        return getValue();
+
+      }
+      throw new java.lang.IllegalStateException();
+    }
+
+    /** Returns true if field corresponding to fieldID is set (has been assigned a value) and false otherwise */
+    @Override
+    public boolean isSet(_Fields field) {
+      if (field == null) {
+        throw new java.lang.IllegalArgumentException();
+      }
+
+      switch (field) {
+      case VALUE:
+        return isSetValue();
+      }
+      throw new java.lang.IllegalStateException();
+    }
+
+    @Override
+    public boolean equals(java.lang.Object that) {
+      if (that instanceof echoPassVoid_args)
+        return this.equals((echoPassVoid_args)that);
+      return false;
+    }
+
+    public boolean equals(echoPassVoid_args that) {
+      if (that == null)
+        return false;
+      if (this == that)
+        return true;
+
+      boolean this_present_value = true && this.isSetValue();
+      boolean that_present_value = true && that.isSetValue();
+      if (this_present_value || that_present_value) {
+        if (!(this_present_value && that_present_value))
+          return false;
+        if (!this.value.equals(that.value))
+          return false;
+      }
+
+      return true;
+    }
+
+    @Override
+    public int hashCode() {
+      int hashCode = 1;
+
+      hashCode = hashCode * 8191 + ((isSetValue()) ? 131071 : 524287);
+      if (isSetValue())
+        hashCode = hashCode * 8191 + value.hashCode();
+
+      return hashCode;
+    }
+
+    @Override
+    public int compareTo(echoPassVoid_args other) {
+      if (!getClass().equals(other.getClass())) {
+        return getClass().getName().compareTo(other.getClass().getName());
+      }
+
+      int lastComparison = 0;
+
+      lastComparison = java.lang.Boolean.compare(isSetValue(), other.isSetValue());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (isSetValue()) {
+        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.value, other.value);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
+      return 0;
+    }
+
+    @org.apache.thrift.annotation.Nullable
+    @Override
+    public _Fields fieldForId(int fieldId) {
+      return _Fields.findByThriftId(fieldId);
+    }
+
+    @Override
+    public void read(org.apache.thrift.protocol.TProtocol iprot) throws org.apache.thrift.TException {
+      scheme(iprot).read(iprot, this);
+    }
+
+    @Override
+    public void write(org.apache.thrift.protocol.TProtocol oprot) throws org.apache.thrift.TException {
+      scheme(oprot).write(oprot, this);
+    }
+
+    @Override
+    public java.lang.String toString() {
+      java.lang.StringBuilder sb = new java.lang.StringBuilder("echoPassVoid_args(");
+      boolean first = true;
+
+      sb.append("value:");
+      if (this.value == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.value);
+      }
+      first = false;
+      sb.append(")");
+      return sb.toString();
+    }
+
+    public void validate() throws org.apache.thrift.TException {
+      // check for required fields
+      // check for sub-struct validity
+    }
+
+    private void writeObject(java.io.ObjectOutputStream out) throws java.io.IOException {
+      try {
+        write(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(out)));
+      } catch (org.apache.thrift.TException te) {
+        throw new java.io.IOException(te);
+      }
+    }
+
+    private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, java.lang.ClassNotFoundException {
+      try {
+        read(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(in)));
+      } catch (org.apache.thrift.TException te) {
+        throw new java.io.IOException(te);
+      }
+    }
+
+    private static class echoPassVoid_argsStandardSchemeFactory implements org.apache.thrift.scheme.SchemeFactory {
+      @Override
+      public echoPassVoid_argsStandardScheme getScheme() {
+        return new echoPassVoid_argsStandardScheme();
+      }
+    }
+
+    private static class echoPassVoid_argsStandardScheme extends org.apache.thrift.scheme.StandardScheme<echoPassVoid_args> {
+
+      @Override
+      public void read(org.apache.thrift.protocol.TProtocol iprot, echoPassVoid_args struct) throws org.apache.thrift.TException {
+        org.apache.thrift.protocol.TField schemeField;
+        iprot.readStructBegin();
+        while (true)
+        {
+          schemeField = iprot.readFieldBegin();
+          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) { 
+            break;
+          }
+          switch (schemeField.id) {
+            case 1: // VALUE
+              if (schemeField.type == org.apache.thrift.protocol.TType.STRING) {
+                struct.value = iprot.readString();
+                struct.setValueIsSet(true);
+              } else { 
+                org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+              }
+              break;
+            default:
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+          }
+          iprot.readFieldEnd();
+        }
+        iprot.readStructEnd();
+
+        // check for required fields of primitive type, which can't be checked in the validate method
+        struct.validate();
+      }
+
+      @Override
+      public void write(org.apache.thrift.protocol.TProtocol oprot, echoPassVoid_args struct) throws org.apache.thrift.TException {
+        struct.validate();
+
+        oprot.writeStructBegin(STRUCT_DESC);
+        if (struct.value != null) {
+          oprot.writeFieldBegin(VALUE_FIELD_DESC);
+          oprot.writeString(struct.value);
+          oprot.writeFieldEnd();
+        }
+        oprot.writeFieldStop();
+        oprot.writeStructEnd();
+      }
+
+    }
+
+    private static class echoPassVoid_argsTupleSchemeFactory implements org.apache.thrift.scheme.SchemeFactory {
+      @Override
+      public echoPassVoid_argsTupleScheme getScheme() {
+        return new echoPassVoid_argsTupleScheme();
+      }
+    }
+
+    private static class echoPassVoid_argsTupleScheme extends org.apache.thrift.scheme.TupleScheme<echoPassVoid_args> {
+
+      @Override
+      public void write(org.apache.thrift.protocol.TProtocol prot, echoPassVoid_args struct) throws org.apache.thrift.TException {
+        org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
+        java.util.BitSet optionals = new java.util.BitSet();
+        if (struct.isSetValue()) {
+          optionals.set(0);
+        }
+        oprot.writeBitSet(optionals, 1);
+        if (struct.isSetValue()) {
+          oprot.writeString(struct.value);
+        }
+      }
+
+      @Override
+      public void read(org.apache.thrift.protocol.TProtocol prot, echoPassVoid_args struct) throws org.apache.thrift.TException {
+        org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
+        java.util.BitSet incoming = iprot.readBitSet(1);
+        if (incoming.get(0)) {
+          struct.value = iprot.readString();
+          struct.setValueIsSet(true);
+        }
+      }
+    }
+
+    private static <S extends org.apache.thrift.scheme.IScheme> S scheme(org.apache.thrift.protocol.TProtocol proto) {
+      return (org.apache.thrift.scheme.StandardScheme.class.equals(proto.getScheme()) ? STANDARD_SCHEME_FACTORY : TUPLE_SCHEME_FACTORY).getScheme();
+    }
+  }
+
+  @SuppressWarnings({"cast", "rawtypes", "serial", "unchecked", "unused"})
+  public static class echoPassVoid_result implements org.apache.thrift.TBase<echoPassVoid_result, echoPassVoid_result._Fields>, java.io.Serializable, Cloneable, Comparable<echoPassVoid_result>   {
+    private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("echoPassVoid_result");
+
+
+    private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new echoPassVoid_resultStandardSchemeFactory();
+    private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new echoPassVoid_resultTupleSchemeFactory();
+
+
+    /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
+    public enum _Fields implements org.apache.thrift.TFieldIdEnum {
+;
+
+      private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
+
+      static {
+        for (_Fields field : java.util.EnumSet.allOf(_Fields.class)) {
+          byName.put(field.getFieldName(), field);
+        }
+      }
+
+      /**
+       * Find the _Fields constant that matches fieldId, or null if its not found.
+       */
+      @org.apache.thrift.annotation.Nullable
+      public static _Fields findByThriftId(int fieldId) {
+        switch(fieldId) {
+          default:
+            return null;
+        }
+      }
+
+      /**
+       * Find the _Fields constant that matches fieldId, throwing an exception
+       * if it is not found.
+       */
+      public static _Fields findByThriftIdOrThrow(int fieldId) {
+        _Fields fields = findByThriftId(fieldId);
+        if (fields == null) throw new java.lang.IllegalArgumentException("Field " + fieldId + " doesn't exist!");
+        return fields;
+      }
+
+      /**
+       * Find the _Fields constant that matches name, or null if its not found.
+       */
+      @org.apache.thrift.annotation.Nullable
+      public static _Fields findByName(java.lang.String name) {
+        return byName.get(name);
+      }
+
+      private final short _thriftId;
+      private final java.lang.String _fieldName;
+
+      _Fields(short thriftId, java.lang.String fieldName) {
+        _thriftId = thriftId;
+        _fieldName = fieldName;
+      }
+
+      @Override
+      public short getThriftFieldId() {
+        return _thriftId;
+      }
+
+      @Override
+      public java.lang.String getFieldName() {
+        return _fieldName;
+      }
+    }
+    public static final java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
+    static {
+      java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+      metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
+      org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(echoPassVoid_result.class, metaDataMap);
+    }
+
+    public echoPassVoid_result() {
+    }
+
+    /**
+     * Performs a deep copy on <i>other</i>.
+     */
+    public echoPassVoid_result(echoPassVoid_result other) {
+    }
+
+    @Override
+    public echoPassVoid_result deepCopy() {
+      return new echoPassVoid_result(this);
+    }
+
+    @Override
+    public void clear() {
+    }
+
+    @Override
+    public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
+      switch (field) {
+      }
+    }
+
+    @org.apache.thrift.annotation.Nullable
+    @Override
+    public java.lang.Object getFieldValue(_Fields field) {
+      switch (field) {
+      }
+      throw new java.lang.IllegalStateException();
+    }
+
+    /** Returns true if field corresponding to fieldID is set (has been assigned a value) and false otherwise */
+    @Override
+    public boolean isSet(_Fields field) {
+      if (field == null) {
+        throw new java.lang.IllegalArgumentException();
+      }
+
+      switch (field) {
+      }
+      throw new java.lang.IllegalStateException();
+    }
+
+    @Override
+    public boolean equals(java.lang.Object that) {
+      if (that instanceof echoPassVoid_result)
+        return this.equals((echoPassVoid_result)that);
+      return false;
+    }
+
+    public boolean equals(echoPassVoid_result that) {
+      if (that == null)
+        return false;
+      if (this == that)
+        return true;
+
+      return true;
+    }
+
+    @Override
+    public int hashCode() {
+      int hashCode = 1;
+
+      return hashCode;
+    }
+
+    @Override
+    public int compareTo(echoPassVoid_result other) {
+      if (!getClass().equals(other.getClass())) {
+        return getClass().getName().compareTo(other.getClass().getName());
+      }
+
+      int lastComparison = 0;
+
+      return 0;
+    }
+
+    @org.apache.thrift.annotation.Nullable
+    @Override
+    public _Fields fieldForId(int fieldId) {
+      return _Fields.findByThriftId(fieldId);
+    }
+
+    @Override
+    public void read(org.apache.thrift.protocol.TProtocol iprot) throws org.apache.thrift.TException {
+      scheme(iprot).read(iprot, this);
+    }
+
+    public void write(org.apache.thrift.protocol.TProtocol oprot) throws org.apache.thrift.TException {
+      scheme(oprot).write(oprot, this);
+      }
+
+    @Override
+    public java.lang.String toString() {
+      java.lang.StringBuilder sb = new java.lang.StringBuilder("echoPassVoid_result(");
+      boolean first = true;
+
+      sb.append(")");
+      return sb.toString();
+    }
+
+    public void validate() throws org.apache.thrift.TException {
+      // check for required fields
+      // check for sub-struct validity
+    }
+
+    private void writeObject(java.io.ObjectOutputStream out) throws java.io.IOException {
+      try {
+        write(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(out)));
+      } catch (org.apache.thrift.TException te) {
+        throw new java.io.IOException(te);
+      }
+    }
+
+    private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, java.lang.ClassNotFoundException {
+      try {
+        read(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(in)));
+      } catch (org.apache.thrift.TException te) {
+        throw new java.io.IOException(te);
+      }
+    }
+
+    private static class echoPassVoid_resultStandardSchemeFactory implements org.apache.thrift.scheme.SchemeFactory {
+      @Override
+      public echoPassVoid_resultStandardScheme getScheme() {
+        return new echoPassVoid_resultStandardScheme();
+      }
+    }
+
+    private static class echoPassVoid_resultStandardScheme extends org.apache.thrift.scheme.StandardScheme<echoPassVoid_result> {
+
+      @Override
+      public void read(org.apache.thrift.protocol.TProtocol iprot, echoPassVoid_result struct) throws org.apache.thrift.TException {
+        org.apache.thrift.protocol.TField schemeField;
+        iprot.readStructBegin();
+        while (true)
+        {
+          schemeField = iprot.readFieldBegin();
+          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) { 
+            break;
+          }
+          switch (schemeField.id) {
+            default:
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+          }
+          iprot.readFieldEnd();
+        }
+        iprot.readStructEnd();
+
+        // check for required fields of primitive type, which can't be checked in the validate method
+        struct.validate();
+      }
+
+      @Override
+      public void write(org.apache.thrift.protocol.TProtocol oprot, echoPassVoid_result struct) throws org.apache.thrift.TException {
+        struct.validate();
+
+        oprot.writeStructBegin(STRUCT_DESC);
+        oprot.writeFieldStop();
+        oprot.writeStructEnd();
+      }
+
+    }
+
+    private static class echoPassVoid_resultTupleSchemeFactory implements org.apache.thrift.scheme.SchemeFactory {
+      @Override
+      public echoPassVoid_resultTupleScheme getScheme() {
+        return new echoPassVoid_resultTupleScheme();
+      }
+    }
+
+    private static class echoPassVoid_resultTupleScheme extends org.apache.thrift.scheme.TupleScheme<echoPassVoid_result> {
+
+      @Override
+      public void write(org.apache.thrift.protocol.TProtocol prot, echoPassVoid_result struct) throws org.apache.thrift.TException {
+        org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
+      }
+
+      @Override
+      public void read(org.apache.thrift.protocol.TProtocol prot, echoPassVoid_result struct) throws org.apache.thrift.TException {
+        org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       }
     }
 

--- a/test/src/main/thrift/test.thrift
+++ b/test/src/main/thrift/test.thrift
@@ -29,4 +29,5 @@ service SimpleThriftService {
   string echoRuntimeFail(1:string value)
   oneway void onewayRuntimeFail(1:string value)
 
+  void echoPassVoid(1:string value)
 }


### PR DESCRIPTION
Update SimpleThriftServiceRunner, used by ThriftBehaviorIT with a thrift protocol that logs the order in which clients and servers call protocol read and write message methods.

In testing, the logging shows the following ordering:

One-way methods:

  client:writeMessageBegin
  serverInput:readMessageBegin
  client:writeMessageEnd
  serverInput:readMessageEnd

Two-way (regular, including void) methods:

  client:writeMessageBegin
  serverInput:readMessageBegin
  client:writeMessageEnd
  serverInput:readMessageEnd
  serverOutput:writeMessageBegin
  client:readMessageBegin
  serverOutput:writeMessageEnd
  client:readMessageEnd

Note: the order of the End methods are soemtimes swapped. It seems that the ordering of those is nondeterministic, which makes sense because they happen in different processes, and neither side has anything more to do to read/write the message, and can move on to the End methods independently.

The client uses its protocol instance to send RPC messages using the write methods, and uses the read methods to receive server response messages.

The server can specify a separate input and output protocol, and uses the read methods on the input protocol to receive client RPC messages, and uses the output protocol to send response messages (either the result of an RPC operation or a serialized exception). The output protocol is not used by thrift oneway methods.

This commit also adds coverage of two-way void methods.