### PR TITLE
Avoid client side errors during manager shutdown.

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
@@ -487,7 +487,9 @@ public class Fate<T> {
   }
 
   /**
-   * Initiates shutdown of background threads and optionally waits on them.
+   * Initiates shutdown of background threads that run fate operations and cleanup fate data and
+   * optionally waits on them. Leaves the fate object in a state where it can still update and read
+   * fate data, like add a new fate operation or get the status of an existing fate operation.
    */
   public void shutdown(long timeout, TimeUnit timeUnit) {
     log.info("Shutting down {} FATE", store.type());
@@ -532,8 +534,13 @@ public class Fate<T> {
     if (deadResCleanerExecutor != null) {
       deadResCleanerExecutor.shutdownNow();
     }
+  }
 
-    // ensure store resources are cleaned up
+  /**
+   * Initiates shutdown of all fate threads and prevents reads and updates of fates persisted data.
+   */
+  public void close() {
+    shutdown(0, SECONDS);
     store.close();
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/ShutdownIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ShutdownIT.java
@@ -86,6 +86,7 @@ public class ShutdownIT extends ConfigurableMacBase {
       Thread async = new Thread(() -> {
         try {
           for (int i = 0; i < 10; i++) {
+            Thread.sleep(100);
             c.tableOperations().delete("table" + i);
           }
         } catch (Exception ex) {
@@ -95,6 +96,9 @@ public class ShutdownIT extends ConfigurableMacBase {
       async.start();
       Thread.sleep(100);
       assertEquals(0, cluster.exec(Admin.class, "stopAll").getProcess().waitFor());
+      // give the backfound delete operations a bit to run
+      Thread.sleep(3000);
+      // The delete operations should get stuck or run, but should not throw an exception
       if (ref.get() != null) {
         throw ref.get();
       }


### PR DESCRIPTION
Client side table operations that used fate could see exceptions during manager shutdown before this fix.  After this fix hopefully that is not the case.  Was occasionally seeing this problems in a ShutdownIT test. Modified ShutdownIT to more reliably cause the problem before this fix, after this fix the test is passing consistently.

fixes #5714