### PR TITLE
FATE config changes

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -457,30 +457,30 @@ public enum Property {
       PropertyType.TIMEDURATION, "Limit calls from metric sinks to zookeeper to update interval.",
       "1.9.3"),
   MANAGER_FATE_USER_CONFIG("manager.fate.user.config",
-      "{\"TABLE_CREATE,TABLE_DELETE,TABLE_RENAME,TABLE_ONLINE,TABLE_OFFLINE,NAMESPACE_CREATE,"
+      "{'pool1':{'TABLE_CREATE,TABLE_DELETE,TABLE_RENAME,TABLE_ONLINE,TABLE_OFFLINE,NAMESPACE_CREATE,"
           + "NAMESPACE_DELETE,NAMESPACE_RENAME,TABLE_TABLET_AVAILABILITY,SHUTDOWN_TSERVER,"
           + "TABLE_BULK_IMPORT2,TABLE_COMPACT,TABLE_CANCEL_COMPACT,TABLE_MERGE,TABLE_DELETE_RANGE,"
-          + "TABLE_SPLIT,TABLE_CLONE,TABLE_IMPORT,TABLE_EXPORT,SYSTEM_MERGE\": 4,"
-          + "\"COMMIT_COMPACTION\": 4,\"SYSTEM_SPLIT\": 4}",
+          + "TABLE_SPLIT,TABLE_CLONE,TABLE_IMPORT,TABLE_EXPORT,SYSTEM_MERGE': 4}, "
+          + "'pool2':{'COMMIT_COMPACTION': 4}, 'pool3':{'SYSTEM_SPLIT': 4}}".replace("'", "\""),
       PropertyType.FATE_USER_CONFIG,
       "The number of threads used to run fault-tolerant executions (FATE) on user"
-          + "tables. These are primarily table operations like merge. Each key/value "
-          + "of the provided JSON corresponds to one thread pool. Each key is a list of one or "
-          + "more FATE operations and each value is the number of threads that will be assigned "
-          + "to the pool.",
+          + "tables. These are primarily table operations like merge. The property value is JSON. "
+          + "Each key is the name of the pool (can be assigned any string). Each value is a JSON "
+          + "object (with a single key/value) whose key is a comma-separated string list of "
+          + "operations and whose value is a pool size for those operations.",
       "4.0.0"),
   MANAGER_FATE_META_CONFIG("manager.fate.meta.config",
-      "{\"TABLE_CREATE,TABLE_DELETE,TABLE_RENAME,TABLE_ONLINE,TABLE_OFFLINE,NAMESPACE_CREATE,"
+      "{'pool1':{'TABLE_CREATE,TABLE_DELETE,TABLE_RENAME,TABLE_ONLINE,TABLE_OFFLINE,NAMESPACE_CREATE,"
           + "NAMESPACE_DELETE,NAMESPACE_RENAME,TABLE_TABLET_AVAILABILITY,SHUTDOWN_TSERVER,"
           + "TABLE_BULK_IMPORT2,TABLE_COMPACT,TABLE_CANCEL_COMPACT,TABLE_MERGE,TABLE_DELETE_RANGE,"
-          + "TABLE_SPLIT,TABLE_CLONE,TABLE_IMPORT,TABLE_EXPORT,SYSTEM_MERGE\": 4,"
-          + "\"COMMIT_COMPACTION\": 4,\"SYSTEM_SPLIT\": 4}",
+          + "TABLE_SPLIT,TABLE_CLONE,TABLE_IMPORT,TABLE_EXPORT,SYSTEM_MERGE': 4}, "
+          + "'pool2':{'COMMIT_COMPACTION': 4}, 'pool3':{'SYSTEM_SPLIT': 4}}".replace("'", "\""),
       PropertyType.FATE_META_CONFIG,
-      "The number of threads used to run fault-tolerant executions (FATE) on Accumulo"
-          + "system tables. These are primarily table operations like merge. Each key/value "
-          + "of the provided JSON corresponds to one thread pool. Each key is a list of one or "
-          + "more FATE operations and each value is the number of threads that will be assigned "
-          + "to the pool.",
+      "The number of threads used to run fault-tolerant executions (FATE) on Accumulo system"
+          + "tables. These are primarily table operations like merge. The property value is JSON. "
+          + "Each key is the name of the pool (can be assigned any string). Each value is a JSON "
+          + "object (with a single key/value) whose key is a comma-separated string list of "
+          + "operations and whose value is a pool size for those operations.",
       "4.0.0"),
   @Deprecated(since = "4.0.0")
   MANAGER_FATE_THREADPOOL_SIZE("manager.fate.threadpool.size", "64",
@@ -493,10 +493,12 @@ public enum Property {
       "1.4.3"),
   MANAGER_FATE_IDLE_CHECK_INTERVAL("manager.fate.idle.check.interval", "60m",
       PropertyType.TIMEDURATION,
-      "The interval at which to check if the number of idle Fate threads has consistently been zero."
-          + " The way this is checked is an approximation. Logs a warning in the Manager log to change"
-          + " MANAGER_FATE_USER_CONFIG or MANAGER_FATE_META_CONFIG. A value less than a minute disables"
-          + " this check and has a maximum value of 60m.",
+      String.format(
+          "The interval at which to check if the number of idle Fate threads has consistently been"
+              + " zero. The way this is checked is an approximation. Logs a warning in the Manager"
+              + " log to change %s or %s. A value less than a minute disables this check and has a"
+              + " maximum value of 60m.",
+          MANAGER_FATE_USER_CONFIG.getKey(), MANAGER_FATE_META_CONFIG.getKey()),
       "4.0.0"),
   MANAGER_STATUS_THREAD_POOL_SIZE("manager.status.threadpool.size", "0", PropertyType.COUNT,
       "The number of threads to use when fetching the tablet server status for balancing.  Zero "

--- a/core/src/main/java/org/apache/accumulo/core/fate/FateExecutor.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/FateExecutor.java
@@ -43,7 +43,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TransferQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
 import org.apache.accumulo.core.conf.Property;
@@ -75,6 +74,7 @@ public class FateExecutor<T> {
   private final Thread workFinder;
   private final TransferQueue<FateId> workQueue;
   private final AtomicInteger idleWorkerCount;
+  private final String name;
   private final String poolName;
   private final ThreadPoolExecutor transactionExecutor;
   private final Set<TransactionRunner> runningTxRunners;
@@ -82,26 +82,26 @@ public class FateExecutor<T> {
   private final ConcurrentLinkedQueue<Integer> idleCountHistory = new ConcurrentLinkedQueue<>();
   private final FateExecutorMetrics<T> fateExecutorMetrics;
 
-  public FateExecutor(Fate<T> fate, T environment, Set<Fate.FateOperation> fateOps, int poolSize) {
+  public FateExecutor(Fate<T> fate, T environment, Set<Fate.FateOperation> fateOps, int poolSize,
+      String name) {
     final FateInstanceType type = fate.getStore().type();
     final String typeStr = type.name().toLowerCase();
-    final String operatesOn = fateOps.stream().map(fo -> fo.name().toLowerCase()).sorted()
-        .collect(Collectors.joining("."));
-    final String transactionRunnerPoolName =
-        ThreadPoolNames.MANAGER_FATE_POOL_PREFIX.poolName + typeStr + "." + operatesOn;
-    final String workFinderThreadName = "fate.work.finder." + typeStr + "." + operatesOn;
+    final String poolName =
+        ThreadPoolNames.MANAGER_FATE_POOL_PREFIX.poolName + typeStr + "." + name;
+    final String workFinderThreadName = "fate.work.finder." + typeStr + "." + name;
 
     this.fate = fate;
     this.environment = environment;
     this.fateOps = Collections.unmodifiableSet(fateOps);
     this.workQueue = new LinkedTransferQueue<>();
     this.runningTxRunners = Collections.synchronizedSet(new HashSet<>());
-    this.poolName = transactionRunnerPoolName;
-    this.transactionExecutor = ThreadPools.getServerThreadPools()
-        .getPoolBuilder(transactionRunnerPoolName).numCoreThreads(poolSize).build();
+    this.name = name;
+    this.poolName = poolName;
+    this.transactionExecutor = ThreadPools.getServerThreadPools().getPoolBuilder(poolName)
+        .numCoreThreads(poolSize).build();
     this.idleWorkerCount = new AtomicInteger(0);
     this.fateExecutorMetrics =
-        new FateExecutorMetrics<>(type, operatesOn, runningTxRunners, idleWorkerCount);
+        new FateExecutorMetrics<>(type, poolName, runningTxRunners, idleWorkerCount);
 
     this.workFinder = Threads.createCriticalThread(workFinderThreadName, new WorkFinder());
     this.workFinder.start();
@@ -112,9 +112,10 @@ public class FateExecutor<T> {
    * grew, stop TransactionRunners if the pool shrunk, and potentially suggest resizing the pool if
    * the load is consistently high.
    */
-  protected void resizeFateExecutor(Map<Set<Fate.FateOperation>,Integer> poolConfigs,
+  protected void resizeFateExecutor(
+      Map<Set<Fate.FateOperation>,Map.Entry<String,Integer>> poolConfigs,
       long idleCheckIntervalMillis) {
-    final int configured = poolConfigs.get(fateOps);
+    final int configured = poolConfigs.get(fateOps).getValue();
     ThreadPools.resizePool(transactionExecutor, () -> configured, poolName);
     synchronized (runningTxRunners) {
       final int running = runningTxRunners.size();
@@ -201,6 +202,10 @@ public class FateExecutor<T> {
         }
       }
     }
+  }
+
+  protected String getName() {
+    return name;
   }
 
   private int getIdleWorkerCount() {
@@ -608,7 +613,7 @@ public class FateExecutor<T> {
 
   @Override
   public String toString() {
-    return String.format("FateExecutor:{FateOps=%s,PoolSize:%s,TransactionRunners:%s}", fateOps,
-        runningTxRunners.size(), runningTxRunners);
+    return String.format("FateExecutor:{FateOps=%s,Name=%s,PoolSize:%s,TransactionRunners:%s}",
+        fateOps, name, runningTxRunners.size(), runningTxRunners);
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/metrics/Metric.java
+++ b/core/src/main/java/org/apache/accumulo/core/metrics/Metric.java
@@ -110,14 +110,14 @@ public enum Metric {
           + "(e.g., state=new, state=in.progress, state=failed, etc.).",
       MetricDocSection.FATE),
   FATE_OPS_THREADS_INACTIVE("accumulo.fate.ops.threads.inactive", MetricType.GAUGE,
-      "Keeps track of the number of idle threads (not working on a fate operation) in the thread pool assigned to work on the operations as shown in the "
-          + FateExecutorMetrics.OPS_ASSIGNED_TAG_KEY
+      "Keeps track of the number of idle threads (not working on a fate operation) in the thread "
+          + "pool. The pool name can be found in the " + FateExecutorMetrics.POOL_NAME_TAG_KEY
           + " tag. The fate instance type can be found in the "
           + FateExecutorMetrics.INSTANCE_TYPE_TAG_KEY + " tag.",
       MetricDocSection.FATE),
   FATE_OPS_THREADS_TOTAL("accumulo.fate.ops.threads.total", MetricType.GAUGE,
-      "Keeps track of the total number of threads in the thread pool assigned to work on the operations as shown in the "
-          + FateExecutorMetrics.OPS_ASSIGNED_TAG_KEY
+      "Keeps track of the total number of threads in the thread pool. The pool name can be found in the "
+          + FateExecutorMetrics.POOL_NAME_TAG_KEY
           + " tag. The fate instance type can be found in the "
           + FateExecutorMetrics.INSTANCE_TYPE_TAG_KEY + " tag.",
       MetricDocSection.FATE),

--- a/test/src/main/java/org/apache/accumulo/test/fate/FateExecutionOrderITBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FateExecutionOrderITBase.java
@@ -47,6 +47,7 @@ import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.client.admin.TabletAvailability;
+import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
@@ -194,7 +195,8 @@ public abstract class FateExecutionOrderITBase extends SharedMiniClusterBase
 
   protected Fate<FeoTestEnv> initializeFate(AccumuloClient client, FateStore<FeoTestEnv> store) {
     return new Fate<>(new FeoTestEnv(client), store, false, r -> r + "",
-        FateTestUtil.createTestFateConfig(1), new ScheduledThreadPoolExecutor(2));
+        FateTestUtil.updateFateConfig(new ConfigurationCopy(), 1, "AllFateOps"),
+        new ScheduledThreadPoolExecutor(2));
   }
 
   private static Entry<FateId,String> toIdStep(Entry<Key,Value> e) {

--- a/test/src/main/java/org/apache/accumulo/test/fate/FateITBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FateITBase.java
@@ -44,6 +44,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.fate.AbstractFateStore;
 import org.apache.accumulo.core.fate.Fate;
 import org.apache.accumulo.core.fate.FateId;
@@ -554,7 +555,8 @@ public abstract class FateITBase extends SharedMiniClusterBase implements FateTe
 
   protected Fate<TestEnv> initializeFate(FateStore<TestEnv> store) {
     return new Fate<>(new TestEnv(), store, false, r -> r + "",
-        FateTestUtil.createTestFateConfig(1), new ScheduledThreadPoolExecutor(2));
+        FateTestUtil.updateFateConfig(new ConfigurationCopy(), 1, "AllFateOps"),
+        new ScheduledThreadPoolExecutor(2));
   }
 
   protected abstract TStatus getTxStatus(ServerContext sctx, FateId fateId);

--- a/test/src/main/java/org/apache/accumulo/test/fate/FatePoolsWatcherITBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FatePoolsWatcherITBase.java
@@ -27,7 +27,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.fate.Fate;
@@ -79,12 +78,12 @@ public abstract class FatePoolsWatcherITBase extends SharedMiniClusterBase
   protected void testIncrease1(FateStore<PoolResizeTestEnv> store, ServerContext sctx)
       throws Exception {
     // Tests changing the config for the FATE thread pools from
-    // {<half the FATE ops/SET1>}: 4 <-- FateExecutor1
-    // {<other half/SET2>}: 5 <-- FateExecutor2
+    // SET1: {<half the FATE ops>: 4} <-- FateExecutor1
+    // SET2: {<other half>: 5} <-- FateExecutor2
     // ---->
-    // {<half the FATE ops/SET1>}: 10 <-- FateExecutor1
-    // {<other half minus one/SET3>}: 9 <-- FateExecutor3
-    // {<remaining FATE op/SET4>}: 8 <-- FateExecutor4
+    // SET1: {<half the FATE ops>: 10} <-- FateExecutor1
+    // SET3: {<other half minus one>: 9} <-- FateExecutor3
+    // SET4: {<remaining FATE op>: 8} <-- FateExecutor4
     // This tests inc size of FATE thread pools for FateExecutors with unchanged fate ops, stopping
     // FateExecutors that are no longer valid (while ensuring none are stopped while in progress on
     // a transaction), and creating new FateExecutors as needed. Essentially, FateExecutor1's pool
@@ -215,12 +214,14 @@ public abstract class FatePoolsWatcherITBase extends SharedMiniClusterBase
 
   protected void testIncrease2(FateStore<PoolResizeTestEnv> store, ServerContext sctx) {
     // Tests changing the config for the FATE thread pools from
-    // {<All FATE ops>}: 2 <-- FateExecutor1
+    // AllFateOps: {<All FATE ops>: 2} <-- FateExecutor1
     // ---->
-    // {<All FATE ops>}: 3 <-- FateExecutor1
+    // AllFateOps: {<All FATE ops>: 3} <-- FateExecutor1
     // when 3 transactions need to be worked on. Ensures after the config change, the third tx
     // is picked up.
-    final ConfigurationCopy config = FateTestUtil.createTestFateConfig(2);
+    final String fateExecName = "AllFateOps";
+    final ConfigurationCopy config =
+        FateTestUtil.updateFateConfig(new ConfigurationCopy(), 2, fateExecName);
     final var env = new PoolResizeTestEnv();
     final Fate<PoolResizeTestEnv> fate = new FastFate<>(env, store, false, r -> r + "", config);
     final int numWorkers = 2;
@@ -249,7 +250,7 @@ public abstract class FatePoolsWatcherITBase extends SharedMiniClusterBase
       assertEquals(numWorkers, fate.getTxRunnersActive(allFateOps));
 
       // increase the pool size
-      changeConfigIncTest2(config, newNumWorkers);
+      FateTestUtil.updateFateConfig(config, newNumWorkers, fateExecName);
 
       // wait for the final tx to be picked up
       Wait.waitFor(() -> env.numWorkers.get() == newNumWorkers);
@@ -291,12 +292,12 @@ public abstract class FatePoolsWatcherITBase extends SharedMiniClusterBase
   protected void testDecrease(FateStore<PoolResizeTestEnv> store, ServerContext sctx)
       throws Exception {
     // Tests changing the config for the FATE thread pools from
-    // {<half the FATE ops/SET1>}: 4 <-- FateExecutor1
-    // {<other half minus one/SET3>}: 5 <-- FateExecutor2
-    // {<remaining FATE op/SET4>}: 6 <-- FateExecutor3
+    // SET1: {<half the FATE ops>: 4} <-- FateExecutor1
+    // SET3: {<other half minus one>: 5} <-- FateExecutor2
+    // SET4: {<remaining FATE op>: 6} <-- FateExecutor3
     // ---->
-    // {<half the FATE ops/SET1>}: 3 <-- FateExecutor1
-    // {<other half/SET2>}: 2 <-- FateExecutor4
+    // SET1: {<half the FATE ops>: 3} <-- FateExecutor1
+    // SET2: {<other half>: 2} <-- FateExecutor4
     // This tests dec size of FATE thread pools for FateExecutors with unchanged fate ops, stopping
     // FateExecutors that are no longer valid (while ensuring none are stopped while in progress on
     // a transaction), and creating new FateExecutors as needed. Essentially, FateExecutor1's pool
@@ -429,7 +430,9 @@ public abstract class FatePoolsWatcherITBase extends SharedMiniClusterBase
   protected void testIdleCountHistory(FateStore<PoolResizeTestEnv> store, ServerContext sctx)
       throws Exception {
     // Tests that a warning to increase pool size is logged when expected
-    var config = configIdleHistoryTest();
+    var config = FateTestUtil.updateFateConfig(new ConfigurationCopy(), 2, "AllFateOps");
+    config.set(Property.MANAGER_FATE_IDLE_CHECK_INTERVAL, "1m");
+
     final var env = new PoolResizeTestEnv();
     final Fate<PoolResizeTestEnv> fate = new FastFate<>(env, store, false, r -> r + "", config);
     try {
@@ -462,15 +465,15 @@ public abstract class FatePoolsWatcherITBase extends SharedMiniClusterBase
   protected void testFatePoolsPartitioning(FateStore<PoolResizeTestEnv> store, ServerContext sctx)
       throws Exception {
     // Ensures FATE ops are correctly partitioned between the pools. Configures 4 FateExecutors:
-    // FateExecutor1 with 2 threads operating on 1/4 of FATE ops
-    // FateExecutor2 with 3 threads operating on 1/4 of FATE ops
-    // FateExecutor3 with 4 threads operating on 1/4 of FATE ops
-    // FateExecutor4 with 5 threads operating on 1/4 of FATE ops
+    // pool1/FateExecutor1 with 2 threads operating on 1/4 of FATE ops
+    // pool2/FateExecutor2 with 3 threads operating on 1/4 of FATE ops
+    // pool3/FateExecutor3 with 4 threads operating on 1/4 of FATE ops
+    // pool4/FateExecutor4 with 5 threads operating on 1/4 of FATE ops
     // Seeds:
-    // 5 transactions on FateExecutor1
-    // 6 transactions on FateExecutor2
-    // 1 transactions on FateExecutor3
-    // 4 transactions on FateExecutor4
+    // 5 transactions on pool1/FateExecutor1
+    // 6 transactions on pool2/FateExecutor2
+    // 1 transactions on pool3/FateExecutor3
+    // 4 transactions on pool4/FateExecutor4
     // Ensures that we only see min(configured threads, transactions seeded) ever running
     // Also ensures that FateExecutors do not pick up any work that they shouldn't
     final int numThreadsPool1 = 2;
@@ -512,17 +515,19 @@ public abstract class FatePoolsWatcherITBase extends SharedMiniClusterBase
     final ConfigurationCopy config = new ConfigurationCopy();
     config.set(Property.GENERAL_THREADPOOL_SIZE, "2");
     config.set(Property.MANAGER_FATE_USER_CONFIG,
-        String.format("{\"%s\": %s, \"%s\": %s, \"%s\": %s, \"%s\": %s}",
+        String.format("{'pool1':{'%s':%d},'pool2':{'%s':%d},'pool3':{'%s':%d},'pool4':{'%s':%d}}",
             userPool1.stream().map(Enum::name).collect(Collectors.joining(",")), numThreadsPool1,
             userPool2.stream().map(Enum::name).collect(Collectors.joining(",")), numThreadsPool2,
             userPool3.stream().map(Enum::name).collect(Collectors.joining(",")), numThreadsPool3,
-            userPool4.stream().map(Enum::name).collect(Collectors.joining(",")), numThreadsPool4));
+            userPool4.stream().map(Enum::name).collect(Collectors.joining(",")), numThreadsPool4)
+            .replace("'", "\""));
     config.set(Property.MANAGER_FATE_META_CONFIG,
-        String.format("{\"%s\": %s, \"%s\": %s, \"%s\": %s, \"%s\": %s}",
+        String.format("{'pool1':{'%s':%d},'pool2':{'%s':%d},'pool3':{'%s':%d},'pool4':{'%s':%d}}",
             metaPool1.stream().map(Enum::name).collect(Collectors.joining(",")), numThreadsPool1,
             metaPool2.stream().map(Enum::name).collect(Collectors.joining(",")), numThreadsPool2,
             metaPool3.stream().map(Enum::name).collect(Collectors.joining(",")), numThreadsPool3,
-            metaPool4.stream().map(Enum::name).collect(Collectors.joining(",")), numThreadsPool4));
+            metaPool4.stream().map(Enum::name).collect(Collectors.joining(",")), numThreadsPool4)
+            .replace("'", "\""));
     config.set(Property.MANAGER_FATE_IDLE_CHECK_INTERVAL, "60m");
 
     final boolean isUserStore = store.type() == FateInstanceType.USER;
@@ -629,84 +634,139 @@ public abstract class FatePoolsWatcherITBase extends SharedMiniClusterBase
     }
   }
 
+  @Test
+  public void testFateExecutorRename() throws Exception {
+    executeTest(this::testFateExecutorRename);
+  }
+
+  protected void testFateExecutorRename(FateStore<PoolResizeTestEnv> store, ServerContext sctx)
+      throws Exception {
+    // tests that attempting to rename a fate executor will cause it to be shutdown and a new one
+    // to be started
+
+    final var env = new PoolResizeTestEnv();
+    final int poolSize = 3;
+    final int newPoolSize = 5;
+    final var config =
+        FateTestUtil.updateFateConfig(new ConfigurationCopy(), poolSize, "AllFateOps");
+    final Fate<PoolResizeTestEnv> fate = new FastFate<>(env, store, false, r -> r + "", config);
+
+    try {
+      // start a single transaction
+      fate.seedTransaction(FateTestUtil.TEST_FATE_OP, fate.startTransaction(),
+          new PoolResizeTestRepo(), true, "testing");
+
+      // wait for the transaction to be worked on
+      Wait.waitFor(() -> env.numWorkers.get() == 1);
+      // wait for all transaction runners to be active/started
+      Wait.waitFor(() -> fate.getTotalTxRunnersActive() == poolSize);
+
+      // rename the fate executor
+      // the only reason for changing the pool size here is so that we can tell that the old fate
+      // executor is shutdown and the new one is started. Changing the pool size does not by itself
+      // cause a shutdown
+      FateTestUtil.updateFateConfig(config, newPoolSize, "NewPoolName");
+
+      // newPoolSize for the newly created fate executor and 1 for the old fate executor that has
+      // begun but not finished shutdown (needs to complete the transaction it's working on)
+      Wait.waitFor(() -> fate.getTotalTxRunnersActive() == newPoolSize + 1);
+
+      // allow work to complete
+      env.isReadyLatch.countDown();
+
+      Wait.waitFor(() -> fate.getTotalTxRunnersActive() == newPoolSize);
+      // at this point, we are certain the old fate executor has completely shutdown
+    } catch (Throwable e) {
+      // If the finally block throws an exception then this exception will never be seen so log it
+      // just in case.
+      log.error("Failure in test", e);
+      throw e;
+    } finally {
+      fate.shutdown(30, TimeUnit.SECONDS);
+      assertEquals(0, fate.getTotalTxRunnersActive());
+    }
+  }
+
   private ConfigurationCopy initConfigIncTest1() {
-    // {<half the FATE ops/SET1>}: 4
-    // {<other half/SET2>}: 5
+    // SET1: {<half the FATE ops>: 4}
+    // SET2: {<other half>: 5}
     ConfigurationCopy config = new ConfigurationCopy();
     config.set(Property.GENERAL_THREADPOOL_SIZE, "2");
-    config.set(Property.MANAGER_FATE_USER_CONFIG, "{\""
-        + USER_FATE_OPS_SET1.stream().map(Enum::name).collect(Collectors.joining(",")) + "\": 4,\""
-        + USER_FATE_OPS_SET2.stream().map(Enum::name).collect(Collectors.joining(",")) + "\": 5}");
-    config.set(Property.MANAGER_FATE_META_CONFIG, "{\""
-        + META_FATE_OPS_SET1.stream().map(Enum::name).collect(Collectors.joining(",")) + "\": 4,\""
-        + META_FATE_OPS_SET2.stream().map(Enum::name).collect(Collectors.joining(",")) + "\": 5}");
+    config.set(Property.MANAGER_FATE_USER_CONFIG,
+        String
+            .format("{'SET1':{'%s':%d},'SET2':{'%s':%d}}",
+                USER_FATE_OPS_SET1.stream().map(Enum::name).collect(Collectors.joining(",")), 4,
+                USER_FATE_OPS_SET2.stream().map(Enum::name).collect(Collectors.joining(",")), 5)
+            .replace("'", "\""));
+    config.set(Property.MANAGER_FATE_META_CONFIG,
+        String
+            .format("{'SET1':{'%s':%d},'SET2':{'%s':%d}}",
+                META_FATE_OPS_SET1.stream().map(Enum::name).collect(Collectors.joining(",")), 4,
+                META_FATE_OPS_SET2.stream().map(Enum::name).collect(Collectors.joining(",")), 5)
+            .replace("'", "\""));
     config.set(Property.MANAGER_FATE_IDLE_CHECK_INTERVAL, "60m");
     return config;
   }
 
   private void changeConfigIncTest1(ConfigurationCopy config) {
-    // {<half the FATE ops/SET1>}: 10
-    // {<other half minus one/SET3>}: 9
-    // {<remaining FATE op/SET4>}: 8
-    config.set(Property.MANAGER_FATE_USER_CONFIG, "{\""
-        + USER_FATE_OPS_SET1.stream().map(Enum::name).collect(Collectors.joining(",")) + "\": 10,"
-        + "\"" + USER_FATE_OPS_SET3.stream().map(Enum::name).collect(Collectors.joining(","))
-        + "\": 9,\"" + USER_FATE_OPS_SET4.stream().map(Enum::name).collect(Collectors.joining(","))
-        + "\": 8}");
-    config.set(Property.MANAGER_FATE_META_CONFIG, "{\""
-        + META_FATE_OPS_SET1.stream().map(Enum::name).collect(Collectors.joining(",")) + "\": 10,"
-        + "\"" + META_FATE_OPS_SET3.stream().map(Enum::name).collect(Collectors.joining(","))
-        + "\": 9,\"" + META_FATE_OPS_SET4.stream().map(Enum::name).collect(Collectors.joining(","))
-        + "\": 8}");
-  }
-
-  private void changeConfigIncTest2(ConfigurationCopy config, int numThreads) {
-    config.set(Property.MANAGER_FATE_USER_CONFIG, "{\"" + Fate.FateOperation.getAllUserFateOps()
-        .stream().map(Enum::name).collect(Collectors.joining(",")) + "\": " + numThreads + "}");
-    config.set(Property.MANAGER_FATE_META_CONFIG, "{\"" + Fate.FateOperation.getAllMetaFateOps()
-        .stream().map(Enum::name).collect(Collectors.joining(",")) + "\": " + numThreads + "}");
+    // SET1: {<half the FATE ops>: 10}
+    // SET3: {<other half minus one>: 9}
+    // SET4: {<remaining FATE op>: 8}
+    config.set(Property.MANAGER_FATE_USER_CONFIG,
+        String
+            .format("{'SET1':{'%s':%d},'SET3':{'%s':%d},'SET4':{'%s':%d}}",
+                USER_FATE_OPS_SET1.stream().map(Enum::name).collect(Collectors.joining(",")), 10,
+                USER_FATE_OPS_SET3.stream().map(Enum::name).collect(Collectors.joining(",")), 9,
+                USER_FATE_OPS_SET4.stream().map(Enum::name).collect(Collectors.joining(",")), 8)
+            .replace("'", "\""));
+    config.set(Property.MANAGER_FATE_META_CONFIG,
+        String
+            .format("{'SET1':{'%s':%d},'SET3':{'%s':%d},'SET4':{'%s':%d}}",
+                META_FATE_OPS_SET1.stream().map(Enum::name).collect(Collectors.joining(",")), 10,
+                META_FATE_OPS_SET3.stream().map(Enum::name).collect(Collectors.joining(",")), 9,
+                META_FATE_OPS_SET4.stream().map(Enum::name).collect(Collectors.joining(",")), 8)
+            .replace("'", "\""));
   }
 
   private ConfigurationCopy initConfigDecTest() {
-    // {<half the FATE ops/SET1>}: 4
-    // {<other half minus one/SET3>}: 5
-    // {<remaining FATE op/SET4>}: 6
+    // SET1: {<half the FATE ops>: 4}
+    // SET3: {<other half minus one>: 5}
+    // SET4: {<remaining FATE op>: 6}
     ConfigurationCopy config = new ConfigurationCopy();
     config.set(Property.GENERAL_THREADPOOL_SIZE, "2");
-    config.set(Property.MANAGER_FATE_USER_CONFIG, "{\""
-        + USER_FATE_OPS_SET1.stream().map(Enum::name).collect(Collectors.joining(",")) + "\": 4,"
-        + "\"" + USER_FATE_OPS_SET3.stream().map(Enum::name).collect(Collectors.joining(","))
-        + "\": 5,\"" + USER_FATE_OPS_SET4.stream().map(Enum::name).collect(Collectors.joining(","))
-        + "\": 6}");
-    config.set(Property.MANAGER_FATE_META_CONFIG, "{\""
-        + META_FATE_OPS_SET1.stream().map(Enum::name).collect(Collectors.joining(",")) + "\": 4,"
-        + "\"" + META_FATE_OPS_SET3.stream().map(Enum::name).collect(Collectors.joining(","))
-        + "\": 5,\"" + META_FATE_OPS_SET4.stream().map(Enum::name).collect(Collectors.joining(","))
-        + "\": 6}");
+    config.set(Property.MANAGER_FATE_USER_CONFIG,
+        String
+            .format("{'SET1':{'%s':%d},'SET3':{'%s':%d},'SET4':{'%s':%d}}",
+                USER_FATE_OPS_SET1.stream().map(Enum::name).collect(Collectors.joining(",")), 4,
+                USER_FATE_OPS_SET3.stream().map(Enum::name).collect(Collectors.joining(",")), 5,
+                USER_FATE_OPS_SET4.stream().map(Enum::name).collect(Collectors.joining(",")), 6)
+            .replace("'", "\""));
+    config.set(Property.MANAGER_FATE_META_CONFIG,
+        String
+            .format("{'SET1':{'%s':%d},'SET3':{'%s':%d},'SET4':{'%s':%d}}",
+                META_FATE_OPS_SET1.stream().map(Enum::name).collect(Collectors.joining(",")), 4,
+                META_FATE_OPS_SET3.stream().map(Enum::name).collect(Collectors.joining(",")), 5,
+                META_FATE_OPS_SET4.stream().map(Enum::name).collect(Collectors.joining(",")), 6)
+            .replace("'", "\""));
     config.set(Property.MANAGER_FATE_IDLE_CHECK_INTERVAL, "60m");
     return config;
   }
 
   private void changeConfigDecTest(ConfigurationCopy config) {
-    // {<half the FATE ops/SET1>}: 3
-    // {<other half/SET2>}: 2
-    config.set(Property.MANAGER_FATE_USER_CONFIG, "{\""
-        + USER_FATE_OPS_SET1.stream().map(Enum::name).collect(Collectors.joining(",")) + "\": 3,\""
-        + USER_FATE_OPS_SET2.stream().map(Enum::name).collect(Collectors.joining(",")) + "\": 2}");
-    config.set(Property.MANAGER_FATE_META_CONFIG, "{\""
-        + META_FATE_OPS_SET1.stream().map(Enum::name).collect(Collectors.joining(",")) + "\": 3,\""
-        + META_FATE_OPS_SET2.stream().map(Enum::name).collect(Collectors.joining(",")) + "\": 2}");
-  }
-
-  private AccumuloConfiguration configIdleHistoryTest() {
-    ConfigurationCopy config = new ConfigurationCopy();
-    config.set(Property.GENERAL_THREADPOOL_SIZE, "2");
-    config.set(Property.MANAGER_FATE_USER_CONFIG, "{\""
-        + ALL_USER_FATE_OPS.stream().map(Enum::name).collect(Collectors.joining(",")) + "\": 2}");
-    config.set(Property.MANAGER_FATE_META_CONFIG, "{\""
-        + ALL_META_FATE_OPS.stream().map(Enum::name).collect(Collectors.joining(",")) + "\": 2}");
-    config.set(Property.MANAGER_FATE_IDLE_CHECK_INTERVAL, "1m");
-    return config;
+    // SET1: {<half the FATE ops>: 3}
+    // SET2: {<other half>: 2}
+    config.set(Property.MANAGER_FATE_USER_CONFIG,
+        String
+            .format("{'SET1':{'%s':%d},'SET2':{'%s':%d}}",
+                USER_FATE_OPS_SET1.stream().map(Enum::name).collect(Collectors.joining(",")), 3,
+                USER_FATE_OPS_SET2.stream().map(Enum::name).collect(Collectors.joining(",")), 2)
+            .replace("'", "\""));
+    config.set(Property.MANAGER_FATE_META_CONFIG,
+        String
+            .format("{'SET1':{'%s':%d},'SET2':{'%s':%d}}",
+                META_FATE_OPS_SET1.stream().map(Enum::name).collect(Collectors.joining(",")), 3,
+                META_FATE_OPS_SET2.stream().map(Enum::name).collect(Collectors.joining(",")), 2)
+            .replace("'", "\""));
   }
 
   public static class PoolResizeTestRepo implements Repo<PoolResizeTestEnv> {

--- a/test/src/main/java/org/apache/accumulo/test/fate/FateTestUtil.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FateTestUtil.java
@@ -93,17 +93,25 @@ public class FateTestUtil {
   }
 
   /**
-   * Returns a config with all FATE operations assigned to a single pool of size numThreads for both
-   * USER and META FATE operations
+   * Returns the config with all FATE operations assigned to a single pool of size "numThreads" for
+   * both USER and META FATE operations. The fate executor is given the name "name"
    */
-  public static ConfigurationCopy createTestFateConfig(int numThreads) {
-    ConfigurationCopy config = new ConfigurationCopy();
+  public static ConfigurationCopy updateFateConfig(ConfigurationCopy config, int numThreads,
+      String name) {
     // this value isn't important, just needs to be set
     config.set(Property.GENERAL_THREADPOOL_SIZE, "2");
-    config.set(Property.MANAGER_FATE_USER_CONFIG, "{\"" + Fate.FateOperation.getAllUserFateOps()
-        .stream().map(Enum::name).collect(Collectors.joining(",")) + "\": " + numThreads + "}");
-    config.set(Property.MANAGER_FATE_META_CONFIG, "{\"" + Fate.FateOperation.getAllMetaFateOps()
-        .stream().map(Enum::name).collect(Collectors.joining(",")) + "\": " + numThreads + "}");
+    config
+        .set(Property.MANAGER_FATE_USER_CONFIG,
+            String
+                .format("{'%s':{'%s': %d}}", name, Fate.FateOperation.getAllUserFateOps().stream()
+                    .map(Enum::name).collect(Collectors.joining(",")), numThreads)
+                .replace("'", "\""));
+    config
+        .set(Property.MANAGER_FATE_META_CONFIG,
+            String
+                .format("{'%s':{'%s': %d}}", name, Fate.FateOperation.getAllMetaFateOps().stream()
+                    .map(Enum::name).collect(Collectors.joining(",")), numThreads)
+                .replace("'", "\""));
     config.set(Property.MANAGER_FATE_IDLE_CHECK_INTERVAL, "60m");
     return config;
   }

--- a/test/src/main/java/org/apache/accumulo/test/fate/FlakyFate.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FlakyFate.java
@@ -40,15 +40,15 @@ public class FlakyFate<T> extends Fate<T> {
       AccumuloConfiguration conf) {
     super(environment, store, false, toLogStrFunc, conf, new ScheduledThreadPoolExecutor(2));
     for (var poolConfig : getPoolConfigurations(conf, getStore().type()).entrySet()) {
-      fateExecutors.add(
-          new FlakyFateExecutor<>(this, environment, poolConfig.getKey(), poolConfig.getValue()));
+      fateExecutors.add(new FlakyFateExecutor<>(this, environment, poolConfig.getKey(),
+          poolConfig.getValue().getValue(), poolConfig.getValue().getKey()));
     }
   }
 
   private static class FlakyFateExecutor<T> extends FateExecutor<T> {
-    private FlakyFateExecutor(Fate<T> fate, T environment, Set<FateOperation> fateOps,
-        int poolSize) {
-      super(fate, environment, fateOps, poolSize);
+    private FlakyFateExecutor(Fate<T> fate, T environment, Set<FateOperation> fateOps, int poolSize,
+        String name) {
+      super(fate, environment, fateOps, poolSize, name);
     }
 
     @Override

--- a/test/src/main/java/org/apache/accumulo/test/fate/MultipleStoresITBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/MultipleStoresITBase.java
@@ -39,6 +39,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.fate.Fate;
 import org.apache.accumulo.core.fate.FateId;
@@ -308,7 +309,8 @@ public abstract class MultipleStoresITBase extends SharedMiniClusterBase {
     final ZooUtil.LockID lock2 = new ZooUtil.LockID("/locks", "L2", 52);
     final Set<ZooUtil.LockID> liveLocks = new HashSet<>();
     final Predicate<ZooUtil.LockID> isLockHeld = liveLocks::contains;
-    final AccumuloConfiguration config = FateTestUtil.createTestFateConfig(numThreads);
+    final AccumuloConfiguration config =
+        FateTestUtil.updateFateConfig(new ConfigurationCopy(), numThreads, "AllFateOps");
     Map<FateId,FateStore.FateReservation> reservations;
 
     try (final FateStore<LatchTestEnv> store1 = testStoreFactory.create(lock1, isLockHeld)) {

--- a/test/src/main/java/org/apache/accumulo/test/fate/SlowFateSplit.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/SlowFateSplit.java
@@ -55,15 +55,15 @@ public class SlowFateSplit<T> extends Fate<T> {
       AccumuloConfiguration conf) {
     super(environment, store, false, toLogStrFunc, conf, new ScheduledThreadPoolExecutor(2));
     for (var poolConfig : getPoolConfigurations(conf, getStore().type()).entrySet()) {
-      fateExecutors.add(
-          new SlowFateSplitExecutor(this, environment, poolConfig.getKey(), poolConfig.getValue()));
+      fateExecutors.add(new SlowFateSplitExecutor(this, environment, poolConfig.getKey(),
+          poolConfig.getValue().getValue(), poolConfig.getValue().getKey()));
     }
   }
 
   private class SlowFateSplitExecutor extends FateExecutor<T> {
     private SlowFateSplitExecutor(Fate<T> fate, T environment, Set<Fate.FateOperation> fateOps,
-        int poolSize) {
-      super(fate, environment, fateOps, poolSize);
+        int poolSize, String name) {
+      super(fate, environment, fateOps, poolSize, name);
     }
 
     @Override


### PR DESCRIPTION
changes the FATE config structure

From:
* being a JSON where each key is a comma-separated list of FATE operations and each value is a pool size for those operations

To:
* being a JSON where each key is some user-defined name and each value is a JSON with a single key/value where the key is a comma-separated list of FATE operations and the value is a pool size for those operations

For example:
* `{"SOME_OPS": 4, "REMAINING_OPS": 10}`

Could become:
* `{"pool1": {"SOME_OPS": 4}, "pool2": {"REMAINING_OPS": 10}}`

This was done to facilitate some way to maintain metrics for these pools without including the (potentially very long) list of FATE operations, which could be an issue for some monitoring systems. Also shortens some log messages. Instead of the FateExecutor objects only being identifiable by their assigned FATE ops, they are now given the name as defined in the config which can be used to identify them as well.

Previously:
* metrics tags would include all the FATE operations for that pool, but these long metrics could be an issue for some monitoring systems
* the pool name would be `accumulo.pool.manager.fate.[user/meta].[THE OPS]`
* the work finder for the pool would be named `fate.work.finder.[user/meta].[THE OPS]`

Now:
* metrics tags include the name instead of the entire list of operations (tag looks like `accumulo.pool.manager.fate.[user/meta].[THE NAME]`)
* the pool name is `accumulo.pool.manager.fate.[user/meta].[THE NAME]`
* the work finder thread for the pool is named `fate.work.finder.[user/meta].[THE NAME]`

closes #5836