### PR TITLE
Fixed NPE in LiveTServerSet

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/manager/LiveTServerSet.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/LiveTServerSet.java
@@ -222,13 +222,13 @@ public class LiveTServerSet implements ZooCacheWatcher {
   }
 
   public synchronized void startListeningForTabletServerChanges(Listener cback) {
-    scanServers();
     Objects.requireNonNull(cback);
     if (this.cback.compareAndSet(null, cback)) {
       this.context.getZooCache().addZooCacheWatcher(this);
     } else if (this.cback.get() != cback) {
       throw new IllegalStateException("Attempted to set different cback object");
     }
+    scanServers();
     ThreadPools.watchCriticalScheduledTask(this.context.getScheduledExecutor()
         .scheduleWithFixedDelay(this::scanServers, 5000, 5000, TimeUnit.MILLISECONDS));
   }


### PR DESCRIPTION
scanServers was being called before the callback object was set resulting in a NPE.