### PR TITLE
adds group summary information to reports.

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
@@ -263,8 +263,7 @@ public class Admin implements KeywordExecutable {
 
   @Parameters(commandDescription = "show service status")
   public static class ServiceStatusCmdOpts extends SubCommandOpts {
-    @Parameter(names = "--json",
-        description = "provide output in json format (--showHosts ignored)")
+    @Parameter(names = "--json", description = "provide output in json format")
     boolean json = false;
     @Parameter(names = "--showHosts",
         description = "provide a summary of service counts with host details")

--- a/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
@@ -268,10 +268,6 @@ public class Admin implements KeywordExecutable {
     @Parameter(names = "--showHosts",
         description = "provide a summary of service counts with host details")
     boolean showHosts = false;
-
-    @Parameter(names = "--csv",
-        description = "provide output in csv format (--json and --noHost ignored)")
-    boolean csv = false;
   }
 
   public static void main(String[] args) {
@@ -431,8 +427,7 @@ public class Admin implements KeywordExecutable {
         executeFateOpsCommand(context, fateOpsCommand);
       } else if (cl.getParsedCommand().equals("serviceStatus")) {
         ServiceStatusCmd ssc = new ServiceStatusCmd();
-        ssc.execute(context, serviceStatusCommandOpts.json, serviceStatusCommandOpts.showHosts,
-            serviceStatusCommandOpts.csv);
+        ssc.execute(context, serviceStatusCommandOpts.json, serviceStatusCommandOpts.showHosts);
       } else if (cl.getParsedCommand().equals("stopManager")
           || cl.getParsedCommand().equals("stopAll")) {
         boolean everything = cl.getParsedCommand().equals("stopAll");

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ServiceStatusCmd.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ServiceStatusCmd.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.server.util;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -134,8 +135,6 @@ public class ServiceStatusCmd {
       ServiceStatusReport.ReportKey displayNames) {
     AtomicInteger errorSum = new AtomicInteger(0);
 
-    // Set<String> hostNames = new TreeSet<>();
-    Set<String> groupNames = new TreeSet<>();
     Map<String,Set<String>> hostsByGroups = new TreeMap<>();
 
     var nodeNames = readNodeNames(zooReader, basePath);
@@ -152,7 +151,6 @@ public class ServiceStatusCmd {
           String[] tokens = nodeData.getHosts().split(",");
           if (tokens.length == 2) {
             String groupName = tokens[1];
-            groupNames.add(groupName);
             hostsByGroups.computeIfAbsent(groupName, s -> new TreeSet<>()).add(host);
           } else {
             hostsByGroups.computeIfAbsent(NO_GROUP_TAG, s -> new TreeSet<>()).add(host);
@@ -162,7 +160,18 @@ public class ServiceStatusCmd {
       });
       errorSum.addAndGet(lock.getFirst());
     });
-    return new StatusSummary(displayNames, groupNames, hostsByGroups, errorSum.get());
+
+    AtomicInteger hostTotal = new AtomicInteger();
+    Map<String,Integer> groupSummary = new HashMap<>();
+    hostsByGroups.forEach((group, host) -> {
+      hostTotal.set(hostTotal.get() + host.size());
+      if (!group.equals(NO_GROUP_TAG)) {
+        groupSummary.put(group, host.size());
+      }
+    });
+
+    return new StatusSummary(displayNames, groupSummary, hostsByGroups, hostTotal.get(),
+        errorSum.get());
   }
 
   /**
@@ -181,7 +190,7 @@ public class ServiceStatusCmd {
     hostByGroup.put(NO_GROUP_TAG, hosts);
 
     return new StatusSummary(temp.getServiceType(), temp.getResourceGroups(), hostByGroup,
-        temp.getErrorCount());
+        hosts.size(), temp.getErrorCount());
 
   }
 
@@ -231,7 +240,8 @@ public class ServiceStatusCmd {
     var result = readAllNodesData(zooReader, lockPath);
     Map<String,Set<String>> byGroup = new TreeMap<>();
     byGroup.put(NO_GROUP_TAG, result.getHosts());
-    return new StatusSummary(displayNames, Set.of(), byGroup, result.getErrorCount());
+    return new StatusSummary(displayNames, Map.of(), byGroup, result.getHosts().size(),
+        result.getErrorCount());
   }
 
   /**
@@ -255,9 +265,11 @@ public class ServiceStatusCmd {
         hostsByGroups.computeIfAbsent(group, set -> new TreeSet<>()).add(host);
       });
     });
+    Map<String,Integer> groupSummary = new HashMap<>();
+    hostsByGroups.forEach((group, hosts) -> groupSummary.put(group, hosts.size()));
 
-    return new StatusSummary(ServiceStatusReport.ReportKey.COMPACTOR, queues, hostsByGroups,
-        errors.get());
+    return new StatusSummary(ServiceStatusReport.ReportKey.COMPACTOR, groupSummary, hostsByGroups,
+        groupSummary.values().stream().reduce(Integer::sum).orElse(0), errors.get());
   }
 
   /**

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ServiceStatusCmd.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ServiceStatusCmd.java
@@ -55,8 +55,7 @@ public class ServiceStatusCmd {
    * Read the service statuses from ZooKeeper, build the status report and then output the report to
    * stdout.
    */
-  public void execute(final ServerContext context, final boolean json, final boolean showHosts,
-      final boolean csv) {
+  public void execute(final ServerContext context, final boolean json, final boolean showHosts) {
 
     ZooReader zooReader = context.getZooReader();
 
@@ -76,9 +75,7 @@ public class ServiceStatusCmd {
 
     ServiceStatusReport report = new ServiceStatusReport(services, showHosts);
 
-    if (csv) {
-      System.out.println(report.toCsv());
-    } else if (json) {
+    if (json) {
       System.out.println(report.toJson());
     } else {
       StringBuilder sb = new StringBuilder(8192);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/serviceStatus/ServiceStatusReport.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/serviceStatus/ServiceStatusReport.java
@@ -22,7 +22,6 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
@@ -86,33 +85,6 @@ public class ServiceStatusReport {
 
   public static ServiceStatusReport fromJson(final String json) {
     return gson.fromJson(json, ServiceStatusReport.class);
-  }
-
-  public String toCsv() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("Service,Resource Group,Host Count,Hosts,Error Count\n");
-
-    for (Map.Entry<ReportKey,StatusSummary> entry : summaries.entrySet()) {
-      ReportKey reportKey = entry.getKey();
-      StatusSummary summary = entry.getValue();
-
-      if (summary == null || summary.getServiceByGroups() == null) {
-        continue;
-      }
-
-      Map<String,Set<String>> groupMap = summary.getServiceByGroups();
-      int errorCount = summary.getErrorCount();
-
-      for (Map.Entry<String,Set<String>> groupEntry : groupMap.entrySet()) {
-        String group = groupEntry.getKey();
-        Set<String> hosts = groupEntry.getValue();
-        String hostList = String.join(";", hosts);
-        sb.append(reportKey.name()).append(",").append(group).append(",").append(hosts.size())
-            .append(",").append(hostList).append(",").append(errorCount).append("\n");
-      }
-    }
-
-    return sb.toString();
   }
 
   public String report(final StringBuilder sb) {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/serviceStatus/StatusSummary.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/serviceStatus/StatusSummary.java
@@ -18,27 +18,25 @@
  */
 package org.apache.accumulo.server.util.serviceStatus;
 
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.TreeMap;
 
 public class StatusSummary {
 
   private final ServiceStatusReport.ReportKey serviceType;
-  private final Set<String> resourceGroups;
+  private final Map<String,Integer> resourceGroups;
   private final Map<String,Set<String>> serviceByGroups;
   private final int serviceCount;
   private final int errorCount;
 
-  public StatusSummary(ServiceStatusReport.ReportKey serviceType, final Set<String> resourceGroups,
-      final Map<String,Set<String>> serviceByGroups, final int errorCount) {
+  public StatusSummary(ServiceStatusReport.ReportKey serviceType,
+      final Map<String,Integer> resourceGroups, final Map<String,Set<String>> serviceByGroups,
+      final int serviceCount, final int errorCount) {
     this.serviceType = serviceType;
     this.resourceGroups = resourceGroups;
     this.serviceByGroups = serviceByGroups;
-    this.serviceCount =
-        serviceByGroups.values().stream().map(Set::size).reduce(Integer::sum).orElse(0);
+    this.serviceCount = serviceCount;
     this.errorCount = errorCount;
   }
 
@@ -50,7 +48,7 @@ public class StatusSummary {
     return serviceType.getDisplayName();
   }
 
-  public Set<String> getResourceGroups() {
+  public Map<String,Integer> getResourceGroups() {
     return resourceGroups;
   }
 
@@ -67,23 +65,7 @@ public class StatusSummary {
   }
 
   public StatusSummary withoutHosts() {
-    Map<String,Set<String>> tmpHosts = new TreeMap<>();
-
-    for (Map.Entry<String,Set<String>> entry : this.serviceByGroups.entrySet()) {
-
-      String group = entry.getKey();
-      int size = entry.getValue().size();
-      ;
-
-      Set<String> hosts = new HashSet<>();
-      for (int i = 0; i < size; i++) {
-        hosts.add("");
-      }
-
-      tmpHosts.put(group, hosts);
-    }
-
-    return new StatusSummary(this.serviceType, this.resourceGroups, tmpHosts, this.errorCount);
+    return new StatusSummary(serviceType, resourceGroups, Map.of(), serviceCount, errorCount);
   }
 
   @Override

--- a/server/base/src/test/java/org/apache/accumulo/server/util/ServiceStatusCmdTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/ServiceStatusCmdTest.java
@@ -111,7 +111,7 @@ public class ServiceStatusCmdTest {
     hostByGroup.put(NO_GROUP_TAG, hosts);
 
     StatusSummary expected =
-        new StatusSummary(ServiceStatusReport.ReportKey.MANAGER, Set.of(), hostByGroup, 0);
+        new StatusSummary(ServiceStatusReport.ReportKey.MANAGER, Map.of(), hostByGroup, 3, 0);
 
     assertEquals(expected.hashCode(), status.hashCode());
     assertEquals(expected.getDisplayName(), status.getDisplayName());
@@ -150,7 +150,7 @@ public class ServiceStatusCmdTest {
     hostByGroup.put(NO_GROUP_TAG, new TreeSet<>(List.of(host1, host2)));
 
     StatusSummary expected =
-        new StatusSummary(ServiceStatusReport.ReportKey.MONITOR, Set.of(), hostByGroup, 0);
+        new StatusSummary(ServiceStatusReport.ReportKey.MONITOR, Map.of(), hostByGroup, 2, 0);
 
     assertEquals(expected.hashCode(), status.hashCode());
     assertEquals(expected.getDisplayName(), status.getDisplayName());
@@ -199,7 +199,7 @@ public class ServiceStatusCmdTest {
     hostByGroup.put(NO_GROUP_TAG, new TreeSet<>(List.of(host1, host2, host3)));
 
     StatusSummary expected =
-        new StatusSummary(ServiceStatusReport.ReportKey.T_SERVER, Set.of(), hostByGroup, 0);
+        new StatusSummary(ServiceStatusReport.ReportKey.T_SERVER, Map.of(), hostByGroup, 3, 0);
 
     assertEquals(expected.hashCode(), status.hashCode());
     assertEquals(expected.getDisplayName(), status.getDisplayName());
@@ -258,7 +258,7 @@ public class ServiceStatusCmdTest {
     hostByGroup.put("rg1", new TreeSet<>(List.of("host1:8080", "host3:9091")));
 
     StatusSummary expected = new StatusSummary(ServiceStatusReport.ReportKey.S_SERVER,
-        Set.of("default", "rg1"), hostByGroup, 0);
+        Map.of("default", 2, "rg1", 2), hostByGroup, 4, 0);
 
     assertEquals(expected, status);
 
@@ -298,7 +298,7 @@ public class ServiceStatusCmdTest {
     hostByGroup.put(NO_GROUP_TAG, hosts);
 
     StatusSummary expected =
-        new StatusSummary(ServiceStatusReport.ReportKey.COORDINATOR, Set.of(), hostByGroup, 0);
+        new StatusSummary(ServiceStatusReport.ReportKey.COORDINATOR, Map.of(), hostByGroup, 3, 0);
 
     assertEquals(expected.hashCode(), status.hashCode());
     assertEquals(expected.getDisplayName(), status.getDisplayName());

--- a/server/base/src/test/java/org/apache/accumulo/server/util/ServiceStatusCmdTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/ServiceStatusCmdTest.java
@@ -401,7 +401,6 @@ public class ServiceStatusCmdTest {
     Admin.ServiceStatusCmdOpts opts = new Admin.ServiceStatusCmdOpts();
     assertFalse(opts.json);
     assertFalse(opts.showHosts);
-    assertFalse(opts.csv);
   }
 
 }

--- a/server/base/src/test/java/org/apache/accumulo/server/util/serviceStatus/ServiceStatusReportTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/serviceStatus/ServiceStatusReportTest.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.server.util.serviceStatus;
 
 import static org.apache.accumulo.server.util.ServiceStatusCmd.NO_GROUP_TAG;
+import static org.apache.accumulo.server.util.serviceStatus.ServiceStatusReport.ReportKey.COMPACTOR;
 import static org.apache.accumulo.server.util.serviceStatus.ServiceStatusReport.ReportKey.MANAGER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -37,7 +38,7 @@ import org.slf4j.LoggerFactory;
 
 public class ServiceStatusReportTest {
 
-  private static final Logger LOG = LoggerFactory.getLogger(ServiceStatusReport.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ServiceStatusReportTest.class);
 
   @Test
   public void printOutputCountTest() {
@@ -50,7 +51,7 @@ public class ServiceStatusReportTest {
   }
 
   @Test
-  public void printOutputHostTest() {
+  public void printOutputNoHostTest() {
     final Map<ServiceStatusReport.ReportKey,StatusSummary> services = buildHostStatus();
     ServiceStatusReport report = new ServiceStatusReport(services, false);
     StringBuilder sb = new StringBuilder(8192);
@@ -74,7 +75,7 @@ public class ServiceStatusReportTest {
 
     Map<String,Set<String>> managerByGroup = new TreeMap<>();
     managerByGroup.put(NO_GROUP_TAG, new TreeSet<>(List.of("hostZ:8080", "hostA:9090")));
-    StatusSummary managerSummary = new StatusSummary(MANAGER, Set.of(), managerByGroup, 1);
+    StatusSummary managerSummary = new StatusSummary(MANAGER, Map.of(), managerByGroup, 2, 1);
     services.put(MANAGER, managerSummary);
     ServiceStatusReport report = new ServiceStatusReport(services, false);
     var encoded = report.toJson();
@@ -86,6 +87,27 @@ public class ServiceStatusReportTest {
 
     var byGroup = report.getSummaries().get(MANAGER).getServiceByGroups();
     assertEquals(new TreeSet<>(List.of("hostZ:8080", "hostA:9090")), byGroup.get(NO_GROUP_TAG));
+  }
+
+  @Test
+  public void jsonCompactorsTest() {
+    final Map<ServiceStatusReport.ReportKey,StatusSummary> services = new TreeMap<>();
+    Map<String,Set<String>> compactorsByGroup = new TreeMap<>();
+    compactorsByGroup.put("TEST", new TreeSet<>(List.of("hostZ:8080", "hostA:9090")));
+    StatusSummary compactorSummary =
+        new StatusSummary(COMPACTOR, Map.of("TEST", 2), compactorsByGroup, 2, 1);
+    services.put(COMPACTOR, compactorSummary);
+    ServiceStatusReport report = new ServiceStatusReport(services, false);
+    var encoded = report.toJson();
+
+    ServiceStatusReport decoded = ServiceStatusReport.fromJson(encoded);
+    assertNotNull(decoded.getReportTime());
+    assertEquals(1, decoded.getTotalZkReadErrors());
+    assertEquals(1, report.getSummaries().size());
+    assertEquals(1, decoded.getSummaries().values().size());
+
+    var byGroup = report.getSummaries().get(COMPACTOR).getServiceByGroups();
+    assertEquals(new TreeSet<>(List.of("hostZ:8080", "hostA:9090")), byGroup.get("TEST"));
   }
 
   /**
@@ -104,20 +126,20 @@ public class ServiceStatusReportTest {
 
     Map<String,Set<String>> managerByGroup = new TreeMap<>();
     managerByGroup.put(NO_GROUP_TAG, new TreeSet<>(List.of("host1:8080", "host2:9090")));
-    StatusSummary managerSummary = new StatusSummary(MANAGER, Set.of(), managerByGroup, 1);
+    StatusSummary managerSummary = new StatusSummary(MANAGER, Map.of(), managerByGroup, 2, 1);
     services.put(MANAGER, managerSummary);
 
     Map<String,Set<String>> monitorByGroup = new TreeMap<>();
     monitorByGroup.put(NO_GROUP_TAG, new TreeSet<>(List.of("host1:8080", "host2:9090")));
     StatusSummary monitorSummary =
-        new StatusSummary(ServiceStatusReport.ReportKey.MONITOR, Set.of(), monitorByGroup, 0);
+        new StatusSummary(ServiceStatusReport.ReportKey.MONITOR, Map.of(), monitorByGroup, 2, 0);
     services.put(ServiceStatusReport.ReportKey.MONITOR, monitorSummary);
 
     Map<String,Set<String>> gcByGroup = new TreeMap<>();
     gcByGroup.put(NO_GROUP_TAG, new TreeSet<>(List.of("host1:8080", "host2:9090")));
 
     StatusSummary gcSummary =
-        new StatusSummary(ServiceStatusReport.ReportKey.GC, Set.of(), gcByGroup, 0);
+        new StatusSummary(ServiceStatusReport.ReportKey.GC, Map.of(), gcByGroup, 2, 0);
     services.put(ServiceStatusReport.ReportKey.GC, gcSummary);
 
     Map<String,Set<String>> tserverByGroup = new TreeMap<>();
@@ -125,7 +147,7 @@ public class ServiceStatusReportTest {
         new TreeSet<>(List.of("host2:9090", "host4:9091", "host1:8080", "host3:9091")));
 
     StatusSummary tserverSummary =
-        new StatusSummary(ServiceStatusReport.ReportKey.T_SERVER, Set.of(), tserverByGroup, 1);
+        new StatusSummary(ServiceStatusReport.ReportKey.T_SERVER, Map.of(), tserverByGroup, 4, 1);
     services.put(ServiceStatusReport.ReportKey.T_SERVER, tserverSummary);
 
     Map<String,Set<String>> sserverByGroup = new TreeMap<>();
@@ -134,13 +156,13 @@ public class ServiceStatusReportTest {
     sserverByGroup.put("rg2", new TreeSet<>(List.of("host4:9091")));
 
     StatusSummary scanServerSummary = new StatusSummary(ServiceStatusReport.ReportKey.S_SERVER,
-        new TreeSet<>(List.of("default", "rg1", "rg2")), sserverByGroup, 2);
+        Map.of("default", 1, "rg1", 2, "rg2", 1), sserverByGroup, 4, 2);
     services.put(ServiceStatusReport.ReportKey.S_SERVER, scanServerSummary);
 
     Map<String,Set<String>> coordinatorByGroup = new TreeMap<>();
     coordinatorByGroup.put(NO_GROUP_TAG, new TreeSet<>(List.of("host4:9090", "host2:9091")));
     StatusSummary coordinatorSummary = new StatusSummary(ServiceStatusReport.ReportKey.COORDINATOR,
-        Set.of(), coordinatorByGroup, 0);
+        Map.of(), coordinatorByGroup, 2, 0);
     services.put(ServiceStatusReport.ReportKey.COORDINATOR, coordinatorSummary);
 
     Map<String,Set<String>> compactorByGroup = new TreeMap<>();
@@ -148,7 +170,7 @@ public class ServiceStatusReportTest {
     compactorByGroup.put("q1", new TreeSet<>(List.of("host3:8080", "host1:9091")));
 
     StatusSummary compactorSummary = new StatusSummary(ServiceStatusReport.ReportKey.COMPACTOR,
-        new TreeSet<>(List.of("q2", "q1")), compactorByGroup, 0);
+        Map.of("q2", 3, "q1", 2), compactorByGroup, 5, 0);
     services.put(ServiceStatusReport.ReportKey.COMPACTOR, compactorSummary);
 
     return services;


### PR DESCRIPTION
Adds resource group summary information to the printed and json reports produced by the `admin serviceStatus` command. 

closes #5051 

new printed summary output
```
ZooKeeper read errors: 0
Managers: count: 1
Monitors: count: 1
Garbage Collectors: count: 1
Tablet Servers: count: 3
Scan Servers: count: 3
  resource groups:
    default: 3
Coordinators: count: 1
Compactors: count: 5
  resource groups:
    q1: 2
    q2: 3
```    
new json summary output 
```
./accumulo admin serviceStatus --json | jq 
{
  "reportTime": "2025-08-05T22:00:03.481Z",
  "zkReadErrors": 0,
  "showHosts": false,
  "summaries": {
    "COMPACTOR": {
      "serviceType": "COMPACTOR",
      "resourceGroups": {
        "q1": 2,
        "q2": 3
      },
      "serviceByGroups": {},
      "serviceCount": 5,
      "errorCount": 0
    },
    "COORDINATOR": {
      "serviceType": "COORDINATOR",
      "resourceGroups": {},
      "serviceByGroups": {},
      "serviceCount": 1,
      "errorCount": 0
    },
    "GC": {
      "serviceType": "GC",
      "resourceGroups": {},
      "serviceByGroups": {},
      "serviceCount": 1,
      "errorCount": 0
    },
    "MANAGER": {
      "serviceType": "MANAGER",
      "resourceGroups": {},
      "serviceByGroups": {},
      "serviceCount": 1,
      "errorCount": 0
    },
    "MONITOR": {
      "serviceType": "MONITOR",
      "resourceGroups": {},
      "serviceByGroups": {},
      "serviceCount": 1,
      "errorCount": 0
    },
    "S_SERVER": {
      "serviceType": "S_SERVER",
      "resourceGroups": {
        "default": 3
      },
      "serviceByGroups": {},
      "serviceCount": 3,
      "errorCount": 0
    },
    "T_SERVER": {
      "serviceType": "T_SERVER",
      "resourceGroups": {},
      "serviceByGroups": {},
      "serviceCount": 3,
      "errorCount": 0
    }
  }
}
```   