### PR TITLE
Restores deprecated column visibility code

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/security/ColumnVisibility.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/ColumnVisibility.java
@@ -20,13 +20,25 @@ package org.apache.accumulo.core.security;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.TreeSet;
+import java.util.function.Supplier;
 
 import org.apache.accumulo.access.AccessExpression;
 import org.apache.accumulo.access.InvalidAccessExpressionException;
+import org.apache.accumulo.core.data.ArrayByteSequence;
+import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.util.BadArgumentException;
 import org.apache.accumulo.core.util.TextUtil;
 import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.WritableComparator;
+
+import com.google.common.base.Suppliers;
 
 /**
  * Validate the column visibility is a valid expression and set the visibility for a Mutation. See
@@ -60,14 +72,18 @@ import org.apache.hadoop.io.Text;
  * <p>
  * In addition to the base set of visibilities, any character can be used in the expression if it is
  * quoted. If the quoted term contains '&quot;' or '\', then escape the character with '\'. The
- * {@link AccessExpression#quote(String)} method can be used to properly quote and escape terms
- * automatically. The following is an example of a quoted term:
+ * {@link #quote(String)} method can be used to properly quote and escape terms automatically. The
+ * following is an example of a quoted term:
  *
  * <pre>
  * &quot;A#C&quot; &amp; B
  * </pre>
  */
 public class ColumnVisibility {
+
+  // This functionality is deprecated so its setup as a supplier so it is only computed if the
+  // deprecated functionality is called.
+  private final Supplier<Node> nodeSupplier;
   private final byte[] expression;
 
   /**
@@ -77,6 +93,390 @@ public class ColumnVisibility {
    */
   public byte[] getExpression() {
     return expression;
+  }
+
+  /**
+   * The node types in a parse tree for a visibility expression.
+   */
+  @Deprecated(since = "4.0.0")
+  public enum NodeType {
+    EMPTY, TERM, OR, AND,
+  }
+
+  /**
+   * All empty nodes are equal and represent the same value.
+   */
+  private static final Node EMPTY_NODE = new Node(NodeType.EMPTY, 0);
+
+  /**
+   * A node in the parse tree for a visibility expression.
+   */
+  @Deprecated(since = "4.0.0")
+  public static class Node {
+    /**
+     * An empty list of nodes.
+     */
+    public static final List<Node> EMPTY = Collections.emptyList();
+    final NodeType type;
+    final int start;
+    int end;
+    List<Node> children = EMPTY;
+
+    public Node(NodeType type, int start) {
+      this.type = type;
+      this.start = start;
+      this.end = start + 1;
+    }
+
+    public Node(int start, int end) {
+      this.type = NodeType.TERM;
+      this.start = start;
+      this.end = end;
+    }
+
+    public void add(Node child) {
+      if (children == EMPTY) {
+        children = new ArrayList<>();
+      }
+
+      children.add(child);
+    }
+
+    public NodeType getType() {
+      return type;
+    }
+
+    public List<Node> getChildren() {
+      return children;
+    }
+
+    public int getTermStart() {
+      return start;
+    }
+
+    public int getTermEnd() {
+      return end;
+    }
+
+    public ByteSequence getTerm(byte[] expression) {
+      if (type != NodeType.TERM) {
+        throw new IllegalStateException();
+      }
+
+      if (expression[start] == '"') {
+        // its a quoted term
+        int qStart = start + 1;
+        int qEnd = end - 1;
+
+        return new ArrayByteSequence(expression, qStart, qEnd - qStart);
+      }
+      return new ArrayByteSequence(expression, start, end - start);
+    }
+  }
+
+  /**
+   * A node comparator. Nodes sort according to node type, terms sort lexicographically. AND and OR
+   * nodes sort by number of children, or if the same by corresponding children.
+   */
+  @Deprecated(since = "4.0.0")
+  public static class NodeComparator implements Comparator<Node>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+    final byte[] text;
+
+    /**
+     * Creates a new comparator.
+     *
+     * @param text expression string, encoded in UTF-8
+     */
+    public NodeComparator(byte[] text) {
+      this.text = text;
+    }
+
+    @Override
+    public int compare(Node a, Node b) {
+      int diff = a.type.ordinal() - b.type.ordinal();
+      if (diff != 0) {
+        return diff;
+      }
+      switch (a.type) {
+        case EMPTY:
+          return 0; // All empty nodes are the same
+        case TERM:
+          return WritableComparator.compareBytes(text, a.start, a.end - a.start, text, b.start,
+              b.end - b.start);
+        case OR:
+        case AND:
+          diff = a.children.size() - b.children.size();
+          if (diff != 0) {
+            return diff;
+          }
+          for (int i = 0; i < a.children.size(); i++) {
+            diff = compare(a.children.get(i), b.children.get(i));
+            if (diff != 0) {
+              return diff;
+            }
+          }
+      }
+      return 0;
+    }
+  }
+
+  /*
+   * Convenience method that delegates to normalize with a new NodeComparator constructed using the
+   * supplied expression.
+   */
+  @Deprecated(since = "4.0.0")
+  public static Node normalize(Node root, byte[] expression) {
+    return normalize(root, expression, new NodeComparator(expression));
+  }
+
+  // @formatter:off
+  /*
+   * Walks an expression's AST in order to:
+   *  1) roll up expressions with the same operant (`a&(b&c) becomes a&b&c`)
+   *  2) sort labels lexicographically (permutations of `a&b&c` are re-ordered to appear as `a&b&c`)
+   *  3) dedupes labels (`a&b&a` becomes `a&b`)
+   */
+  // @formatter:on
+  @Deprecated(since = "4.0.0")
+  public static Node normalize(Node root, byte[] expression, NodeComparator comparator) {
+    if (root.type != NodeType.TERM) {
+      TreeSet<Node> rolledUp = new TreeSet<>(comparator);
+      java.util.Iterator<Node> itr = root.children.iterator();
+      while (itr.hasNext()) {
+        Node c = normalize(itr.next(), expression, comparator);
+        if (c.type == root.type) {
+          rolledUp.addAll(c.children);
+          itr.remove();
+        }
+      }
+      rolledUp.addAll(root.children);
+      root.children.clear();
+      root.children.addAll(rolledUp);
+
+      // need to promote a child if it's an only child
+      if (root.children.size() == 1) {
+        return root.children.get(0);
+      }
+    }
+
+    return root;
+  }
+
+  /*
+   * Walks an expression's AST and appends a string representation to a supplied StringBuilder. This
+   * method adds parens where necessary.
+   */
+  @Deprecated(since = "4.0.0")
+  public static void stringify(Node root, byte[] expression, StringBuilder out) {
+    if (root.type == NodeType.TERM) {
+      out.append(new String(expression, root.start, root.end - root.start, UTF_8));
+    } else {
+      String sep = "";
+      for (Node c : root.children) {
+        out.append(sep);
+        boolean parens = (c.type != NodeType.TERM && root.type != c.type);
+        if (parens) {
+          out.append("(");
+        }
+        stringify(c, expression, out);
+        if (parens) {
+          out.append(")");
+        }
+        sep = root.type == NodeType.AND ? "&" : "|";
+      }
+    }
+  }
+
+  /**
+   * Generates a byte[] that represents a normalized, but logically equivalent, form of this
+   * evaluator's expression.
+   *
+   * @return normalized expression in byte[] form
+   */
+  @Deprecated(since = "4.0.0")
+  public byte[] flatten() {
+    Node normRoot = normalize(nodeSupplier.get(), expression);
+    StringBuilder builder = new StringBuilder(expression.length);
+    stringify(normRoot, expression, builder);
+    return builder.toString().getBytes(UTF_8);
+  }
+
+  @Deprecated
+  private static class ColumnVisibilityParser {
+    private int index = 0;
+    private int parens = 0;
+
+    public ColumnVisibilityParser() {}
+
+    Node parse(byte[] expression) {
+      if (expression.length > 0) {
+        Node node = parse_(expression);
+        if (node == null) {
+          throw new BadArgumentException("operator or missing parens",
+              new String(expression, UTF_8), index - 1);
+        }
+        if (parens != 0) {
+          throw new BadArgumentException("parenthesis mis-match", new String(expression, UTF_8),
+              index - 1);
+        }
+        return node;
+      }
+      return null;
+    }
+
+    Node processTerm(int start, int end, Node expr, byte[] expression) {
+      if (start != end) {
+        if (expr != null) {
+          throw new BadArgumentException("expression needs | or &", new String(expression, UTF_8),
+              start);
+        }
+        return new Node(start, end);
+      }
+      if (expr == null) {
+        throw new BadArgumentException("empty term", new String(expression, UTF_8), start);
+      }
+      return expr;
+    }
+
+    Node parse_(byte[] expression) {
+      Node result = null;
+      Node expr = null;
+      int wholeTermStart = index;
+      int subtermStart = index;
+      boolean subtermComplete = false;
+
+      while (index < expression.length) {
+        switch (expression[index++]) {
+          case '&':
+            expr = processTerm(subtermStart, index - 1, expr, expression);
+            if (result != null) {
+              if (!result.type.equals(NodeType.AND)) {
+                throw new BadArgumentException("cannot mix & and |", new String(expression, UTF_8),
+                    index - 1);
+              }
+            } else {
+              result = new Node(NodeType.AND, wholeTermStart);
+            }
+            result.add(expr);
+            expr = null;
+            subtermStart = index;
+            subtermComplete = false;
+            break;
+          case '|':
+            expr = processTerm(subtermStart, index - 1, expr, expression);
+            if (result != null) {
+              if (!result.type.equals(NodeType.OR)) {
+                throw new BadArgumentException("cannot mix | and &", new String(expression, UTF_8),
+                    index - 1);
+              }
+            } else {
+              result = new Node(NodeType.OR, wholeTermStart);
+            }
+            result.add(expr);
+            expr = null;
+            subtermStart = index;
+            subtermComplete = false;
+            break;
+          case '(':
+            parens++;
+            if (subtermStart != index - 1 || expr != null) {
+              throw new BadArgumentException("expression needs & or |",
+                  new String(expression, UTF_8), index - 1);
+            }
+            expr = parse_(expression);
+            subtermStart = index;
+            subtermComplete = false;
+            break;
+          case ')':
+            parens--;
+            Node child = processTerm(subtermStart, index - 1, expr, expression);
+            if (child == null && result == null) {
+              throw new BadArgumentException("empty expression not allowed",
+                  new String(expression, UTF_8), index);
+            }
+            if (result == null) {
+              return child;
+            }
+            if (result.type == child.type) {
+              for (Node c : child.children) {
+                result.add(c);
+              }
+            } else {
+              result.add(child);
+            }
+            result.end = index - 1;
+            return result;
+          case '"':
+            if (subtermStart != index - 1) {
+              throw new BadArgumentException("expression needs & or |",
+                  new String(expression, UTF_8), index - 1);
+            }
+
+            while (index < expression.length && expression[index] != '"') {
+              if (expression[index] == '\\') {
+                index++;
+                if (index == expression.length
+                    || (expression[index] != '\\' && expression[index] != '"')) {
+                  throw new BadArgumentException("invalid escaping within quotes",
+                      new String(expression, UTF_8), index - 1);
+                }
+              }
+              index++;
+            }
+
+            if (index == expression.length) {
+              throw new BadArgumentException("unclosed quote", new String(expression, UTF_8),
+                  subtermStart);
+            }
+
+            if (subtermStart + 1 == index) {
+              throw new BadArgumentException("empty term", new String(expression, UTF_8),
+                  subtermStart);
+            }
+
+            index++;
+
+            subtermComplete = true;
+
+            break;
+          default:
+            if (subtermComplete) {
+              throw new BadArgumentException("expression needs & or |",
+                  new String(expression, UTF_8), index - 1);
+            }
+
+            byte c = expression[index - 1];
+            if (!Authorizations.isValidAuthChar(c)) {
+              throw new BadArgumentException("bad character (" + c + ")",
+                  new String(expression, UTF_8), index - 1);
+            }
+        }
+      }
+      Node child = processTerm(subtermStart, index, expr, expression);
+      if (result != null) {
+        result.add(child);
+        result.end = index;
+      } else {
+        result = child;
+      }
+      if (result.type != NodeType.TERM) {
+        if (result.children.size() < 2) {
+          throw new BadArgumentException("missing term", new String(expression, UTF_8), index);
+        }
+      }
+      return result;
+    }
+  }
+
+  private Node createNodeTree(byte[] expression) {
+    if (expression != null && expression.length > 0) {
+      ColumnVisibilityParser p = new ColumnVisibilityParser();
+      return p.parse(expression);
+    } else {
+      return EMPTY_NODE;
+    }
   }
 
   private static final byte[] EMPTY_BYTES = new byte[0];
