### PR TITLE
Small FATE improvements

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
@@ -334,7 +334,7 @@ public class Fate<T> {
     synchronized (fateExecutors) {
       for (var fateExecutor : fateExecutors) {
         if (fateExecutor.getFateOps().equals(fateOps)) {
-          return fateExecutor.getRunningTxRunners().size();
+          return fateExecutor.getNumRunningTxRunners();
         }
       }
     }
@@ -348,7 +348,7 @@ public class Fate<T> {
   @VisibleForTesting
   public int getTotalTxRunnersActive() {
     synchronized (fateExecutors) {
-      return fateExecutors.stream().mapToInt(fe -> fe.getRunningTxRunners().size()).sum();
+      return fateExecutors.stream().mapToInt(FateExecutor::getNumRunningTxRunners).sum();
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/fate/FateExecutor.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/FateExecutor.java
@@ -45,6 +45,7 @@ import java.util.concurrent.TransferQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
 import org.apache.accumulo.core.fate.Fate.TxInfo;
 import org.apache.accumulo.core.fate.FateStore.FateTxStore;
@@ -105,96 +106,94 @@ public class FateExecutor<T> {
   protected void resizeFateExecutor(Map<Set<Fate.FateOperation>,Integer> poolConfigs,
       long idleCheckIntervalMillis) {
     final var pool = transactionExecutor;
-    final var runningTxRunners = getRunningTxRunners();
     final int configured = poolConfigs.get(fateOps);
     ThreadPools.resizePool(pool, () -> configured, poolName);
-    final int needed = configured - runningTxRunners.size();
-    if (needed > 0) {
-      // If the pool grew, then ensure that there is a TransactionRunner for each thread
-      for (int i = 0; i < needed; i++) {
-        try {
-          pool.execute(new TransactionRunner());
-        } catch (RejectedExecutionException e) {
-          // RejectedExecutionException could be shutting down
-          if (pool.isShutdown()) {
-            // The exception is expected in this case, no need to spam the logs.
-            log.trace("Expected error adding transaction runner to FaTE executor pool. "
-                + "The pool is shutdown.", e);
-          } else {
-            // This is bad, FaTE may no longer work!
-            log.error("Unexpected error adding transaction runner to FaTE executor pool.", e);
+    synchronized (runningTxRunners) {
+      final int needed = configured - runningTxRunners.size();
+      if (needed > 0) {
+        // If the pool grew, then ensure that there is a TransactionRunner for each thread
+        for (int i = 0; i < needed; i++) {
+          try {
+            pool.execute(new TransactionRunner());
+          } catch (RejectedExecutionException e) {
+            // RejectedExecutionException could be shutting down
+            if (pool.isShutdown()) {
+              // The exception is expected in this case, no need to spam the logs.
+              log.trace("Expected error adding transaction runner to FaTE executor pool. "
+                      + "The pool is shutdown.", e);
+            } else {
+              // This is bad, FaTE may no longer work!
+              log.error("Unexpected error adding transaction runner to FaTE executor pool.", e);
+            }
+            break;
           }
-          break;
         }
-      }
-      idleCountHistory.clear();
-    } else if (needed < 0) {
-      // If we need the pool to shrink, then ensure excess TransactionRunners are safely
-      // stopped.
-      // Flag the necessary number of TransactionRunners to safely stop when they are done
-      // work on a transaction.
-      int numFlagged = (int) runningTxRunners.stream()
-          .filter(FateExecutor.TransactionRunner::isFlaggedToStop).count();
-      int numToStop = -1 * (numFlagged + needed);
-      for (var runner : runningTxRunners) {
-        if (numToStop <= 0) {
-          break;
-        }
-        if (runner.flagStop()) {
-          log.trace("Flagging a TransactionRunner to stop...");
-          numToStop--;
-        }
-      }
-    } else {
-      // The pool size did not change, but should it based on idle Fate threads? Maintain
-      // count of the last X minutes of idle Fate threads. If zero 95% of the time, then
-      // suggest that the pool size be increased or the fate ops assigned to that pool be
-      // split into separate pools.
-      final long interval = Math.min(60, TimeUnit.MILLISECONDS.toMinutes(idleCheckIntervalMillis));
-      var fateConfigProp = fate.getFateConfigProp();
-
-      if (interval == 0) {
         idleCountHistory.clear();
-      } else {
-        if (idleCountHistory.size() >= interval * 2) { // this task runs every 30s
-          int zeroFateThreadsIdleCount = 0;
-          for (Integer idleConsumerCount : idleCountHistory) {
-            if (idleConsumerCount == 0) {
-              zeroFateThreadsIdleCount++;
-            }
+      } else if (needed < 0) {
+        // If we need the pool to shrink, then ensure excess TransactionRunners are safely
+        // stopped.
+        // Flag the necessary number of TransactionRunners to safely stop when they are done
+        // work on a transaction.
+        int numFlagged = (int) runningTxRunners.stream()
+                .filter(FateExecutor.TransactionRunner::isFlaggedToStop).count();
+        int numToStop = -1 * (numFlagged + needed);
+        for (var runner : runningTxRunners) {
+          if (numToStop <= 0) {
+            break;
           }
-          boolean needMoreThreads =
-              (zeroFateThreadsIdleCount / (double) idleCountHistory.size()) >= 0.95;
-          if (needMoreThreads) {
-            fate.getNeedMoreThreadsWarnCount().incrementAndGet();
-            log.warn(
-                "All {} Fate threads working on the fate ops {} appear to be busy for "
-                    + "the last {} minutes. Consider increasing the value for the "
-                    + "entry in the property {} or splitting the fate ops across "
-                    + "multiple entries/pools.",
-                fate.getStore().type(), fateOps, interval, fateConfigProp.getKey());
-            // Clear the history so that we don't log for interval minutes.
-            idleCountHistory.clear();
-          } else {
-            while (idleCountHistory.size() >= interval * 2) {
-              idleCountHistory.remove();
-            }
+          if (runner.flagStop()) {
+            log.trace("Flagging a TransactionRunner to stop...");
+            numToStop--;
           }
         }
-        idleCountHistory.add(workQueue.getWaitingConsumerCount());
+      } else {
+        // The pool size did not change, but should it based on idle Fate threads? Maintain
+        // count of the last X minutes of idle Fate threads. If zero 95% of the time, then
+        // suggest that the pool size be increased or the fate ops assigned to that pool be
+        // split into separate pools.
+        final long interval = Math.min(60, TimeUnit.MILLISECONDS.toMinutes(idleCheckIntervalMillis));
+        var fateConfigProp = fate.getFateConfigProp();
+
+        if (interval == 0) {
+          idleCountHistory.clear();
+        } else {
+          if (idleCountHistory.size() >= interval * 2) { // this task runs every 30s
+            int zeroFateThreadsIdleCount = 0;
+            for (Integer idleConsumerCount : idleCountHistory) {
+              if (idleConsumerCount == 0) {
+                zeroFateThreadsIdleCount++;
+              }
+            }
+            boolean needMoreThreads =
+                    (zeroFateThreadsIdleCount / (double) idleCountHistory.size()) >= 0.95;
+            if (needMoreThreads) {
+              fate.getNeedMoreThreadsWarnCount().incrementAndGet();
+              log.warn(
+                      "All {} Fate threads working on the fate ops {} appear to be busy for "
+                              + "the last {} minutes. Consider increasing the value for the "
+                              + "entry in the property {} or splitting the fate ops across "
+                              + "multiple entries/pools.",
+                      fate.getStore().type(), fateOps, interval, fateConfigProp.getKey());
+              // Clear the history so that we don't log for interval minutes.
+              idleCountHistory.clear();
+            } else {
+              while (idleCountHistory.size() >= interval * 2) {
+                idleCountHistory.remove();
+              }
+            }
+          }
+          idleCountHistory.add(workQueue.getWaitingConsumerCount());
+        }
       }
     }
   }
 
   /**
-   * @return an unmodifiable, shallow copy of the currently running transaction runners
+   * @return the number of currently running transaction runners
    */
-  protected Set<TransactionRunner> getRunningTxRunners() {
-    Set<TransactionRunner> copy;
-    synchronized (runningTxRunners) {
-      copy = new HashSet<>(runningTxRunners);
-    }
-    return Collections.unmodifiableSet(copy);
+  @VisibleForTesting
+  protected int getNumRunningTxRunners() {
+    return runningTxRunners.size();
   }
 
   protected Set<Fate.FateOperation> getFateOps() {
@@ -205,14 +204,14 @@ public class FateExecutor<T> {
    * Initiates the shutdown of this FateExecutor. This means the pool executing TransactionRunners
    * will no longer accept new TransactionRunners, the currently running TransactionRunners will
    * terminate after they are done with their current transaction, if applicable, and the work
-   * finder is interrupted. {@link #isShutdown()} returns true after this is called.
+   * finder is shutdown. {@link #isShutdown()} returns true after this is called.
    */
   protected void initiateShutdown() {
     transactionExecutor.shutdown();
     synchronized (runningTxRunners) {
       runningTxRunners.forEach(TransactionRunner::flagStop);
     }
-    workFinder.interrupt();
+    // work finder will terminate since this.isShutdown() is true
   }
 
   /**
@@ -233,8 +232,8 @@ public class FateExecutor<T> {
     if (timeout > 0) {
       while (((System.nanoTime() - start) < timeUnit.toNanos(timeout)) && isAlive()) {
         if (!transactionExecutor.awaitTermination(1, SECONDS)) {
-          log.debug("Fate {} is waiting for worker threads for fate ops {} to terminate",
-              fate.getStore().type(), fateOps);
+          log.debug("Fate {} is waiting for {} worker threads for fate ops {} to terminate",
+              fate.getStore().type(), runningTxRunners.size(), fateOps);
           continue;
         }
 
@@ -306,17 +305,16 @@ public class FateExecutor<T> {
             }
           });
         } catch (Exception e) {
-          if (!fate.getKeepRunning().get() || isShutdown()) {
-            log.debug("Expected failure while attempting to find work for fate: either fate is "
-                + "being shutdown and therefore all fate threads are being shutdown or the "
-                + "fate threads assigned to work on {} were invalidated by config changes "
-                + "and are being shutdown", fateOps, e);
-          } else {
-            log.warn("Unexpected failure while attempting to find work for fate", e);
-          }
-
+          log.warn("Unexpected failure while attempting to find work for fate", e);
           workQueue.clear();
         }
+      }
+
+      if (!fate.getKeepRunning().get() || isShutdown()) {
+        log.debug("FATE work finder for ops {} is gracefully exiting: either FATE is "
+                + "being shutdown ({}) and therefore all FATE threads are being shutdown or the "
+                + "FATE threads assigned to work on the ops were invalidated by config changes "
+                + "and are being shutdown ({})", fateOps, !fate.getKeepRunning().get(), isShutdown());
       }
     }
 


### PR DESCRIPTION
This PR partially addresses #5787

I have reached a dead end with debugging this test.

The test logic has no issues as far as I can tell and the FATE logic (as far as I can tell) has one potential concurrency issue (which I addressed in this PR), but the failure still occurs occassionally. From jstacking the test process in a failure case, it appears that the thread is either getting stuck on the `workQueue.poll(100, MILLISECONDS)` call or it is repeatedly retrying it, neither of which should be possible given the shutdown logic. Here is the code:
```
while (fate.getKeepRunning().get() && !stop.get()) {
    FateId unreservedFateId = workQueue.poll(100, MILLISECONDS);
    ...
```
The jstack trace shows this throughout the time FATE is trying to shutdown:
```
"accumulo.pool.manager.fate.user.commit_compaction.namespace_create.namespace_delete.namespace_rename.shutdown_tserver.system_split.system_merge.table_bulk_import2.table_cancel_compact.table_clone.table_compact-Worker-1" #57 daemon prio=5 os_prio=0 cpu=82600.00ms elapsed=86.73s tid=0x00007693e00058f0 nid=0x2304f runnable  [0x00007694a5ef9000]
   java.lang.Thread.State: RUNNABLE
        at java.util.concurrent.LinkedTransferQueue.awaitMatch(java.base@17.0.15/LinkedTransferQueue.java:652)
        at java.util.concurrent.LinkedTransferQueue.xfer(java.base@17.0.15/LinkedTransferQueue.java:616)
        at java.util.concurrent.LinkedTransferQueue.poll(java.base@17.0.15/LinkedTransferQueue.java:1294)
        at org.apache.accumulo.core.fate.FateExecutor$TransactionRunner.reserveFateTx(FateExecutor.java:349)
        at org.apache.accumulo.core.fate.FateExecutor$TransactionRunner.run(FateExecutor.java:378)
        at org.apache.accumulo.core.trace.TraceWrappedRunnable.run(TraceWrappedRunnable.java:52)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@17.0.15/ThreadPoolExecutor.java:1136)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@17.0.15/ThreadPoolExecutor.java:635)
        at org.apache.accumulo.core.trace.TraceWrappedRunnable.run(TraceWrappedRunnable.java:52)
        at java.lang.Thread.run(java.base@17.0.15/Thread.java:840)
```
This doesn't make sense as:
1) When we shutdown FATE, we first set keepRunning to false, so the while loop should terminate
2) The poll will return after, at most, 100ms

I have run out of ideas. This could use another set of eyes, if anyone has the time. I can explain anything in regards to test logic or the fate logic, if needed.
