### PR TITLE
adds ranges to table locks

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/AdminUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/AdminUtil.java
@@ -430,10 +430,10 @@ public class AdminUtil<T> {
 
     for (TransactionStatus txStatus : fateStatus.getTransactions()) {
       fmt.format(
-          "%-15s fateId: %s  status: %-18s locked: %-15s locking: %-15s op: %-15s created: %s lock range: (%s,%s]%n",
+          "%-15s fateId: %s  status: %-18s locked: %-15s locking: %-15s op: %-15s created: %s lock range: %s%n",
           txStatus.getFateOp(), txStatus.getFateId(), txStatus.getStatus(), txStatus.getHeldLocks(),
           txStatus.getWaitingLocks(), txStatus.getTop(), txStatus.getTimeCreatedFormatted(),
-          txStatus.getLockRange().getStartRow(), txStatus.getLockRange().getEndRow());
+          txStatus.getLockRange());
     }
     fmt.format(" %s transactions", fateStatus.getTransactions().size());
   }

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/DistributedReadWriteLock.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/DistributedReadWriteLock.java
@@ -61,8 +61,10 @@ public class DistributedReadWriteLock implements java.util.concurrent.locks.Read
 
   private static final Logger log = LoggerFactory.getLogger(DistributedReadWriteLock.class);
 
