### PR TITLE
fixes error with concurrent merge and bulk import

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/LockRange.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/LockRange.java
@@ -51,6 +51,10 @@ public class LockRange {
     return range.contains(widenedRange.range);
   }
 
+  public boolean contains(Text row) {
+    return range.contains(row);
+  }
+
   public static LockRange of(String startRow, String endRow) {
     return of(startRow == null ? null : new Text(startRow),
         endRow == null ? null : new Text(endRow));

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/LinkingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/LinkingIterator.java
@@ -124,7 +124,8 @@ public class LinkingIterator implements Iterator<TabletMetadata> {
 
       // ensure the previous tablet still exists in the metadata table
       if (Iterators.size(iteratorFactory.apply(new Range(prevMetaRow))) == 0) {
-        throw new TabletDeletedException("Tablet " + prevMetaRow + " was deleted while iterating");
+        throw new TabletDeletedException("Tablet " + prevMetaRow + " was deleted while iterating",
+            prevTablet.getTableId(), prevTablet.getEndRow());
       }
 
       // start scanning at next possible row in metadata table

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletDeletedException.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletDeletedException.java
@@ -18,11 +18,34 @@
  */
 package org.apache.accumulo.core.metadata.schema;
 
+import java.util.Optional;
+
+import org.apache.accumulo.core.data.TableId;
+import org.apache.hadoop.io.Text;
+
 public class TabletDeletedException extends RuntimeException {
 
   private static final long serialVersionUID = 1L;
+  private final TableId tableId;
+  private final Text deletedEndRow;
+
+  public TabletDeletedException(String msg, TableId tableId, Text deletedEndRow) {
+    super(msg);
+    this.tableId = tableId;
+    this.deletedEndRow = deletedEndRow;
+  }
 
   public TabletDeletedException(String msg) {
     super(msg);
+    tableId = null;
+    deletedEndRow = null;
+  }
+
+  public Optional<TableId> getDeletedTableId() {
+    return Optional.ofNullable(tableId);
+  }
+
+  public Optional<Text> getDeletedEndRow() {
+    return Optional.ofNullable(deletedEndRow);
   }
 }


### PR DESCRIPTION
When the bulk import code was scanning outside of its locked range this caused an error when there was a concurrent merge.  Added detection for this case and threw the correct exception instead of an internal error.   Found this bug when running apache/accumulo-testing#299.