### PR TITLE
Update how SimpleSharedMacTestSuiteIT is executed

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -54,6 +54,8 @@ jobs:
       run: src/build/ci/find-startMini-without-stopMini.sh
     - name: Check for unapproved use of abstract classes ending in IT
       run: src/build/ci/find-unapproved-abstract-ITs.sh
+    - name: Check for unapproved package naming conventions
+      run: src/build/ci/check-module-package-conventions.sh
     - name: Build with Maven (Fast Build)
       timeout-minutes: 20
       run: mvn -B -V -e -ntp "-Dstyle.color=always" clean package dependency:resolve -DskipTests -DskipFormat -DverifyFormat

--- a/pom.xml
+++ b/pom.xml
@@ -1529,6 +1529,13 @@
       <id>sunny</id>
       <properties>
         <failsafe.groups>SunnyDay</failsafe.groups>
+        <!--
+          exclude junit-platform-suite engine from this list of engines to run,
+          so it skips the SimpleSuite tests, which contain no sunny tests, to
+          prevent the suite engine from running the BeforeSuite and AfterSuite
+          minicluster setup and teardown unnecessarily for zero tests
+        -->
+        <failsafe.includeJUnit5Engines>junit-jupiter</failsafe.includeJUnit5Engines>
       </properties>
     </profile>
     <profile>

