### PR TITLE
Add test helper method to copy exported files into given dir

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/ComprehensiveITBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/ComprehensiveITBase.java
@@ -27,9 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -99,7 +97,6 @@ import org.apache.accumulo.core.security.SystemPermission;
 import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.test.util.Wait;
-import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.Test;
@@ -1313,17 +1310,7 @@ public abstract class ComprehensiveITBase extends SharedMiniClusterBase {
 
     client.tableOperations().exportTable(srcTable, exportDir);
 
-    fs.mkdirs(new Path(importDir));
-    try (var inputStream = fs.open(new Path(exportDir + "/distcp.txt"));
-        var inputStreamReader = new InputStreamReader(inputStream);
-        var reader = new BufferedReader(inputStreamReader)) {
-      String line;
-      while ((line = reader.readLine()) != null) {
-        var srcPath = new Path(line);
-        Path destPath = new Path(importDir, srcPath.getName());
-        FileUtil.copy(fs, srcPath, fs, destPath, false, fs.getConf());
-      }
-    }
+    ImportExportIT.copyExportedFilesToImportDirs(fs, new Path(exportDir), new Path(importDir));
 
     client.tableOperations().importTable(importTable, importDir);
 

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
@@ -196,7 +196,7 @@ public class ShellServerIT extends SharedMiniClusterBase {
         // ourselves by hand.
         FileSystem fs = getCluster().getFileSystem();
         Path importDir = new Path(import_);
-        Path exportPath = new Path(exportUri.substring(7));
+        Path exportPath = new Path(exportDir.toUri());
         ImportExportIT.copyExportedFilesToImportDirs(fs, exportPath, importDir);
       } else {
         String[] distCpArgs = {"-f", exportUri + "/distcp.txt", import_};

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
@@ -31,7 +31,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
@@ -89,6 +88,7 @@ import org.apache.accumulo.core.util.format.FormatterConfig;
 import org.apache.accumulo.harness.MiniClusterConfigurationCallback;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
+import org.apache.accumulo.test.ImportExportIT;
 import org.apache.accumulo.test.functional.SlowIterator;
 import org.apache.accumulo.test.util.Wait;
 import org.apache.hadoop.conf.Configuration;
@@ -187,7 +187,6 @@ public class ShellServerIT extends SharedMiniClusterBase {
       java.nio.file.Path exportDir =
           java.nio.file.Path.of(rootPath).resolve("ShellServerIT.export");
       String exportUri = "file://" + exportDir;
-      String localTmp = "file://" + java.nio.file.Path.of(rootPath).resolve("ShellServerIT.tmp");
       ts.exec("exporttable -t " + table + " " + exportUri, true);
       DistCp cp = new DistCp(new Configuration(false), null);
       String import_ = "file://" + java.nio.file.Path.of(rootPath).resolve("ShellServerIT.import");
@@ -196,29 +195,9 @@ public class ShellServerIT extends SharedMiniClusterBase {
         // DistCp bugs out trying to get a fs delegation token to perform the cp. Just copy it
         // ourselves by hand.
         FileSystem fs = getCluster().getFileSystem();
-        FileSystem localFs = FileSystem.getLocal(new Configuration(false));
-
-        // Path on local fs to cp into
-        Path localTmpPath = new Path(localTmp);
-        localFs.mkdirs(localTmpPath);
-
-        // Path in remote fs to importtable from
         Path importDir = new Path(import_);
-        fs.mkdirs(importDir);
-
-        // Implement a poor-man's DistCp
-        try (BufferedReader reader =
-            Files.newBufferedReader(exportDir.resolve("distcp.txt"), UTF_8)) {
-          for (String line; (line = reader.readLine()) != null;) {
-            Path exportedFile = new Path(line);
-            // There isn't a cp on FileSystem??
-            log.info("Copying {} to {}", line, localTmpPath);
-            fs.copyToLocalFile(exportedFile, localTmpPath);
-            Path tmpFile = new Path(localTmpPath, exportedFile.getName());
-            log.info("Moving {} to the import directory {}", tmpFile, importDir);
-            fs.moveFromLocalFile(tmpFile, importDir);
-          }
-        }
+        Path exportPath = new Path(exportUri.substring(7));
+        ImportExportIT.copyExportedFilesToImportDirs(fs, exportPath, importDir);
       } else {
         String[] distCpArgs = {"-f", exportUri + "/distcp.txt", import_};
         assertEquals(0, cp.run(distCpArgs), "Failed to run distcp: " + Arrays.toString(distCpArgs));


### PR DESCRIPTION
Created `ImportExportIT.copyExportedFilesToImportDirs()` to help with copying exported files from a given dir into another dir.