### PR TITLE
avoids reassignment of hosted tablet during shutdown

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -1819,8 +1819,12 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener, 
 
   // recovers state from the persistent transaction to shutdown a server
   public void shutdownTServer(TServerInstance server) {
-    nextEvent.event("Tablet Server shutdown requested for %s", server);
     serversToShutdown.add(server);
+    nextEvent.event("Tablet Server shutdown requested for %s", server);
+  }
+
+  public boolean isShuttingDown(TServerInstance server) {
+    return serversToShutdown.contains(server);
   }
 
   public EventCoordinator getEventCoordinator() {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -1818,13 +1818,12 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener, 
   }
 
   // recovers state from the persistent transaction to shutdown a server
-  public void shutdownTServer(TServerInstance server) {
-    serversToShutdown.add(server);
-    nextEvent.event("Tablet Server shutdown requested for %s", server);
-  }
-
-  public boolean isShuttingDown(TServerInstance server) {
-    return serversToShutdown.contains(server);
+  public boolean shutdownTServer(TServerInstance server) {
+    if (serversToShutdown.add(server)) {
+      nextEvent.event("Tablet Server shutdown requested for %s", server);
+      return true;
+    }
+    return false;
   }
 
   public EventCoordinator getEventCoordinator() {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/ManagerClientServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/ManagerClientServiceHandler.java
@@ -349,7 +349,14 @@ public class ManagerClientServiceHandler implements ManagerClientService.Iface {
           SecurityErrorCode.PERMISSION_DENIED);
     }
     log.info("Tablet Server {} has reported it's shutting down", tabletServer);
-    manager.tserverSet.tabletServerShuttingDown(tabletServer);
+    var tserver = new TServerInstance(tabletServer);
+    if (!manager.isShuttingDown(tserver)) {
+      Fate<Manager> fate = manager.fate();
+      long tid = fate.startTransaction();
+      String msg = "Shutdown tserver " + tabletServer;
+      fate.seedTransaction("ShutdownTServer", tid,
+          new TraceRepo<>(new ShutdownTServer(tserver, false)), true, msg);
+    }
   }
 
   @Override

--- a/server/manager/src/main/java/org/apache/accumulo/manager/ManagerClientServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/ManagerClientServiceHandler.java
@@ -350,7 +350,9 @@ public class ManagerClientServiceHandler implements ManagerClientService.Iface {
     }
     log.info("Tablet Server {} has reported it's shutting down", tabletServer);
     var tserver = new TServerInstance(tabletServer);
-    if (!manager.isShuttingDown(tserver)) {
+    if (manager.shutdownTServer(tserver)) {
+      // If there is an exception seeding the fate tx this should cause the RPC to fail which should
+      // cause the tserver to halt. Because of that not making an attempt to handle failure here.
       Fate<Manager> fate = manager.fate();
       long tid = fate.startTransaction();
       String msg = "Shutdown tserver " + tabletServer;

--- a/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/ShutdownTServerTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/ShutdownTServerTest.java
@@ -55,8 +55,7 @@ public class ShutdownTServerTest {
     // Put in a table info record, don't care what
     status.tableMap.put("a_table", new TableInfo());
 
-    manager.shutdownTServer(tserver);
-    EasyMock.expectLastCall().once();
+    EasyMock.expect(manager.shutdownTServer(tserver)).andReturn(true).once();
     EasyMock.expect(manager.onlineTabletServers()).andReturn(Collections.singleton(tserver));
     EasyMock.expect(manager.getConnection(tserver)).andReturn(tserverCnxn);
     EasyMock.expect(tserverCnxn.getTableMap(false)).andReturn(status);
@@ -74,8 +73,7 @@ public class ShutdownTServerTest {
 
     // reset the table map to the empty set to simulate all tablets unloaded
     status.tableMap = new HashMap<>();
-    manager.shutdownTServer(tserver);
-    EasyMock.expectLastCall().once();
+    EasyMock.expect(manager.shutdownTServer(tserver)).andReturn(false).once();
     EasyMock.expect(manager.onlineTabletServers()).andReturn(Collections.singleton(tserver));
     EasyMock.expect(manager.getConnection(tserver)).andReturn(tserverCnxn);
     EasyMock.expect(tserverCnxn.getTableMap(false)).andReturn(status);


### PR DESCRIPTION
When a tablet server is gracefully shutdown it notifies the manager it is shutting down. The manager would remove the server from the set of live tservers which caused the manger to treat all tablets on that tserver as assigned to dead tservers.

Saw this when debugging a failure with GracefulShutdownIT. Saw the manager initiate log recovery and reassignment for the root tablet before it unloaded from the tserver that was shutting down. This caused errors with the metadata tablet consistency check during unload of the root tablet because the manager had modified the tablet metadata before unload.

This fix modifies the tablet server to use the existing fate operation for shutting down a tserver.