### PR TITLE
Fail if config cmd used with rg but not -s or -d

### DIFF
--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ConfigCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ConfigCommand.java
@@ -213,6 +213,12 @@ public class ConfigCommand extends Command {
         logSysPropChanged(theProp, "set");
       }
     } else {
+
+      if (rgid != null) {
+        throw new IllegalArgumentException(
+            "resource group argument must be accompanied by -s or -d argument.");
+      }
+
       boolean warned = false;
       // display properties
       final TreeMap<String,String> systemConfig = new TreeMap<>();


### PR DESCRIPTION
The config command will print all matching resource
group properties by default. There is no need for
the resource group to be specified unless setting
or deleting a property.

Related to #5859