### PR TITLE
Removes the need for the LockWatcherWrapper

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/lock/ServiceLock.java
+++ b/core/src/main/java/org/apache/accumulo/core/lock/ServiceLock.java
@@ -70,26 +70,28 @@ public class ServiceLock implements Watcher {
     LOCK_DELETED, SESSION_EXPIRED
   }
 
-  public interface LockWatcher {
+  public interface AccumuloLockWatcher {
+
+    boolean isLocked();
+
+    void acquiredLock();
+
+    void failedToAcquireLock(Exception e);
+
     void lostLock(LockLossReason reason);
 
     /**
      * lost the ability to monitor the lock node, and its status is unknown
      */
     void unableToMonitorLockNode(Exception e);
-  }
 
-  public interface AccumuloLockWatcher extends LockWatcher {
-    void acquiredLock();
-
-    void failedToAcquireLock(Exception e);
   }
 
   private final ServiceLockPath path;
   protected final ZooSession zooKeeper;
   private final Prefix vmLockPrefix;
 
-  private LockWatcher lockWatcher;
+  private AccumuloLockWatcher lockWatcher;
   private String lockNodeName;
   private volatile boolean lockWasAcquired;
   private volatile boolean watchingParent;
@@ -110,45 +112,12 @@ public class ServiceLock implements Watcher {
     }
   }
 
