### PR TITLE
Fixed ShutdownIT after recent Admin.stop change

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/functional/ShutdownIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ShutdownIT.java
@@ -34,6 +34,7 @@ import org.apache.accumulo.server.util.Admin;
 import org.apache.accumulo.test.TestIngest;
 import org.apache.accumulo.test.TestRandomDeletes;
 import org.apache.accumulo.test.VerifyIngest;
+import org.apache.accumulo.test.util.Wait;
 import org.junit.jupiter.api.Test;
 
 public class ShutdownIT extends ConfigurableMacBase {
@@ -128,6 +129,7 @@ public class ShutdownIT extends ConfigurableMacBase {
     log.info("Stopping " + doomed);
     assertEquals(0,
         cluster.exec(Admin.class, "stop", doomed.toHostPortString()).getProcess().waitFor());
+    Wait.waitFor(() -> c.instanceOperations().getServers(ServerId.Type.TABLET_SERVER).size() == 1);
     tabletServers = c.instanceOperations().getServers(ServerId.Type.TABLET_SERVER);
     assertEquals(1, tabletServers.size());
     assertNotEquals(tabletServers.iterator().next(), doomed);


### PR DESCRIPTION
The IT was expecting the tserver to be down, but now it may take a little time for the tserver to stop. Modified the test to wait for the tserver to stop.