### PR TITLE
Fixes some FATE tests:

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateExecutionOrderIT_SimpleSuite.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateExecutionOrderIT_SimpleSuite.java
@@ -33,12 +33,14 @@ public class UserFateExecutionOrderIT_SimpleSuite extends FateExecutionOrderITBa
   public void executeTest(FateTestExecutor<FeoTestEnv> testMethod, int maxDeferred,
       AbstractFateStore.FateIdGenerator fateIdGenerator) throws Exception {
     var table = getUniqueNames(1)[0];
-    try (ClientContext client = (ClientContext) Accumulo.newClient().from(getClientProps()).build();
-        FateStore<FeoTestEnv> fs = new UserFateStore<>(client, table, createDummyLockID(), null,
-            maxDeferred, fateIdGenerator)) {
+    try (ClientContext client =
+        (ClientContext) Accumulo.newClient().from(getClientProps()).build()) {
       createFateTable(client, table);
-      testMethod.execute(fs, getCluster().getServerContext());
-      client.tableOperations().delete(table);
+      try (FateStore<FeoTestEnv> fs = new UserFateStore<>(client, table, createDummyLockID(), null,
+          maxDeferred, fateIdGenerator)) {
+        testMethod.execute(fs, getCluster().getServerContext());
+        client.tableOperations().delete(table);
+      }
     }
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateIT_SimpleSuite.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateIT_SimpleSuite.java
@@ -66,11 +66,13 @@ public class UserFateIT_SimpleSuite extends FateITBase {
   public void executeTest(FateTestExecutor<TestEnv> testMethod, int maxDeferred,
       FateIdGenerator fateIdGenerator) throws Exception {
     table = getUniqueNames(1)[0];
-    try (ClientContext client = (ClientContext) Accumulo.newClient().from(getClientProps()).build();
-        FateStore<TestEnv> fs = new UserFateStore<>(client, table, createDummyLockID(), null,
-            maxDeferred, fateIdGenerator)) {
+    try (ClientContext client =
+        (ClientContext) Accumulo.newClient().from(getClientProps()).build()) {
       createFateTable(client, table);
-      testMethod.execute(fs, getCluster().getServerContext());
+      try (FateStore<TestEnv> fs = new UserFateStore<>(client, table, createDummyLockID(), null,
+          maxDeferred, fateIdGenerator)) {
+        testMethod.execute(fs, getCluster().getServerContext());
+      }
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/fate/user/UserFatePoolsWatcherIT_SimpleSuite.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/user/UserFatePoolsWatcherIT_SimpleSuite.java
@@ -49,11 +49,13 @@ public class UserFatePoolsWatcherIT_SimpleSuite extends FatePoolsWatcherITBase {
   public void executeTest(FateTestExecutor<PoolResizeTestEnv> testMethod, int maxDeferred,
       AbstractFateStore.FateIdGenerator fateIdGenerator) throws Exception {
     table = getUniqueNames(1)[0];
-    try (ClientContext client = (ClientContext) Accumulo.newClient().from(getClientProps()).build();
-        FateStore<PoolResizeTestEnv> fs = new UserFateStore<>(client, table, createDummyLockID(),
-            null, maxDeferred, fateIdGenerator)) {
+    try (ClientContext client =
+        (ClientContext) Accumulo.newClient().from(getClientProps()).build()) {
       createFateTable(client, table);
-      testMethod.execute(fs, getCluster().getServerContext());
+      try (FateStore<PoolResizeTestEnv> fs = new UserFateStore<>(client, table, createDummyLockID(),
+          null, maxDeferred, fateIdGenerator)) {
+        testMethod.execute(fs, getCluster().getServerContext());
+      }
     }
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateStoreFateIT_SimpleSuite.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateStoreFateIT_SimpleSuite.java
@@ -55,11 +55,13 @@ public class UserFateStoreFateIT_SimpleSuite extends FateStoreITBase {
   public void executeTest(FateTestExecutor<TestEnv> testMethod, int maxDeferred,
       FateIdGenerator fateIdGenerator) throws Exception {
     String table = getUniqueNames(1)[0] + "fatestore";
-    try (ClientContext client = (ClientContext) Accumulo.newClient().from(getClientProps()).build();
-        FateStore<TestEnv> fs = new UserFateStore<>(client, table, createDummyLockID(), null,
-            maxDeferred, fateIdGenerator)) {
+    try (ClientContext client =
+        (ClientContext) Accumulo.newClient().from(getClientProps()).build()) {
       createFateTable(client, table);
-      testMethod.execute(fs, getCluster().getServerContext());
+      try (FateStore<TestEnv> fs = new UserFateStore<>(client, table, createDummyLockID(), null,
+          maxDeferred, fateIdGenerator)) {
+        testMethod.execute(fs, getCluster().getServerContext());
+      }
     }
   }
 


### PR DESCRIPTION
Some uses of UserFateStore were creating the UserFateStore before creating the table that the UserFateStore is using. This can lead to failures.

Examined all uses of the UserFateStore constructors. All uses are now safe.

closes #5818