### PR TITLE
Handle IllegalStateException in serviceLock

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ServiceLock.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ServiceLock.java
@@ -155,7 +155,11 @@ public class ServiceLock implements Watcher {
 
     LockWatcherWrapper lww = new LockWatcherWrapper(lw);
 
-    lock(lww, data);
+    try {
+      lock(lww, data);
+    } catch (IllegalStateException e) {
+      lww.failedToAcquireLock(e);
+    }
 
     if (lww.acquiredLock) {
       return true;


### PR DESCRIPTION
 Adds a try/catch method to handle the IllegalStateException that could be thrown by the lock method.  
 
 This handler allows the cleanup operation to run which sets the createdNodeName back to null. 
 
 See the commit diff for test behavior before and after the code change.
 