### PR TITLE
Removed table name lock in Manager

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/PopulateZookeeper.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/PopulateZookeeper.java
@@ -51,29 +51,23 @@ class PopulateZookeeper extends ManagerRepo {
   public Repo<Manager> call(FateId fateId, Manager manager) throws Exception {
     // reserve the table name in zookeeper or fail
 
-    Utils.getTableNameLock().lock();
+    var context = manager.getContext();
+    // write tableName & tableId, first to Table Mapping and then to Zookeeper
+    context.getTableMapping(tableInfo.getNamespaceId()).put(tableInfo.getTableId(),
+        tableInfo.getTableName(), TableOperation.CREATE);
+    manager.getTableManager().addTable(tableInfo.getTableId(), tableInfo.getNamespaceId(),
+        tableInfo.getTableName());
+
     try {
-      var context = manager.getContext();
-      // write tableName & tableId, first to Table Mapping and then to Zookeeper
-      context.getTableMapping(tableInfo.getNamespaceId()).put(tableInfo.getTableId(),
-          tableInfo.getTableName(), TableOperation.CREATE);
-      manager.getTableManager().addTable(tableInfo.getTableId(), tableInfo.getNamespaceId(),
-          tableInfo.getTableName());
-
-      try {
-        PropUtil.setProperties(context, TablePropKey.of(tableInfo.getTableId()), tableInfo.props);
-      } catch (IllegalStateException ex) {
-        throw new ThriftTableOperationException(null, tableInfo.getTableName(),
-            TableOperation.CREATE, TableOperationExceptionType.OTHER,
-            "Property or value not valid for create " + tableInfo.getTableName() + " in "
-                + tableInfo.props);
-      }
-
-      context.clearTableListCache();
-      return new ChooseDir(tableInfo);
-    } finally {
-      Utils.getTableNameLock().unlock();
+      PropUtil.setProperties(context, TablePropKey.of(tableInfo.getTableId()), tableInfo.props);
+    } catch (IllegalStateException ex) {
+      throw new ThriftTableOperationException(null, tableInfo.getTableName(), TableOperation.CREATE,
+          TableOperationExceptionType.OTHER, "Property or value not valid for create "
+              + tableInfo.getTableName() + " in " + tableInfo.props);
     }
+
+    context.clearTableListCache();
+    return new ChooseDir(tableInfo);
 
   }
 


### PR DESCRIPTION
Created `testDefendAgainstThreadsCreateSameTableNameConcurrently()` in TableOperationsIT to ensure that Zookeeper can defend against concurrent create table operations that try to create a table with the same table name. Verified it worked and removed the lock in the call method in the PopulateZookeeper file.

Closes #5724