### PR TITLE
Improved metadata columns test coverage

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/SuspendingTServer.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/SuspendingTServer.java
@@ -33,7 +33,7 @@ public class SuspendingTServer {
   public final HostAndPort server;
   public final SteadyTime suspensionTime;
 
-  SuspendingTServer(HostAndPort server, SteadyTime suspensionTime) {
+  public SuspendingTServer(HostAndPort server, SteadyTime suspensionTime) {
     this.server = Objects.requireNonNull(server);
     this.suspensionTime = Objects.requireNonNull(suspensionTime);
   }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -113,6 +113,7 @@ import com.google.common.net.HostAndPort;
 public class TabletMetadata {
 
   private static final Logger log = LoggerFactory.getLogger(TabletMetadata.class);
+  private Set<ColumnType> callLog;
 
   private final TableId tableId;
   private final Text prevEndRow;
@@ -148,6 +149,7 @@ public class TabletMetadata {
   private final TServerInstance migration;
 
   private TabletMetadata(Builder tmBuilder) {
+    this.callLog = new HashSet<>();
     this.tableId = tmBuilder.tableId;
     this.prevEndRow = tmBuilder.prevEndRow;
     this.sawPrevEndRow = tmBuilder.sawPrevEndRow;
@@ -471,6 +473,12 @@ public class TabletMetadata {
 
   }
 
+  // For testing. callLog is a set that adds ColumnTypes that are called during the testing on this
+  // TabletMetadata obj.
+  public void setCallLog(HashSet<ColumnType> callLog) {
+    this.callLog = callLog;
+  }
+
   public TableId getTableId() {
     return tableId;
   }
@@ -481,6 +489,8 @@ public class TabletMetadata {
 
   private void ensureFetched(ColumnType col) {
     Preconditions.checkState(fetchedCols.contains(col), "%s was not fetched", col);
+    // For testing. All ColumnTypes that get called in this object are added here
+    callLog.add(col);
   }
 
   public Text getPrevEndRow() {

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -113,7 +113,6 @@ import com.google.common.net.HostAndPort;
 public class TabletMetadata {
 
   private static final Logger log = LoggerFactory.getLogger(TabletMetadata.class);
-  private Set<ColumnType> callLog;
 
   private final TableId tableId;
   private final Text prevEndRow;
@@ -149,7 +148,6 @@ public class TabletMetadata {
   private final TServerInstance migration;
 
   private TabletMetadata(Builder tmBuilder) {
-    this.callLog = new HashSet<>();
     this.tableId = tmBuilder.tableId;
     this.prevEndRow = tmBuilder.prevEndRow;
     this.sawPrevEndRow = tmBuilder.sawPrevEndRow;
@@ -473,12 +471,6 @@ public class TabletMetadata {
 
   }
 
-  // For testing. callLog is a set that adds ColumnTypes that are called during the testing on this
-  // TabletMetadata obj.
-  public void setCallLog(HashSet<ColumnType> callLog) {
-    this.callLog = callLog;
-  }
-
   public TableId getTableId() {
     return tableId;
   }
@@ -489,8 +481,6 @@ public class TabletMetadata {
 
   private void ensureFetched(ColumnType col) {
     Preconditions.checkState(fetchedCols.contains(col), "%s was not fetched", col);
-    // For testing. All ColumnTypes that get called in this object are added here
-    callLog.add(col);
   }
 
   public Text getPrevEndRow() {

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
@@ -141,7 +141,6 @@ public class TabletMetadataTest {
     DIRECTORY_COLUMN.put(mutation, new Value("t-0001757"));
     FLUSH_COLUMN.put(mutation, new Value("6"));
     TIME_COLUMN.put(mutation, new Value("M123456789"));
-    Value opidValue1 = new Value("SPLITTING:FATE:META:12345678-9abc-def1-2345-6789abcdef12");
     var opid = TabletOperationId.from(TabletOperationType.SPLITTING,
         FateId.from(FateInstanceType.META, UUID.randomUUID()));
     OPID_COLUMN.put(mutation, new Value(opid.canonical()));
@@ -192,6 +191,8 @@ public class TabletMetadataTest {
 
     SteadyTime suspensionTime = SteadyTime.from(1000L, TimeUnit.MILLISECONDS);
     TServerInstance ser1 = new TServerInstance(HostAndPort.fromParts("server1", 8555), "s001");
+    SuspendingTServer suspendingTServer =
+        new SuspendingTServer(HostAndPort.fromParts("server1", 8555), suspensionTime);
     Value suspend = SuspendingTServer.toValue(ser1, suspensionTime);
     SUSPEND_COLUMN.put(mutation, suspend);
 
@@ -231,7 +232,7 @@ public class TabletMetadataTest {
     allColumns.remove(OPID);
     assertFalse(tm.getHostingRequested());
     allColumns.remove(HOSTING_REQUESTED);
-    assertEquals(suspensionTime, tm.getSuspend().suspensionTime);
+    assertEquals(suspendingTServer, tm.getSuspend());
     allColumns.remove(SUSPEND);
     assertEquals("OK", tm.getCloned());
     allColumns.remove(CLONED);

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
@@ -66,7 +66,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.lang.reflect.Constructor;
 import java.time.Duration;
 import java.util.AbstractMap;
-import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -125,7 +124,7 @@ public class TabletMetadataTest {
 
   @Test
   public void testAllColumns() {
-    List<ColumnType> allColumns = new ArrayList<>(List.of(ColumnType.values()));
+    Set<ColumnType> allColumns = EnumSet.allOf(ColumnType.class);
 
     KeyExtent extent = new KeyExtent(TableId.of("5"), new Text("df"), new Text("da"));
 

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
@@ -279,10 +279,8 @@ public class TabletMetadataTest {
     assertEquals(tsi, tm.getMigration());
     allColumns.remove(MIGRATION);
 
-    /*
-     * Testing that all the columns are tested
-     */
-    assertTrue(allColumns.isEmpty());
+    assertTrue(allColumns.isEmpty(),
+        "Not all columns are testing. Add testing to remaining columns.");
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
@@ -33,14 +33,27 @@ import static org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSec
 import static org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily.AVAILABILITY_COLUMN;
 import static org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily.MERGEABILITY_COLUMN;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.AVAILABILITY;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.CLONED;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.COMPACTED;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.DIR;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.ECOMP;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.FILES;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.FLUSH_ID;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.FLUSH_NONCE;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.HOSTING_REQUESTED;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LAST;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LOADED;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LOCATION;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LOGS;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.MERGEABILITY;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.MERGED;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.MIGRATION;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.OPID;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.PREV_ROW;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.SCANS;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.SELECTED;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.SUSPEND;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.TIME;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.UNSPLITTABLE;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.USER_COMPACTION_REQUESTED;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -110,11 +123,14 @@ import org.junit.jupiter.api.Test;
 import com.google.common.net.HostAndPort;
 
 public class TabletMetadataTest {
-  private HashSet<ColumnType> recordedCalls = new HashSet<>();
 
   @Test
   public void testAllColumns() {
-    var allColumns = Arrays.stream(TabletMetadata.ColumnType.class.getEnumConstants());
+    Set<ColumnType> currentTestedColumns = new HashSet<>(Arrays.asList(LOCATION, PREV_ROW, FILES, LAST, LOADED, SCANS, DIR,
+            TIME, CLONED, FLUSH_ID, FLUSH_NONCE, LOGS, SUSPEND, ECOMP, MERGED, AVAILABILITY, HOSTING_REQUESTED, OPID,
+            SELECTED, COMPACTED, USER_COMPACTION_REQUESTED, UNSPLITTABLE, MERGEABILITY, MIGRATION));
+    List<ColumnType> allColumns = List.of(ColumnType.values());
+
     KeyExtent extent = new KeyExtent(TableId.of("5"), new Text("df"), new Text("da"));
 
     Mutation mutation = TabletColumnFamily.createPrevRowMutation(extent);
@@ -197,8 +213,6 @@ public class TabletMetadataTest {
     TabletMetadata tm = TabletMetadata.convertRow(rowMap.entrySet().iterator(),
         EnumSet.allOf(ColumnType.class), true, false);
 
-    tm.setCallLog(recordedCalls);
-
     assertTrue(tm.getCompacted().isEmpty());
     assertEquals(
         TabletMergeabilityMetadata
@@ -246,10 +260,9 @@ public class TabletMetadataTest {
     assertEquals(tsi, tm.getMigration());
 
     /*
-     * Testing that each ColumnType has tests within this method, as long as they're performed on
-     * the same TabletMetadata object
+     * Testing that each
      */
-    allColumns.forEach(columnType -> assertTrue(recordedCalls.contains(columnType)));
+    allColumns.forEach(columnType -> assertTrue(currentTestedColumns.contains(columnType)));
   }
 
   @Test


### PR DESCRIPTION
Improved the test coverage of metadata columns by adding a test within the testAllColumns method of TabletMetadataTest that fails if new columns are added to the metadata stores but are untested. Added tests for all current ColumnTypes that had not been tested.

Closes #5521