### PR TITLE
fixes NPE in ServiceLockPaths

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/lock/ServiceLockPaths.java
+++ b/core/src/main/java/org/apache/accumulo/core/lock/ServiceLockPaths.java
@@ -447,7 +447,13 @@ public class ServiceLockPaths {
             }
             addressPredicate = s -> true;
           } else {
-            servers = zooCache.getChildren(typePath + "/" + group);
+            var children = zooCache.getChildren(typePath + "/" + group);
+            if (children == null) {
+              // resource group no longer exist
+              servers = List.of();
+            } else {
+              servers = children;
+            }
             addressPredicate = addressSelector.getPredicate();
           }
 


### PR DESCRIPTION
UserFateOpsCommandsIT was failing because of the following error in the Manager.  Modified ServiceLockPaths to avoid the NPE.

```
Critical thread CompactionCoordinator Thread died
java.lang.NullPointerException
        at org.apache.accumulo.core.lock.ServiceLockPaths.get(ServiceLockPaths.java:456)
        at org.apache.accumulo.core.lock.ServiceLockPaths.getCompactor(ServiceLockPaths.java:290)
        at org.apache.accumulo.core.util.compaction.ExternalCompactionUtil.getCompactionsRunningOnCompactors(ExternalCompactionUtil.java:206)
        at org.apache.accumulo.manager.compaction.coordinator.CompactionCoordinator.getCompactionsRunningOnCompactors(CompactionCoordinator.java:1212)
        at org.apache.accumulo.manager.compaction.coordinator.CompactionCoordinator.run(CompactionCoordinator.java:409)
        at org.apache.accumulo.core.util.threads.Threads.lambda$createCriticalThread$0(Threads.java:76)
        at org.apache.accumulo.core.trace.TraceWrappedRunnable.run(TraceWrappedRunnable.java:52)
        at java.base/java.lang.Thread.run(Thread.java:829)
```