### PR TITLE
Improves FATE metrics

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -458,13 +458,6 @@ public enum Property {
   MANAGER_FATE_METRICS_MIN_UPDATE_INTERVAL("manager.fate.metrics.min.update.interval", "60s",
       PropertyType.TIMEDURATION, "Limit calls from metric sinks to zookeeper to update interval.",
       "1.9.3"),
-  @Deprecated(since = "4.0.0")
-  MANAGER_FATE_THREADPOOL_SIZE("manager.fate.threadpool.size", "64",
-      PropertyType.FATE_THREADPOOL_SIZE,
-      "Previously, the number of threads used to run fault-tolerant executions (FATE)."
-          + " This is no longer used in 4.0+. MANAGER_FATE_USER_CONFIG and"
-          + " MANAGER_FATE_META_CONFIG are the replacement and must be set instead.",
-      "1.4.3"),
   MANAGER_FATE_USER_CONFIG("manager.fate.user.config",
       "{\"TABLE_CREATE,TABLE_DELETE,TABLE_RENAME,TABLE_ONLINE,TABLE_OFFLINE,NAMESPACE_CREATE,"
           + "NAMESPACE_DELETE,NAMESPACE_RENAME,TABLE_TABLET_AVAILABILITY,SHUTDOWN_TSERVER,"
@@ -491,6 +484,15 @@ public enum Property {
           + "more FATE operations and each value is the number of threads that will be assigned "
           + "to the pool.",
       "4.0.0"),
+  @Deprecated(since = "4.0.0")
+  MANAGER_FATE_THREADPOOL_SIZE("manager.fate.threadpool.size", "64",
+      PropertyType.FATE_THREADPOOL_SIZE,
+      String.format(
+          "Previously, the number of threads used to run fault-tolerant executions (FATE)."
+              + " This is no longer used in 4.0+. %s and %s are the replacement and must be"
+              + " set instead.",
+          MANAGER_FATE_USER_CONFIG.getKey(), MANAGER_FATE_META_CONFIG.getKey()),
+      "1.4.3"),
   MANAGER_FATE_IDLE_CHECK_INTERVAL("manager.fate.idle.check.interval", "60m",
       PropertyType.TIMEDURATION,
       "The interval at which to check if the number of idle Fate threads has consistently been zero."

--- a/core/src/main/java/org/apache/accumulo/core/fate/FateExecutorMetrics.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/FateExecutorMetrics.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.fate;
+
+import java.util.Set;
+import java.util.concurrent.TransferQueue;
+
+import org.apache.accumulo.core.metrics.Metric;
+import org.apache.accumulo.core.metrics.MetricsProducer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+
+public class FateExecutorMetrics<T> implements MetricsProducer {
+  private static final Logger log = LoggerFactory.getLogger(FateExecutorMetrics.class.getName());
+  private final FateInstanceType type;
+  private final String operatesOn;
+  private final Set<FateExecutor<T>.TransactionRunner> runningTxRunners;
+  private final TransferQueue<FateId> workQueue;
+  private MeterRegistry registry;
+  public static final String INSTANCE_TYPE_TAG_KEY = "instanceType";
+  public static final String OPS_ASSIGNED_TAG_KEY = "ops.assigned";
+
+  protected FateExecutorMetrics(FateInstanceType type, String operatesOn,
+      Set<FateExecutor<T>.TransactionRunner> runningTxRunners, TransferQueue<FateId> workQueue) {
+    this.type = type;
+    this.operatesOn = operatesOn;
+    this.runningTxRunners = runningTxRunners;
+    this.workQueue = workQueue;
+  }
+
+  @Override
+  public void registerMetrics(MeterRegistry registry) {
+    Gauge.builder(Metric.FATE_OPS_THREADS_TOTAL.getName(), runningTxRunners::size)
+        .description(Metric.FATE_OPS_THREADS_TOTAL.getDescription())
+        .tag(INSTANCE_TYPE_TAG_KEY, type.name().toLowerCase()).tag(OPS_ASSIGNED_TAG_KEY, operatesOn)
+        .register(registry);
+    Gauge.builder(Metric.FATE_OPS_THREADS_INACTIVE.getName(), workQueue::getWaitingConsumerCount)
+        .description(Metric.FATE_OPS_THREADS_INACTIVE.getDescription())
+        .tag(INSTANCE_TYPE_TAG_KEY, type.name().toLowerCase()).tag(OPS_ASSIGNED_TAG_KEY, operatesOn)
+        .register(registry);
+    this.registry = registry;
+  }
+
+  public void clearMetrics() {
+    // noop if metrics were never configured
+    if (isRegistered()) {
+      var threadsTotalMeter = registry.find(Metric.FATE_OPS_THREADS_TOTAL.getName())
+          .tags(INSTANCE_TYPE_TAG_KEY, type.name().toLowerCase(), OPS_ASSIGNED_TAG_KEY, operatesOn)
+          .meter();
+      // meter will be null if it could not be found, ignore IDE warning if one is seen
+      if (threadsTotalMeter == null) {
+        // throwing ISE directly instead of using Preconditions due to spotbugs flagging as
+        // potential NPE otherwise
+        throw new IllegalStateException(String.format(
+            "Did not find expected meter{name: %s tags: %s=%s, %s=%s} in the registry",
+            Metric.FATE_OPS_THREADS_TOTAL.getName(), INSTANCE_TYPE_TAG_KEY,
+            type.name().toLowerCase(), OPS_ASSIGNED_TAG_KEY, operatesOn));
+      } else {
+        registry.remove(threadsTotalMeter);
+      }
+
+      var threadsInactiveMeter = registry.find(Metric.FATE_OPS_THREADS_INACTIVE.getName())
+          .tags(INSTANCE_TYPE_TAG_KEY, type.name().toLowerCase(), OPS_ASSIGNED_TAG_KEY, operatesOn)
+          .meter();
+      // meter will be null if it could not be found, ignore IDE warning if one is seen
+      if (threadsInactiveMeter == null) {
+        // throwing ISE directly instead of using Preconditions due to spotbugs flagging as
+        // potential NPE otherwise
+        throw new IllegalStateException(String.format(
+            "Did not find expected meter{name: %s tags: %s=%s, %s=%s} in the registry",
+            Metric.FATE_OPS_THREADS_TOTAL.getName(), INSTANCE_TYPE_TAG_KEY,
+            type.name().toLowerCase(), OPS_ASSIGNED_TAG_KEY, operatesOn));
+      } else {
+        registry.remove(threadsInactiveMeter);
+      }
+    }
+  }
+
+  public boolean isRegistered() {
+    return registry != null;
+  }
+}

--- a/core/src/main/java/org/apache/accumulo/core/metrics/Metric.java
+++ b/core/src/main/java/org/apache/accumulo/core/metrics/Metric.java
@@ -21,6 +21,8 @@ package org.apache.accumulo.core.metrics;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.accumulo.core.fate.FateExecutorMetrics;
+
 public enum Metric {
   // General Server Metrics
   SERVER_IDLE("accumulo.server.idle", MetricType.GAUGE,
@@ -104,7 +106,20 @@ public enum Metric {
       "Count of errors that occurred when attempting to gather fate metrics.",
       MetricDocSection.FATE),
   FATE_TX("accumulo.fate.tx", MetricType.GAUGE,
-      "The state is now in a tag (e.g., state=new, state=in.progress, state=failed, etc.).",
+      "Count of FATE operations in a certain state. The state is now in a tag "
+          + "(e.g., state=new, state=in.progress, state=failed, etc.).",
+      MetricDocSection.FATE),
+  FATE_OPS_THREADS_INACTIVE("accumulo.fate.ops.threads.inactive", MetricType.GAUGE,
+      "Keeps track of the number of idle threads (not working on a fate operation) in the thread pool assigned to work on the operations as shown in the "
+          + FateExecutorMetrics.OPS_ASSIGNED_TAG_KEY
+          + " tag. The fate instance type can be found in the "
+          + FateExecutorMetrics.INSTANCE_TYPE_TAG_KEY + " tag.",
+      MetricDocSection.FATE),
+  FATE_OPS_THREADS_TOTAL("accumulo.fate.ops.threads.total", MetricType.GAUGE,
+      "Keeps track of the total number of threads in the thread pool assigned to work on the operations as shown in the "
+          + FateExecutorMetrics.OPS_ASSIGNED_TAG_KEY
+          + " tag. The fate instance type can be found in the "
+          + FateExecutorMetrics.INSTANCE_TYPE_TAG_KEY + " tag.",
       MetricDocSection.FATE),
 
   // Garbage Collection Metrics

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -997,8 +997,8 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener {
     }
 
     MetricsInfo metricsInfo = getContext().getMetricsInfo();
-    ManagerMetrics managerMetrics = new ManagerMetrics(getConfiguration(), this);
-    var producers = managerMetrics.getProducers(getConfiguration(), this);
+    ManagerMetrics managerMetrics = new ManagerMetrics();
+    List<MetricsProducer> producers = new ArrayList<>();
     producers.add(balanceManager.getMetrics());
 
     final TabletGroupWatcher userTableTGW =
@@ -1111,10 +1111,6 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener {
       throw new IllegalStateException("Upgrade coordinator is unexpectedly not complete");
     }
 
-    metricsInfo.addMetricsProducers(producers.toArray(new MetricsProducer[0]));
-    metricsInfo.init(MetricsInfo.serviceTags(getContext().getInstanceName(), getApplicationName(),
-        getAdvertiseAddress(), getResourceGroup()));
-
     balanceManager.startBackGroundTask();
     Threads.createCriticalThread("ScanServer Cleanup Thread", new ScanServerZKCleaner()).start();
 
@@ -1137,10 +1133,16 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener {
         throw new IllegalStateException(
             "Unexpected previous fate reference map already initialized");
       }
+      managerMetrics.configureFateMetrics(getConfiguration(), this, fateRefs.get());
       fateReadyLatch.countDown();
     } catch (KeeperException | InterruptedException e) {
       throw new IllegalStateException("Exception setting up FaTE cleanup thread", e);
     }
+
+    producers.addAll(managerMetrics.getProducers(this));
+    metricsInfo.addMetricsProducers(producers.toArray(new MetricsProducer[0]));
+    metricsInfo.init(MetricsInfo.serviceTags(getContext().getInstanceName(), getApplicationName(),
+        getAdvertiseAddress(), getResourceGroup()));
 
     ThreadPools.watchCriticalScheduledTask(context.getScheduledExecutor()
         .scheduleWithFixedDelay(() -> ScanServerMetadataEntries.clean(context), 10, 10, MINUTES));

--- a/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/meta/MetaFateMetrics.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/meta/MetaFateMetrics.java
@@ -21,11 +21,14 @@ package org.apache.accumulo.manager.metrics.fate.meta;
 import static org.apache.accumulo.core.metrics.Metric.FATE_ERRORS;
 import static org.apache.accumulo.core.metrics.Metric.FATE_OPS_ACTIVITY;
 
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.fate.FateExecutor;
 import org.apache.accumulo.core.fate.ReadOnlyFateStore;
 import org.apache.accumulo.core.fate.zookeeper.MetaFateStore;
+import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.metrics.fate.FateMetrics;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.zookeeper.KeeperException;
@@ -38,8 +41,9 @@ public class MetaFateMetrics extends FateMetrics<MetaFateMetricValues> {
   private final AtomicLong totalOpsGauge = new AtomicLong(0);
   private final AtomicLong fateErrorsGauge = new AtomicLong(0);
 
-  public MetaFateMetrics(ServerContext context, long minimumRefreshDelay) {
-    super(context, minimumRefreshDelay);
+  public MetaFateMetrics(ServerContext context, long minimumRefreshDelay,
+      Set<FateExecutor<Manager>> fateExecutors) {
+    super(context, minimumRefreshDelay, fateExecutors);
   }
 
   @Override

--- a/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/user/UserFateMetrics.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/user/UserFateMetrics.java
@@ -18,16 +18,21 @@
  */
 package org.apache.accumulo.manager.metrics.fate.user;
 
+import java.util.Set;
+
+import org.apache.accumulo.core.fate.FateExecutor;
 import org.apache.accumulo.core.fate.ReadOnlyFateStore;
 import org.apache.accumulo.core.fate.user.UserFateStore;
 import org.apache.accumulo.core.metadata.SystemTables;
+import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.metrics.fate.FateMetrics;
 import org.apache.accumulo.server.ServerContext;
 
 public class UserFateMetrics extends FateMetrics<UserFateMetricValues> {
 
-  public UserFateMetrics(ServerContext context, long minimumRefreshDelay) {
-    super(context, minimumRefreshDelay);
+  public UserFateMetrics(ServerContext context, long minimumRefreshDelay,
+      Set<FateExecutor<Manager>> fateExecutors) {
+    super(context, minimumRefreshDelay, fateExecutors);
   }
 
   @Override

--- a/test/src/main/java/org/apache/accumulo/test/fate/FlakyFate.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FlakyFate.java
@@ -44,7 +44,7 @@ public class FlakyFate<T> extends Fate<T> {
   @Override
   protected void startFateExecutors(T environment, AccumuloConfiguration conf,
       Set<FateExecutor<T>> fateExecutors) {
-    for (var poolConfig : getPoolConfigurations(conf).entrySet()) {
+    for (var poolConfig : getPoolConfigurations(conf, getStore().type()).entrySet()) {
       fateExecutors.add(
           new FlakyFateExecutor<>(this, environment, poolConfig.getKey(), poolConfig.getValue()));
     }

--- a/test/src/main/java/org/apache/accumulo/test/fate/SlowFateSplit.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/SlowFateSplit.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test.fate;
+
+import java.util.Set;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.function.Function;
+
+import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
+import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.fate.Fate;
+import org.apache.accumulo.core.fate.FateExecutor;
+import org.apache.accumulo.core.fate.FateId;
+import org.apache.accumulo.core.fate.FateStore;
+import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.test.functional.SlowIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Causes the first step in a Split FATE operation to sleep for
+ * {@link SlowFateSplitManager#SLEEP_TIME_MS}. Split was chosen as it can be executed on system and
+ * user tables (allowing for testing of meta and user fate ops) and is easy to avoid automatic
+ * splits from occurring (just don't have tables exceed the split threshold in testing). This allows
+ * us to sleep for splits we initiate via {@link TableOperation}. This is useful when we want a fate
+ * thread to be occupied working on some operation. A potential alternative to this is compacting
+ * with a {@link SlowIterator} attached to the table, however, this will result in the operation
+ * never being ready ({@link Repo#isReady(FateId, Object)}). So, it would exist as an operation to
+ * work on, but a thread will briefly reserve it, see it's not isReady, and unreserve it. This class
+ * is useful when we need a fate op reserved by a thread and being worked on for a configurable
+ * time, but don't have direct access to the Fate objects/are testing Fate as it operates within the
+ * Manager instead of directly working with Fate objects.
+ */
+public class SlowFateSplit<T> extends Fate<T> {
+  private static final Logger log = LoggerFactory.getLogger(SlowFateSplit.class);
+  private boolean haveSlept = false;
+
+  public SlowFateSplit(T environment, FateStore<T> store, Function<Repo<T>,String> toLogStrFunc,
+      AccumuloConfiguration conf) {
+    super(environment, store, false, toLogStrFunc, conf, new ScheduledThreadPoolExecutor(2));
+  }
+
+  @Override
+  protected void startFateExecutors(T environment, AccumuloConfiguration conf,
+      Set<FateExecutor<T>> fateExecutors) {
+    for (var poolConfig : getPoolConfigurations(conf, getStore().type()).entrySet()) {
+      fateExecutors.add(
+          new SlowFateSplitExecutor(this, environment, poolConfig.getKey(), poolConfig.getValue()));
+    }
+  }
+
+  private class SlowFateSplitExecutor extends FateExecutor<T> {
+    private SlowFateSplitExecutor(Fate<T> fate, T environment, Set<Fate.FateOperation> fateOps,
+        int poolSize) {
+      super(fate, environment, fateOps, poolSize);
+    }
+
+    @Override
+    protected Repo<T> executeCall(FateId fateId, Repo<T> repo) throws Exception {
+      var next = super.executeCall(fateId, repo);
+      var fateOp = (FateOperation) SlowFateSplit.this.getStore().read(fateId)
+          .getTransactionInfo(TxInfo.FATE_OP);
+      if (fateOp == SlowFateSplitManager.SLOW_OP && !haveSlept) {
+        var sleepTime = SlowFateSplitManager.SLEEP_TIME_MS;
+        log.debug("{} sleeping in {} for {}", fateId, getClass().getSimpleName(), sleepTime);
+        Thread.sleep(sleepTime);
+        log.debug("{} slept in {} for {}", fateId, getClass().getSimpleName(), sleepTime);
+        haveSlept = true;
+      }
+      return next;
+    }
+  }
+}

--- a/test/src/main/java/org/apache/accumulo/test/fate/SlowFateSplitManager.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/SlowFateSplitManager.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test.fate;
+
+import java.io.IOException;
+
+import org.apache.accumulo.core.cli.ConfigOpts;
+import org.apache.accumulo.core.fate.Fate;
+import org.apache.accumulo.core.fate.FateStore;
+import org.apache.accumulo.manager.Manager;
+import org.apache.accumulo.manager.tableOps.TraceRepo;
+import org.apache.accumulo.server.ServerContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * See {@link SlowFateSplit}
+ */
+public class SlowFateSplitManager extends Manager {
+  private static final Logger log = LoggerFactory.getLogger(SlowFateSplitManager.class);
+  // causes splits to take at least 10 seconds to complete
+  public static final long SLEEP_TIME_MS = 10_000;
+  // important that this is an op that can be initiated on some system table as well as user tables
+  public static final Fate.FateOperation SLOW_OP = Fate.FateOperation.TABLE_SPLIT;
+
+  protected SlowFateSplitManager(ConfigOpts opts, String[] args) throws IOException {
+    super(opts, ServerContext::new, args);
+  }
+
+  @Override
+  protected Fate<Manager> initializeFateInstance(ServerContext context, FateStore<Manager> store) {
+    log.info("Creating Slow Split Fate for {}", store.type());
+    return new SlowFateSplit<>(this, store, TraceRepo::toLogString, getConfiguration());
+  }
+
+  public static void main(String[] args) throws Exception {
+    try (SlowFateSplitManager manager = new SlowFateSplitManager(new ConfigOpts(), args)) {
+      manager.runServer();
+    }
+  }
+}


### PR DESCRIPTION
- Removes FATE metrics which are no longer useful (due to 4.0 FATE changes) and replaces them with more appropriate metrics.
	- These new metrics are: a Gauge to track the number of total threads per FateExecutor and a Gauge to track the total number of idle threads (not currently working on a fate operation) per FateExecutor.
		- Background info/existing functionality:
			- Fate's set of fate executors may change as Fate config is changed. Each FateExecutor has a pool of threads which work on some subset of fate operations based on the fate configuration properties. If these properties are changed such that a FateExecutor is no longer applicable, the FateExecutor is stopped and new FateExecutor(s) are started to accurately represent config changes.
		- What this means for these metric changes:
			- If a FateExecutor is stopped, it's metrics will be removed from the registry. This avoids the registry getting flooded with metrics that are no longer applicable/no longer give relevant info on the Fate system.
- Adds testing for these new metrics in MetricsIT and adds two new classes to aid in testing these metrics: SlowFateSplitManager and SlowFateSplit.
- Some minor misc. changes:
	- Improved description for the deprecated MANAGER_FATE_THREADPOOL_SIZE property
	- Improved the set of non thrift ops in the Fate class to gather the ops at run time
	- Improved the FATE_TX metric description

closes #5147