-  public static interface DistributedLock extends Lock {
+  public interface DistributedLock extends Lock {
     LockType getType();
+
+    LockRange getRange();
   }
 
   static class ReadLock implements DistributedLock {
@@ -70,22 +72,30 @@ public class DistributedReadWriteLock implements java.util.concurrent.locks.Read
     final QueueLock qlock;
     final FateId fateId;
     long entry = -1;
+    final LockRange range;
 
-    ReadLock(QueueLock qlock, FateId fateId) {
+    ReadLock(QueueLock qlock, FateId fateId, LockRange range) {
       this.qlock = qlock;
       this.fateId = fateId;
+      this.range = range;
     }
 
     // for recovery
-    ReadLock(QueueLock qlock, FateId fateId, long entry) {
+    ReadLock(QueueLock qlock, FateId fateId, LockRange range, long entry) {
       this.qlock = qlock;
       this.fateId = fateId;
       this.entry = entry;
+      this.range = range;
     }
 
     @Override
     public LockType getType() {
       return LockType.READ;
+    }
+
+    @Override
+    public LockRange getRange() {
+      return range;
     }
 
     @Override
@@ -114,12 +124,14 @@ public class DistributedReadWriteLock implements java.util.concurrent.locks.Read
     @Override
     public boolean tryLock() {
       if (entry == -1) {
-        entry = qlock.addEntry(FateLockEntry.from(this.getType(), this.fateId));
+        entry = qlock.addEntry(FateLockEntry.from(this.getType(), this.fateId, range));
         log.info("Added lock entry {} fateId {} lockType {}", entry, fateId, getType());
       }
 
-      SortedMap<Long,Supplier<FateLockEntry>> entries =
-          qlock.getEntries((seq, lockData) -> seq <= entry);
+      // If there are any write locks with a lower sequence number and an overlapping range then
+      // this should not lock.
+      SortedMap<Long,Supplier<FateLockEntry>> entries = qlock
+          .getEntries((seq, lockData) -> seq <= entry && lockData.get().getRange().overlaps(range));
       for (Entry<Long,Supplier<FateLockEntry>> entry : entries.entrySet()) {
         if (entry.getKey().equals(this.entry)) {
           return true;
@@ -154,7 +166,7 @@ public class DistributedReadWriteLock implements java.util.concurrent.locks.Read
         return;
       }
       log.debug("Removing lock entry {} fateId {} lockType {}", entry, this.fateId, getType());
-      qlock.removeEntry(FateLockEntry.from(this.getType(), this.fateId), entry);
+      qlock.removeEntry(FateLockEntry.from(this.getType(), this.fateId, range), entry);
       entry = -1;
     }
 
@@ -166,12 +178,12 @@ public class DistributedReadWriteLock implements java.util.concurrent.locks.Read
 
   static class WriteLock extends ReadLock {
 
-    WriteLock(QueueLock qlock, FateId fateId) {
-      super(qlock, fateId);
+    WriteLock(QueueLock qlock, FateId fateId, LockRange range) {
+      super(qlock, fateId, range);
     }
 
-    WriteLock(QueueLock qlock, FateId fateId, long entry) {
-      super(qlock, fateId, entry);
+    WriteLock(QueueLock qlock, FateId fateId, LockRange range, long entry) {
+      super(qlock, fateId, range, entry);
     }
 
     @Override
@@ -182,11 +194,14 @@ public class DistributedReadWriteLock implements java.util.concurrent.locks.Read
     @Override
     public boolean tryLock() {
       if (entry == -1) {
-        entry = qlock.addEntry(FateLockEntry.from(this.getType(), this.fateId));
+        entry = qlock.addEntry(FateLockEntry.from(this.getType(), this.fateId, range));
         log.info("Added lock entry {} fateId {} lockType {}", entry, this.fateId, getType());
       }
-      SortedMap<Long,Supplier<FateLockEntry>> entries =
-          qlock.getEntries((seq, locData) -> seq <= entry);
+
+      // If there are any read or write locks with a lower sequence number and an overlapping range
+      // then this should not lock.
+      SortedMap<Long,Supplier<FateLockEntry>> entries = qlock
+          .getEntries((seq, locData) -> seq <= entry && locData.get().getRange().overlaps(range));
       Iterator<Entry<Long,Supplier<FateLockEntry>>> iterator = entries.entrySet().iterator();
       if (!iterator.hasNext()) {
         throw new IllegalStateException("Did not find our own lock in the queue: " + this.entry
@@ -198,10 +213,12 @@ public class DistributedReadWriteLock implements java.util.concurrent.locks.Read
 
   private final QueueLock qlock;
   private final FateId fateId;
+  private final LockRange range;
 
-  public DistributedReadWriteLock(QueueLock qlock, FateId fateId) {
+  public DistributedReadWriteLock(QueueLock qlock, FateId fateId, LockRange range) {
     this.qlock = qlock;
     this.fateId = fateId;
+    this.range = range;
   }
 
   public static DistributedLock recoverLock(QueueLock qlock, FateId fateId) {
@@ -216,9 +233,10 @@ public class DistributedReadWriteLock implements java.util.concurrent.locks.Read
         FateLockEntry lockEntry = entry.getValue().get();
         switch (lockEntry.getLockType()) {
           case READ:
-            return new ReadLock(qlock, lockEntry.getFateId(), entry.getKey());
+            return new ReadLock(qlock, lockEntry.getFateId(), lockEntry.getRange(), entry.getKey());
           case WRITE:
-            return new WriteLock(qlock, lockEntry.getFateId(), entry.getKey());
+            return new WriteLock(qlock, lockEntry.getFateId(), lockEntry.getRange(),
+                entry.getKey());
           default:
             throw new IllegalStateException("Unknown lock type " + lockEntry.getLockType());
         }
@@ -229,11 +247,11 @@ public class DistributedReadWriteLock implements java.util.concurrent.locks.Read
 
   @Override
   public DistributedLock readLock() {
-    return new ReadLock(qlock, fateId);
+    return new ReadLock(qlock, fateId, range);
   }
 
   @Override
   public DistributedLock writeLock() {
-    return new WriteLock(qlock, fateId);
+    return new WriteLock(qlock, fateId, range);
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/FateLock.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/FateLock.java
@@ -178,16 +178,6 @@ public class FateLock implements QueueLock {
       fateLockEntry = Suppliers
           .memoize(() -> FateLockEntry.deserialize(nodeName.substring(PREFIX.length(), len - 11)));
     }
-
-    @Override
-    public boolean equals(Object o) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public int hashCode() {
-      throw new UnsupportedOperationException();
-    }
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/FateLock.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/FateLock.java
@@ -73,6 +73,9 @@ public class FateLock implements QueueLock {
   }
 
   public static class FateLockEntry {
+
+    private static final String DELIMITER = "_";
+
     final LockType lockType;
     final FateId fateId;
     final LockRange range;
@@ -84,7 +87,7 @@ public class FateLock implements QueueLock {
     }
 
     private FateLockEntry(String entry) {
-      var fields = entry.split("_", 4);
+      var fields = entry.split(DELIMITER, 4);
       this.lockType = LockType.valueOf(fields[0]);
       this.fateId = FateId.from(fields[1]);
       this.range = LockRange.of(decodeRow(fields[2]), decodeRow(fields[3]));
@@ -121,8 +124,8 @@ public class FateLock implements QueueLock {
     }
 
     public String serialize() {
-      return lockType.name() + "_" + fateId.canonical() + "_" + encodeRow(range.getStartRow()) + "_"
-          + encodeRow(range.getEndRow());
+      return lockType.name() + DELIMITER + fateId.canonical() + DELIMITER
+          + encodeRow(range.getStartRow()) + DELIMITER + encodeRow(range.getEndRow());
     }
 
     public static FateLockEntry from(LockType lockType, FateId fateId, LockRange range) {

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/FateLock.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/FateLock.java
@@ -87,7 +87,7 @@ public class FateLock implements QueueLock {
       var fields = entry.split("_", 4);
       this.lockType = LockType.valueOf(fields[0]);
       this.fateId = FateId.from(fields[1]);
-      this.range = LockRange.of(decode(fields[2]), decode(fields[3]));
+      this.range = LockRange.of(decodeRow(fields[2]), decodeRow(fields[3]));
     }
 
     public LockType getLockType() {
@@ -121,8 +121,8 @@ public class FateLock implements QueueLock {
     }
 
     public String serialize() {
-      return lockType.name() + "_" + fateId.canonical() + "_" + encode(range.getStartRow()) + "_"
-          + encode(range.getEndRow());
+      return lockType.name() + "_" + fateId.canonical() + "_" + encodeRow(range.getStartRow()) + "_"
+          + encodeRow(range.getEndRow());
     }
 
     public static FateLockEntry from(LockType lockType, FateId fateId, LockRange range) {

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/FateLock.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/FateLock.java
@@ -102,7 +102,7 @@ public class FateLock implements QueueLock {
       return range;
     }
 
-    private String encode(Text row) {
+    private String encodeRow(Text row) {
       if (row == null) {
         return "N";
       } else {

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/FateLock.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/FateLock.java
@@ -110,7 +110,7 @@ public class FateLock implements QueueLock {
       }
     }
 
-    private Text decode(String enc) {
+    private Text decodeRow(String enc) {
       if (enc.charAt(0) == 'P') {
         return new Text(Base64.getDecoder().decode(enc.substring(1)));
       } else if (enc.charAt(0) == 'N') {

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/LockRange.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/LockRange.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.fate.zookeeper;
+
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.hadoop.io.Text;
+
+public class LockRange {
+  final KeyExtent range;
+
+  private static final LockRange INF = new LockRange(null, null);
+
+  private LockRange(Text startRow, Text endRow) {
+    this.range = new KeyExtent(TableId.of("0"), endRow, startRow);
+  }
+
+  public Text getStartRow() {
+    return range.prevEndRow();
+  }
+
+  public Text getEndRow() {
+    return range.endRow();
+  }
+
+  public boolean overlaps(LockRange other) {
+    return range.overlaps(other.range);
+  }
+
+  public boolean isInfinite() {
+    return range.prevEndRow() == null && range.endRow() == null;
+  }
+
+  public static LockRange of(String startRow, String endRow) {
+    return of(startRow == null ? null : new Text(startRow),
+        endRow == null ? null : new Text(endRow));
+  }
+
+  public static LockRange of(byte[] startRow, byte[] endRow) {
+    return of(startRow == null ? null : new Text(startRow),
+        endRow == null ? null : new Text(endRow));
+  }
+
+  public static LockRange of(KeyExtent extent) {
+    return of(extent.prevEndRow(), extent.endRow());
+  }
+
+  public static LockRange of(Text startRow, Text endRow) {
+    if (startRow == null && endRow == null) {
+      return infinite();
+    }
+
+    return new LockRange(startRow, endRow);
+  }
+
+  public static LockRange infinite() {
+    return INF;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof LockRange) {
+      var other = (LockRange) o;
+      return range.equals(other.range);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return range.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return "(" + range.prevEndRow() + "," + range.endRow() + "]";
+  }
+}

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/LockRange.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/LockRange.java
@@ -47,6 +47,10 @@ public class LockRange {
     return range.prevEndRow() == null && range.endRow() == null;
   }
 
+  public boolean contains(LockRange widenedRange) {
+    return range.contains(widenedRange.range);
+  }
+
   public static LockRange of(String startRow, String endRow) {
     return of(startRow == null ? null : new Text(startRow),
         endRow == null ? null : new Text(endRow));

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/LockRange.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/LockRange.java
@@ -23,7 +23,7 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.hadoop.io.Text;
 
 public class LockRange {
-  final KeyExtent range;
+  private final KeyExtent range;
 
   private static final LockRange INF = new LockRange(null, null);
 

--- a/core/src/test/java/org/apache/accumulo/core/fate/zookeeper/DistributedReadWriteLockTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/fate/zookeeper/DistributedReadWriteLockTest.java
@@ -19,6 +19,8 @@
 package org.apache.accumulo.core.fate.zookeeper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -32,6 +34,7 @@ import java.util.function.Supplier;
 
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.FateInstanceType;
+import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.DistributedLock;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.QueueLock;
 import org.apache.accumulo.core.fate.zookeeper.FateLock.FateLockEntry;
@@ -102,8 +105,8 @@ public class DistributedReadWriteLockTest {
     data.read();
     QueueLock qlock = new MockQueueLock();
 
-    final ReadWriteLock locker =
-        new DistributedReadWriteLock(qlock, FateId.from(FateInstanceType.USER, UUID.randomUUID()));
+    final ReadWriteLock locker = new DistributedReadWriteLock(qlock,
+        FateId.from(FateInstanceType.USER, UUID.randomUUID()), LockRange.infinite());
     final Lock readLock = locker.readLock();
     final Lock writeLock = locker.writeLock();
     readLock.lock();
@@ -146,10 +149,69 @@ public class DistributedReadWriteLockTest {
     }
   }
 
+  private DistributedLock recover(QueueLock queueLock, FateId fateId, LockRange expectedRange,
+      LockType expectedType) {
+    var dlock = DistributedReadWriteLock.recoverLock(queueLock, fateId);
+    assertEquals(expectedRange, dlock.getRange());
+    assertEquals(expectedType, dlock.getType());
+    return dlock;
+  }
+
+  @Test
+  public void testRanges() {
+    QueueLock qlock = new MockQueueLock();
+
+    FateId fateIdInfToC = FateId.from(FateInstanceType.USER, UUID.randomUUID());
+    var rInfToC = LockRange.of(null, "C");
+
+    FateId fateIdQtoInf = FateId.from(FateInstanceType.USER, UUID.randomUUID());
+    var rQtoInf = LockRange.of("Q", null);
+
+    FateId fateIdBtoX = FateId.from(FateInstanceType.USER, UUID.randomUUID());
+    var rBtoX = LockRange.of("B", "X");
+
+    FateId fateIdEtoM = FateId.from(FateInstanceType.USER, UUID.randomUUID());
+    var rEtoM = LockRange.of("E", "M");
+
+    FateId fateIdJtoL = FateId.from(FateInstanceType.USER, UUID.randomUUID());
+    var rJtoL = LockRange.of("J", "L");
+
+    FateId fateIdInf = FateId.from(FateInstanceType.USER, UUID.randomUUID());
+    var rInf = LockRange.infinite();
+
+    assertTrue(new DistributedReadWriteLock(qlock, fateIdInfToC, rInfToC).writeLock().tryLock());
+    assertTrue(new DistributedReadWriteLock(qlock, fateIdQtoInf, rQtoInf).writeLock().tryLock());
+    assertFalse(new DistributedReadWriteLock(qlock, fateIdBtoX, rBtoX).readLock().tryLock());
+    assertTrue(new DistributedReadWriteLock(qlock, fateIdEtoM, rEtoM).readLock().tryLock());
+    assertFalse(new DistributedReadWriteLock(qlock, fateIdJtoL, rJtoL).writeLock().tryLock());
+    assertFalse(new DistributedReadWriteLock(qlock, fateIdInf, rInf).readLock().tryLock());
+
+    recover(qlock, fateIdInfToC, rInfToC, LockType.WRITE).unlock();
+    assertFalse(recover(qlock, fateIdBtoX, rBtoX, LockType.READ).tryLock());
+    assertFalse(recover(qlock, fateIdJtoL, rJtoL, LockType.WRITE).tryLock());
+    assertFalse(recover(qlock, fateIdInf, rInf, LockType.READ).tryLock());
+    recover(qlock, fateIdQtoInf, rQtoInf, LockType.WRITE).unlock();
+    assertFalse(recover(qlock, fateIdJtoL, rJtoL, LockType.WRITE).tryLock());
+    assertTrue(recover(qlock, fateIdBtoX, rBtoX, LockType.READ).tryLock());
+    assertFalse(recover(qlock, fateIdJtoL, rJtoL, LockType.WRITE).tryLock());
+    assertFalse(recover(qlock, fateIdInf, rInf, LockType.READ).tryLock());
+    recover(qlock, fateIdEtoM, rEtoM, LockType.READ).unlock();
+    assertFalse(recover(qlock, fateIdJtoL, rJtoL, LockType.WRITE).tryLock());
+    assertFalse(recover(qlock, fateIdInf, rInf, LockType.READ).tryLock());
+    recover(qlock, fateIdBtoX, rBtoX, LockType.READ).unlock();
+    assertTrue(recover(qlock, fateIdJtoL, rJtoL, LockType.WRITE).tryLock());
+    recover(qlock, fateIdJtoL, rJtoL, LockType.WRITE).unlock();
+    assertTrue(recover(qlock, fateIdInf, rInf, LockType.READ).tryLock());
+    recover(qlock, fateIdInf, rInf, LockType.READ).unlock();
+
+    assertTrue(qlock.getEntries((id, data) -> true).isEmpty());
+  }
+
   @Test
   public void testFateLockEntrySerDes() {
     var uuid = UUID.randomUUID();
-    var entry = FateLockEntry.from(LockType.READ, FateId.from(FateInstanceType.USER, uuid));
+    var entry = FateLockEntry.from(LockType.READ, FateId.from(FateInstanceType.USER, uuid),
+        LockRange.infinite());
     assertEquals(LockType.READ, entry.getLockType());
     assertEquals(FateId.from(FateInstanceType.USER, uuid), entry.getFateId());
 

--- a/core/src/test/java/org/apache/accumulo/core/fate/zookeeper/FateLockTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/fate/zookeeper/FateLockTest.java
@@ -34,7 +34,7 @@ public class FateLockTest {
   public void testParsing() {
     var fateId = FateId.from(FateInstanceType.USER, UUID.randomUUID());
     // ZooKeeper docs state that sequence numbers are formatted using %010d
-    String lockData = "WRITE:" + fateId.canonical();
+    String lockData = "WRITE_" + fateId.canonical() + "_N_N";
     var lockNode =
         new FateLock.NodeName(FateLock.PREFIX + lockData + "#" + String.format("%010d", 40));
     assertEquals(40, lockNode.sequence);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
@@ -89,7 +89,7 @@ import org.apache.accumulo.core.volume.Volume;
 import org.apache.accumulo.manager.tableOps.ChangeTableState;
 import org.apache.accumulo.manager.tableOps.TraceRepo;
 import org.apache.accumulo.manager.tableOps.availability.LockTable;
-import org.apache.accumulo.manager.tableOps.bulkVer2.PrepBulkImport;
+import org.apache.accumulo.manager.tableOps.bulkVer2.ComputeBulkRange;
 import org.apache.accumulo.manager.tableOps.clone.CloneTable;
 import org.apache.accumulo.manager.tableOps.compact.CompactRange;
 import org.apache.accumulo.manager.tableOps.compact.cancel.CancelCompactions;
@@ -664,7 +664,7 @@ class FateServiceHandler implements FateService.Iface {
 
         goalMessage += "Bulk import (v2)  " + dir + " to " + tableName + "(" + tableId + ")";
         manager.fate(type).seedTransaction(op, fateId,
-            new TraceRepo<>(new PrepBulkImport(tableId, dir, setTime)), autoCleanup, goalMessage);
+            new TraceRepo<>(new ComputeBulkRange(tableId, dir, setTime)), autoCleanup, goalMessage);
         break;
       }
       case TABLE_TABLET_AVAILABILITY: {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/ChangeTableState.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/ChangeTableState.java
@@ -26,6 +26,7 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
+import org.apache.accumulo.core.fate.zookeeper.LockRange;
 import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.manager.Manager;
 import org.slf4j.LoggerFactory;
@@ -55,7 +56,7 @@ public class ChangeTableState extends ManagerRepo {
     // reserve the table so that this op does not run concurrently with create, clone, or delete
     // table
     return Utils.reserveNamespace(env, namespaceId, fateId, LockType.READ, true, top)
-        + Utils.reserveTable(env, tableId, fateId, LockType.WRITE, true, top);
+        + Utils.reserveTable(env, tableId, fateId, LockType.WRITE, true, top, LockRange.infinite());
   }
 
   @Override

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
@@ -23,6 +23,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Base64;
+import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
@@ -38,15 +40,21 @@ import org.apache.accumulo.core.clientImpl.TabletMergeabilityUtil;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
 import org.apache.accumulo.core.data.AbstractId;
+import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.NamespaceId;
+import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.DistributedLock;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.fate.zookeeper.FateLock;
+import org.apache.accumulo.core.fate.zookeeper.LockRange;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.fate.zookeeper.ZooReservation;
+import org.apache.accumulo.core.metadata.schema.Ample;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.server.ServerContext;
@@ -56,6 +64,9 @@ import org.apache.hadoop.io.Text;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.MoreCollectors;
 
 public class Utils {
   private static final byte[] ZERO_BYTE = {'0'};
@@ -79,11 +90,126 @@ public class Utils {
   }
 
   static final Lock tableNameLock = new ReentrantLock();
-  static final Lock idLock = new ReentrantLock();
+
+  private static KeyExtent findContaining(Ample ample, TableId tableId, Text row) {
+    Objects.requireNonNull(row);
+    try (var tablets = ample.readTablets().forTable(tableId).overlapping(row, true, row)
+        .fetch(TabletMetadata.ColumnType.PREV_ROW).build()) {
+      return tablets.stream().collect(MoreCollectors.onlyElement()).getExtent();
+    }
+  }
+
+  /**
+   * Widen a range to the greatest table split that is below the range and least table split that is
+   * above the range.
+   */
+  public static KeyExtent widen(Ample ample, KeyExtent extent) {
+    Text prevRowOfStartRowTablet = extent.prevEndRow();
+    Text endRowOfEndRowTablet = extent.endRow();
+
+    if (extent.prevEndRow() != null) {
+      // The startRow is not inclusive, so do not want to find the tablet containing startRow but
+      // instead find the tablet that contains the next possible row after startRow
+      Text nextPossibleRow = new Key(extent.prevEndRow()).followingKey(PartialKey.ROW).getRow();
+      prevRowOfStartRowTablet =
+          findContaining(ample, extent.tableId(), nextPossibleRow).prevEndRow();
+    }
+
+    if (extent.endRow() != null) {
+      // find the tablet containing endRow and pass its end row to the CompactionDriver constructor.
+      endRowOfEndRowTablet = findContaining(ample, extent.tableId(), extent.endRow()).endRow();
+    }
+
+    return new KeyExtent(extent.tableId(), endRowOfEndRowTablet, prevRowOfStartRowTablet);
+  }
+
+  public static LockRange widen(Ample ample, TableId tableId, LockRange range, TableOperation op,
+      boolean tableMustExists) throws AcceptableThriftTableOperationException {
+    if (range.isInfinite()) {
+      return range;
+    }
+    try {
+      var wext = widen(ample, new KeyExtent(tableId, range.getEndRow(), range.getStartRow()));
+      return LockRange.of(wext.prevEndRow(), wext.endRow());
+    } catch (NoSuchElementException nse) {
+      if (tableMustExists) {
+        throw new AcceptableThriftTableOperationException(tableId.canonical(), "", op,
+            TableOperationExceptionType.NOTFOUND, "Table does not exist");
+      } else {
+        log.debug("Attempted to widen range {} but no metadata entries found for table {}", range,
+            tableId);
+        return LockRange.infinite();
+      }
+    }
+
+  }
 
   public static long reserveTable(Manager env, TableId tableId, FateId fateId, LockType lockType,
       boolean tableMustExist, TableOperation op) throws Exception {
-    if (getLock(env.getContext(), tableId, fateId, lockType).tryLock()) {
+    return reserveTable(env, tableId, fateId, lockType, tableMustExist, op, LockRange.infinite());
+  }
+
+  public static long reserveTable(Manager env, TableId tableId, FateId fateId, LockType lockType,
+      boolean tableMustExist, TableOperation op, final LockRange range) throws Exception {
+    final LockRange widenedRange;
+    if (lockType == LockType.WRITE) {
+      /*
+       * Write locks are widened to table split points to avoid non-overlapping ranges operating on
+       * the same tablet. For example assume a table has splits at c,e and two fate operations need
+       * write locks on ranges (a1,c2] and (d1,d9]. The fate ranges do not overlap, however both
+       * will operate on the tablet (c,e]. When the ranges are widened, (a1,c2] turns into (null,e]
+       * and (d1,d9] turns into (c,e]. The widened ranges for the fate operations overlap which
+       * prevents both from operating on the same tablet.
+       *
+       * Widening is only done for write locks because those need to work on mutually exclusive sets
+       * of tablets w/ other write or read locks. Read locks do not need to be mutually exclusive w/
+       * each other and it does not matter if they operate on the same tablet so widening is not
+       * needed for that case. Widening write locks is sufficient for detecting overlap w/ any
+       * tablets that read locks need to use. For example if a write locks is obtained on (a1,c2]
+       * and it widens to (null,e] then a read lock on (d1,d9] would overlap with the widened range.
+       *
+       * Only widening for write locks is nice because fate operations that get read locks are
+       * probably more frequent. So the work of widening is not done on most fate operations. Also
+       * widening an infinite range is a quick operation, so create/delete table will not be slowed
+       * down by widening.
+       */
+      widenedRange = widen(env.getContext().getAmple(), tableId, range, op, tableMustExist);
+      log.trace("{} widened write lock range from {} to {}", fateId, range, widenedRange);
+    } else {
+      widenedRange = range;
+    }
+
+    var lock = getLock(env.getContext(), tableId, fateId, lockType, widenedRange);
+    if (lockType == LockType.WRITE && !widenedRange.equals(lock.getRange())) {
+      // It is possible the range changed since the lock entry was created. Pre existing locks are
+      // found using the fate id and could have a different range.
+      lock.unlock();
+      // This should be a rare event, log at info in case it happens a lot.
+      log.info(
+          "{} widened range {} differs from existing lock range {}, deleted lock and will retry",
+          fateId, widenedRange, lock.getRange());
+      return 100;
+    } else if (lockType == LockType.READ) {
+      // Not expecting the lock range on a read lock to change.
+      Preconditions.checkState(widenedRange.equals(lock.getRange()));
+    }
+
+    if (lock.tryLock()) {
+      if (lockType == LockType.WRITE) {
+        // Now that table lock is acquired see if the range still widens to the same thing. If not
+        // it means the table splits changed so release the lock and try again later. Once the lock
+        // is acquired assuming the table splits in this range can not change, so this recheck is
+        // done after getting the lock.
+        var widenedRange2 = widen(env.getContext().getAmple(), tableId, range, op, tableMustExist);
+        if (!widenedRange.equals(widenedRange2)) {
+          lock.unlock();
+          log.info(
+              "{} widened range {} changed to {} after acquiring lock, deleted lock and will retry",
+              fateId, widenedRange, widenedRange2);
+          return 100;
+        }
+      }
+
       if (tableMustExist) {
         ZooReaderWriter zk = env.getContext().getZooSession().asReaderWriter();
         if (!zk.exists(Constants.ZTABLES + "/" + tableId)) {
@@ -91,7 +217,8 @@ public class Utils {
               TableOperationExceptionType.NOTFOUND, "Table does not exist");
         }
       }
-      log.info("table {} {} locked for {} operation: {}", tableId, fateId, lockType, op);
+      log.info("table {} {} locked for {} operation: {} range:{}", tableId, fateId, lockType, op,
+          range);
       return 0;
     } else {
       return 100;
@@ -100,19 +227,19 @@ public class Utils {
 
   public static void unreserveTable(Manager env, TableId tableId, FateId fateId,
       LockType lockType) {
-    getLock(env.getContext(), tableId, fateId, lockType).unlock();
+    getLock(env.getContext(), tableId, fateId, lockType, LockRange.infinite()).unlock();
     log.info("table {} {} unlocked for {}", tableId, fateId, lockType);
   }
 
   public static void unreserveNamespace(Manager env, NamespaceId namespaceId, FateId fateId,
       LockType lockType) {
-    getLock(env.getContext(), namespaceId, fateId, lockType).unlock();
+    getLock(env.getContext(), namespaceId, fateId, lockType, LockRange.infinite()).unlock();
     log.info("namespace {} {} unlocked for {}", namespaceId, fateId, lockType);
   }
 
   public static long reserveNamespace(Manager env, NamespaceId namespaceId, FateId fateId,
       LockType lockType, boolean mustExist, TableOperation op) throws Exception {
-    if (getLock(env.getContext(), namespaceId, fateId, lockType).tryLock()) {
+    if (getLock(env.getContext(), namespaceId, fateId, lockType, LockRange.infinite()).tryLock()) {
       if (mustExist) {
         ZooReaderWriter zk = env.getContext().getZooSession().asReaderWriter();
         if (!zk.exists(Constants.ZNAMESPACES + "/" + namespaceId)) {
@@ -148,8 +275,8 @@ public class Utils {
         fateId);
   }
 
-  private static Lock getLock(ServerContext context, AbstractId<?> id, FateId fateId,
-      LockType lockType) {
+  private static DistributedLock getLock(ServerContext context, AbstractId<?> id, FateId fateId,
+      LockType lockType, LockRange range) {
     FateLock qlock = new FateLock(context.getZooSession().asReaderWriter(),
         FateLock.path(Constants.ZTABLE_LOCKS + "/" + id.canonical()));
     DistributedLock lock = DistributedReadWriteLock.recoverLock(qlock, fateId);
@@ -162,7 +289,7 @@ public class Utils {
                 + " on object " + id + ". Expected " + lockType + " lock instead.");
       }
     } else {
-      DistributedReadWriteLock locker = new DistributedReadWriteLock(qlock, fateId);
+      DistributedReadWriteLock locker = new DistributedReadWriteLock(qlock, fateId, range);
       switch (lockType) {
         case WRITE:
           lock = locker.writeLock();
@@ -177,16 +304,12 @@ public class Utils {
     return lock;
   }
 
-  public static Lock getIdLock() {
-    return idLock;
-  }
-
   public static Lock getTableNameLock() {
     return tableNameLock;
   }
 
-  public static Lock getReadLock(Manager env, AbstractId<?> id, FateId fateId) {
-    return Utils.getLock(env.getContext(), id, fateId, LockType.READ);
+  public static Lock getReadLock(Manager env, AbstractId<?> id, FateId fateId, LockRange range) {
+    return Utils.getLock(env.getContext(), id, fateId, LockType.READ, range);
   }
 
   /**

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
@@ -199,9 +199,7 @@ public class Utils {
     if (lock.tryLock()) {
       if (lockType == LockType.WRITE) {
         // Now that table lock is acquired see if the range still widens to the same thing. If not
-        // it means the table splits changed so release the lock and try again later. Once the lock
-        // is acquired assuming the table splits in this range can not change, so this recheck is
-        // done after getting the lock.
+        // it means the table splits changed so release the lock and try again later. The table splits in this range can not change once the lock is acquired, so this recheck is done after getting the lock.
         var widenedRange2 = widen(env.getContext().getAmple(), tableId, range, op, tableMustExist);
         if (!widenedRange.equals(widenedRange2)) {
           lock.unlock();

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
@@ -199,7 +199,9 @@ public class Utils {
     if (lock.tryLock()) {
       if (lockType == LockType.WRITE) {
         // Now that table lock is acquired see if the range still widens to the same thing. If not
-        // it means the table splits changed so release the lock and try again later. The table splits in this range can not change once the lock is acquired, so this recheck is done after getting the lock.
+        // it means the table splits changed so release the lock and try again later. The table
+        // splits in this range can not change once the lock is acquired, so this recheck is done
+        // after getting the lock.
         var widenedRange2 = widen(env.getContext().getAmple(), tableId, range, op, tableMustExist);
         if (!widenedRange.equals(widenedRange2)) {
           lock.unlock();

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
@@ -100,8 +100,8 @@ public class Utils {
   }
 
   /**
-   * Widen a range to the greatest table split that is below the range and least table split that is
-   * above the range.
+   * Widen a range to the greatest table split that is before the range and least table split that
+   * is after the range.
    */
   public static KeyExtent widen(Ample ample, KeyExtent extent) {
     Text prevRowOfStartRowTablet = extent.prevEndRow();
@@ -116,7 +116,7 @@ public class Utils {
     }
 
     if (extent.endRow() != null) {
-      // find the tablet containing endRow and pass its end row to the CompactionDriver constructor.
+      // find the tablet containing endRow and use its endRow
       endRowOfEndRowTablet = findContaining(ample, extent.tableId(), extent.endRow()).endRow();
     }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/availability/LockTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/availability/LockTable.java
@@ -48,8 +48,6 @@ public class LockTable extends ManagerRepo {
 
   @Override
   public long isReady(FateId fateId, Manager manager) throws Exception {
-    // TODO could this get a READ table lock?
-    // TODO need to pass a LockRange, the ranges seems really complex for this
     return Utils.reserveNamespace(manager, namespaceId, fateId,
         DistributedReadWriteLock.LockType.READ, true, TableOperation.SET_TABLET_AVAILABILITY)
         + Utils.reserveTable(manager, tableId, fateId, DistributedReadWriteLock.LockType.WRITE,

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/availability/LockTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/availability/LockTable.java
@@ -48,6 +48,8 @@ public class LockTable extends ManagerRepo {
 
   @Override
   public long isReady(FateId fateId, Manager manager) throws Exception {
+    // TODO could this get a READ table lock?
+    // TODO need to pass a LockRange, the ranges seems really complex for this
     return Utils.reserveNamespace(manager, namespaceId, fateId,
         DistributedReadWriteLock.LockType.READ, true, TableOperation.SET_TABLET_AVAILABILITY)
         + Utils.reserveTable(manager, tableId, fateId, DistributedReadWriteLock.LockType.WRITE,

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/CleanUpBulkImport.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/CleanUpBulkImport.java
@@ -29,6 +29,7 @@ import org.apache.accumulo.core.data.AbstractId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.LockRange;
 import org.apache.accumulo.core.gc.ReferenceFile;
 import org.apache.accumulo.core.manager.thrift.BulkImportState;
 import org.apache.accumulo.core.metadata.schema.Ample;
@@ -75,7 +76,7 @@ public class CleanUpBulkImport extends ManagerRepo {
     removeBulkLoadEntries(ample, info.tableId, fateId, firstSplit, lastSplit);
 
     Utils.unreserveHdfsDirectory(manager, info.sourceDir, fateId);
-    Utils.getReadLock(manager, info.tableId, fateId).unlock();
+    Utils.getReadLock(manager, info.tableId, fateId, LockRange.infinite()).unlock();
     // delete json renames and mapping files
     Path renamingFile = new Path(bulkDir, Constants.BULK_RENAME_FILE);
     Path mappingFile = new Path(bulkDir, Constants.BULK_LOAD_MAPPING);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/ComputeBulkRange.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/ComputeBulkRange.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.manager.tableOps.bulkVer2;
+
+import java.util.Optional;
+
+import org.apache.accumulo.core.clientImpl.bulk.BulkSerialize;
+import org.apache.accumulo.core.clientImpl.bulk.LoadMappingIterator;
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.core.fate.FateId;
+import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.manager.Manager;
+import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.server.fs.VolumeManager;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.Text;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ComputeBulkRange extends ManagerRepo {
+  private static final long serialVersionUID = 1L;
+
+  private static final Logger log = LoggerFactory.getLogger(ComputeBulkRange.class);
+
+  private final BulkInfo bulkInfo;
+
+  public ComputeBulkRange(TableId tableId, String sourceDir, boolean setTime) {
+    BulkInfo info = new BulkInfo();
+    info.tableId = tableId;
+    info.sourceDir = sourceDir;
+    info.setTime = setTime;
+    this.bulkInfo = info;
+  }
+
+  @Override
+  public Repo<Manager> call(FateId fateId, Manager manager) throws Exception {
+
+    VolumeManager fs = manager.getVolumeManager();
+    final Path bulkDir = new Path(bulkInfo.sourceDir);
+
+    try (LoadMappingIterator lmi =
+        BulkSerialize.readLoadMapping(bulkDir.toString(), bulkInfo.tableId, fs::open)) {
+      KeyExtent first = lmi.next().getKey();
+      KeyExtent last = first;
+      while (lmi.hasNext()) {
+        last = lmi.next().getKey();
+      }
+
+      bulkInfo.firstSplit =
+          Optional.ofNullable(first.prevEndRow()).map(Text::getBytes).orElse(null);
+      bulkInfo.lastSplit = Optional.ofNullable(last.endRow()).map(Text::getBytes).orElse(null);
+
+      log.trace("{} first split:{} last split:{}", fateId, first.prevEndRow(), last.endRow());
+
+      return new PrepBulkImport(bulkInfo);
+    }
+  }
+}

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CleanUp.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CleanUp.java
@@ -30,6 +30,7 @@ import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.fate.zookeeper.LockRange;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.Ample.ConditionalResult.Status;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
@@ -120,8 +121,8 @@ public class CleanUp extends ManagerRepo {
   @Override
   public Repo<Manager> call(FateId fateId, Manager manager) throws Exception {
     CompactionConfigStorage.deleteConfig(manager.getContext(), fateId);
-    Utils.getReadLock(manager, tableId, fateId).unlock();
-    Utils.getReadLock(manager, namespaceId, fateId).unlock();
+    Utils.getReadLock(manager, tableId, fateId, LockRange.infinite()).unlock();
+    Utils.getReadLock(manager, namespaceId, fateId, LockRange.infinite()).unlock();
     return null;
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactRange.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactRange.java
@@ -20,31 +20,25 @@ package org.apache.accumulo.manager.tableOps.compact;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.accumulo.core.client.admin.CompactionConfig;
 import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
-import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.NamespaceId;
-import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
-import org.apache.accumulo.core.metadata.schema.Ample;
-import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.fate.zookeeper.LockRange;
 import org.apache.accumulo.core.util.TextUtil;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.accumulo.server.compaction.CompactionConfigStorage;
 import org.apache.hadoop.io.Text;
-
-import com.google.common.collect.MoreCollectors;
 
 public class CompactRange extends ManagerRepo {
 
@@ -83,44 +77,18 @@ public class CompactRange extends ManagerRepo {
   public long isReady(FateId fateId, Manager env) throws Exception {
     return Utils.reserveNamespace(env, namespaceId, fateId, LockType.READ, true,
         TableOperation.COMPACT)
-        + Utils.reserveTable(env, tableId, fateId, LockType.READ, true, TableOperation.COMPACT);
+        + Utils.reserveTable(env, tableId, fateId, LockType.READ, true, TableOperation.COMPACT,
+            LockRange.of(startRow, endRow));
   }
 
   @Override
   public Repo<Manager> call(final FateId fateId, Manager env) throws Exception {
     CompactionConfigStorage.setConfig(env.getContext(), fateId, config);
-    KeyExtent keyExtent;
-    byte[] prevRowOfStartRowTablet = startRow;
-    byte[] endRowOfEndRowTablet = endRow;
-
-    if (startRow != null) {
-      // The startRow in a compaction range is not inclusive, so do not want to find the tablet
-      // containing startRow but instead find the tablet that contains the next possible row after
-      // startRow
-      Text nextPossibleRow = new Key(startRow).followingKey(PartialKey.ROW).getRow();
-      keyExtent = findContaining(env.getContext().getAmple(), tableId, nextPossibleRow);
-      prevRowOfStartRowTablet =
-          keyExtent.prevEndRow() == null ? null : TextUtil.getBytes(keyExtent.prevEndRow());
-    }
-
-    if (endRow != null) {
-      // find the tablet containing endRow and pass its end row to the CompactionDriver constructor.
-      keyExtent = findContaining(env.getContext().getAmple(), tableId, new Text(endRow));
-      endRowOfEndRowTablet =
-          keyExtent.endRow() == null ? null : TextUtil.getBytes(keyExtent.endRow());
-    }
-    return new CompactionDriver(namespaceId, tableId, prevRowOfStartRowTablet,
-        endRowOfEndRowTablet);
-  }
-
-  private static KeyExtent findContaining(Ample ample, TableId tableId, Text row) {
-    Objects.requireNonNull(row);
-    try (var tablets = ample.readTablets().forTable(tableId).overlapping(row, true, row)
-        .fetch(TabletMetadata.ColumnType.PREV_ROW).build()) {
-      return tablets.stream().collect(MoreCollectors.onlyElement()).getExtent();
-
-    }
-
+    var widenedExtent = Utils.widen(env.getContext().getAmple(), new KeyExtent(tableId,
+        endRow == null ? null : new Text(endRow), startRow == null ? null : new Text(startRow)));
+    return new CompactionDriver(namespaceId, tableId,
+        widenedExtent.prevEndRow() == null ? null : TextUtil.getBytes(widenedExtent.prevEndRow()),
+        widenedExtent.endRow() == null ? null : TextUtil.getBytes(widenedExtent.endRow()));
   }
 
   @Override

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/TableRangeOp.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/TableRangeOp.java
@@ -24,6 +24,7 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
+import org.apache.accumulo.core.fate.zookeeper.LockRange;
 import org.apache.accumulo.core.metadata.SystemTables;
 import org.apache.accumulo.core.util.TextUtil;
 import org.apache.accumulo.manager.Manager;
@@ -44,7 +45,8 @@ public class TableRangeOp extends ManagerRepo {
   public long isReady(FateId fateId, Manager env) throws Exception {
     return Utils.reserveNamespace(env, data.namespaceId, fateId, LockType.READ, true,
         TableOperation.MERGE)
-        + Utils.reserveTable(env, data.tableId, fateId, LockType.WRITE, true, TableOperation.MERGE);
+        + Utils.reserveTable(env, data.tableId, fateId, LockType.WRITE, true, TableOperation.MERGE,
+            LockRange.of(data.getReserveExtent()));
   }
 
   public TableRangeOp(MergeInfo.Operation op, NamespaceId namespaceId, TableId tableId,

--- a/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/bulkVer2/PrepBulkImportTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/bulkVer2/PrepBulkImportTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.manager.tableOps.bulkVer2;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -34,7 +33,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -126,16 +124,9 @@ public class PrepBulkImportTest {
       }
     };
 
-    var sortedExtents = loadRanges.keySet().stream().sorted().collect(Collectors.toList());
-    String minPrevEndRow =
-        Optional.ofNullable(sortedExtents.get(0).prevEndRow()).map(Text::toString).orElse(null);
-    String maxPrevEndRow = Optional.ofNullable(sortedExtents.get(sortedExtents.size() - 1).endRow())
-        .map(Text::toString).orElse(null);
-
     try (LoadMappingIterator lmi = createLoadMappingIter(loadRanges)) {
-      var extent = PrepBulkImport.validateLoadMapping("1", lmi, tabletIterFactory, maxTablets, 0,
+      PrepBulkImport.validateLoadMapping("1", lmi, tabletIterFactory, maxTablets, 0,
           FateId.from(FateInstanceType.USER, UUID.randomUUID().toString()), skipDistance);
-      assertEquals(nke(minPrevEndRow, maxPrevEndRow), extent, loadRanges + " " + tabletRanges);
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/fate/FateOpsCommandsITBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FateOpsCommandsITBase.java
@@ -785,7 +785,7 @@ public abstract class FateOpsCommandsITBase extends SharedMiniClusterBase
     AdminUtil.FateStatus status = null;
     try {
       status = AdminUtil.getTransactionStatus(Map.of(store.type(), mockedStore), null, null, null,
-          new HashMap<>(), new HashMap<>());
+          new HashMap<>(), new HashMap<>(), Map.of());
     } catch (Exception e) {
       fail("An unexpected error occurred in getTransactionStatus():\n" + e);
     }

--- a/test/src/main/java/org/apache/accumulo/test/fate/RangedTableLocksIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/RangedTableLocksIT.java
@@ -1,0 +1,401 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test.fate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+
+import org.apache.accumulo.core.client.Accumulo;
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.admin.CloneConfiguration;
+import org.apache.accumulo.core.client.admin.CompactionConfig;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
+import org.apache.accumulo.core.client.admin.TabletAvailability;
+import org.apache.accumulo.core.client.admin.TabletMergeability;
+import org.apache.accumulo.core.client.rfile.RFile;
+import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
+import org.apache.accumulo.core.clientImpl.ClientContext;
+import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
+import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.fate.AdminUtil;
+import org.apache.accumulo.core.fate.FateId;
+import org.apache.accumulo.core.fate.zookeeper.LockRange;
+import org.apache.accumulo.core.metadata.schema.Ample;
+import org.apache.accumulo.harness.AccumuloClusterHarness;
+import org.apache.accumulo.manager.tableOps.Utils;
+import org.apache.accumulo.minicluster.ServerType;
+import org.apache.accumulo.test.util.Wait;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.Text;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests ranged table locks used by fate operations.
+ */
+public class RangedTableLocksIT extends AccumuloClusterHarness {
+
+  @Test
+  public void testCompactBulkMergeClone() throws Exception {
+    getCluster().getClusterControl().stopAllServers(ServerType.COMPACTOR);
+
+    ExecutorService executor = Executors.newCachedThreadPool();
+
+    var names = getUniqueNames(2);
+    String table = names[0];
+    String clone = names[1];
+
+    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
+      SortedMap<Text,TabletMergeability> splits = new TreeMap<>();
+      for (char c = 'b'; c < 'y'; c++) {
+        splits.put(new Text(c + ""), TabletMergeability.never());
+      }
+      client.tableOperations().create(table, new NewTableConfiguration().withSplits(splits));
+
+      SortedSet<String> expectedRows = new TreeSet<>();
+      try (var writer = client.createBatchWriter(table)) {
+        for (char c = 'b'; c < 'y'; c++) {
+          Mutation m = new Mutation(c + "");
+          m.at().family("test").qualifier("1").put("3");
+          writer.addMutation(m);
+          expectedRows.add(c + "");
+        }
+      }
+
+      // start a compaction that will get stuck because no compactors are running
+      var compactionFuture = executor.submit(() -> {
+        client.tableOperations().compact(table,
+            new CompactionConfig().setEndRow(new Text("b5")).setWait(true));
+        return null;
+      });
+
+      Wait.waitFor(() -> !getLocksInfo().heldLocks.isEmpty());
+      var lockInfo = getLocksInfo();
+      assertEquals(lockInfo.heldLocks.keySet(), lockInfo.findId(LockRange.of(null, "b5")));
+
+      // this bulk will overlap the compaction range, but should not get stuck because both are read
+      // locks
+      bulkImport(client, table, List.of("aa"));
+      expectedRows.add("aa");
+      assertEquals(expectedRows, getTableRows(client, table));
+
+      // start a merge operation that should get stuck because it overlaps the tablet that
+      // compaction has locked for read
+      var mergeFuture = executor.submit(() -> {
+        client.tableOperations().merge(table, new Text("b6"), new Text("c9"));
+        return null;
+      });
+
+      Wait.waitFor(() -> getLocksInfo().waitingLocks.size() == 1);
+      // the merge range should widen to table split points
+      lockInfo = getLocksInfo();
+      assertEquals(lockInfo.waitingLocks.keySet(), lockInfo.findId(LockRange.of("b", "d")));
+
+      // start a bulk operation that should get stuck waiting on the merge operation
+      var bulkFuture = executor.submit(() -> {
+        bulkImport(client, table, List.of("ab", "cc"));
+        return null;
+      });
+
+      Wait.waitFor(() -> getLocksInfo().waitingLocks.size() == 2);
+
+      var splitsCopy = new TreeSet<>(splits.keySet());
+      // splits should still be the same as when the table was created
+      assertEquals(splitsCopy, new TreeSet<>(client.tableOperations().listSplits(table)));
+
+      // merge should not block because its range does not overlap w/ the other blocked operations
+      client.tableOperations().merge(table, new Text("h1"), new Text("k9"));
+
+      assertTrue(splitsCopy.remove(new Text("i")));
+      assertTrue(splitsCopy.remove(new Text("j")));
+      assertTrue(splitsCopy.remove(new Text("k")));
+      // verify the split removed the expected ranges
+      assertEquals(splitsCopy, new TreeSet<>(client.tableOperations().listSplits(table)));
+
+      // the clone operation should get stuck trying to get a read lock on the entire source table
+      // range
+      var cloneFuture = executor.submit(() -> {
+        client.tableOperations().clone(table, clone, CloneConfiguration.empty());
+        return null;
+      });
+
+      Wait.waitFor(() -> getLocksInfo().waitingLocks.size() == 3);
+
+      assertEquals(expectedRows, getTableRows(client, table));
+
+      // bulk import should not block because it does not overlap any write locks. It does overlap
+      // the clone operation which has a read lock.
+      bulkImport(client, table, List.of("qq", "xx"));
+      expectedRows.add("qq");
+      expectedRows.add("xx");
+      assertEquals(expectedRows, getTableRows(client, table));
+
+      // nothing should have changed w/ the locks as a result of the merge running, also any locks
+      // from the merge should be gone
+      lockInfo = getLocksInfo();
+
+      // remove the fate op that only has a lock on the namespace
+      lockInfo.heldLocks.values().removeIf(idList -> idList.equals(List.of("R:+default")));
+      assertEquals(lockInfo.heldLocks.keySet(), lockInfo.findId(LockRange.of(null, "b5")));
+      assertEquals(lockInfo.waitingLocks.keySet(),
+          lockInfo.findId(LockRange.of("b", "d"), LockRange.of(null, "d"), LockRange.infinite()));
+
+      // should not be able to complete until compactors are started
+      assertFalse(compactionFuture.isDone());
+      assertFalse(mergeFuture.isDone());
+      assertFalse(bulkFuture.isDone());
+      assertFalse(cloneFuture.isDone());
+
+      // starting the compactors should allow the compaction to finish and then the merge to finish
+      getCluster().getClusterControl().startAllServers(ServerType.COMPACTOR);
+
+      // should complete w/o errors
+      compactionFuture.get();
+      mergeFuture.get();
+      bulkFuture.get();
+      cloneFuture.get();
+
+      // verify the merge removed the split
+      assertTrue(splitsCopy.remove(new Text("c")));
+      assertEquals(splitsCopy, new TreeSet<>(client.tableOperations().listSplits(table)));
+
+      var prevExpectedRows = new TreeSet<>(expectedRows);
+
+      // verify data from the bulk import that was blocked and then ran
+      expectedRows.add("ab");
+      expectedRows.add("cc");
+      assertEquals(expectedRows, getTableRows(client, table));
+
+      var cloneRows = getTableRows(client, clone);
+      // The clone operation and the bulk operation were both waiting on the merge operation. Once
+      // the merge completes, both clone and bulk import can start running concurrently. So the
+      // clone may or may not pick up the imported data.
+      assertTrue(cloneRows.equals(expectedRows) || cloneRows.equals(prevExpectedRows),
+          cloneRows::toString);
+
+    } finally {
+      executor.shutdownNow();
+    }
+
+  }
+
+  @Test
+  public void testWiden() throws Exception {
+    var names = getUniqueNames(2);
+    var table1 = names[0];
+    var table2 = names[1];
+    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
+      SortedMap<Text,TabletMergeability> splits = new TreeMap<>();
+      for (char c = 'b'; c < 'y'; c++) {
+        splits.put(new Text(c + ""), TabletMergeability.never());
+      }
+      client.tableOperations().create(table1, new NewTableConfiguration().withSplits(splits));
+      client.tableOperations().create(table2);
+
+      ClientContext ctx = ((ClientContext) client);
+      Ample ample = ctx.getAmple();
+
+      TableId tableId1 = ctx.getTableId(table1);
+      TableId tableId2 = ctx.getTableId(table2);
+
+      TableOperation op = TableOperation.MERGE;
+
+      assertEquals(LockRange.infinite(),
+          Utils.widen(ample, tableId1, LockRange.infinite(), op, true));
+      assertEquals(LockRange.infinite(),
+          Utils.widen(ample, tableId2, LockRange.infinite(), op, true));
+      assertEquals(LockRange.infinite(),
+          Utils.widen(ample, tableId2, LockRange.of(null, "m"), op, true));
+      assertEquals(LockRange.infinite(),
+          Utils.widen(ample, tableId2, LockRange.of("m", "q"), op, true));
+      assertEquals(LockRange.infinite(),
+          Utils.widen(ample, tableId2, LockRange.of("m", null), op, true));
+
+      assertEquals(LockRange.of(null, "c"),
+          Utils.widen(ample, tableId1, LockRange.of(null, "bb"), op, true));
+      assertEquals(LockRange.of(null, "c"),
+          Utils.widen(ample, tableId1, LockRange.of(null, "c"), op, true));
+      assertEquals(LockRange.of(null, "c"),
+          Utils.widen(ample, tableId1, LockRange.of("aa", "bb"), op, true));
+      assertEquals(LockRange.of(null, "c"),
+          Utils.widen(ample, tableId1, LockRange.of("aa", "c"), op, true));
+
+      assertEquals(LockRange.of("e", "j"),
+          Utils.widen(ample, tableId1, LockRange.of("ee", "ii"), op, true));
+      assertEquals(LockRange.of("e", "j"),
+          Utils.widen(ample, tableId1, LockRange.of("e", "ii"), op, true));
+      assertEquals(LockRange.of("e", "j"),
+          Utils.widen(ample, tableId1, LockRange.of("ee", "j"), op, true));
+      assertEquals(LockRange.of("e", "j"),
+          Utils.widen(ample, tableId1, LockRange.of("e", "j"), op, true));
+
+      assertEquals(LockRange.of("q", null),
+          Utils.widen(ample, tableId1, LockRange.of("qq", null), op, true));
+      assertEquals(LockRange.of("q", null),
+          Utils.widen(ample, tableId1, LockRange.of("q", null), op, true));
+      assertEquals(LockRange.of("q", null),
+          Utils.widen(ample, tableId1, LockRange.of("qq", "zz"), op, true));
+      assertEquals(LockRange.of("q", null),
+          Utils.widen(ample, tableId1, LockRange.of("q", "zz"), op, true));
+
+      TableId nonExistentTableId = TableId.of("abcdefg");
+
+      for (var lockRange : List.of(LockRange.of("c", "f"), LockRange.of(null, "f"),
+          LockRange.of("c", null))) {
+        var expception = assertThrows(AcceptableThriftTableOperationException.class,
+            () -> Utils.widen(ample, nonExistentTableId, lockRange, op, true));
+        assertEquals(nonExistentTableId.canonical(), expception.getTableId());
+        assertEquals(TableOperationExceptionType.NOTFOUND, expception.getType());
+
+        assertEquals(LockRange.infinite(),
+            Utils.widen(ample, nonExistentTableId, lockRange, op, false));
+      }
+
+      // when the lock range is infinite no metadata lookup is done
+      assertEquals(LockRange.infinite(),
+          Utils.widen(ample, nonExistentTableId, LockRange.infinite(), op, true));
+    }
+  }
+
+  /**
+   * Ranged table locks have mechanisms for handling race conditions during widening of ranges.
+   * Concurrent merge operations may exercise this code.
+   */
+  @Test
+  public void testConcurrentMerge() throws Exception {
+    String table = getUniqueNames(1)[0];
+
+    ExecutorService executor = Executors.newCachedThreadPool();
+
+    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
+      SortedMap<Text,TabletMergeability> splits = new TreeMap<>();
+      for (int r = 0; r < 1_000; r += 10) {
+        splits.put(new Text(String.format("%06d", r)), TabletMergeability.never());
+      }
+      client.tableOperations().create(table, new NewTableConfiguration().withSplits(splits)
+          .withInitialTabletAvailability(TabletAvailability.HOSTED));
+
+      Set<String> expectedRows = new TreeSet<>();
+      try (var writer = client.createBatchWriter(table)) {
+        for (int r = 0; r < 1_000; r++) {
+          var row = String.format("%06d", r);
+          expectedRows.add(row);
+          Mutation m = new Mutation(row);
+          m.put("f", "q", "v");
+          writer.addMutation(m);
+        }
+      }
+
+      List<Future<?>> futures = new ArrayList<>();
+      // create 9 sets of 3 concurrent merge operations where each set of 3 merge operations overlap
+      // w/ each other
+      for (int r = 100; r < 1_000; r += 100) {
+        int row = r;
+        futures.add(executor.submit(() -> {
+          client.tableOperations().merge(table, new Text(String.format("%06d", row - 15)),
+              new Text(String.format("%06d", row + 5)));
+          return null;
+        }));
+        futures.add(executor.submit(() -> {
+          client.tableOperations().merge(table, new Text(String.format("%06d", row - 5)),
+              new Text(String.format("%06d", row + 15)));
+          return null;
+        }));
+        futures.add(executor.submit(() -> {
+          client.tableOperations().merge(table, new Text(String.format("%06d", row)),
+              new Text(String.format("%06d", row + 20)));
+          return null;
+        }));
+
+        // remove splits that should be removed by these merge operations.
+        splits.subMap(new Text(String.format("%06d", row - 15)),
+            new Text(String.format("%06d", row + 20))).clear();
+      }
+
+      // wait for all merge operations to complete and ensure none failed
+      for (var future : futures) {
+        future.get();
+      }
+
+      // ensure the table data and splits are correct
+      assertEquals(expectedRows, getTableRows(client, table));
+      assertEquals(splits.keySet(), new TreeSet<>(client.tableOperations().listSplits(table)));
+    }
+  }
+
+  private SortedSet<String> getTableRows(AccumuloClient client, String table) throws Exception {
+    try (var scanner = client.createScanner(table)) {
+      return scanner.stream().map(Map.Entry::getKey).map(k -> k.getRowData().toString())
+          .collect(Collectors.toCollection(TreeSet::new));
+    }
+  }
+
+  private void bulkImport(AccumuloClient client, String table, List<String> rows) throws Exception {
+    var bulkDir = new Path(getCluster().getTemporaryPath(), UUID.randomUUID().toString());
+    try (var writer = RFile.newWriter().to(new Path(bulkDir, "f1.rf").toString())
+        .withFileSystem(getFileSystem()).build()) {
+      writer.startDefaultLocalityGroup();
+      for (var row : rows) {
+        writer.append(Key.builder().row(row).family("").qualifier("").build(), "");
+      }
+    }
+
+    client.tableOperations().importDirectory(bulkDir.toString()).to(table).load();
+  }
+
+  static class LocksInfo {
+    Map<FateId,List<String>> heldLocks = new HashMap<>();
+    Map<FateId,List<String>> waitingLocks = new HashMap<>();
+    Map<FateId,LockRange> lockRanges = new HashMap<>();
+
+    Set<FateId> findId(LockRange... ranges) {
+      var lrs = Set.of(ranges);
+      return lockRanges.entrySet().stream().filter(e -> lrs.contains(e.getValue()))
+          .map(Map.Entry::getKey).collect(Collectors.toSet());
+    }
+  }
+
+  static LocksInfo getLocksInfo() throws Exception {
+    var zTableLocksPath = getServerContext().getServerPaths().createTableLocksPath();
+    LocksInfo locksInfo = new LocksInfo();
+    AdminUtil.findLocks(getServerContext().getZooSession(), zTableLocksPath, locksInfo.heldLocks,
+        locksInfo.waitingLocks, locksInfo.lockRanges);
+    return locksInfo;
+  }
+
+}

--- a/test/src/main/java/org/apache/accumulo/test/fate/RangedTableLocksIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/RangedTableLocksIT.java
@@ -277,10 +277,10 @@ public class RangedTableLocksIT extends AccumuloClusterHarness {
 
       for (var lockRange : List.of(LockRange.of("c", "f"), LockRange.of(null, "f"),
           LockRange.of("c", null))) {
-        var expception = assertThrows(AcceptableThriftTableOperationException.class,
+        var exception = assertThrows(AcceptableThriftTableOperationException.class,
             () -> Utils.widen(ample, nonExistentTableId, lockRange, op, true));
-        assertEquals(nonExistentTableId.canonical(), expception.getTableId());
-        assertEquals(TableOperationExceptionType.NOTFOUND, expception.getType());
+        assertEquals(nonExistentTableId.canonical(), exception.getTableId());
+        assertEquals(TableOperationExceptionType.NOTFOUND, exception.getType());
 
         assertEquals(LockRange.infinite(),
             Utils.widen(ample, nonExistentTableId, lockRange, op, false));

--- a/test/src/main/java/org/apache/accumulo/test/fate/RangedTableLocksIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/RangedTableLocksIT.java
@@ -355,6 +355,8 @@ public class RangedTableLocksIT extends AccumuloClusterHarness {
       // ensure the table data and splits are correct
       assertEquals(expectedRows, getTableRows(client, table));
       assertEquals(splits.keySet(), new TreeSet<>(client.tableOperations().listSplits(table)));
+    } finally {
+      executor.shutdownNow();
     }
   }
 


### PR DESCRIPTION
Added ranges to table locks using the ranges from fate operations.  For write locks these ranges are widened to the nearest splits, see comments in Utils.reserveTable for details.  See comments and code in DistributedReadWriteLock.WriteLock.tryLock() and
DistributedReadWriteLock.ReadLock.tryLock() for details about how these ranges change lock behavior.  Added tests to excercise this new locking behavior. Modified the `accumulo admin fate -l` command to display lock ranges.  Also modified how this command determines if a lock is held or waiting.

fixes #2483