### PR TITLE
Fixes broken TotalQueuedIT 2.1+

### DIFF
--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
@@ -182,7 +182,7 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
       mkdirs(config.getAccumuloDir());
     }
 
-    if (config.useMiniDFS()) {
+    if (config.getUseMiniDFS()) {
       File nn = new File(config.getAccumuloDir(), "nn");
       mkdirs(nn);
       File dn = new File(config.getAccumuloDir(), "dn");
@@ -480,7 +480,7 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
       justification = "insecure socket used for reservation")
   @Override
   public synchronized void start() throws IOException, InterruptedException {
-    if (config.useMiniDFS() && miniDFS.get() == null) {
+    if (config.getUseMiniDFS() && miniDFS.get() == null) {
       throw new IllegalStateException("Cannot restart mini when using miniDFS");
     }
 
@@ -883,7 +883,7 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
     }
 
     var miniDFSActual = miniDFS.get();
-    if (config.useMiniDFS() && miniDFSActual != null) {
+    if (config.getUseMiniDFS() && miniDFSActual != null) {
       miniDFSActual.shutdown();
     }
     for (Process p : cleanup) {
@@ -979,7 +979,7 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
   @Override
   public Path getTemporaryPath() {
     String p;
-    if (config.useMiniDFS()) {
+    if (config.getUseMiniDFS()) {
       p = "/tmp/";
     } else {
       File tmp = new File(config.getDir(), "tmp");

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
@@ -608,7 +608,7 @@ public class MiniAccumuloConfigImpl {
     return this;
   }
 
-  public boolean useMiniDFS() {
+  public boolean getUseMiniDFS() {
     return useMiniDFS;
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/TotalQueuedIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TotalQueuedIT.java
@@ -52,7 +52,9 @@ public class TotalQueuedIT extends ConfigurableMacBase {
   @Override
   public void configure(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
     cfg.setNumTservers(1);
+    // use mini DFS so walogs sync and flush will work
     cfg.useMiniDFS(true);
+    // property is a fixed property (requires restart to be picked up), so set here in initial cfg
     cfg.setProperty(Property.TSERV_TOTAL_MUTATION_QUEUE_MAX.getKey(), "" + SMALL_QUEUE_SIZE);
   }
 


### PR DESCRIPTION
Problem was two-fold:
1) ed40b628514750c95e3e40abcd8330493f4d99a3 updated the set of fixed
   properties to be more accurate. This test was changing a property
that was newly declared as fixed, so config change wasn't being picked up since related servers weren't restarted. Now restart related servers (the TServers) after config change.
2) The config set before starting the MAC called `cfg.useMiniDFS()`
   which simply returned the value of `useMiniDFS`, and didn't set
anything. This caused things to hang after restarting the TServers. Changed to `cfg.useMiniDFS(true)` and renamed `useMiniDFS()` -> `getUseMiniDFS()`