### PR TITLE
Fixes NPE from recent FATE changes

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/FateExecutor.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/FateExecutor.java
@@ -393,8 +393,8 @@ public class FateExecutor<T> {
             }
             state.status = txStore.getStatus();
             state.op = txStore.top();
-            runnerLog.trace("Processing FATE transaction {} id: {} status: {}", state.op.getName(),
-                txStore.getID(), state.status);
+            runnerLog.trace("Processing FATE transaction {} id: {} status: {}",
+                state.op == null ? null : state.op.getName(), txStore.getID(), state.status);
             if (state.status == FAILED_IN_PROGRESS) {
               processFailed(txStore, state.op);
             } else if (state.status == SUBMITTED || state.status == IN_PROGRESS) {


### PR DESCRIPTION
This fixes the test failures testing the cancel command, which were resulting in NPE.
Will run the full set of FATE tests now to verify fix.