### PR TITLE
Cause Compactor to exit when error loading classes

### DIFF
--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -105,6 +105,7 @@ import org.apache.accumulo.server.ServerOpts;
 import org.apache.accumulo.server.compaction.CompactionInfo;
 import org.apache.accumulo.server.compaction.CompactionWatcher;
 import org.apache.accumulo.server.compaction.FileCompactor;
+import org.apache.accumulo.server.compaction.FileCompactor.CompactionClassLoadingException;
 import org.apache.accumulo.server.compaction.RetryableThriftCall;
 import org.apache.accumulo.server.compaction.RetryableThriftCall.RetriesExceededException;
 import org.apache.accumulo.server.conf.TableConfiguration;
@@ -582,6 +583,9 @@ public class Compactor extends AbstractServer
           TCompactionStatusUpdate update2 = new TCompactionStatusUpdate(TCompactionState.SUCCEEDED,
               "Compaction completed successfully", -1, -1, -1, this.getCompactionAge().toNanos());
           updateCompactionState(job, update2);
+        } catch (FileCompactor.CompactionClassLoadingException ccle) {
+          LOG.error("Error loading classes for compaction", ccle);
+          err.set(ccle);
         } catch (FileCompactor.CompactionCanceledException cce) {
           LOG.debug("Compaction canceled {}", job.getExternalCompactionId());
           err.set(cce);
@@ -825,6 +829,15 @@ public class Compactor extends AbstractServer
                     -1, -1, -1, fcr.getCompactionAge().toNanos());
                 updateCompactionState(job, update);
                 updateCompactionFailed(job);
+                if (err.get() instanceof CompactionClassLoadingException) {
+                  // Compaction failed because it could not load classes.
+                  // Raise an InterruptedException here which will be caught
+                  // below to exit the Compactor. If we don't exit, then this
+                  // Compactor will get the next job and continue to fail.
+                  LOG.error(
+                      "CompactionClassLoadingException occurred. Check iterator class configuration. Exiting Compactor.");
+                  throw new InterruptedException();
+                }
               } catch (RetriesExceededException e) {
                 LOG.error("Error updating coordinator with compaction failure: id: {}, extent: {}",
                     job.getExternalCompactionId(), fromThriftExtent, e);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
@@ -78,6 +78,7 @@ import org.apache.accumulo.server.ServiceEnvironmentImpl;
 import org.apache.accumulo.server.compaction.CompactionStats;
 import org.apache.accumulo.server.compaction.FileCompactor;
 import org.apache.accumulo.server.compaction.FileCompactor.CompactionCanceledException;
+import org.apache.accumulo.server.compaction.FileCompactor.CompactionClassLoadingException;
 import org.apache.accumulo.server.compaction.FileCompactor.CompactionEnv;
 import org.apache.accumulo.server.conf.TableConfiguration;
 import org.apache.accumulo.server.fs.VolumeManager;
@@ -559,8 +560,8 @@ public class CompactableUtils {
    */
   static CompactionStats compact(Tablet tablet, CompactionJob job,
       CompactableImpl.CompactionInfo cInfo, CompactionEnv cenv,
-      Map<StoredTabletFile,DataFileValue> compactFiles, TabletFile tmpFileName)
-      throws IOException, CompactionCanceledException, InterruptedException {
+      Map<StoredTabletFile,DataFileValue> compactFiles, TabletFile tmpFileName) throws IOException,
+      CompactionCanceledException, CompactionClassLoadingException, InterruptedException {
     TableConfiguration tableConf = tablet.getTableConfiguration();
 
     AccumuloConfiguration compactionConfig = getCompactionConfig(tableConf,

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
@@ -137,7 +137,8 @@ public class MinorCompactor extends FileCompactor {
           log.warn("MinC failed ({}) to create {} retrying ...", e.getMessage(), outputFileName, e);
           reportedProblem = true;
           retryCounter++;
-        } catch (CompactionCanceledException | InterruptedException e) {
+        } catch (CompactionCanceledException | CompactionClassLoadingException
+            | InterruptedException e) {
           throw new IllegalStateException(e);
         }
 


### PR DESCRIPTION
AccumuloVFSClassLoader.getContextClassLoader throws an UncheckedIOException when there is an issue getting the ClassLoader for a context name. This runtime exception escapes all the way up to the calling code in Compactor and TabletServer, which fails the compaction and moves on to the next compaction. If there is an issue getting the ClassLoader for the context once, then it's likely to happen again. It's probably not safe to terminate the TabletServer in this case, but is likely safe for the Compactor.

This change captures the RuntimeException in the
FileCompactor.compactLocalityGroup where the iterator stack is created and raises a new checked exception which is handled in the calling code.