### PR TITLE
Fixed issue with exception in server run method not being logged

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/AbstractServer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/AbstractServer.java
@@ -75,6 +75,27 @@ public abstract class AbstractServer
     ServerAddress get() throws UnknownHostException;
   }
 
+  public static void startServer(AbstractServer server, Logger LOG) throws Exception {
+    try {
+      server.runServer();
+    } catch (Exception e) {
+      System.err
+          .println(server.getClass().getSimpleName() + " died, exception thrown from runServer.");
+      e.printStackTrace();
+      LOG.error("{} died, exception thrown from runServer.", server.getClass().getSimpleName(), e);
+      throw e;
+    } finally {
+      try {
+        server.close();
+      } catch (Exception e) {
+        System.err.println("Exception thrown while closing " + server.getClass().getSimpleName());
+        e.printStackTrace();
+        LOG.error("Exception thrown while closing {}", server.getClass().getSimpleName(), e);
+        throw e;
+      }
+    }
+  }
+
   private final MetricSource metricSource;
   private final ServerContext context;
   protected final String applicationName;

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -1063,9 +1063,9 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
   }
 
   public static void main(String[] args) throws Exception {
-    try (Compactor compactor = new Compactor(new ConfigOpts(), args)) {
-      compactor.runServer();
-    }
+    Compactor compactor = new Compactor(new ConfigOpts(), args);
+    compactor.runServer();
+    compactor.close();
   }
 
   @Override

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -1063,15 +1063,7 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
   }
 
   public static void main(String[] args) throws Exception {
-    try (Compactor compactor = new Compactor(new ConfigOpts(), args)) {
-      try {
-        compactor.runServer();
-      } catch (Exception e) {
-        System.err.println("Compactor died, exception thrown from runServer.");
-        e.printStackTrace();
-        LOG.error("Compactor died, exception thrown from runServer.", e);
-      }
-    }
+    AbstractServer.startServer(new Compactor(new ConfigOpts(), args), LOG);
   }
 
   @Override

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -1063,9 +1063,15 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
   }
 
   public static void main(String[] args) throws Exception {
-    Compactor compactor = new Compactor(new ConfigOpts(), args);
-    compactor.runServer();
-    compactor.close();
+    try (Compactor compactor = new Compactor(new ConfigOpts(), args)) {
+      try {
+        compactor.runServer();
+      } catch (Exception e) {
+        System.err.println("Compactor died, exception thrown from runServer.");
+        e.printStackTrace();
+        LOG.error("Compactor died, exception thrown from runServer.", e);
+      }
+    }
   }
 
   @Override

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -110,9 +110,15 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
   }
 
   public static void main(String[] args) throws Exception {
-    SimpleGarbageCollector gc = new SimpleGarbageCollector(new ConfigOpts(), args);
-    gc.runServer();
-    gc.close();
+    try (SimpleGarbageCollector gc = new SimpleGarbageCollector(new ConfigOpts(), args)) {
+      try {
+        gc.runServer();
+      } catch (Exception e) {
+        System.err.println("SimpleGarbageCollector died, exception thrown from runServer.");
+        e.printStackTrace();
+        log.error("SimpleGarbageCollector died, exception thrown from runServer.", e);
+      }
+    }
   }
 
   /**

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -110,9 +110,9 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
   }
 
   public static void main(String[] args) throws Exception {
-    try (SimpleGarbageCollector gc = new SimpleGarbageCollector(new ConfigOpts(), args)) {
-      gc.runServer();
-    }
+    SimpleGarbageCollector gc = new SimpleGarbageCollector(new ConfigOpts(), args);
+    gc.runServer();
+    gc.close();
   }
 
   /**

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -110,15 +110,7 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
   }
 
   public static void main(String[] args) throws Exception {
-    try (SimpleGarbageCollector gc = new SimpleGarbageCollector(new ConfigOpts(), args)) {
-      try {
-        gc.runServer();
-      } catch (Exception e) {
-        System.err.println("SimpleGarbageCollector died, exception thrown from runServer.");
-        e.printStackTrace();
-        log.error("SimpleGarbageCollector died, exception thrown from runServer.", e);
-      }
-    }
+    AbstractServer.startServer(new SimpleGarbageCollector(new ConfigOpts(), args), log);
   }
 
   /**

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -481,15 +481,7 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener {
   }
 
   public static void main(String[] args) throws Exception {
-    try (Manager manager = new Manager(new ConfigOpts(), ServerContext::new, args)) {
-      try {
-        manager.runServer();
-      } catch (Exception e) {
-        System.err.println("Manager died, exception thrown from runServer.");
-        e.printStackTrace();
-        log.error("Manager died, exception thrown from runServer.", e);
-      }
-    }
+    AbstractServer.startServer(new Manager(new ConfigOpts(), ServerContext::new, args), log);
   }
 
   protected Manager(ConfigOpts opts, Function<SiteConfiguration,ServerContext> serverContextFactory,

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -481,9 +481,15 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener {
   }
 
   public static void main(String[] args) throws Exception {
-    Manager manager = new Manager(new ConfigOpts(), ServerContext::new, args);
-    manager.runServer();
-    manager.close();
+    try (Manager manager = new Manager(new ConfigOpts(), ServerContext::new, args)) {
+      try {
+        manager.runServer();
+      } catch (Exception e) {
+        System.err.println("Manager died, exception thrown from runServer.");
+        e.printStackTrace();
+        log.error("Manager died, exception thrown from runServer.", e);
+      }
+    }
   }
 
   protected Manager(ConfigOpts opts, Function<SiteConfiguration,ServerContext> serverContextFactory,

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -481,9 +481,9 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener {
   }
 
   public static void main(String[] args) throws Exception {
-    try (Manager manager = new Manager(new ConfigOpts(), ServerContext::new, args)) {
-      manager.runServer();
-    }
+    Manager manager = new Manager(new ConfigOpts(), ServerContext::new, args);
+    manager.runServer();
+    manager.close();
   }
 
   protected Manager(ConfigOpts opts, Function<SiteConfiguration,ServerContext> serverContextFactory,

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -117,9 +117,9 @@ public class Monitor extends AbstractServer implements Connection.Listener {
   private final long START_TIME;
 
   public static void main(String[] args) throws Exception {
-    try (Monitor monitor = new Monitor(new ConfigOpts(), args)) {
-      monitor.runServer();
-    }
+    Monitor monitor = new Monitor(new ConfigOpts(), args);
+    monitor.runServer();
+    monitor.close();
   }
 
   Monitor(ConfigOpts opts, String[] args) {

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -117,9 +117,15 @@ public class Monitor extends AbstractServer implements Connection.Listener {
   private final long START_TIME;
 
   public static void main(String[] args) throws Exception {
-    Monitor monitor = new Monitor(new ConfigOpts(), args);
-    monitor.runServer();
-    monitor.close();
+    try (Monitor monitor = new Monitor(new ConfigOpts(), args)) {
+      try {
+        monitor.runServer();
+      } catch (Exception e) {
+        System.err.println("Monitor died, exception thrown from runServer.");
+        e.printStackTrace();
+        log.error("Monitor died, exception thrown from runServer.", e);
+      }
+    }
   }
 
   Monitor(ConfigOpts opts, String[] args) {

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -117,15 +117,7 @@ public class Monitor extends AbstractServer implements Connection.Listener {
   private final long START_TIME;
 
   public static void main(String[] args) throws Exception {
-    try (Monitor monitor = new Monitor(new ConfigOpts(), args)) {
-      try {
-        monitor.runServer();
-      } catch (Exception e) {
-        System.err.println("Monitor died, exception thrown from runServer.");
-        e.printStackTrace();
-        log.error("Monitor died, exception thrown from runServer.", e);
-      }
-    }
+    AbstractServer.startServer(new Monitor(new ConfigOpts(), args), log);
   }
 
   Monitor(ConfigOpts opts, String[] args) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -1137,9 +1137,9 @@ public class ScanServer extends AbstractServer
   }
 
   public static void main(String[] args) throws Exception {
-    try (ScanServer tserver = new ScanServer(new ConfigOpts(), args)) {
-      tserver.runServer();
-    }
+    ScanServer sserver = new ScanServer(new ConfigOpts(), args);
+    sserver.runServer();
+    sserver.close();
   }
 
 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -1137,15 +1137,7 @@ public class ScanServer extends AbstractServer
   }
 
   public static void main(String[] args) throws Exception {
-    try (ScanServer sserver = new ScanServer(new ConfigOpts(), args)) {
-      try {
-        sserver.runServer();
-      } catch (Exception e) {
-        System.err.println("ScanServer died, exception thrown from runServer.");
-        e.printStackTrace();
-        LOG.error("ScanServer died, exception thrown from runServer.", e);
-      }
-    }
+    AbstractServer.startServer(new ScanServer(new ConfigOpts(), args), LOG);
   }
 
 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -1137,9 +1137,15 @@ public class ScanServer extends AbstractServer
   }
 
   public static void main(String[] args) throws Exception {
-    ScanServer sserver = new ScanServer(new ConfigOpts(), args);
-    sserver.runServer();
-    sserver.close();
+    try (ScanServer sserver = new ScanServer(new ConfigOpts(), args)) {
+      try {
+        sserver.runServer();
+      } catch (Exception e) {
+        System.err.println("ScanServer died, exception thrown from runServer.");
+        e.printStackTrace();
+        LOG.error("ScanServer died, exception thrown from runServer.", e);
+      }
+    }
   }
 
 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -214,9 +214,9 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
   private final ServerContext context;
 
   public static void main(String[] args) throws Exception {
-    try (TabletServer tserver = new TabletServer(new ConfigOpts(), ServerContext::new, args)) {
-      tserver.runServer();
-    }
+    TabletServer tserver = new TabletServer(new ConfigOpts(), ServerContext::new, args);
+    tserver.runServer();
+    tserver.close();
   }
 
   protected TabletServer(ConfigOpts opts,

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -214,15 +214,7 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
   private final ServerContext context;
 
   public static void main(String[] args) throws Exception {
-    try (TabletServer tserver = new TabletServer(new ConfigOpts(), ServerContext::new, args)) {
-      try {
-        tserver.runServer();
-      } catch (Exception e) {
-        System.err.println("TabletServer died, exception thrown from runServer.");
-        e.printStackTrace();
-        log.error("TabletServer died, exception thrown from runServer.", e);
-      }
-    }
+    AbstractServer.startServer(new TabletServer(new ConfigOpts(), ServerContext::new, args), log);
   }
 
   protected TabletServer(ConfigOpts opts,

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -214,9 +214,15 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
   private final ServerContext context;
 
   public static void main(String[] args) throws Exception {
-    TabletServer tserver = new TabletServer(new ConfigOpts(), ServerContext::new, args);
-    tserver.runServer();
-    tserver.close();
+    try (TabletServer tserver = new TabletServer(new ConfigOpts(), ServerContext::new, args)) {
+      try {
+        tserver.runServer();
+      } catch (Exception e) {
+        System.err.println("TabletServer died, exception thrown from runServer.");
+        e.printStackTrace();
+        log.error("TabletServer died, exception thrown from runServer.", e);
+      }
+    }
   }
 
   protected TabletServer(ConfigOpts opts,


### PR DESCRIPTION
The use of try-with-resources in the server process' main method causes the server's close method to always be called. When an exception occurs in the runServer method it may not be logged because the invocation of the close method consumes enough time that the lock watcher is fired which ends up halting the JVM.

Closes #5794