### PR TITLE
Print the correct context in the log message

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
@@ -235,8 +235,7 @@ class ScanDataSource implements DataSource {
       } else {
         context = pic.getServiceEnv();
         if (context != null) {
-          log.trace("Loading iterators for scan with table context: {}",
-              context);
+          log.trace("Loading iterators for scan with table context: {}", context);
         } else {
           log.trace("Loading iterators for scan");
         }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
@@ -236,7 +236,7 @@ class ScanDataSource implements DataSource {
         context = pic.getServiceEnv();
         if (context != null) {
           log.trace("Loading iterators for scan with table context: {}",
-              scanParams.getClassLoaderContext());
+              context);
         } else {
           log.trace("Loading iterators for scan");
         }


### PR DESCRIPTION
scanParams.getClassLoaderContext() is always null when this log message is generated. 
Use the correct context instead.