### PR TITLE
Fixes several Monitor bugs

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/lock/ServiceLock.java
+++ b/core/src/main/java/org/apache/accumulo/core/lock/ServiceLock.java
@@ -547,7 +547,7 @@ public class ServiceLock implements Watcher {
     // Wait for the delete to happen on the server before exiting method
     Timer start = Timer.startNew();
     while (zooKeeper.exists(pathToDelete, null) != null) {
-      Thread.onSpinWait();
+      Thread.sleep(100);
       if (start.hasElapsed(10, SECONDS)) {
         start.restart();
         LOG.debug("[{}] Still waiting for zookeeper to delete all at {}", vmLockPrefix,

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -224,7 +224,7 @@ public class Monitor extends AbstractServer implements Connection.Listener {
       return;
     }
     // DO NOT ADD CODE HERE that could throw an exception before we enter the try block
-    // Otherwise, we'll never release the lock by unsetting 'fetching' in the the finally block
+    // Otherwise, we'll never release the lock by unsetting 'fetching' in the finally block
     try {
       while (retry) {
         ManagerClientService.Client client = null;

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/SystemInformation.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/SystemInformation.java
@@ -376,6 +376,9 @@ public class SystemInformation {
   private void updateAggregates(final MetricResponse response,
       final Map<Id,CumulativeDistributionSummary> total,
       final Map<String,Map<Id,CumulativeDistributionSummary>> rg) {
+    if (response.getMetrics() == null) {
+      return;
+    }
 
     final Map<Id,CumulativeDistributionSummary> rgMetrics =
         rg.computeIfAbsent(response.getResourceGroup(), (k) -> new ConcurrentHashMap<>());

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
@@ -638,14 +638,6 @@ function getSserversDetail(group) {
 }
 
 /**
- * REST GET call for /manager,
- * stores it on a sessionStorage variable
- */
-function getManager() {
-  return getJSONForTable(REST_V2_PREFIX + '/manager', 'manager');
-}
-
-/**
  * REST GET call for /compactors/summary,
  * stores it on a sessionStorage variable
  */


### PR DESCRIPTION
- Replaced all uses of Thread.onSpinWait() with Thread.sleep() throughout the code. Was being incorrectly used in while loops that were not expected to very quickly change state. Thread.sleep() is more appropriate for these longer waits. The uses of Thread.onSpinWait() would result in very high CPU usage.
- Fixed NullPointerException seen in the Monitor. SystemInformation.updateAggregates() needed to check that response.getMetrics() != null.
- Monitor homepage would show no data in the "Accumulo Manager" table, "/manager" endpoint would show Manager status as "undefined". Fixed these issues.

Navigating through all the monitor pages, all seem to be correct now. Data appears accurate and no Javascript errors in console.

closes #5842