### PR TITLE
Fix intermittent AdvertiseAndBindIT failures

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/functional/AdvertiseAndBindIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/AdvertiseAndBindIT.java
@@ -49,6 +49,8 @@ public class AdvertiseAndBindIT extends ConfigurableMacBase {
     cfg.setNumCompactors(1);
     cfg.setNumScanServers(1);
     cfg.setNumTservers(1);
+    cfg.setProperty(Property.COMPACTOR_PORTSEARCH, "true");
+    cfg.setProperty(Property.TSERV_PORTSEARCH, "true");
     cfg.setServerClass(ServerType.COMPACTION_COORDINATOR, CompactionCoordinator.class);
     cfg.setProperty(Property.INSTANCE_ZK_TIMEOUT, "10s");
   }


### PR DESCRIPTION
This change sets the compactor and tserver port search properties to true for MiniAccumuloCluster. When this test fails I'm seeing the following stack trace in the Compactor log. The sserver port search property defaults to true, which is why it is not included in this change.

Thread 'org.apache.accumulo.compactor.Compactor' died. java.lang.RuntimeException: Failed to start the compactor client service
        at org.apache.accumulo.compactor.Compactor.run(Compactor.java:807)
        at org.apache.accumulo.core.trace.TraceWrappedRunnable.run(TraceWrappedRunnable.java:52)
        at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: java.net.UnknownHostException: Unable to find a listen port
        at org.apache.accumulo.server.rpc.TServerUtils.startServer(TServerUtils.java:219)
        at org.apache.accumulo.compactor.Compactor.startCompactorClientService(Compactor.java:415)
        at org.apache.accumulo.compactor.Compactor.run(Compactor.java:805)