### PR TITLE
Fix TestAmple shared writer overrides

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/ample/metadata/TestAmple.java
+++ b/test/src/main/java/org/apache/accumulo/test/ample/metadata/TestAmple.java
@@ -258,6 +258,32 @@ public class TestAmple {
       public void setServiceLock(ServiceLock lock) {
         context.setServiceLock(lock);
       }
+
+      @Override
+      public java.util.function.Supplier<ConditionalWriter> getSharedMetadataWriter() {
+        return () -> {
+          try {
+            return new ConditionalWriterDelegator(
+                createConditionalWriter(ample.tables.get(Ample.DataLevel.METADATA)),
+                ample.cwInterceptor.get());
+          } catch (TableNotFoundException e) {
+            throw new RuntimeException(e);
+          }
+        };
+      }
+
+      @Override
+      public java.util.function.Supplier<ConditionalWriter> getSharedUserWriter() {
+        return () -> {
+          try {
+            return new ConditionalWriterDelegator(
+                createConditionalWriter(ample.tables.get(Ample.DataLevel.USER)),
+                ample.cwInterceptor.get());
+          } catch (TableNotFoundException e) {
+            throw new RuntimeException(e);
+          }
+        };
+      }
     };
   }
 


### PR DESCRIPTION
Changes made in #5763 added shared ConditionalWriters for ample. This PR fixes the related methods in TestAmple.

Several ITs were broken including TestAmpleIT_SimpleSuite, UserFateStoreFateIT_SimpleSuite, multiple other tests in SimpleSharedMacTestSuiteIT. These should all be fixed now with this PR.