--- a/src/build/ci/check-module-package-conventions.sh
+++ b/src/build/ci/check-module-package-conventions.sh
@@ -1,0 +1,130 @@
+#! /usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# The purpose of this ci script is to ensure that a pull request
+# doesn't unintentionally add a jar resource that would cause
+# problems with jar sealing by breaking our package naming
+# conventions, which are to use package names based on the
+# module, so they are unique.
+NUM_EXPECTED=0
+ALLOWED=(
+  # test module uses main path for ITs, so log4j2-test.properties is okay there
+  test/src/main/resources/log4j2-test.properties
+
+  # special exceptions for the main assembly resources; these can be at the root
+  assemble/src/main/resources/LICENSE
+  assemble/src/main/resources/NOTICE
+
+  # special exceptions for the native tarball assembly resources; these can be at the root
+  server/native/src/main/resources/LICENSE
+  server/native/src/main/resources/Makefile
+  server/native/src/main/resources/NOTICE
+
+  # TODO: these test classes should be moved into the correct package for the module
+  start/src/test/java/test/HelloWorldTemplate
+  start/src/test/java/test/TestTemplate
+  start/src/test/java/test/Test.java
+  test/src/main/java/org/apache/accumulo/harness/conf/AccumuloClusterConfiguration.java
+  test/src/main/java/org/apache/accumulo/harness/conf/AccumuloMiniClusterConfiguration.java
+  test/src/main/java/org/apache/accumulo/harness/conf/AccumuloClusterPropertyConfiguration.java
+  test/src/main/java/org/apache/accumulo/harness/conf/StandaloneAccumuloClusterConfiguration.java
+  test/src/main/java/org/apache/accumulo/harness/Timeout.java
+  test/src/main/java/org/apache/accumulo/harness/WithTestNames.java
+  test/src/main/java/org/apache/accumulo/harness/AccumuloClusterHarness.java
+  test/src/main/java/org/apache/accumulo/harness/AccumuloITBase.java
+  test/src/main/java/org/apache/accumulo/harness/MiniClusterConfigurationCallback.java
+  test/src/main/java/org/apache/accumulo/harness/MiniClusterHarness.java
+  test/src/main/java/org/apache/accumulo/harness/SharedMiniClusterBase.java
+  test/src/main/java/org/apache/accumulo/harness/TestingKdc.java
+
+  # TODO: these test resources should be moved into the correct package for the module
+  core/src/test/resources/accumulo.jceks
+  core/src/test/resources/empty.jceks
+  core/src/test/resources/site-cfg.jceks
+  core/src/test/resources/accumulo2.properties
+  core/src/test/resources/passwords.jceks
+  minicluster/src/test/resources/FooFilter.jar
+  server/tserver/src/test/resources/walog-from-15.walog
+  server/tserver/src/test/resources/walog-from-16.walog
+  server/tserver/src/test/resources/walog-from-14/550e8400-e29b-41d4-a716-446655440000
+  server/tserver/src/test/resources/walog-from-20.walog
+  test/src/main/resources/v2_import_test/README.md
+  test/src/main/resources/v2_import_test/data/A0000008.rf
+  test/src/main/resources/v2_import_test/data/A0000009.rf
+  test/src/main/resources/v2_import_test/data/A000000a.rf
+  test/src/main/resources/v2_import_test/data/A000000b.rf
+  test/src/main/resources/v2_import_test/data/distcp.txt
+  test/src/main/resources/v2_import_test/data/exportMetadata.zip
+
+  # TODO: these minicluster classes should be moved into the correct package for the module
+  minicluster/src/main/java/org/apache/accumulo/cluster/standalone/StandaloneAccumuloCluster.java
+  minicluster/src/main/java/org/apache/accumulo/cluster/standalone/StandaloneClusterControl.java
+  minicluster/src/main/java/org/apache/accumulo/cluster/ClusterUsers.java
+  minicluster/src/main/java/org/apache/accumulo/cluster/ClusterUser.java
+  minicluster/src/main/java/org/apache/accumulo/cluster/RemoteShell.java
+  minicluster/src/main/java/org/apache/accumulo/cluster/AccumuloCluster.java
+  minicluster/src/main/java/org/apache/accumulo/cluster/ClusterControl.java
+  minicluster/src/main/java/org/apache/accumulo/cluster/RemoteShellOptions.java
+  minicluster/src/test/java/org/apache/accumulo/cluster/standalone/StandaloneAccumuloClusterTest.java
+  minicluster/src/test/java/org/apache/accumulo/cluster/standalone/StandaloneClusterControlTest.java
+)
+
+ALLOWED_PIPE_SEP=$({ for x in "${ALLOWED[@]}"; do echo "$x"; done; } | paste -sd'|')
+
+function findwrongpackagesinmodules() {
+  local modulepom
+  local moduledir
+  local packagename
+  local findargs
+  shopt -s globstar
+  for modulepom in **/pom.xml; do
+    [[ $modulepom =~ ^(target|.*/target)/.*$ ]] && continue
+    moduledir=$(dirname "$modulepom")
+    [[ $moduledir == '.' ]] && continue
+    (
+      cd "$moduledir" || exit 1
+      packagename=$(basename "$moduledir")
+      # some modules have package naming conventions that differ
+      # slightly from the module name
+      [[ $moduledir == server/base ]] && packagename=server
+      [[ $moduledir == iterator-test-harness ]] && packagename=iteratortest
+      [[ $moduledir == hadoop-mapreduce ]] && packagename=hadoop
+      findargs=(
+        # allow any that use the expected package name, optionally ending with Impl
+        -not -regex '^src/\(main\|test\)/\(java\|resources\)/org/apache/accumulo/'"${packagename}"'\(Impl\)?/.*'
+        # some test resources are okay at the root
+        -not -regex '^src/test/resources/\(log4j2-test\|accumulo\)[.]properties$'
+      )
+      find src/{main,test}/{java,resources} -type f "${findargs[@]}" 2>/dev/null
+    ) | xargs -I '{}' echo "$moduledir/{}"
+  done | grep -Pv "^(${ALLOWED_PIPE_SEP//./[.]})\$"
+}
+
+function comparecounts() {
+  local count
+  count=$(findwrongpackagesinmodules | wc -l)
+  if [[ $NUM_EXPECTED -ne $count ]]; then
+    echo "Expected $NUM_EXPECTED, but found $count unapproved package names in the maven modules:"
+    findwrongpackagesinmodules 'print'
+    return 1
+  fi
+}
+
+comparecounts && echo "Found exactly $NUM_EXPECTED unapproved package names in the maven modules"

--- a/test/src/main/java/org/apache/accumulo/harness/SharedMiniClusterBase.java
+++ b/test/src/main/java/org/apache/accumulo/harness/SharedMiniClusterBase.java
@@ -48,7 +48,7 @@ import org.apache.accumulo.core.clientImpl.ClientInfo;
 import org.apache.accumulo.core.clientImpl.Namespace;
 import org.apache.accumulo.core.conf.ClientProperty;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl;
