### PR TITLE
Fixes 404 return code when calling tabletMergabilityInfo.

### DIFF
--- a/assemble/pom.xml
+++ b/assemble/pom.xml
@@ -62,6 +62,11 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
       <artifactId>jackson-jakarta-rs-base</artifactId>
       <optional>true</optional>

--- a/server/monitor/pom.xml
+++ b/server/monitor/pom.xml
@@ -44,6 +44,10 @@
       <artifactId>jackson-datatype-jdk8</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
     </dependency>

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/CustomObjectMapper.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/CustomObjectMapper.java
@@ -36,6 +36,7 @@ import org.apache.accumulo.monitor.next.serializers.ThriftSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import io.micrometer.core.instrument.Meter.Id;
 import io.micrometer.core.instrument.cumulative.CumulativeDistributionSummary;
@@ -59,6 +60,7 @@ public class CustomObjectMapper implements ContextResolver<ObjectMapper> {
     module.addSerializer(TabletId.class, new TabletIdSerializer());
     mapper.registerModule(module);
     mapper.registerModule(new Jdk8Module());
+    mapper.registerModule(new JavaTimeModule());
 
   }
 


### PR DESCRIPTION
Saw the following Error message in console log that mentioned the Duration datatype was not able to be serialized.
```
Java 8 date/time type `java.time.Duration` not supported by default: add Module "com.fasterxml.jackson.datatype:jackson-datatype-jsr310" to enable handling (through reference chain: java.util.Collections$SynchronizedRandomAccessList[1]->org.apache.accumulo.monitor.next.SystemInformation$SanitizedTabletInformation["tabletMergeabilityInfo"]->org.apache.accumulo.core.client.admin.TabletMergeabilityInfo["tabletMergeability"]->org.apache.accumulo.core.client.admin.TabletMergeability["delay"])
```
 Added the jackson JavaTimeModule to fix the 404 return.
 Tested locally and confirmed the 404 return code was fixed.