@@ -89,6 +489,7 @@ public class ColumnVisibility {
    */
   public ColumnVisibility() {
     expression = EMPTY_BYTES;
+    nodeSupplier = Suppliers.memoize(() -> createNodeTree(expression));
   }
 
   /**
@@ -126,6 +527,7 @@ public class ColumnVisibility {
       // exceptions itself.
       throw new BadArgumentException(e);
     }
+    nodeSupplier = Suppliers.memoize(() -> createNodeTree(this.expression));
   }
 
   /**
@@ -138,6 +540,7 @@ public class ColumnVisibility {
   public ColumnVisibility(AccessExpression expression) {
     // AccessExpression is a validated immutable object, so no need to re validate
     this.expression = expression.getExpression().getBytes(UTF_8);
+    nodeSupplier = Suppliers.memoize(() -> createNodeTree(this.expression));
   }
 
   @Override
@@ -170,5 +573,54 @@ public class ColumnVisibility {
   @Override
   public int hashCode() {
     return Arrays.hashCode(expression);
+  }
+
+  /**
+   * Gets the parse tree for this column visibility.
+   *
+   * @return parse tree node
+   */
+  @Deprecated(since = "4.0.0")
+  public Node getParseTree() {
+    return nodeSupplier.get();
+  }
+
+  /**
+   * Properly quotes terms in a column visibility expression. If no quoting is needed, then nothing
+   * is done.
+   *
+   * <p>
+   * Examples of using quote :
+   *
+   * <pre>
+   * import static org.apache.accumulo.core.security.ColumnVisibility.quote;
+   *   .
+   *   .
+   *   .
+   * String s = quote(&quot;A#C&quot;) + &quot;&amp;&quot; + quote(&quot;FOO&quot;);
+   * ColumnVisibility cv = new ColumnVisibility(s);
+   * </pre>
+   *
+   * @param term term to quote
+   * @return quoted term (unquoted if unnecessary)
+   * @deprecated use {@link AccessExpression#quote(String)}
+   */
+  @Deprecated(since = "4.0.0")
+  public static String quote(String term) {
+    return AccessExpression.quote(term);
+  }
+
+  /**
+   * Properly quotes terms in a column visibility expression. If no quoting is needed, then nothing
+   * is done.
+   *
+   * @param term term to quote, encoded as UTF-8 bytes
+   * @return quoted term (unquoted if unnecessary), encoded as UTF-8 bytes
+   * @see #quote(String)
+   * @deprecated use {@link AccessExpression#quote(byte[])}
+   */
+  @Deprecated(since = "4.0.0")
+  public static byte[] quote(byte[] term) {
+    return AccessExpression.quote(term);
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/security/VisibilityEvaluator.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/VisibilityEvaluator.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.security;
+
+import org.apache.accumulo.access.AccessEvaluator;
+import org.apache.accumulo.access.InvalidAccessExpressionException;
+import org.apache.accumulo.core.data.ArrayByteSequence;
+
+/**
+ * A class which evaluates visibility expressions against a set of authorizations.
+ *
+ * @deprecated since 4.0.0 Use Accumulo Access library instead
+ */
+@Deprecated(since = "4.0.0")
+public class VisibilityEvaluator {
+  private final AccessEvaluator accessEvaluator;
+
+  /**
+   * Properly escapes an authorization string. The string can be quoted if desired.
+   *
+   * @param auth authorization string, as UTF-8 encoded bytes
+   * @param quote true to wrap escaped authorization in quotes
+   * @return escaped authorization string
+   */
+  public static byte[] escape(byte[] auth, boolean quote) {
+    int escapeCount = 0;
+
+    for (byte value : auth) {
+      if (value == '"' || value == '\\') {
+        escapeCount++;
+      }
+    }
+
+    if (escapeCount > 0 || quote) {
+      byte[] escapedAuth = new byte[auth.length + escapeCount + (quote ? 2 : 0)];
+      int index = quote ? 1 : 0;
+      for (byte b : auth) {
+        if (b == '"' || b == '\\') {
+          escapedAuth[index++] = '\\';
+        }
+        escapedAuth[index++] = b;
+      }
+
+      if (quote) {
+        escapedAuth[0] = '"';
+        escapedAuth[escapedAuth.length - 1] = '"';
+      }
+
+      auth = escapedAuth;
+    }
+    return auth;
+  }
+
+  /**
+   * Creates a new evaluator for the authorizations found in the given container.
+   *
+   * @since 1.7.0
+   */
+  public VisibilityEvaluator(AuthorizationContainer authsContainer) {
+    // TODO need to look into efficiency and correctness of this
+    this.accessEvaluator =
+        AccessEvaluator.of(auth -> authsContainer.contains(new ArrayByteSequence(auth)));
+  }
+
+  /**
+   * Creates a new evaluator for the given collection of authorizations. Each authorization string
+   * is escaped before handling, and the original strings are unchanged.
+   *
+   * @param authorizations authorizations object
+   */
+  public VisibilityEvaluator(Authorizations authorizations) {
+    this.accessEvaluator = AccessEvaluator.of(authorizations.toAccessAuthorizations());
+  }
+
+  /**
+   * Evaluates the given column visibility against the authorizations provided to this evaluator. A
+   * visibility passes evaluation if all authorizations in it are contained in those known to the
+   * evaluator, and all AND and OR subexpressions have at least two children.
+   *
+   * @param visibility column visibility to evaluate
+   * @return true if visibility passes evaluation
+   * @throws VisibilityParseException if an AND or OR subexpression has less than two children, or a
+   *         subexpression is of an unknown type
+   */
+  public boolean evaluate(ColumnVisibility visibility) throws VisibilityParseException {
+    try {
+      return accessEvaluator.canAccess(visibility.getExpression());
+    } catch (InvalidAccessExpressionException e) {
+      // This is thrown for compatability with the exception this class used to evaluate expressions
+      // itself.
+      throw new VisibilityParseException(e);
+    }
+  }
+}

--- a/core/src/test/java/org/apache/accumulo/core/security/ColumnVisibilityTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/security/ColumnVisibilityTest.java
@@ -19,13 +19,25 @@
 package org.apache.accumulo.core.security;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.Test;
 
 public class ColumnVisibilityTest {
+
+  @SuppressWarnings("deprecation")
+  private static org.apache.accumulo.core.security.ColumnVisibility.NodeType AND =
+      org.apache.accumulo.core.security.ColumnVisibility.NodeType.AND;
+  @SuppressWarnings("deprecation")
+  private static org.apache.accumulo.core.security.ColumnVisibility.NodeType OR =
+      org.apache.accumulo.core.security.ColumnVisibility.NodeType.OR;
+  @SuppressWarnings("deprecation")
+  private static org.apache.accumulo.core.security.ColumnVisibility.NodeType TERM =
+      org.apache.accumulo.core.security.ColumnVisibility.NodeType.TERM;
 
   private void shouldThrow(String... strings) {
     for (String s : strings) {
@@ -55,6 +67,14 @@ public class ColumnVisibilityTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
+  public void testEmptyFlatten() {
+    // empty visibility is valid
+    new ColumnVisibility().flatten();
+    new ColumnVisibility("").flatten();
+  }
+
+  @Test
   public void testSimple() {
     shouldNotThrow("test", "(one)");
   }
@@ -72,6 +92,14 @@ public class ColumnVisibilityTest {
     shouldThrow("a*b");
   }
 
+  @SuppressWarnings("deprecation")
+  public void normalized(String... values) {
+    for (int i = 0; i < values.length; i += 2) {
+      ColumnVisibility cv = new ColumnVisibility(values[i].getBytes(UTF_8));
+      assertArrayEquals(cv.flatten(), values[i + 1].getBytes(UTF_8));
+    }
+  }
+
   @Test
   public void testComplexCompound() {
     shouldNotThrow("(a|b)&(x|y)");
@@ -79,6 +107,17 @@ public class ColumnVisibilityTest {
     shouldNotThrow("A&FOO&(L|M)", "(A|B)&FOO&(L|M)", "A&B&(L|M|FOO)", "((A|B|C)|foo)&bar");
     shouldNotThrow("(one&two)|(foo&bar)", "(one|foo)&three", "one|foo|bar", "(one|foo)|bar",
         "((one|foo)|bar)&two");
+  }
+
+  @Test
+  public void testNormalization() {
+    normalized("a", "a", "(a)", "a", "b|a", "a|b", "(b)|a", "a|b", "(b|(a|c))&x", "x&(a|b|c)",
+        "(((a)))", "a");
+    final String normForm = "a&b&c";
+    normalized("b&c&a", normForm, "c&b&a", normForm, "a&(b&c)", normForm, "(a&c)&b", normForm);
+
+    // this an expression that's basically `expr | expr`
+    normalized("(d&c&b&a)|(b&c&a&d)", "a&b&c&d");
   }
 
   @Test
@@ -125,5 +164,106 @@ public class ColumnVisibilityTest {
     shouldNotThrow("A&\"B.D\"");
     shouldNotThrow("A&\"B\\\\D\"");
     shouldNotThrow("A&\"B\\\"D\"");
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void testToString() {
+    ColumnVisibility cv = new ColumnVisibility(ColumnVisibility.quote("a"));
+    assertEquals("[a]", cv.toString());
+
+    // multi-byte
+    cv = new ColumnVisibility(ColumnVisibility.quote("五"));
+    assertEquals("[\"五\"]", cv.toString());
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void testParseTree() {
+    var node = parse("(W)|(U&V)");
+    assertNode(node, OR, 0, 9);
+    assertNode(node.getChildren().get(0), TERM, 1, 2);
+    assertNode(node.getChildren().get(1), AND, 5, 8);
+  }
+
+  @Test
+  public void testParseTreeWithNoChildren() {
+    var node = parse("ABC");
+    assertNode(node, TERM, 0, 3);
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void testParseTreeWithTwoChildren() {
+    var node = parse("ABC|DEF");
+    assertNode(node, OR, 0, 7);
+    assertNode(node.getChildren().get(0), TERM, 0, 3);
+    assertNode(node.getChildren().get(1), TERM, 4, 7);
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void testParseTreeWithParenthesesAndTwoChildren() {
+    var node = parse("(ABC|DEF)");
+    assertNode(node, OR, 1, 8);
+    assertNode(node.getChildren().get(0), TERM, 1, 4);
+    assertNode(node.getChildren().get(1), TERM, 5, 8);
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void testParseTreeWithParenthesizedChildren() {
+    var node = parse("ABC|(DEF&GHI)");
+    assertNode(node, OR, 0, 13);
+    assertNode(node.getChildren().get(0), TERM, 0, 3);
+    assertNode(node.getChildren().get(1), AND, 5, 12);
+    assertNode(node.getChildren().get(1).children.get(0), TERM, 5, 8);
+    assertNode(node.getChildren().get(1).children.get(1), TERM, 9, 12);
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void testParseTreeWithMoreParentheses() {
+    var node = parse("(W)|(U&V)");
+    assertNode(node, OR, 0, 9);
+    assertNode(node.getChildren().get(0), TERM, 1, 2);
+    assertNode(node.getChildren().get(1), AND, 5, 8);
+    assertNode(node.getChildren().get(1).children.get(0), TERM, 5, 6);
+    assertNode(node.getChildren().get(1).children.get(1), TERM, 7, 8);
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void testEmptyParseTreesAreEqual() {
+    var comparator =
+        new org.apache.accumulo.core.security.ColumnVisibility.NodeComparator(new byte[] {});
+    var empty = new ColumnVisibility().getParseTree();
+    assertEquals(0, comparator.compare(empty, parse("")));
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void testParseTreesOrdering() {
+    byte[] expression = "(b&c&d)|((a|m)&y&z)|(e&f)".getBytes(UTF_8);
+    byte[] flattened = new ColumnVisibility(expression).flatten();
+
+    // Convert to String for indexOf convenience
+    String flat = new String(flattened, UTF_8);
+    assertTrue(flat.indexOf('e') < flat.indexOf('|'), "shortest expressions sort first");
+    assertTrue(flat.indexOf('b') < flat.indexOf('a'), "shortest children sort first");
+  }
+
+  @SuppressWarnings("deprecation")
+  private org.apache.accumulo.core.security.ColumnVisibility.Node parse(String s) {
+    ColumnVisibility v = new ColumnVisibility(s);
+    return v.getParseTree();
+  }
+
+  @SuppressWarnings("deprecation")
+  private void assertNode(org.apache.accumulo.core.security.ColumnVisibility.Node node,
+      org.apache.accumulo.core.security.ColumnVisibility.NodeType nodeType, int start, int end) {
+    assertEquals(node.type, nodeType);
+    assertEquals(start, node.start);
+    assertEquals(end, node.end);
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/security/VisibilityEvaluatorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/security/VisibilityEvaluatorTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.security;
+
+import static org.apache.accumulo.core.security.ColumnVisibility.quote;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.accumulo.core.util.ByteArraySet;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("deprecation")
+public class VisibilityEvaluatorTest {
+
+  @Test
+  public void testVisibilityEvaluator() throws VisibilityParseException {
+    VisibilityEvaluator ct = new VisibilityEvaluator(
+        new Authorizations(ByteArraySet.fromStrings("one", "two", "three", "four")));
+
+    // test for empty vis
+    assertTrue(ct.evaluate(new ColumnVisibility(new byte[0])));
+
+    // test for and
+    assertTrue(ct.evaluate(new ColumnVisibility("one&two")), "'and' test");
+
+    // test for or
+    assertTrue(ct.evaluate(new ColumnVisibility("foor|four")), "'or' test");
+
+    // test for and and or
+    assertTrue(ct.evaluate(new ColumnVisibility("(one&two)|(foo&bar)")), "'and' and 'or' test");
+
+    // test for false negatives
+    for (String marking : new String[] {"one", "one|five", "five|one", "(one)",
+        "(one&two)|(foo&bar)", "(one|foo)&three", "one|foo|bar", "(one|foo)|bar",
+        "((one|foo)|bar)&two"}) {
+      assertTrue(ct.evaluate(new ColumnVisibility(marking)), marking);
+    }
+
+    // test for false positives
+    for (String marking : new String[] {"five", "one&five", "five&one", "((one|foo)|bar)&goober"}) {
+      assertFalse(ct.evaluate(new ColumnVisibility(marking)), marking);
+    }
+  }
+
+  @Test
+  public void testQuotedExpressions() throws VisibilityParseException {
+
+    Authorizations auths = new Authorizations("A#C", "A\"C", "A\\C", "AC");
+    VisibilityEvaluator ct = new VisibilityEvaluator(auths);
+    runQuoteTest(ct);
+
+    // construct VisibilityEvaluator using another constructor and run test again
+    ct = new VisibilityEvaluator((AuthorizationContainer) auths);
+    runQuoteTest(ct);
+  }
+
+  private void runQuoteTest(VisibilityEvaluator ct) throws VisibilityParseException {
+    assertTrue(ct.evaluate(new ColumnVisibility(quote("A#C") + "|" + quote("A?C"))));
+    assertTrue(ct.evaluate(
+        new ColumnVisibility(new ColumnVisibility(quote("A#C") + "|" + quote("A?C")).flatten())));
+    assertTrue(ct.evaluate(new ColumnVisibility(quote("A\"C") + "&" + quote("A\\C"))));
+    assertTrue(ct.evaluate(
+        new ColumnVisibility(new ColumnVisibility(quote("A\"C") + "&" + quote("A\\C")).flatten())));
+    assertTrue(
+        ct.evaluate(new ColumnVisibility("(" + quote("A\"C") + "|B)&(" + quote("A#C") + "|D)")));
+
+    assertFalse(ct.evaluate(new ColumnVisibility(quote("A#C") + "&B")));
+
+    assertTrue(ct.evaluate(new ColumnVisibility(quote("A#C"))));
+    assertTrue(ct.evaluate(new ColumnVisibility("(" + quote("A#C") + ")")));
+  }
+
+  @Test
+  public void testQuote() {
+    assertEquals("\"A#C\"", quote("A#C"));
+    assertEquals("\"A\\\"C\"", quote("A\"C"));
+    assertEquals("\"A\\\"\\\\C\"", quote("A\"\\C"));
+    assertEquals("ACS", quote("ACS"));
+    assertEquals("\"九\"", quote("九"));
+    assertEquals("\"五十\"", quote("五十"));
+  }
+
+  @Test
+  public void testNonAscii() throws VisibilityParseException {
+    VisibilityEvaluator ct = new VisibilityEvaluator(new Authorizations("五", "六", "八", "九", "五十"));
+
+    assertTrue(ct.evaluate(new ColumnVisibility(quote("五") + "|" + quote("四"))));
+    assertFalse(ct.evaluate(new ColumnVisibility(quote("五") + "&" + quote("四"))));
+    assertTrue(
+        ct.evaluate(new ColumnVisibility(quote("五") + "&(" + quote("四") + "|" + quote("九") + ")")));
+    assertTrue(ct.evaluate(new ColumnVisibility("\"五\"&(\"四\"|\"五十\")")));
+    assertFalse(
+        ct.evaluate(new ColumnVisibility(quote("五") + "&(" + quote("四") + "|" + quote("三") + ")")));
+    assertFalse(ct.evaluate(new ColumnVisibility("\"五\"&(\"四\"|\"三\")")));
+  }
+}


### PR DESCRIPTION
Since column visibility changes are no longer being deprecated in 3.1.0, restored the code that was deprecated and then removed.

Made the following changes in this commit

 * Reverted commit d1caa6411c2f5c5deb3a89be4f3e2afb5abdf530
 * pulled changes from commit 355ef24bc512ab893f8f6bf33f8d3f4052f9ee10
 * Changed deprecated since 3.1.0 to 4.0.0