### PR TITLE
fixes race condition in ClientTabletCacheImpl

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientTabletCacheImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientTabletCacheImpl.java
@@ -682,9 +682,9 @@ public class ClientTabletCacheImpl extends ClientTabletCache {
     }
   }
 
-  private void lookupTablet(ClientContext context, Text row, LockCheckerSession lcSession, CachedTablet before)
-      throws AccumuloException, AccumuloSecurityException, TableNotFoundException,
-      InvalidTabletHostingRequestException {
+  private void lookupTablet(ClientContext context, Text row, LockCheckerSession lcSession,
+      CachedTablet before) throws AccumuloException, AccumuloSecurityException,
+      TableNotFoundException, InvalidTabletHostingRequestException {
     Text metadataRow = new Text(tableId.canonical());
     metadataRow.append(new byte[] {';'}, 0, 1);
     metadataRow.append(row.getBytes(), 0, row.getLength());
@@ -695,7 +695,8 @@ public class ClientTabletCacheImpl extends ClientTabletCache {
     }
 
     try (var unused = lookupLocks.lock(ptl.getExtent())) {
-      // Now that the lock is acquired, detect if another thread populated cache since the last time the cache was read.  If so then do not need to read from metadata store.
+      // Now that the lock is acquired, detect if another thread populated cache since the last time
+      // the cache was read. If so then do not need to read from metadata store.
       CachedTablet after = findTabletInCache(row);
       if (after != null && after != before && lcSession.checkLock(after) != null) {
         return;
@@ -863,8 +864,8 @@ public class ClientTabletCacheImpl extends ClientTabletCache {
   }
 
   private CachedTablet lookupTabletLocationAndCheckLock(ClientContext context, Text row,
-      LockCheckerSession lcSession, CachedTablet before) throws AccumuloException, AccumuloSecurityException,
-      TableNotFoundException, InvalidTabletHostingRequestException {
+      LockCheckerSession lcSession, CachedTablet before) throws AccumuloException,
+      AccumuloSecurityException, TableNotFoundException, InvalidTabletHostingRequestException {
     lookupTablet(context, row, lcSession, before);
     return lcSession.checkLock(findTabletInCache(row));
   }


### PR DESCRIPTION
Fixes the following race condition.

 1. Thread 1 reads the cache and finds it stale/missing
 2. Thread 2 reads the cache and finds it stale/missing
 3. Thread 2 goes through the entire process of reading metadata and updating the cache
 4. Thread 1 does the pre lock read of the cache (this reread of the cache causes the race condition).
 5. Thread 1 does the post lock read of the cache and finds its the same and unessecairly reads the metadata table

This change avoids reading from the cache twice before locking and updating and only reads once.  This way the cache entry used to make a decision after the lock is obtianed is the same one that was seen as stale.