### PR TITLE
compress data used by tablet management iterator

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -193,6 +193,12 @@
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.lz4</groupId>
+      <artifactId>lz4-java</artifactId>
+      <version>1.7.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <testResources>

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -377,6 +377,9 @@ public enum Property {
   GENERAL_PROCESS_BIND_ADDRESS("general.process.bind.addr", "0.0.0.0", PropertyType.STRING,
       "The local IP address to which this server should bind for sending and receiving network traffic.",
       "3.0.0"),
+  GENERAL_SERVER_ITERATOR_OPTIONS_COMPRESSION_ALGO("general.server.iter.opts.compression", "none",
+      PropertyType.COMPRESSION_TYPE,
+      "Compression algorithm name to use for server-side iterator options compression.", "2.1.4"),
   GENERAL_SERVER_LOCK_VERIFICATION_INTERVAL("general.server.lock.verification.interval", "2m",
       PropertyType.TIMEDURATION,
       "Interval at which the Manager and TabletServer should verify their server locks. A value of zero"

--- a/core/src/test/java/org/apache/accumulo/core/conf/PropertyTypeTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/PropertyTypeTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.conf;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -84,17 +85,21 @@ public class PropertyTypeTest extends WithTestNames {
   }
 
   private void valid(final String... args) {
-    for (String s : args) {
-      assertTrue(type.isValidFormat(s),
-          s + " should be valid for " + PropertyType.class.getSimpleName() + "." + type.name());
-    }
+    assertAll(() -> {
+      for (String s : args) {
+        assertTrue(type.isValidFormat(s),
+            s + " should be valid for " + PropertyType.class.getSimpleName() + "." + type.name());
+      }
+    });
   }
 
   private void invalid(final String... args) {
-    for (String s : args) {
-      assertFalse(type.isValidFormat(s),
-          s + " should be invalid for " + PropertyType.class.getSimpleName() + "." + type.name());
-    }
+    assertAll(() -> {
+      for (String s : args) {
+        assertFalse(type.isValidFormat(s),
+            s + " should be invalid for " + PropertyType.class.getSimpleName() + "." + type.name());
+      }
+    });
   }
 
   @Test
@@ -315,6 +320,18 @@ public class PropertyTypeTest extends WithTestNames {
   public void testTypeDROP_CACHE_SELECTION() {
     valid("all", "ALL", "NON-import", "NON-IMPORT", "non-import", "none", "NONE", "nOnE");
     invalid(null, "", "AL L", " ALL", "non import", "     ");
+  }
+
+  @Test
+  public void testTypeCOMPRESSION_TYPE() {
+    valid("none", "gz", "lz4", "snappy");
+    // The following are valid at runtime with the correct configuration
+    //
+    // bzip2 java implementation does not implement Compressor/Decompressor, requires native
+    // lzo not included in implementation due to license issues, but can be added by user
+    // zstd requires hadoop native libraries built with zstd support
+    //
+    invalid(null, "", "bzip2", "lzo", "zstd");
   }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -952,6 +952,7 @@
                 <unused>biz.aQute.bnd:biz.aQute.bnd.annotation:jar:*</unused>
                 <unused>org.junit.jupiter:junit-jupiter-engine:jar:*</unused>
                 <unused>org.junit.platform:junit-platform-suite-engine:jar:*</unused>
+                <unused>org.lz4:lz4-java:jar:*</unused>
               </ignoredUnusedDeclaredDependencies>
             </configuration>
           </execution>

--- a/server/base/src/main/java/org/apache/accumulo/server/iterators/ServerIteratorOptions.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/iterators/ServerIteratorOptions.java
@@ -39,6 +39,7 @@ import org.apache.accumulo.core.spi.file.rfile.compression.NoCompression;
 import org.apache.hadoop.io.compress.Compressor;
 import org.apache.hadoop.io.compress.Decompressor;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
 public class ServerIteratorOptions {
@@ -66,8 +67,9 @@ public class ServerIteratorOptions {
     }
   }
 
-  public static void compressOption(final AccumuloConfiguration config,
-      IteratorSetting iteratorSetting, String option, Serializer serializer) {
+  @VisibleForTesting
+  static void compressOption(final AccumuloConfiguration config, IteratorSetting iteratorSetting,
+      String option, Serializer serializer) {
     final String algo = config.get(Property.GENERAL_SERVER_ITERATOR_OPTIONS_COMPRESSION_ALGO);
     final CompressionAlgorithm ca = Compression.getCompressionAlgorithmByName(algo);
     final Compressor c = ca.getCompressor();
@@ -113,7 +115,8 @@ public class ServerIteratorOptions {
     });
   }
 
-  public static <T> T decompressOption(Map<String,String> options, String option,
+  @VisibleForTesting
+  static <T> T decompressOption(Map<String,String> options, String option,
       Deserializer<T> deserializer) {
     var val = options.get(option);
     if (val == null) {

--- a/server/base/src/main/java/org/apache/accumulo/server/iterators/ServerIteratorOptions.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/iterators/ServerIteratorOptions.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.iterators;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Base64;
+import java.util.Map;
+
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.file.rfile.bcfile.Compression;
+import org.apache.accumulo.core.file.rfile.bcfile.CompressionAlgorithm;
+import org.apache.accumulo.core.spi.file.rfile.compression.NoCompression;
+import org.apache.hadoop.io.compress.Compressor;
+import org.apache.hadoop.io.compress.Decompressor;
+
+import com.google.common.base.Preconditions;
+
+public class ServerIteratorOptions {
+  static final String COMPRESSION_ALGO = "__COMPRESSION_ALGO";
+
+  private static final String NONE = new NoCompression().getName();
+
+  public interface Serializer {
+    void serialize(DataOutput dataOutput) throws IOException;
+  }
+
+  public static void compressOption(final AccumuloConfiguration config,
+      IteratorSetting iteratorSetting, String option, String value) {
+    final String algo = config.get(Property.GENERAL_SERVER_ITERATOR_OPTIONS_COMPRESSION_ALGO);
+    setAlgo(iteratorSetting, algo);
+
+    if (algo.equals(NONE)) {
+      iteratorSetting.addOption(option, value);
+    } else {
+      compressOption(config, iteratorSetting, option, dataOutput -> {
+        byte[] bytes = value.getBytes(UTF_8);
+        dataOutput.writeInt(bytes.length);
+        dataOutput.write(bytes);
+      });
+    }
+  }
+
+  public static void compressOption(final AccumuloConfiguration config,
+      IteratorSetting iteratorSetting, String option, Serializer serializer) {
+    final String algo = config.get(Property.GENERAL_SERVER_ITERATOR_OPTIONS_COMPRESSION_ALGO);
+    final CompressionAlgorithm ca = Compression.getCompressionAlgorithmByName(algo);
+    final Compressor c = ca.getCompressor();
+
+    setAlgo(iteratorSetting, algo);
+
+    try (ByteArrayOutputStream baos = new ByteArrayOutputStream(); DataOutputStream dos =
+        new DataOutputStream(ca.createCompressionStream(baos, c, 32 * 1024))) {
+      serializer.serialize(dos);
+      dos.close();
+      var val = Base64.getEncoder().encodeToString(baos.toByteArray());
+      iteratorSetting.addOption(option, val);
+    } catch (IOException ioe) {
+      throw new UncheckedIOException(ioe);
+    } finally {
+      ca.returnCompressor(c);
+    }
+  }
+
+  private static void setAlgo(IteratorSetting iteratorSetting, String algo) {
+    if (iteratorSetting.getOptions().containsKey(COMPRESSION_ALGO)) {
+      Preconditions.checkArgument(iteratorSetting.getOptions().get(COMPRESSION_ALGO).equals(algo));
+    } else {
+      iteratorSetting.addOption(COMPRESSION_ALGO, algo);
+    }
+  }
+
+  public interface Deserializer<T> {
+    T deserialize(DataInputStream dataInput) throws IOException;
+  }
+
+  public static String decompressOption(Map<String,String> options, String option) {
+    var algo = options.getOrDefault(COMPRESSION_ALGO, NONE);
+    if (algo.equals(NONE)) {
+      return options.get(option);
+    }
+
+    return decompressOption(options, option, dataInput -> {
+      int len = dataInput.readInt();
+      byte[] data = new byte[len];
+      dataInput.readFully(data);
+      return new String(data, UTF_8);
+    });
+  }
+
+  public static <T> T decompressOption(Map<String,String> options, String option,
+      Deserializer<T> deserializer) {
+    var val = options.get(option);
+    if (val == null) {
+      try {
+        return deserializer.deserialize(null);
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+    var algo = options.getOrDefault(COMPRESSION_ALGO, NONE);
+    final byte[] data = Base64.getDecoder().decode(val);
+    final CompressionAlgorithm ca = Compression.getCompressionAlgorithmByName(algo);
+    final Decompressor d = ca.getDecompressor();
+    try (ByteArrayInputStream baos = new ByteArrayInputStream(data); DataInputStream dais =
+        new DataInputStream(ca.createDecompressionStream(baos, d, 256 * 1024))) {
+      return deserializer.deserialize(dais);
+    } catch (IOException ioe) {
+      throw new UncheckedIOException(ioe);
+    } finally {
+      ca.returnDecompressor(d);
+    }
+  }
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementScanner.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementScanner.java
@@ -90,7 +90,7 @@ public class TabletManagementScanner implements ClosableIterator<TabletManagemen
       throw new RuntimeException("Error obtaining locations for table: " + tableName);
     }
     cleanable = CleanerUtil.unclosed(this, TabletManagementScanner.class, closed, log, mdScanner);
-    TabletManagementIterator.configureScanner(mdScanner, tmgmtParams);
+    TabletManagementIterator.configureScanner(context.getConfiguration(), mdScanner, tmgmtParams);
     mdScanner.setRanges(ranges);
     iter = mdScanner.iterator();
   }

--- a/server/base/src/test/java/org/apache/accumulo/server/iterators/ServerIteratorOptionsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/iterators/ServerIteratorOptionsTest.java
@@ -128,7 +128,7 @@ public class ServerIteratorOptionsTest {
     Set<KeyExtent> extents2 =
         ServerIteratorOptions.decompressOption(iterSetting.getOptions(), "k1", dataInput -> {
           int num = dataInput.readInt();
-          HashSet<KeyExtent> es = new HashSet<KeyExtent>();
+          HashSet<KeyExtent> es = new HashSet<>(num);
           for (int i = 0; i < num; i++) {
             es.add(KeyExtent.readFrom(dataInput));
           }
@@ -173,7 +173,7 @@ public class ServerIteratorOptionsTest {
     Set<KeyExtent> extents2 =
         ServerIteratorOptions.decompressOption(iterSetting.getOptions(), "k1", dataInput -> {
           int num = dataInput.readInt();
-          HashSet<KeyExtent> es = new HashSet<KeyExtent>();
+          HashSet<KeyExtent> es = new HashSet<>(num);
           for (int i = 0; i < num; i++) {
             es.add(KeyExtent.readFrom(dataInput));
           }

--- a/server/base/src/test/java/org/apache/accumulo/server/iterators/ServerIteratorOptionsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/iterators/ServerIteratorOptionsTest.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.iterators;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.conf.SiteConfiguration;
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.hadoop.io.Text;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.base.Strings;
+
+public class ServerIteratorOptionsTest {
+    @Test
+    public void testStringNone() {
+        var aconf = SiteConfiguration.empty()
+                .withOverrides(
+                        Map.of(Property.GENERAL_SERVER_ITERATOR_OPTIONS_COMPRESSION_ALGO.getKey(), "none"))
+                .build();
+
+        String v1 = Strings.repeat("a", 100_000);
+        String v2 = Strings.repeat("b", 110_000);
+
+        IteratorSetting iterSetting = new IteratorSetting(100, "ti", "TestIter.class");
+
+        ServerIteratorOptions.compressOption(aconf, iterSetting, "k1", v1);
+        ServerIteratorOptions.compressOption(aconf, iterSetting, "k2", v2);
+
+        assertEquals(3, iterSetting.getOptions().size());
+
+        // should not copy string when compression type is none
+        assertSame(v1, iterSetting.getOptions().get("k1"));
+        assertSame(v2, iterSetting.getOptions().get("k2"));
+        assertEquals("none", iterSetting.getOptions().get(ServerIteratorOptions.COMPRESSION_ALGO));
+
+        // should not copy string when compression type is none
+        assertSame(v1, ServerIteratorOptions.decompressOption(iterSetting.getOptions(), "k1"));
+        assertSame(v2, ServerIteratorOptions.decompressOption(iterSetting.getOptions(), "k2"));
+    }
+
+    @Test
+    public void testStringCompress() {
+        var aconf = SiteConfiguration.empty()
+                .withOverrides(
+                        Map.of(Property.GENERAL_SERVER_ITERATOR_OPTIONS_COMPRESSION_ALGO.getKey(), "gz"))
+                .build();
+
+        String v1 = Strings.repeat("a", 100_000);
+        String v2 = Strings.repeat("b", 110_000);
+
+        assertEquals(100_000, v1.length());
+        assertEquals(110_000, v2.length());
+
+        IteratorSetting iterSetting = new IteratorSetting(100, "ti", "TestIter.class");
+
+        ServerIteratorOptions.compressOption(aconf, iterSetting, "k1", v1);
+        ServerIteratorOptions.compressOption(aconf, iterSetting, "k2", v2);
+
+        assertEquals(3, iterSetting.getOptions().size());
+
+        // the stored value should be much smaller
+        assertTrue(iterSetting.getOptions().get("k1").length() < 1000);
+        assertTrue(iterSetting.getOptions().get("k2").length() < 1000);
+        assertEquals("gz", iterSetting.getOptions().get(ServerIteratorOptions.COMPRESSION_ALGO));
+
+        // should not copy string when compression type is none
+        assertEquals(v1, ServerIteratorOptions.decompressOption(iterSetting.getOptions(), "k1"));
+        assertEquals(v2, ServerIteratorOptions.decompressOption(iterSetting.getOptions(), "k2"));
+    }
+
+    @Test
+    public void testSerializeNone() {
+        var aconf = SiteConfiguration.empty()
+                .withOverrides(
+                        Map.of(Property.GENERAL_SERVER_ITERATOR_OPTIONS_COMPRESSION_ALGO.getKey(), "none"))
+                .build();
+
+        IteratorSetting iterSetting = new IteratorSetting(100, "ti", "TestIter.class");
+
+        Set<KeyExtent> extents = new HashSet<>();
+        TableId tableId = TableId.of("1234");
+
+        for (int i = 1; i < 100_000; i++) {
+            var extent = new KeyExtent(tableId, new Text(String.format("%10d", i)),
+                    new Text(String.format("%10d", i - 1)));
+            extents.add(extent);
+        }
+
+        ServerIteratorOptions.compressOption(aconf, iterSetting, "k1", dataOutput -> {
+            dataOutput.writeInt(extents.size());
+            for (var extent : extents) {
+                extent.writeTo(dataOutput);
+            }
+        });
+
+        // expected minimum size of data, will be larger
+        int expMinSize = 100_000 * (4 + 10 + 10);
+        System.out.println(iterSetting.getOptions().get("k1").length());
+        assertTrue(iterSetting.getOptions().get("k1").length() > expMinSize);
+
+        Set<KeyExtent> extents2 =
+                ServerIteratorOptions.decompressOption(iterSetting.getOptions(), "k1", dataInput -> {
+                    int num = dataInput.readInt();
+                    HashSet<KeyExtent> es = new HashSet<KeyExtent>();
+                    for (int i = 0; i < num; i++) {
+                        es.add(KeyExtent.readFrom(dataInput));
+                    }
+                    return es;
+                });
+
+        assertEquals(extents, extents2);
+        assertNotSame(extents, extents2);
+    }
+
+    @Test
+    public void testSerializeGz() {
+        var aconf = SiteConfiguration.empty()
+                .withOverrides(
+                        Map.of(Property.GENERAL_SERVER_ITERATOR_OPTIONS_COMPRESSION_ALGO.getKey(), "gz"))
+                .build();
+
+        IteratorSetting iterSetting = new IteratorSetting(100, "ti", "TestIter.class");
+
+        Set<KeyExtent> extents = new HashSet<>();
+        TableId tableId = TableId.of("1234");
+
+        for (int i = 1; i < 100_000; i++) {
+            var extent = new KeyExtent(tableId, new Text(String.format("%10d", i)),
+                    new Text(String.format("%10d", i - 1)));
+            extents.add(extent);
+        }
+
+        ServerIteratorOptions.compressOption(aconf, iterSetting, "k1", dataOutput -> {
+            dataOutput.writeInt(extents.size());
+            for (var extent : extents) {
+                extent.writeTo(dataOutput);
+            }
+        });
+
+        // expected minimum size of data
+        int expMinSize = 100_000 * (4 + 10 + 10);
+        System.out.println(iterSetting.getOptions().get("k1").length());
+        // should be smaller than the expected min size because of compression
+        assertTrue(iterSetting.getOptions().get("k1").length() < expMinSize);
+
+        Set<KeyExtent> extents2 =
+                ServerIteratorOptions.decompressOption(iterSetting.getOptions(), "k1", dataInput -> {
+                    int num = dataInput.readInt();
+                    HashSet<KeyExtent> es = new HashSet<KeyExtent>();
+                    for (int i = 0; i < num; i++) {
+                        es.add(KeyExtent.readFrom(dataInput));
+                    }
+                    return es;
+                });
+
+        assertEquals(extents, extents2);
+    }
+}

--- a/server/base/src/test/java/org/apache/accumulo/server/iterators/ServerIteratorOptionsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/iterators/ServerIteratorOptionsTest.java
@@ -38,148 +38,148 @@ import org.junit.jupiter.api.Test;
 import com.google.common.base.Strings;
 
 public class ServerIteratorOptionsTest {
-    @Test
-    public void testStringNone() {
-        var aconf = SiteConfiguration.empty()
-                .withOverrides(
-                        Map.of(Property.GENERAL_SERVER_ITERATOR_OPTIONS_COMPRESSION_ALGO.getKey(), "none"))
-                .build();
+  @Test
+  public void testStringNone() {
+    var aconf = SiteConfiguration.empty()
+        .withOverrides(
+            Map.of(Property.GENERAL_SERVER_ITERATOR_OPTIONS_COMPRESSION_ALGO.getKey(), "none"))
+        .build();
 
-        String v1 = Strings.repeat("a", 100_000);
-        String v2 = Strings.repeat("b", 110_000);
+    String v1 = Strings.repeat("a", 100_000);
+    String v2 = Strings.repeat("b", 110_000);
 
-        IteratorSetting iterSetting = new IteratorSetting(100, "ti", "TestIter.class");
+    IteratorSetting iterSetting = new IteratorSetting(100, "ti", "TestIter.class");
 
-        ServerIteratorOptions.compressOption(aconf, iterSetting, "k1", v1);
-        ServerIteratorOptions.compressOption(aconf, iterSetting, "k2", v2);
+    ServerIteratorOptions.compressOption(aconf, iterSetting, "k1", v1);
+    ServerIteratorOptions.compressOption(aconf, iterSetting, "k2", v2);
 
-        assertEquals(3, iterSetting.getOptions().size());
+    assertEquals(3, iterSetting.getOptions().size());
 
-        // should not copy string when compression type is none
-        assertSame(v1, iterSetting.getOptions().get("k1"));
-        assertSame(v2, iterSetting.getOptions().get("k2"));
-        assertEquals("none", iterSetting.getOptions().get(ServerIteratorOptions.COMPRESSION_ALGO));
+    // should not copy string when compression type is none
+    assertSame(v1, iterSetting.getOptions().get("k1"));
+    assertSame(v2, iterSetting.getOptions().get("k2"));
+    assertEquals("none", iterSetting.getOptions().get(ServerIteratorOptions.COMPRESSION_ALGO));
 
-        // should not copy string when compression type is none
-        assertSame(v1, ServerIteratorOptions.decompressOption(iterSetting.getOptions(), "k1"));
-        assertSame(v2, ServerIteratorOptions.decompressOption(iterSetting.getOptions(), "k2"));
+    // should not copy string when compression type is none
+    assertSame(v1, ServerIteratorOptions.decompressOption(iterSetting.getOptions(), "k1"));
+    assertSame(v2, ServerIteratorOptions.decompressOption(iterSetting.getOptions(), "k2"));
+  }
+
+  @Test
+  public void testStringCompress() {
+    var aconf = SiteConfiguration.empty()
+        .withOverrides(
+            Map.of(Property.GENERAL_SERVER_ITERATOR_OPTIONS_COMPRESSION_ALGO.getKey(), "gz"))
+        .build();
+
+    String v1 = Strings.repeat("a", 100_000);
+    String v2 = Strings.repeat("b", 110_000);
+
+    assertEquals(100_000, v1.length());
+    assertEquals(110_000, v2.length());
+
+    IteratorSetting iterSetting = new IteratorSetting(100, "ti", "TestIter.class");
+
+    ServerIteratorOptions.compressOption(aconf, iterSetting, "k1", v1);
+    ServerIteratorOptions.compressOption(aconf, iterSetting, "k2", v2);
+
+    assertEquals(3, iterSetting.getOptions().size());
+
+    // the stored value should be much smaller
+    assertTrue(iterSetting.getOptions().get("k1").length() < 1000);
+    assertTrue(iterSetting.getOptions().get("k2").length() < 1000);
+    assertEquals("gz", iterSetting.getOptions().get(ServerIteratorOptions.COMPRESSION_ALGO));
+
+    // should not copy string when compression type is none
+    assertEquals(v1, ServerIteratorOptions.decompressOption(iterSetting.getOptions(), "k1"));
+    assertEquals(v2, ServerIteratorOptions.decompressOption(iterSetting.getOptions(), "k2"));
+  }
+
+  @Test
+  public void testSerializeNone() {
+    var aconf = SiteConfiguration.empty()
+        .withOverrides(
+            Map.of(Property.GENERAL_SERVER_ITERATOR_OPTIONS_COMPRESSION_ALGO.getKey(), "none"))
+        .build();
+
+    IteratorSetting iterSetting = new IteratorSetting(100, "ti", "TestIter.class");
+
+    Set<KeyExtent> extents = new HashSet<>();
+    TableId tableId = TableId.of("1234");
+
+    for (int i = 1; i < 100_000; i++) {
+      var extent = new KeyExtent(tableId, new Text(String.format("%10d", i)),
+          new Text(String.format("%10d", i - 1)));
+      extents.add(extent);
     }
 
-    @Test
-    public void testStringCompress() {
-        var aconf = SiteConfiguration.empty()
-                .withOverrides(
-                        Map.of(Property.GENERAL_SERVER_ITERATOR_OPTIONS_COMPRESSION_ALGO.getKey(), "gz"))
-                .build();
+    ServerIteratorOptions.compressOption(aconf, iterSetting, "k1", dataOutput -> {
+      dataOutput.writeInt(extents.size());
+      for (var extent : extents) {
+        extent.writeTo(dataOutput);
+      }
+    });
 
-        String v1 = Strings.repeat("a", 100_000);
-        String v2 = Strings.repeat("b", 110_000);
+    // expected minimum size of data, will be larger
+    int expMinSize = 100_000 * (4 + 10 + 10);
+    System.out.println(iterSetting.getOptions().get("k1").length());
+    assertTrue(iterSetting.getOptions().get("k1").length() > expMinSize);
 
-        assertEquals(100_000, v1.length());
-        assertEquals(110_000, v2.length());
-
-        IteratorSetting iterSetting = new IteratorSetting(100, "ti", "TestIter.class");
-
-        ServerIteratorOptions.compressOption(aconf, iterSetting, "k1", v1);
-        ServerIteratorOptions.compressOption(aconf, iterSetting, "k2", v2);
-
-        assertEquals(3, iterSetting.getOptions().size());
-
-        // the stored value should be much smaller
-        assertTrue(iterSetting.getOptions().get("k1").length() < 1000);
-        assertTrue(iterSetting.getOptions().get("k2").length() < 1000);
-        assertEquals("gz", iterSetting.getOptions().get(ServerIteratorOptions.COMPRESSION_ALGO));
-
-        // should not copy string when compression type is none
-        assertEquals(v1, ServerIteratorOptions.decompressOption(iterSetting.getOptions(), "k1"));
-        assertEquals(v2, ServerIteratorOptions.decompressOption(iterSetting.getOptions(), "k2"));
-    }
-
-    @Test
-    public void testSerializeNone() {
-        var aconf = SiteConfiguration.empty()
-                .withOverrides(
-                        Map.of(Property.GENERAL_SERVER_ITERATOR_OPTIONS_COMPRESSION_ALGO.getKey(), "none"))
-                .build();
-
-        IteratorSetting iterSetting = new IteratorSetting(100, "ti", "TestIter.class");
-
-        Set<KeyExtent> extents = new HashSet<>();
-        TableId tableId = TableId.of("1234");
-
-        for (int i = 1; i < 100_000; i++) {
-            var extent = new KeyExtent(tableId, new Text(String.format("%10d", i)),
-                    new Text(String.format("%10d", i - 1)));
-            extents.add(extent);
-        }
-
-        ServerIteratorOptions.compressOption(aconf, iterSetting, "k1", dataOutput -> {
-            dataOutput.writeInt(extents.size());
-            for (var extent : extents) {
-                extent.writeTo(dataOutput);
-            }
+    Set<KeyExtent> extents2 =
+        ServerIteratorOptions.decompressOption(iterSetting.getOptions(), "k1", dataInput -> {
+          int num = dataInput.readInt();
+          HashSet<KeyExtent> es = new HashSet<KeyExtent>();
+          for (int i = 0; i < num; i++) {
+            es.add(KeyExtent.readFrom(dataInput));
+          }
+          return es;
         });
 
-        // expected minimum size of data, will be larger
-        int expMinSize = 100_000 * (4 + 10 + 10);
-        System.out.println(iterSetting.getOptions().get("k1").length());
-        assertTrue(iterSetting.getOptions().get("k1").length() > expMinSize);
+    assertEquals(extents, extents2);
+    assertNotSame(extents, extents2);
+  }
 
-        Set<KeyExtent> extents2 =
-                ServerIteratorOptions.decompressOption(iterSetting.getOptions(), "k1", dataInput -> {
-                    int num = dataInput.readInt();
-                    HashSet<KeyExtent> es = new HashSet<KeyExtent>();
-                    for (int i = 0; i < num; i++) {
-                        es.add(KeyExtent.readFrom(dataInput));
-                    }
-                    return es;
-                });
+  @Test
+  public void testSerializeGz() {
+    var aconf = SiteConfiguration.empty()
+        .withOverrides(
+            Map.of(Property.GENERAL_SERVER_ITERATOR_OPTIONS_COMPRESSION_ALGO.getKey(), "gz"))
+        .build();
 
-        assertEquals(extents, extents2);
-        assertNotSame(extents, extents2);
+    IteratorSetting iterSetting = new IteratorSetting(100, "ti", "TestIter.class");
+
+    Set<KeyExtent> extents = new HashSet<>();
+    TableId tableId = TableId.of("1234");
+
+    for (int i = 1; i < 100_000; i++) {
+      var extent = new KeyExtent(tableId, new Text(String.format("%10d", i)),
+          new Text(String.format("%10d", i - 1)));
+      extents.add(extent);
     }
 
-    @Test
-    public void testSerializeGz() {
-        var aconf = SiteConfiguration.empty()
-                .withOverrides(
-                        Map.of(Property.GENERAL_SERVER_ITERATOR_OPTIONS_COMPRESSION_ALGO.getKey(), "gz"))
-                .build();
+    ServerIteratorOptions.compressOption(aconf, iterSetting, "k1", dataOutput -> {
+      dataOutput.writeInt(extents.size());
+      for (var extent : extents) {
+        extent.writeTo(dataOutput);
+      }
+    });
 
-        IteratorSetting iterSetting = new IteratorSetting(100, "ti", "TestIter.class");
+    // expected minimum size of data
+    int expMinSize = 100_000 * (4 + 10 + 10);
+    System.out.println(iterSetting.getOptions().get("k1").length());
+    // should be smaller than the expected min size because of compression
+    assertTrue(iterSetting.getOptions().get("k1").length() < expMinSize);
 
-        Set<KeyExtent> extents = new HashSet<>();
-        TableId tableId = TableId.of("1234");
-
-        for (int i = 1; i < 100_000; i++) {
-            var extent = new KeyExtent(tableId, new Text(String.format("%10d", i)),
-                    new Text(String.format("%10d", i - 1)));
-            extents.add(extent);
-        }
-
-        ServerIteratorOptions.compressOption(aconf, iterSetting, "k1", dataOutput -> {
-            dataOutput.writeInt(extents.size());
-            for (var extent : extents) {
-                extent.writeTo(dataOutput);
-            }
+    Set<KeyExtent> extents2 =
+        ServerIteratorOptions.decompressOption(iterSetting.getOptions(), "k1", dataInput -> {
+          int num = dataInput.readInt();
+          HashSet<KeyExtent> es = new HashSet<KeyExtent>();
+          for (int i = 0; i < num; i++) {
+            es.add(KeyExtent.readFrom(dataInput));
+          }
+          return es;
         });
 
-        // expected minimum size of data
-        int expMinSize = 100_000 * (4 + 10 + 10);
-        System.out.println(iterSetting.getOptions().get("k1").length());
-        // should be smaller than the expected min size because of compression
-        assertTrue(iterSetting.getOptions().get("k1").length() < expMinSize);
-
-        Set<KeyExtent> extents2 =
-                ServerIteratorOptions.decompressOption(iterSetting.getOptions(), "k1", dataInput -> {
-                    int num = dataInput.readInt();
-                    HashSet<KeyExtent> es = new HashSet<KeyExtent>();
-                    for (int i = 0; i < num; i++) {
-                        es.add(KeyExtent.readFrom(dataInput));
-                    }
-                    return es;
-                });
-
-        assertEquals(extents, extents2);
-    }
+    assertEquals(extents, extents2);
+  }
 }

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletManagementIteratorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletManagementIteratorIT.java
@@ -103,7 +103,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
@@ -334,8 +333,6 @@ public class TabletManagementIteratorIT extends AccumuloClusterHarness {
       // clean up
       dropTables(client, t1, t2, t3, t4, metaCopy1, metaCopy2, metaCopy3, metaCopy4, metaCopy5,
           metaCopy6);
-    } finally {
-      super.teardownCluster();
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletManagementIteratorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletManagementIteratorIT.java
@@ -457,7 +457,8 @@ public class TabletManagementIteratorIT extends AccumuloClusterHarness {
     Map<KeyExtent,Set<TabletManagement.ManagementAction>> results = new HashMap<>();
     List<KeyExtent> resultList = new ArrayList<>();
     try (Scanner scanner = client.createScanner(table, Authorizations.EMPTY)) {
-      TabletManagementIterator.configureScanner(((ClientContext) client).getConfiguration(), scanner, tabletMgmtParams);
+      TabletManagementIterator.configureScanner(((ClientContext) client).getConfiguration(),
+          scanner, tabletMgmtParams);
       scanner.updateScanIteratorOption("tabletChange", "debug", "1");
       for (Entry<Key,Value> e : scanner) {
         if (e != null) {


### PR DESCRIPTION
Closes #5639 

Most of this was copied from changes made in #5627. The changes made in #5627 could not be cleanly merged up since the code was too different so this PR integrates that code into main.