### PR TITLE
Add override for min maven version to version 3.9.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,7 @@
     <!-- versions-maven-plugin ignore patterns for snapshots, alpha, beta, milestones, and release candidates -->
     <maven.version.ignore>.+-SNAPSHOT,(?i).*(alpha|beta)[0-9.-]*,(?i).*[.-](m|rc)[0-9]+</maven.version.ignore>
     <minimalJavaBuildVersion>17</minimalJavaBuildVersion>
+    <minimalMavenBuildVersion>3.9.11</minimalMavenBuildVersion>
     <!-- timestamp for reproducible outputs, updated on release by the release plugin -->
     <project.build.outputTimestamp>2024-07-29T06:03:16Z</project.build.outputTimestamp>
     <rat.consoleOutput>true</rat.consoleOutput>

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
     <!-- versions-maven-plugin ignore patterns for snapshots, alpha, beta, milestones, and release candidates -->
     <maven.version.ignore>.+-SNAPSHOT,(?i).*(alpha|beta)[0-9.-]*,(?i).*[.-](m|rc)[0-9]+</maven.version.ignore>
     <minimalJavaBuildVersion>17</minimalJavaBuildVersion>
-    <minimalMavenBuildVersion>3.9.11</minimalMavenBuildVersion>
+    <minimalMavenBuildVersion>3.9</minimalMavenBuildVersion>
     <!-- timestamp for reproducible outputs, updated on release by the release plugin -->
     <project.build.outputTimestamp>2024-07-29T06:03:16Z</project.build.outputTimestamp>
     <rat.consoleOutput>true</rat.consoleOutput>


### PR DESCRIPTION
The current minumum version for maven that is enforced via the maven-enforcer-plugin is version 3.6.3 as defined in the parent pom [here](https://github.com/apache/maven-apache-parent/blob/b8689ef9c894f0fd8ab202e6eb55acc97793fa4a/pom.xml#L99)

This version is no longer being supported. This PR overrides that minimum to 3.9.11 which is the current LTS version.

This fixes a discrepancy between a feature of the .mvn/maven.config file added in #5716 which has a comment and the version 3.6.3 not supporting that comment.