### PR TITLE
Fixes accumulo-cluster script behavior:

### DIFF
--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -277,7 +277,7 @@ function quote() {
 }
 
 # call debug to print the command only, or execute asynchronously if debug is off
-function debugOrRun() {
+function debugOrRunAsync() {
   debug "$(quote "$@")" || ("$@") &
 }
 
@@ -458,9 +458,9 @@ function execute_command() {
   servers_per_host="${!S:-1}"
 
   if [[ $ARG_LOCAL == 1 ]]; then
-    debugOrRun bash -c "ACCUMULO_CLUSTER_ARG=$servers_per_host \"$bin/accumulo-service\" $service $control_cmd -a $host $*"
+    debugOrRunAsync bash -c "ACCUMULO_CLUSTER_ARG=$servers_per_host \"$bin/accumulo-service\" $service $control_cmd -a $host $*"
   else
-    debugOrRun "${SSH[@]}" "$host" "bash -c 'ACCUMULO_CLUSTER_ARG=$servers_per_host \"$bin/accumulo-service\" $service $control_cmd -a $host $*'"
+    debugOrRunAsync "${SSH[@]}" "$host" "bash -c 'ACCUMULO_CLUSTER_ARG=$servers_per_host \"$bin/accumulo-service\" $service $control_cmd -a $host $*'"
   fi
 }
 


### PR DESCRIPTION
"accumulo-cluster start" would briefly return control back to command line, continue execution, then hang but everything seemed to start as expected. Cause was background tasks were started and not waited on before exiting, but would still complete after exit. So, functionality wasn't wrong, it just was strange behavior/confusing to see. Now wait for those tasks to complete.

closes #5698