### PR TITLE
Fix AccumuloVFSClassLoader race condition

### DIFF
--- a/start/src/main/java/org/apache/accumulo/start/classloader/vfs/AccumuloVFSClassLoader.java
+++ b/start/src/main/java/org/apache/accumulo/start/classloader/vfs/AccumuloVFSClassLoader.java
@@ -244,6 +244,8 @@ public class AccumuloVFSClassLoader {
             }
           }
 
+        } else {
+          localLoader = loader;
         }
       }
     }


### PR DESCRIPTION
Run into a race condition:

- ThreadA sets localLoader to null
- ThreadA waits for lock
- ThreadB has the lock
- ThreadB initializes loader and returns
- ThreadA gets the lock
- ThreadA finds that loader is not null, but localLoader is so turns into an infinite loop and prevents master/ts init

We should set localLoader if we find someone else already initialized loader to prevent this.