### PR TITLE
fixes log recovery by creating parent directories

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/RFileOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/RFileOperations.java
@@ -148,7 +148,7 @@ public class RFileOperations extends FileOperations {
           builder = builder.syncBlock();
         }
 
-        // create parent directories if they do not exists
+        // create parent directories if they do not exist
         builder = builder.recursive();
 
         switch (ecEnable) {

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/RFileOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/RFileOperations.java
@@ -148,6 +148,9 @@ public class RFileOperations extends FileOperations {
           builder = builder.syncBlock();
         }
 
+        // create parent directories if they do not exists
+        builder = builder.recursive();
+
         switch (ecEnable) {
           case ENABLE:
             String ecPolicyName =


### PR DESCRIPTION
Changes in #5743 made RFileOperations use a HDFS builder to create an output stream.  Prior to using the builder the calls to HDFS to create an output stream would also create parent directories if they did not exist.  Seems the log recovery code in accumulo was relying on this behavior.  Added an option to the builder to create parent dirs if they do not exists.

This problem was detected by TotalQueuedIT which was failing in log recovery and the tserver had exception about a parent directory not existing.  With these changes TotalQueuedIT now passes.

Could not find javadoc on the old HDFS API calls that mentioned that the parent directory was created.  Wrote some test code that called the previous APIs and confirmed that parent dirs were created if needed.