-import org.apache.accumulo.suites.SimpleSharedMacTestSuiteIT;
+import org.apache.accumulo.test.suites.SimpleSharedMacTestSuiteIT;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.security.UserGroupInformation;

--- a/test/src/main/java/org/apache/accumulo/test/ComprehensiveTableOperationsIT_SimpleSuite.java
+++ b/test/src/main/java/org/apache/accumulo/test/ComprehensiveTableOperationsIT_SimpleSuite.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.test;
 
-import static org.apache.accumulo.harness.AccumuloITBase.SUNNY_DAY;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -93,7 +92,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -106,7 +104,6 @@ import com.google.common.net.HostAndPort;
  * avoiding duplicating existing testing. This does not test for edge cases, but rather tests for
  * basic expected functionality of all table operations against user tables and all system tables.
  */
-@Tag(SUNNY_DAY)
 public class ComprehensiveTableOperationsIT_SimpleSuite extends SharedMiniClusterBase {
   private static final Logger log =
       LoggerFactory.getLogger(ComprehensiveTableOperationsIT_SimpleSuite.class);

--- a/test/src/main/java/org/apache/accumulo/test/suites/SimpleSharedMacTestSuiteIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/suites/SimpleSharedMacTestSuiteIT.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.suites;
+package org.apache.accumulo.test.suites;
 
 import org.apache.accumulo.harness.MiniClusterConfigurationCallback;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
@@ -43,7 +43,7 @@ import org.junit.platform.suite.api.Suite;
  * IMPORTANT NOTE: Only the concrete classes should be marked with "IT_SimpleSuite". For example,
  * marking an abstract class will not add its implementations to the suite.
  */
-@Suite
+@Suite(failIfNoTests = false)
 // look in this package and subpackages
 @SelectPackages("org.apache.accumulo.test")
 // need to override the default pattern ".*Test"


### PR DESCRIPTION
* Revert d21fc1bb4124df757e5d0691fd19281655d75761 for PR #5852, since #5851 can be fixed with this change instead, without adding a new test to the sunny profile; comprehensive table operations testing is outside the scope of the basic test case that the sunny profile should be limited to doing
* Add the `failIfNoTests = false` option to the `@Suite` annotation so that it does not fail if some combination of options fails to result in any matching test cases to run (minicluster is still started for the test, though no tests will run; that is addressed by the next change below)
* Explicitly run only the regular junit-jupiter engine, and not the junit-platform-suite engine, by default when running the sunny profile, so that it does not execute SimpleSharedMacTestSuiteIT's BeforeSuite and AfterSuite methods, which is a waste of time since that suite does not have any tests with the SunnyDay tag

Also:
* Move the class so it fits into the module/package naming conventions
* Add a CI check for module/package naming conventions for future work

More background:

  The maven-surefire-plugin/maven-failsafe-plugin's JUnit5 provider will use both the normal (non-suite) `junit-jupiter` engine and the `junit-platform-suite` engine. These engines behave differently when handling the surefire/failsafe option to filter tests based on groups. The regular engine will filter tests based on the configured groups by the `@Tag` annotation before executing the tests. The suite engine appears to identify the suites to run first, then filters the test cases contained in that suite by the `@Tag` annotation. While the regular engine's failure to find any tests can be handled by the Maven properties, `(surefire|failsafe).failIfNoSpecifiedTests`, that does not work for the suite engine. Instead, the suite engine requires `@Suite(failIfNoTests = false)` to be used. That will prevent the failure to find tests from failing the build, but it will still execute the suite's `@BeforeSuite` and `@AfterSuite` methods. An additional configuration is needed to explicitly control which engines are executed by surefire/failsafe in order to avoid executing "empty" suites' before/after steps entirely. In Accumulo, we do not have any suite tests that need to run during the `sunny` profile, so we can safely skip the suite engine's execution when activating that profile. We do not want to exclude the engine, though, because that limits the user's ability to override settings on the command-line with an exclude option. So instead, we limit the set of included engines to only the regular one, so users can still override the include/exclude properties to have more granular control, if they wish.