### PR TITLE
Remove outdated TODO in TableOperations.putSplits

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
@@ -192,10 +192,6 @@ public interface TableOperations {
    *
    * Ensures that tablets are split along a set of keys.
    *
-   * TODO: This method currently only adds new splits (existing are stripped). The intent in a
-   * future PR is so support updating existing splits and the TabletMergeabilty setting. See
-   * https://github.com/apache/accumulo/issues/5014
-   *
    * <p>
    * Note that while the documentation for Text specifies that its bytestream should be UTF-8, the
    * encoding is not enforced by operations that work with byte arrays.


### PR DESCRIPTION
Fixes #5791

From what I can tell the feature mentioned in the TODO comment (updating existing splits) can be removed because:
* putSplits() properly collects and handles existing splits that need TabletMergeability updates
https://github.com/apache/accumulo/blob/a893ee5c5327748e101369850b983248cabf6153/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java#L524
* `updateSplitWithMergeabilityTest()` seems to properly cover this case
* there are also tests covering concurrently updating overlapping splits properly