-  private static class LockWatcherWrapper implements AccumuloLockWatcher {
-
-    boolean acquiredLock = false;
-    final LockWatcher lw;
-
-    public LockWatcherWrapper(LockWatcher lw2) {
-      this.lw = lw2;
-    }
-
-    @Override
-    public void acquiredLock() {
-      acquiredLock = true;
-    }
-
-    @Override
-    public void failedToAcquireLock(Exception e) {
-      LOG.debug("Failed to acquire lock", e);
-    }
-
-    @Override
-    public void lostLock(LockLossReason reason) {
-      lw.lostLock(reason);
-    }
-
-    @Override
-    public void unableToMonitorLockNode(Exception e) {
-      lw.unableToMonitorLockNode(e);
-    }
-
-  }
-
-  public synchronized boolean tryLock(LockWatcher lw, ServiceLockData lockData)
+  public synchronized boolean tryLock(AccumuloLockWatcher lw, ServiceLockData lockData)
       throws KeeperException, InterruptedException {
 
-    LockWatcherWrapper lww = new LockWatcherWrapper(lw);
+    lock(lw, lockData);
 
-    lock(lww, lockData);
-
-    if (lww.acquiredLock) {
+    if (lw.isLocked()) {
       return true;
     }
 
@@ -368,7 +337,7 @@ public class ServiceLock implements Watcher {
   }
 
   private void lostLock(LockLossReason reason) {
-    LockWatcher localLw = lockWatcher;
+    AccumuloLockWatcher localLw = lockWatcher;
     lockNodeName = null;
     lockId = null;
     lockWatcher = null;
@@ -533,7 +502,7 @@ public class ServiceLock implements Watcher {
       throw new IllegalStateException();
     }
 
-    LockWatcher localLw = lockWatcher;
+    AccumuloLockWatcher localLw = lockWatcher;
     String localLock = lockNodeName;
 
     lockNodeName = null;

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
@@ -674,6 +674,11 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
       }
 
       @Override
+      public boolean isLocked() {
+        return lockAcquired.get();
+      }
+
+      @Override
       public void acquiredLock() {
         log.debug("Acquired ZK lock for MiniAccumuloClusterImpl");
         lockAcquired.set(true);

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -83,7 +83,7 @@ import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileSKVIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.SystemIteratorUtil;
 import org.apache.accumulo.core.lock.ServiceLock;
-import org.apache.accumulo.core.lock.ServiceLock.LockWatcher;
+import org.apache.accumulo.core.lock.ServiceLock.AccumuloLockWatcher;
 import org.apache.accumulo.core.lock.ServiceLockData;
 import org.apache.accumulo.core.lock.ServiceLockData.ServiceDescriptor;
 import org.apache.accumulo.core.lock.ServiceLockData.ServiceDescriptors;
@@ -373,8 +373,9 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
         getContext().getServerPaths().createCompactorPath(getResourceGroup(), clientAddress);
     ServiceLockSupport.createNonHaServiceLockPath(Type.COMPACTOR, zoo, path);
     compactorLock = new ServiceLock(getContext().getZooSession(), path, compactorId);
-    LockWatcher lw = new ServiceLockWatcher(Type.COMPACTOR, () -> getShutdownComplete().get(),
-        (type) -> getContext().getLowMemoryDetector().logGCInfo(getConfiguration()));
+    AccumuloLockWatcher lw =
+        new ServiceLockWatcher(Type.COMPACTOR, () -> getShutdownComplete().get(),
+            (type) -> getContext().getLowMemoryDetector().logGCInfo(getConfiguration()));
 
     try {
       for (int i = 0; i < 25; i++) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -70,7 +70,7 @@ import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.accumulo.core.file.blockfile.cache.impl.BlockCacheConfiguration;
 import org.apache.accumulo.core.lock.ServiceLock;
-import org.apache.accumulo.core.lock.ServiceLock.LockWatcher;
+import org.apache.accumulo.core.lock.ServiceLock.AccumuloLockWatcher;
 import org.apache.accumulo.core.lock.ServiceLockData;
 import org.apache.accumulo.core.lock.ServiceLockData.ServiceDescriptor;
 import org.apache.accumulo.core.lock.ServiceLockData.ServiceDescriptors;
@@ -320,8 +320,9 @@ public class ScanServer extends AbstractServer
       ServiceLockSupport.createNonHaServiceLockPath(Type.SCAN_SERVER, zoo, zLockPath);
       serverLockUUID = UUID.randomUUID();
       scanServerLock = new ServiceLock(getContext().getZooSession(), zLockPath, serverLockUUID);
-      LockWatcher lw = new ServiceLockWatcher(Type.SCAN_SERVER, () -> getShutdownComplete().get(),
-          (type) -> context.getLowMemoryDetector().logGCInfo(getConfiguration()));
+      AccumuloLockWatcher lw =
+          new ServiceLockWatcher(Type.SCAN_SERVER, () -> getShutdownComplete().get(),
+              (type) -> context.getLowMemoryDetector().logGCInfo(getConfiguration()));
 
       for (int i = 0; i < 120 / 5; i++) {
         zoo.putPersistentData(zLockPath.toString(), new byte[0], NodeExistsPolicy.SKIP);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -79,7 +79,7 @@ import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.accumulo.core.file.blockfile.cache.impl.BlockCacheConfiguration;
 import org.apache.accumulo.core.lock.ServiceLock;
-import org.apache.accumulo.core.lock.ServiceLock.LockWatcher;
+import org.apache.accumulo.core.lock.ServiceLock.AccumuloLockWatcher;
 import org.apache.accumulo.core.lock.ServiceLockData;
 import org.apache.accumulo.core.lock.ServiceLockData.ServiceDescriptor;
 import org.apache.accumulo.core.lock.ServiceLockData.ServiceDescriptors;
@@ -488,8 +488,9 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
       UUID tabletServerUUID = UUID.randomUUID();
       tabletServerLock = new ServiceLock(getContext().getZooSession(), zLockPath, tabletServerUUID);
 
-      LockWatcher lw = new ServiceLockWatcher(Type.TABLET_SERVER, () -> getShutdownComplete().get(),
-          (type) -> context.getLowMemoryDetector().logGCInfo(getConfiguration()));
+      AccumuloLockWatcher lw =
+          new ServiceLockWatcher(Type.TABLET_SERVER, () -> getShutdownComplete().get(),
+              (type) -> context.getLowMemoryDetector().logGCInfo(getConfiguration()));
 
       for (int i = 0; i < 120 / 5; i++) {
         zoo.putPersistentData(zLockPath.toString(), new byte[0], NodeExistsPolicy.SKIP);

--- a/test/src/main/java/org/apache/accumulo/test/lock/ServiceLockIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/lock/ServiceLockIT.java
@@ -128,6 +128,11 @@ public class ServiceLockIT {
     public void unableToMonitorLockNode(final Exception e) {}
 
     @Override
+    public boolean isLocked() {
+      return lockHeld;
+    }
+
+    @Override
     public void acquiredLock() {
       this.lockHeld = true;
     }
@@ -154,6 +159,11 @@ public class ServiceLockIT {
       this.reason = reason;
       changes++;
       this.notifyAll();
+    }
+
+    @Override
+    public boolean isLocked() {
+      return locked;
     }
 
     @Override


### PR DESCRIPTION
Removes the LockWatcher interface and switches to using the AccumuloLockWatcher.

Removes the need for a LockWatcherWrapper

Adds a boolean to track lockAcquired state. Made boolean outside of watcher to follow original LockWatcherWrapper implementation.

