### PR TITLE
Fix FatePoolsWatcherITBase debugging

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/fate/FatePoolsWatcherITBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FatePoolsWatcherITBase.java
@@ -189,7 +189,6 @@ public abstract class FatePoolsWatcherITBase extends SharedMiniClusterBase
     // {<All FATE ops>}: 3 <-- FateExecutor1
     // when 3 transactions need to be worked on. Ensures after the config change, the third tx
     // is picked up.
-    boolean allAssertsOccurred = false;
     final ConfigurationCopy config = FateTestUtil.createTestFateConfig(2);
     final var env = new PoolResizeTestEnv();
     final Fate<PoolResizeTestEnv> fate = new FastFate<>(env, store, false, r -> r + "", config);
@@ -242,13 +241,8 @@ public abstract class FatePoolsWatcherITBase extends SharedMiniClusterBase
       // workers should still be running: we haven't shutdown FATE, just not working on anything
       Wait.waitFor(() -> fate.getTotalTxRunnersActive() == newNumWorkers);
       assertEquals(newNumWorkers, fate.getTxRunnersActive(allFateOps));
-
-      allAssertsOccurred = true;
-    } catch (Exception e) {
-      System.out.println("Failure: " + e);
     } finally {
       fate.shutdown(30, TimeUnit.SECONDS);
-      assertTrue(allAssertsOccurred);
       assertEquals(0, fate.getTotalTxRunnersActive());
     }
   }
@@ -271,7 +265,6 @@ public abstract class FatePoolsWatcherITBase extends SharedMiniClusterBase
     // FateExecutors that are no longer valid (while ensuring none are stopped while in progress on
     // a transaction), and creating new FateExecutors as needed. Essentially, FateExecutor1's pool
     // size should shrink and FateExecutor4 should replace 2 and 3.
-    boolean allAssertsOccurred = false;
     final ConfigurationCopy config = initConfigDecTest();
     final var env = new PoolResizeTestEnv();
     final Fate<PoolResizeTestEnv> fate = new FastFate<>(env, store, false, r -> r + "", config);
@@ -381,12 +374,8 @@ public abstract class FatePoolsWatcherITBase extends SharedMiniClusterBase
       assertEquals(numWorkersSet2, fate.getTxRunnersActive(set2));
       assertEquals(0, fate.getTxRunnersActive(set3));
       assertEquals(0, fate.getTxRunnersActive(set4));
-      allAssertsOccurred = true;
-    } catch (Exception e) {
-      System.out.println("Failure: " + e);
     } finally {
       fate.shutdown(30, TimeUnit.SECONDS);
-      assertTrue(allAssertsOccurred);
       assertEquals(0, fate.getTotalTxRunnersActive());
     }
   }
@@ -399,7 +388,6 @@ public abstract class FatePoolsWatcherITBase extends SharedMiniClusterBase
   protected void testIdleCountHistory(FateStore<PoolResizeTestEnv> store, ServerContext sctx)
       throws Exception {
     // Tests that a warning to increase pool size is logged when expected
-    boolean allAssertsOccurred = false;
     var config = configIdleHistoryTest();
     final var env = new PoolResizeTestEnv();
     final Fate<PoolResizeTestEnv> fate = new FastFate<>(env, store, false, r -> r + "", config);
@@ -414,12 +402,8 @@ public abstract class FatePoolsWatcherITBase extends SharedMiniClusterBase
       // can finish work now
       env.isReadyLatch.countDown();
       Wait.waitFor(() -> env.numWorkers.get() == 0);
-      allAssertsOccurred = true;
-    } catch (Exception e) {
-      System.out.println("Failure: " + e);
     } finally {
       fate.shutdown(30, TimeUnit.SECONDS);
-      assertTrue(allAssertsOccurred);
       assertEquals(0, fate.getTotalTxRunnersActive());
     }
   }
@@ -511,7 +495,6 @@ public abstract class FatePoolsWatcherITBase extends SharedMiniClusterBase
     final Set<Fate.FateOperation> pool3 = isUserStore ? userPool3 : metaPool3;
     final Set<Fate.FateOperation> pool4 = isUserStore ? userPool4 : metaPool4;
 
-    boolean allAssertsOccurred = false;
     final var env = new PoolResizeTestEnv();
     final Fate<PoolResizeTestEnv> fate = new FastFate<>(env, store, false, r -> r + "", config);
 
@@ -589,10 +572,8 @@ public abstract class FatePoolsWatcherITBase extends SharedMiniClusterBase
       // can finish work now
       env.isReadyLatch.countDown();
       Wait.waitFor(() -> env.numWorkers.get() == 0);
-      allAssertsOccurred = true;
     } finally {
       fate.shutdown(30, TimeUnit.SECONDS);
-      assertTrue(allAssertsOccurred);
       assertEquals(0, fate.getTotalTxRunnersActive());
     }
   }


### PR DESCRIPTION
Was catching exceptions and hiding assertion failures, but was using a boolean to check that all assertions occurred. No longer catch exceptions in the test, allowing us to remove the all assertions occurred check.

This is just a follow on to PR #5790 which introduced these changes for one test but not all