### PR TITLE
Refactor common code into Before/AfterEach blocks in FateIT

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
@@ -421,8 +421,8 @@ public class Fate<T> {
    */
   public void shutdown(boolean wait) {
     keepRunning.set(false);
+    executor.shutdownNow();
     if (wait) {
-      executor.shutdownNow();
       while (!executor.isTerminated()) {
         try {
           executor.awaitTermination(1, SECONDS);
@@ -430,8 +430,6 @@ public class Fate<T> {
           throw new IllegalStateException(e);
         }
       }
-    } else {
-      executor.shutdown();
     }
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
@@ -421,6 +421,9 @@ public class Fate<T> {
    */
   public void shutdown(boolean wait) {
     keepRunning.set(false);
+    if (executor == null) {
+      return;
+    }
     executor.shutdownNow();
     if (wait) {
       while (!executor.isTerminated()) {

--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
@@ -346,7 +346,6 @@ public class FateIT {
     fate.seedTransaction("TestOperation", txid, new TestOperation(NS, TID), true, "Test Op");
     assertEquals(SUBMITTED, getTxStatus(zk, txid));
     assertTrue(fate.cancel(txid));
-    fate = null;
   }
 
   @Test


### PR DESCRIPTION
Each test case in FateIT was doing the same exact steps to setup a `Fate<Manager>` object. This PR moves that common setup into `@BeforeEach` and `@AfterEach` blocks.

It may be easier to look at 12599f236c2e34eda9e96ea6fb51dec14084bdeb. The other commit is purely formatting and the diff is larger due to whitespace differences.