### PR TITLE
Remove Table id lock in Manager

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,3 @@
+# Remove this file when the snapshot repository is no longer needed to resolve SNAPSHOT dependencies
 -P
 use-apache-snapshots

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,3 +1,2 @@
-# Remove this file when the snapshot repository is no longer needed to resolve SNAPSHOT dependencies
 -P
 use-apache-snapshots

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneTable.java
@@ -55,14 +55,9 @@ public class CloneTable extends ManagerRepo {
   @Override
   public Repo<Manager> call(FateId fateId, Manager environment) throws Exception {
 
-    Utils.getIdLock().lock();
-    try {
-      cloneInfo.setTableId(
-          Utils.getNextId(cloneInfo.getTableName(), environment.getContext(), TableId::of));
-      return new ClonePermissions(cloneInfo);
-    } finally {
-      Utils.getIdLock().unlock();
-    }
+    cloneInfo.setTableId(
+        Utils.getNextId(cloneInfo.getTableName(), environment.getContext(), TableId::of));
+    return new ClonePermissions(cloneInfo);
   }
 
   @Override

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/CreateTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/CreateTable.java
@@ -79,14 +79,9 @@ public class CreateTable extends ManagerRepo {
 
     // assuming only the manager process is creating tables
 
-    Utils.getIdLock().lock();
-    try {
-      String tName = tableInfo.getTableName();
-      tableInfo.setTableId(Utils.getNextId(tName, manager.getContext(), TableId::of));
-      return new SetupPermissions(tableInfo);
-    } finally {
-      Utils.getIdLock().unlock();
-    }
+    String tName = tableInfo.getTableName();
+    tableInfo.setTableId(Utils.getNextId(tName, manager.getContext(), TableId::of));
+    return new SetupPermissions(tableInfo);
   }
 
   @Override

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/CreateNamespace.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/CreateNamespace.java
@@ -46,14 +46,9 @@ public class CreateNamespace extends ManagerRepo {
 
   @Override
   public Repo<Manager> call(FateId fateId, Manager manager) throws Exception {
-    Utils.getIdLock().lock();
-    try {
-      namespaceInfo.namespaceId =
-          Utils.getNextId(namespaceInfo.namespaceName, manager.getContext(), NamespaceId::of);
-      return new SetupNamespacePermissions(namespaceInfo);
-    } finally {
-      Utils.getIdLock().unlock();
-    }
+    namespaceInfo.namespaceId =
+        Utils.getNextId(namespaceInfo.namespaceName, manager.getContext(), NamespaceId::of);
+    return new SetupNamespacePermissions(namespaceInfo);
 
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportTable.java
@@ -95,13 +95,9 @@ public class ImportTable extends ManagerRepo {
 
     // assuming only the manager process is creating tables
 
-    Utils.getIdLock().lock();
-    try {
-      tableInfo.tableId = Utils.getNextId(tableInfo.tableName, env.getContext(), TableId::of);
-      return new ImportSetupPermissions(tableInfo);
-    } finally {
-      Utils.getIdLock().unlock();
-    }
+    tableInfo.tableId = Utils.getNextId(tableInfo.tableName, env.getContext(), TableId::of);
+    return new ImportSetupPermissions(tableInfo);
+
   }
 
   @SuppressFBWarnings(value = "OS_OPEN_STREAM",

--- a/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
@@ -39,6 +39,10 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.client.Accumulo;
@@ -72,6 +76,7 @@ import org.apache.accumulo.core.metadata.SystemTables;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
+import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.accumulo.test.functional.BadIterator;
 import org.apache.accumulo.test.functional.FunctionalTestUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -832,6 +837,33 @@ public class TableOperationsIT extends AccumuloClusterHarness {
     KeyExtent ke = new KeyExtent(TableId.of(id), endRow == null ? null : new Text(endRow),
         prevEndRow == null ? null : new Text(prevEndRow));
     expected.put(new TabletIdImpl(ke), availability);
+  }
+
+  @Test
+  public void testUniquenessOfTableId() throws ExecutionException, InterruptedException {
+    Set<TableId> hash = new HashSet<>();
+
+    ExecutorService pool = Executors.newFixedThreadPool(64);
+
+    for (int i = 0; i < 1000; i++) {
+      int finalI = i;
+
+      Future<TableId> future = pool.submit(() -> {
+        TableId tableId = null;
+
+        try {
+          tableId = Utils.getNextId("yes" + finalI, getServerContext(), TableId::of);
+        } catch (Exception e) {
+          System.out.println(e.getMessage());
+        }
+        return tableId;
+      });
+
+      hash.add(future.get());
+
+    }
+
+    assertEquals(1000, hash.size());
   }
 
 }

--- a/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
@@ -853,11 +853,8 @@ public class TableOperationsIT extends AccumuloClusterHarness {
       Future<TableId> future = pool.submit(() -> {
         TableId tableId = null;
 
-        try {
-          tableId = Utils.getNextId("Testing" + finalI, getServerContext(), TableId::of);
-        } catch (Exception e) {
-          e.printStackTrace();
-        }
+        tableId = Utils.getNextId("Testing" + finalI, getServerContext(), TableId::of);
+
         return tableId;
       });
 

--- a/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
@@ -841,6 +841,8 @@ public class TableOperationsIT extends AccumuloClusterHarness {
 
   @Test
   public void testUniquenessOfTableId() throws ExecutionException, InterruptedException {
+    List<Future<TableId>> futureList = new ArrayList<>();
+
     Set<TableId> hash = new HashSet<>();
 
     ExecutorService pool = Executors.newFixedThreadPool(64);
@@ -852,16 +854,21 @@ public class TableOperationsIT extends AccumuloClusterHarness {
         TableId tableId = null;
 
         try {
-          tableId = Utils.getNextId("yes" + finalI, getServerContext(), TableId::of);
+          tableId = Utils.getNextId("Testing" + finalI, getServerContext(), TableId::of);
         } catch (Exception e) {
-          System.out.println(e.getMessage());
+          e.printStackTrace();
         }
         return tableId;
       });
 
-      hash.add(future.get());
-
+      futureList.add(future);
     }
+
+    for (Future<TableId> tab : futureList) {
+      hash.add(tab.get());
+    }
+
+    pool.shutdown();
 
     assertEquals(1000, hash.size());
   }


### PR DESCRIPTION
Create test `testUniquenessOfTableId()` in TableOperationsIT to ensure that concurrent calls will get a unique table id, and that the lock in Manager can be removed.

Closes #5723