### PR TITLE
Migrate instanceof usage from java 11 to improved java 17 pattern

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/bloomfilter/DynamicBloomFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/bloomfilter/DynamicBloomFilter.java
@@ -134,12 +134,10 @@ public class DynamicBloomFilter extends Filter {
 
   @Override
   public void and(final Filter filter) {
-    if (filter == null || !(filter instanceof DynamicBloomFilter)
+    if (filter == null || !(filter instanceof DynamicBloomFilter dbf)
         || filter.vectorSize != this.vectorSize || filter.nbHash != this.nbHash) {
       throw new IllegalArgumentException("filters cannot be and-ed");
     }
-
-    DynamicBloomFilter dbf = (DynamicBloomFilter) filter;
 
     if (dbf.matrix.length != this.matrix.length || dbf.nr != this.nr) {
       throw new IllegalArgumentException("filters cannot be and-ed");
@@ -174,12 +172,10 @@ public class DynamicBloomFilter extends Filter {
 
   @Override
   public void or(final Filter filter) {
-    if (filter == null || !(filter instanceof DynamicBloomFilter)
+    if (filter == null || !(filter instanceof DynamicBloomFilter dbf)
         || filter.vectorSize != this.vectorSize || filter.nbHash != this.nbHash) {
       throw new IllegalArgumentException("filters cannot be or-ed");
     }
-
-    DynamicBloomFilter dbf = (DynamicBloomFilter) filter;
 
     if (dbf.matrix.length != this.matrix.length || dbf.nr != this.nr) {
       throw new IllegalArgumentException("filters cannot be or-ed");
@@ -191,11 +187,10 @@ public class DynamicBloomFilter extends Filter {
 
   @Override
   public void xor(final Filter filter) {
-    if (filter == null || !(filter instanceof DynamicBloomFilter)
+    if (filter == null || !(filter instanceof DynamicBloomFilter dbf)
         || filter.vectorSize != this.vectorSize || filter.nbHash != this.nbHash) {
       throw new IllegalArgumentException("filters cannot be xor-ed");
     }
-    DynamicBloomFilter dbf = (DynamicBloomFilter) filter;
 
     if (dbf.matrix.length != this.matrix.length || dbf.nr != this.nr) {
       throw new IllegalArgumentException("filters cannot be xor-ed");

--- a/core/src/main/java/org/apache/accumulo/core/client/BatchWriterConfig.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/BatchWriterConfig.java
@@ -291,8 +291,7 @@ public class BatchWriterConfig implements Writable {
 
   @Override
   public boolean equals(Object o) {
-    if (o instanceof BatchWriterConfig) {
-      BatchWriterConfig other = (BatchWriterConfig) o;
+    if (o instanceof BatchWriterConfig other) {
 
       if (maxMemory != null) {
         if (!maxMemory.equals(other.maxMemory)) {

--- a/core/src/main/java/org/apache/accumulo/core/client/ClientSideIteratorScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/ClientSideIteratorScanner.java
@@ -185,8 +185,7 @@ public class ClientSideIteratorScanner extends ScannerOptions implements Scanner
       setSamplerConfiguration(samplerConfig);
     }
 
-    if (scanner instanceof ScannerImpl) {
-      var scannerImpl = (ScannerImpl) scanner;
+    if (scanner instanceof ScannerImpl scannerImpl) {
       this.context = () -> scannerImpl.getClientContext();
       this.tableId = () -> scannerImpl.getTableId();
     } else {

--- a/core/src/main/java/org/apache/accumulo/core/client/ConditionalWriter.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/ConditionalWriter.java
@@ -62,8 +62,7 @@ public interface ConditionalWriter extends AutoCloseable {
         if (exception instanceof AccumuloException) {
           throw new AccumuloException(exception);
         }
-        if (exception instanceof AccumuloSecurityException) {
-          AccumuloSecurityException ase = (AccumuloSecurityException) exception;
+        if (exception instanceof AccumuloSecurityException ase) {
           throw new AccumuloSecurityException(ase.getUser(),
               SecurityErrorCode.valueOf(ase.getSecurityErrorCode().name()), ase.getTableInfo(),
               ase);

--- a/core/src/main/java/org/apache/accumulo/core/client/IteratorSetting.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/IteratorSetting.java
@@ -289,10 +289,9 @@ public class IteratorSetting implements Writable {
     if (obj == null) {
       return false;
     }
-    if (!(obj instanceof IteratorSetting)) {
+    if (!(obj instanceof IteratorSetting other)) {
       return false;
     }
-    IteratorSetting other = (IteratorSetting) obj;
     if (iteratorClass == null) {
       if (other.iteratorClass != null) {
         return false;

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/DelegationTokenConfig.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/DelegationTokenConfig.java
@@ -63,8 +63,7 @@ public class DelegationTokenConfig {
 
   @Override
   public boolean equals(Object o) {
-    if (o instanceof DelegationTokenConfig) {
-      DelegationTokenConfig other = (DelegationTokenConfig) o;
+    if (o instanceof DelegationTokenConfig other) {
       return lifetime == other.lifetime;
     }
     return false;

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/DiskUsage.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/DiskUsage.java
@@ -44,11 +44,9 @@ public class DiskUsage {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof DiskUsage)) {
+    if (!(o instanceof DiskUsage diskUsage)) {
       return false;
     }
-
-    DiskUsage diskUsage = (DiskUsage) o;
 
     return Objects.equals(tables, diskUsage.tables) && Objects.equals(usage, diskUsage.usage);
   }

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/PluginConfig.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/PluginConfig.java
@@ -75,8 +75,7 @@ public class PluginConfig {
 
   @Override
   public boolean equals(Object o) {
-    if (o instanceof PluginConfig) {
-      PluginConfig ocsc = (PluginConfig) o;
+    if (o instanceof PluginConfig ocsc) {
       return className.equals(ocsc.className) && options.equals(ocsc.options);
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/sample/SamplerConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/sample/SamplerConfiguration.java
@@ -73,8 +73,7 @@ public class SamplerConfiguration {
 
   @Override
   public boolean equals(Object o) {
-    if (o instanceof SamplerConfiguration) {
-      SamplerConfiguration osc = (SamplerConfiguration) o;
+    if (o instanceof SamplerConfiguration osc) {
 
       return className.equals(osc.className) && options.equals(osc.options);
     }

--- a/core/src/main/java/org/apache/accumulo/core/client/security/tokens/KerberosToken.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/security/tokens/KerberosToken.java
@@ -123,10 +123,9 @@ public class KerberosToken implements AuthenticationToken {
     if (obj == null) {
       return false;
     }
-    if (!(obj instanceof KerberosToken)) {
+    if (!(obj instanceof KerberosToken other)) {
       return false;
     }
-    KerberosToken other = (KerberosToken) obj;
 
     return principal.equals(other.principal);
   }

--- a/core/src/main/java/org/apache/accumulo/core/client/summary/SummarizerConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/summary/SummarizerConfiguration.java
@@ -101,8 +101,7 @@ public class SummarizerConfiguration {
    */
   @Override
   public boolean equals(Object o) {
-    if (o instanceof SummarizerConfiguration) {
-      SummarizerConfiguration osc = (SummarizerConfiguration) o;
+    if (o instanceof SummarizerConfiguration osc) {
       return className.equals(osc.className) && options.equals(osc.options);
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/AuthenticationTokenIdentifier.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/AuthenticationTokenIdentifier.java
@@ -170,8 +170,7 @@ public class AuthenticationTokenIdentifier extends TokenIdentifier {
     if (o == null) {
       return false;
     }
-    if (o instanceof AuthenticationTokenIdentifier) {
-      AuthenticationTokenIdentifier other = (AuthenticationTokenIdentifier) o;
+    if (o instanceof AuthenticationTokenIdentifier other) {
       return impl.equals(other.impl);
     }
     return false;

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientTabletCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientTabletCache.java
@@ -242,8 +242,7 @@ public abstract class ClientTabletCache {
 
     @Override
     public boolean equals(Object o) {
-      if (o instanceof CachedTablet) {
-        CachedTablet otl = (CachedTablet) o;
+      if (o instanceof CachedTablet otl) {
         return getExtent().equals(otl.getExtent())
             && getTserverLocation().equals(otl.getTserverLocation())
             && getTserverSession().equals(otl.getTserverSession())

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
@@ -432,8 +432,7 @@ public class InstanceOperationsImpl implements InstanceOperations {
         try {
           ret.addAll(future.get());
         } catch (InterruptedException | ExecutionException e) {
-          if (e.getCause() instanceof ThriftSecurityException) {
-            ThriftSecurityException tse = (ThriftSecurityException) e.getCause();
+          if (e.getCause() instanceof ThriftSecurityException tse) {
             throw new AccumuloSecurityException(tse.user, tse.code, e);
           }
           throw new AccumuloException(e);

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/NamespaceOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/NamespaceOperationsImpl.java
@@ -303,8 +303,7 @@ public class NamespaceOperationsImpl extends NamespaceOperationsHelper {
       Throwable eCause = e.getCause();
       if (eCause instanceof TableNotFoundException) {
         Throwable tnfeCause = eCause.getCause();
-        if (tnfeCause instanceof NamespaceNotFoundException) {
-          var nnfe = (NamespaceNotFoundException) tnfeCause;
+        if (tnfeCause instanceof NamespaceNotFoundException nnfe) {
           nnfe.addSuppressed(e);
           throw nnfe;
         }
@@ -328,8 +327,7 @@ public class NamespaceOperationsImpl extends NamespaceOperationsHelper {
       Throwable eCause = e.getCause();
       if (eCause instanceof TableNotFoundException) {
         Throwable tnfeCause = eCause.getCause();
-        if (tnfeCause instanceof NamespaceNotFoundException) {
-          var nnfe = (NamespaceNotFoundException) tnfeCause;
+        if (tnfeCause instanceof NamespaceNotFoundException nnfe) {
           nnfe.addSuppressed(e);
           throw nnfe;
         }
@@ -368,8 +366,7 @@ public class NamespaceOperationsImpl extends NamespaceOperationsHelper {
       Throwable eCause = e.getCause();
       if (eCause instanceof TableNotFoundException) {
         Throwable tnfeCause = eCause.getCause();
-        if (tnfeCause instanceof NamespaceNotFoundException) {
-          var nnfe = (NamespaceNotFoundException) tnfeCause;
+        if (tnfeCause instanceof NamespaceNotFoundException nnfe) {
           nnfe.addSuppressed(e);
           throw nnfe;
         }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ResourceGroupOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ResourceGroupOperationsImpl.java
@@ -117,8 +117,7 @@ public class ResourceGroupOperationsImpl implements ResourceGroupOperations {
       }
     } catch (AccumuloException | AccumuloSecurityException e) {
       Throwable t = e.getCause();
-      if (t instanceof ThriftResourceGroupNotExistsException) {
-        var te = (ThriftResourceGroupNotExistsException) t;
+      if (t instanceof ThriftResourceGroupNotExistsException te) {
         throw new ResourceGroupNotFoundException(te.getResourceGroupName());
       }
       throw e;
@@ -144,8 +143,7 @@ public class ResourceGroupOperationsImpl implements ResourceGroupOperations {
           ResourceGroupPredicate.DEFAULT_RG_ONLY);
     } catch (AccumuloException | AccumuloSecurityException e) {
       Throwable t = e.getCause();
-      if (t instanceof ThriftResourceGroupNotExistsException) {
-        ThriftResourceGroupNotExistsException te = (ThriftResourceGroupNotExistsException) t;
+      if (t instanceof ThriftResourceGroupNotExistsException te) {
         throw new ResourceGroupNotFoundException(te.getResourceGroupName());
       }
       throw e;
@@ -165,8 +163,7 @@ public class ResourceGroupOperationsImpl implements ResourceGroupOperations {
           ResourceGroupPredicate.exact(group));
     } catch (AccumuloException | AccumuloSecurityException e) {
       Throwable t = e.getCause();
-      if (t instanceof ThriftResourceGroupNotExistsException) {
-        ThriftResourceGroupNotExistsException te = (ThriftResourceGroupNotExistsException) t;
+      if (t instanceof ThriftResourceGroupNotExistsException te) {
         throw new ResourceGroupNotFoundException(te.getResourceGroupName());
       }
       throw e;
@@ -200,8 +197,7 @@ public class ResourceGroupOperationsImpl implements ResourceGroupOperations {
           ResourceGroupPredicate.DEFAULT_RG_ONLY);
     } catch (AccumuloException | AccumuloSecurityException e) {
       Throwable t = e.getCause();
-      if (t instanceof ThriftResourceGroupNotExistsException) {
-        ThriftResourceGroupNotExistsException te = (ThriftResourceGroupNotExistsException) t;
+      if (t instanceof ThriftResourceGroupNotExistsException te) {
         throw new ResourceGroupNotFoundException(te.getResourceGroupName());
       }
       throw e;
@@ -262,8 +258,7 @@ public class ResourceGroupOperationsImpl implements ResourceGroupOperations {
           ResourceGroupPredicate.DEFAULT_RG_ONLY);
     } catch (AccumuloException | AccumuloSecurityException e) {
       Throwable t = e.getCause();
-      if (t instanceof ThriftResourceGroupNotExistsException) {
-        ThriftResourceGroupNotExistsException te = (ThriftResourceGroupNotExistsException) t;
+      if (t instanceof ThriftResourceGroupNotExistsException te) {
         throw new ResourceGroupNotFoundException(te.getResourceGroupName());
       }
       throw e;
@@ -281,8 +276,7 @@ public class ResourceGroupOperationsImpl implements ResourceGroupOperations {
           ResourceGroupPredicate.DEFAULT_RG_ONLY);
     } catch (AccumuloException | AccumuloSecurityException e) {
       Throwable t = e.getCause();
-      if (t instanceof ThriftResourceGroupNotExistsException) {
-        ThriftResourceGroupNotExistsException te = (ThriftResourceGroupNotExistsException) t;
+      if (t instanceof ThriftResourceGroupNotExistsException te) {
         throw new ResourceGroupNotFoundException(te.getResourceGroupName());
       }
       throw e;

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerIterator.java
@@ -211,8 +211,7 @@ public class ScannerIterator implements Iterator<Entry<Key,Value>> {
     if (ee.getCause() instanceof IsolationException) {
       throw new IsolationException(ee);
     }
-    if (ee.getCause() instanceof TableDeletedException) {
-      TableDeletedException cause = (TableDeletedException) ee.getCause();
+    if (ee.getCause() instanceof TableDeletedException cause) {
       throw new TableDeletedException(cause.getTableId(), cause);
     }
     if (ee.getCause() instanceof TableOfflineException) {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -609,17 +609,15 @@ public class TableOperationsImpl extends TableOperationsHelper {
         // Below all exceptions are wrapped and rethrown. This is done so that the user knows
         // what code path got them here. If the wrapping was not done, the user would only
         // have the stack trace for the background thread.
-        if (excep instanceof TableNotFoundException) {
-          TableNotFoundException tnfe = (TableNotFoundException) excep;
+        if (excep instanceof TableNotFoundException tnfe) {
           throw new TableNotFoundException(tableId.canonical(), tableName,
               "Table not found by background thread", tnfe);
         } else if (excep instanceof TableOfflineException) {
           log.debug("TableOfflineException occurred in background thread. Throwing new exception",
               excep);
           throw new TableOfflineException(tableId, tableName);
-        } else if (excep instanceof AccumuloSecurityException) {
+        } else if (excep instanceof AccumuloSecurityException base) {
           // base == background accumulo security exception
-          AccumuloSecurityException base = (AccumuloSecurityException) excep;
           throw new AccumuloSecurityException(base.getUser(), base.asThriftException().getCode(),
               base.getTableInfo(), excep);
         } else if (excep instanceof AccumuloServerException) {
@@ -1127,8 +1125,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
       return modifyProperties(tableName, mapMutator);
     } catch (AccumuloException ae) {
       Throwable cause = ae.getCause();
-      if (cause instanceof TableNotFoundException) {
-        var tnfe = (TableNotFoundException) cause;
+      if (cause instanceof TableNotFoundException tnfe) {
         tnfe.addSuppressed(ae);
         throw tnfe;
       }
@@ -1191,8 +1188,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
           ResourceGroupPredicate.ANY);
     } catch (AccumuloException e) {
       Throwable t = e.getCause();
-      if (t instanceof TableNotFoundException) {
-        var tnfe = (TableNotFoundException) t;
+      if (t instanceof TableNotFoundException tnfe) {
         tnfe.addSuppressed(e);
         throw tnfe;
       }
@@ -1213,8 +1209,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
           ResourceGroupPredicate.ANY);
     } catch (AccumuloException e) {
       Throwable t = e.getCause();
-      if (t instanceof TableNotFoundException) {
-        var tnfe = (TableNotFoundException) t;
+      if (t instanceof TableNotFoundException tnfe) {
         tnfe.addSuppressed(e);
         throw tnfe;
       }
@@ -1803,8 +1798,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
       throw e;
     } catch (AccumuloException e) {
       Throwable t = e.getCause();
-      if (t instanceof TableNotFoundException) {
-        var tnfe = (TableNotFoundException) t;
+      if (t instanceof TableNotFoundException tnfe) {
         tnfe.addSuppressed(e);
         throw tnfe;
       }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportKey.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportKey.java
@@ -88,10 +88,9 @@ public class ThriftTransportKey {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof ThriftTransportKey)) {
+    if (!(o instanceof ThriftTransportKey ttk)) {
       return false;
     }
-    ThriftTransportKey ttk = (ThriftTransportKey) o;
     return type.equals(ttk.type) && server.equals(ttk.server) && timeout == ttk.timeout
         && (!isSsl() || (ttk.isSsl() && sslParams.equals(ttk.sslParams)))
         && (!isSasl() || (ttk.isSasl() && saslParams.equals(ttk.saslParams)));

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/Bulk.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/Bulk.java
@@ -153,10 +153,9 @@ public class Bulk {
       if (o == this) {
         return true;
       }
-      if (!(o instanceof FileInfo)) {
+      if (!(o instanceof FileInfo other)) {
         return false;
       }
-      FileInfo other = (FileInfo) o;
       return this.name.equals(other.name) && this.estSize == other.estSize
           && this.estEntries == other.estEntries;
     }
@@ -218,10 +217,9 @@ public class Bulk {
       if (o == this) {
         return true;
       }
-      if (!(o instanceof Files)) {
+      if (!(o instanceof Files other)) {
         return false;
       }
-      Files other = (Files) o;
       return this.files.equals(other.files);
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/data/ByteSequence.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/ByteSequence.java
@@ -122,8 +122,7 @@ public abstract class ByteSequence implements Comparable<ByteSequence>, Serializ
 
   @Override
   public boolean equals(Object o) {
-    if (o instanceof ByteSequence) {
-      ByteSequence obs = (ByteSequence) o;
+    if (o instanceof ByteSequence obs) {
 
       if (this == o) {
         return true;

--- a/core/src/main/java/org/apache/accumulo/core/data/ColumnUpdate.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/ColumnUpdate.java
@@ -127,10 +127,9 @@ public class ColumnUpdate {
 
   @Override
   public boolean equals(Object obj) {
-    if (!(obj instanceof ColumnUpdate)) {
+    if (!(obj instanceof ColumnUpdate upd)) {
       return false;
     }
-    ColumnUpdate upd = (ColumnUpdate) obj;
     return Arrays.equals(getColumnFamily(), upd.getColumnFamily())
         && Arrays.equals(getColumnQualifier(), upd.getColumnQualifier())
         && Arrays.equals(getColumnVisibility(), upd.getColumnVisibility())

--- a/core/src/main/java/org/apache/accumulo/core/data/Condition.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Condition.java
@@ -304,10 +304,9 @@ public class Condition {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof Condition)) {
+    if (!(o instanceof Condition condition)) {
       return false;
     }
-    Condition condition = (Condition) o;
     return Objects.equals(cf, condition.cf) && Objects.equals(cq, condition.cq)
         && Objects.equals(cv, condition.cv) && Objects.equals(val, condition.val)
         && Objects.equals(ts, condition.ts) && Arrays.equals(iterators, condition.iterators);

--- a/core/src/main/java/org/apache/accumulo/core/data/ConditionalMutation.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/ConditionalMutation.java
@@ -133,10 +133,9 @@ public class ConditionalMutation extends Mutation {
     if (o == this) {
       return true;
     }
-    if (o == null || !(o instanceof ConditionalMutation)) {
+    if (o == null || !(o instanceof ConditionalMutation cm)) {
       return false;
     }
-    ConditionalMutation cm = (ConditionalMutation) o;
     if (!conditions.equals(cm.conditions)) {
       return false;
     }

--- a/core/src/main/java/org/apache/accumulo/core/dataImpl/KeyExtent.java
+++ b/core/src/main/java/org/apache/accumulo/core/dataImpl/KeyExtent.java
@@ -284,10 +284,9 @@ public class KeyExtent implements Comparable<KeyExtent> {
     if (o == this) {
       return true;
     }
-    if (!(o instanceof KeyExtent)) {
+    if (!(o instanceof KeyExtent oke)) {
       return false;
     }
-    KeyExtent oke = (KeyExtent) o;
     return tableId().equals(oke.tableId()) && Objects.equals(endRow(), oke.endRow())
         && Objects.equals(prevEndRow(), oke.prevEndRow());
   }

--- a/core/src/main/java/org/apache/accumulo/core/fate/FateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/FateStore.java
@@ -231,8 +231,7 @@ public interface FateStore<T> extends ReadOnlyFateStore<T>, AutoCloseable {
       if (obj == this) {
         return true;
       }
-      if (obj instanceof FateReservation) {
-        FateReservation other = (FateReservation) obj;
+      if (obj instanceof FateReservation other) {
         return Arrays.equals(this.getSerialized(), other.getSerialized());
       }
       return false;

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/FateLock.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/FateLock.java
@@ -141,10 +141,9 @@ public class FateLock implements QueueLock {
       if (this == o) {
         return true;
       }
-      if (!(o instanceof FateLockEntry)) {
+      if (!(o instanceof FateLockEntry that)) {
         return false;
       }
-      FateLockEntry that = (FateLockEntry) o;
       return lockType == that.lockType && Objects.equals(fateId, that.fateId)
           && Objects.equals(range, that.range);
     }

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/LockRange.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/LockRange.java
@@ -79,8 +79,7 @@ public class LockRange {
 
   @Override
   public boolean equals(Object o) {
-    if (o instanceof LockRange) {
-      var other = (LockRange) o;
+    if (o instanceof LockRange other) {
       return range.equals(other.range);
     }
     return false;

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooUtil.java
@@ -123,8 +123,7 @@ public class ZooUtil {
       if (obj == this) {
         return true;
       }
-      if (obj instanceof LockID) {
-        LockID other = (LockID) obj;
+      if (obj instanceof LockID other) {
         return this.path.equals(other.path) && this.node.equals(other.node)
             && this.eid == other.eid;
       }

--- a/core/src/main/java/org/apache/accumulo/core/gc/GcCandidate.java
+++ b/core/src/main/java/org/apache/accumulo/core/gc/GcCandidate.java
@@ -48,8 +48,7 @@ public class GcCandidate implements Comparable<GcCandidate> {
     if (this == obj) {
       return true;
     }
-    if (obj instanceof GcCandidate) {
-      GcCandidate candidate = (GcCandidate) obj;
+    if (obj instanceof GcCandidate candidate) {
       return this.uid == candidate.getUid() && this.path.equals(candidate.getPath());
     }
     return false;

--- a/core/src/main/java/org/apache/accumulo/core/metadata/CompactableFileImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/CompactableFileImpl.java
@@ -78,8 +78,7 @@ public class CompactableFileImpl implements CompactableFile {
 
   @Override
   public boolean equals(Object o) {
-    if (o instanceof CompactableFileImpl) {
-      var ocfi = (CompactableFileImpl) o;
+    if (o instanceof CompactableFileImpl ocfi) {
 
       return storedTabletFile.equals(ocfi.storedTabletFile);
     }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/ReferencedTabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/ReferencedTabletFile.java
@@ -211,8 +211,7 @@ public class ReferencedTabletFile extends AbstractTabletFile<ReferencedTabletFil
 
   @Override
   public boolean equals(Object obj) {
-    if (obj instanceof ReferencedTabletFile) {
-      ReferencedTabletFile that = (ReferencedTabletFile) obj;
+    if (obj instanceof ReferencedTabletFile that) {
       return parts.getNormalizedPath().equals(that.parts.getNormalizedPath())
           && range.equals(that.range);
     }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/SuspendingTServer.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/SuspendingTServer.java
@@ -55,10 +55,9 @@ public class SuspendingTServer {
 
   @Override
   public boolean equals(Object rhsObject) {
-    if (!(rhsObject instanceof SuspendingTServer)) {
+    if (!(rhsObject instanceof SuspendingTServer rhs)) {
       return false;
     }
-    SuspendingTServer rhs = (SuspendingTServer) rhsObject;
     return server.equals(rhs.server) && suspensionTime.equals(rhs.suspensionTime);
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/UnreferencedTabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/UnreferencedTabletFile.java
@@ -69,8 +69,7 @@ public class UnreferencedTabletFile extends AbstractTabletFile<UnreferencedTable
 
   @Override
   public boolean equals(Object obj) {
-    if (obj instanceof UnreferencedTabletFile) {
-      UnreferencedTabletFile that = (UnreferencedTabletFile) obj;
+    if (obj instanceof UnreferencedTabletFile that) {
       return path.equals(that.path);
     }
     return false;

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/DataFileValue.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/DataFileValue.java
@@ -91,8 +91,7 @@ public class DataFileValue {
 
   @Override
   public boolean equals(Object o) {
-    if (o instanceof DataFileValue) {
-      DataFileValue odfv = (DataFileValue) o;
+    if (o instanceof DataFileValue odfv) {
 
       return size == odfv.size && numEntries == odfv.numEntries && time == odfv.time;
     }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataTime.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataTime.java
@@ -100,8 +100,7 @@ public final class MetadataTime implements Comparable<MetadataTime> {
 
   @Override
   public boolean equals(Object o) {
-    if (o instanceof MetadataTime) {
-      MetadataTime t = (MetadataTime) o;
+    if (o instanceof MetadataTime t) {
       return time == t.getTime() && type == t.getType();
     }
     return false;

--- a/core/src/main/java/org/apache/accumulo/core/rpc/SaslClientDigestCallbackHandler.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/SaslClientDigestCallbackHandler.java
@@ -108,8 +108,7 @@ public class SaslClientDigestCallbackHandler extends SaslDigestCallbackHandler {
     if (o == null) {
       return false;
     }
-    if (o instanceof SaslClientDigestCallbackHandler) {
-      SaslClientDigestCallbackHandler other = (SaslClientDigestCallbackHandler) o;
+    if (o instanceof SaslClientDigestCallbackHandler other) {
       return userName.equals(other.userName) && Arrays.equals(userPassword, other.userPassword);
     }
     return false;

--- a/core/src/main/java/org/apache/accumulo/core/rpc/SaslConnectionParams.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/SaslConnectionParams.java
@@ -248,8 +248,7 @@ public class SaslConnectionParams {
 
   @Override
   public boolean equals(Object o) {
-    if (o instanceof SaslConnectionParams) {
-      SaslConnectionParams other = (SaslConnectionParams) o;
+    if (o instanceof SaslConnectionParams other) {
       if (!kerberosServerPrimary.equals(other.kerberosServerPrimary)) {
         return false;
       }

--- a/core/src/main/java/org/apache/accumulo/core/rpc/SslConnectionParams.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/SslConnectionParams.java
@@ -262,11 +262,10 @@ public class SslConnectionParams {
 
   @Override
   public boolean equals(Object obj) {
-    if (!(obj instanceof SslConnectionParams)) {
+    if (!(obj instanceof SslConnectionParams other)) {
       return false;
     }
 
-    SslConnectionParams other = (SslConnectionParams) obj;
     if (clientAuth != other.clientAuth) {
       return false;
     }

--- a/core/src/main/java/org/apache/accumulo/core/sample/impl/SamplerConfigurationImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/sample/impl/SamplerConfigurationImpl.java
@@ -71,8 +71,7 @@ public class SamplerConfigurationImpl implements Writable {
 
   @Override
   public boolean equals(Object o) {
-    if (o instanceof SamplerConfigurationImpl) {
-      SamplerConfigurationImpl osc = (SamplerConfigurationImpl) o;
+    if (o instanceof SamplerConfigurationImpl osc) {
 
       return className.equals(osc.className) && options.equals(osc.options);
     }

--- a/core/src/main/java/org/apache/accumulo/core/security/Authorizations.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/Authorizations.java
@@ -327,8 +327,7 @@ public class Authorizations implements Iterable<byte[]>, Serializable, Authoriza
       return false;
     }
 
-    if (o instanceof Authorizations) {
-      Authorizations ao = (Authorizations) o;
+    if (o instanceof Authorizations ao) {
 
       return auths.equals(ao.auths);
     }

--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/GroupBalancer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/GroupBalancer.java
@@ -404,8 +404,7 @@ public abstract class GroupBalancer implements TabletBalancer {
 
     @Override
     public boolean equals(Object o) {
-      if (o instanceof TserverGroupInfo) {
-        TserverGroupInfo otgi = (TserverGroupInfo) o;
+      if (o instanceof TserverGroupInfo otgi) {
         return tsi.equals(otgi.tsi);
       }
 

--- a/core/src/main/java/org/apache/accumulo/core/spi/fs/DelegatingChooser.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/fs/DelegatingChooser.java
@@ -149,8 +149,7 @@ public class DelegatingChooser implements VolumeChooser {
         log.trace("Change detected for {} for {}", property, key);
       }
       try {
-        if (key instanceof TableId) {
-          TableId tableId = (TableId) key;
+        if (key instanceof TableId tableId) {
           return env.getServiceEnv().instantiate(tableId, className, VolumeChooser.class);
         } else {
           return env.getServiceEnv().instantiate(className, VolumeChooser.class);

--- a/core/src/main/java/org/apache/accumulo/core/util/ColumnFQ.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/ColumnFQ.java
@@ -73,13 +73,12 @@ public class ColumnFQ implements Comparable<ColumnFQ> {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof ColumnFQ)) {
+    if (!(o instanceof ColumnFQ ocfq)) {
       return false;
     }
     if (this == o) {
       return true;
     }
-    ColumnFQ ocfq = (ColumnFQ) o;
     return ocfq.colf.equals(colf) && ocfq.colq.equals(colq);
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/util/Pair.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/Pair.java
@@ -38,8 +38,7 @@ public class Pair<A,B> {
 
   @Override
   public boolean equals(Object o) {
-    if (o instanceof Pair<?,?>) {
-      Pair<?,?> other = (Pair<?,?>) o;
+    if (o instanceof Pair<?,?> other) {
       return Objects.equals(first, other.first) && Objects.equals(second, other.second);
     }
     return false;

--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionJobImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionJobImpl.java
@@ -84,8 +84,7 @@ public class CompactionJobImpl implements CompactionJob {
 
   @Override
   public boolean equals(Object o) {
-    if (o instanceof CompactionJobImpl) {
-      CompactionJobImpl ocj = (CompactionJobImpl) o;
+    if (o instanceof CompactionJobImpl ocj) {
 
       return priority == ocj.priority && group.equals(ocj.group) && files.equals(ocj.files)
           && kind == ocj.kind;

--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionServicesConfig.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionServicesConfig.java
@@ -91,8 +91,7 @@ public class CompactionServicesConfig {
 
   @Override
   public boolean equals(Object o) {
-    if (o instanceof CompactionServicesConfig) {
-      var oc = (CompactionServicesConfig) o;
+    if (o instanceof CompactionServicesConfig oc) {
       return getPlanners().equals(oc.getPlanners()) && getOptions().equals(oc.getOptions());
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/NamedThreadFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/NamedThreadFactory.java
@@ -48,8 +48,7 @@ class NamedThreadFactory implements ThreadFactory {
   @Override
   public Thread newThread(Runnable r) {
     String threadName = null;
-    if (r instanceof NamedRunnable) {
-      NamedRunnable nr = (NamedRunnable) r;
+    if (r instanceof NamedRunnable nr) {
       threadName = String.format(FORMAT, name, nr.getName(), threadNum.getAndIncrement());
     } else {
       threadName =

--- a/core/src/main/java/org/apache/accumulo/core/volume/VolumeImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/volume/VolumeImpl.java
@@ -105,8 +105,7 @@ public class VolumeImpl implements Volume {
 
   @Override
   public boolean equals(Object o) {
-    if (o instanceof VolumeImpl) {
-      VolumeImpl other = (VolumeImpl) o;
+    if (o instanceof VolumeImpl other) {
       return getFileSystem().equals(other.getFileSystem())
           && getBasePath().equals(other.getBasePath());
     }

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapred/AccumuloRecordReader.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapred/AccumuloRecordReader.java
@@ -150,9 +150,8 @@ public abstract class AccumuloRecordReader<K,V> implements RecordReader<K,V> {
     log.debug("Creating scanner for table: " + table);
     log.debug("Authorizations are: " + authorizations);
 
-    if (baseSplit instanceof BatchInputSplit) {
+    if (baseSplit instanceof BatchInputSplit multiRangeSplit) {
       BatchScanner scanner;
-      BatchInputSplit multiRangeSplit = (BatchInputSplit) baseSplit;
 
       try {
         // Note: BatchScanner will use at most one thread per tablet, currently BatchInputSplit

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/AccumuloRecordReader.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/AccumuloRecordReader.java
@@ -167,8 +167,7 @@ public abstract class AccumuloRecordReader<K,V> extends RecordReader<K,V> {
     log.debug("Creating scanner for table: " + table);
     log.debug("Authorizations are: " + authorizations);
 
-    if (split instanceof BatchInputSplit) {
-      BatchInputSplit batchSplit = (BatchInputSplit) split;
+    if (split instanceof BatchInputSplit batchSplit) {
 
       BatchScanner scanner;
       try {

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/RowHashIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/RowHashIT.java
@@ -151,9 +151,8 @@ public class RowHashIT extends ConfigurableMacBase {
         // For MapReduce, Kerberos credentials don't make it to the Mappers and Reducers,
         // so we need to request a delegation token and use that instead.
         AuthenticationToken authToken = ClientProperty.getAuthenticationToken(props);
-        if (authToken instanceof KerberosToken) {
+        if (authToken instanceof KerberosToken krbToken) {
           log.info("Received KerberosToken, fetching DelegationToken for MapReduce");
-          final KerberosToken krbToken = (KerberosToken) authToken;
 
           try {
             UserGroupInformation user = UserGroupInformation.getCurrentUser();

--- a/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/IteratorTestInput.java
+++ b/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/IteratorTestInput.java
@@ -151,10 +151,9 @@ public class IteratorTestInput {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof IteratorTestInput)) {
+    if (!(o instanceof IteratorTestInput that)) {
       return false;
     }
-    IteratorTestInput that = (IteratorTestInput) o;
 
     return inclusive == that.inclusive && iteratorClass.equals(that.iteratorClass)
         && iteratorOptions.equals(that.iteratorOptions) && range.equals(that.range)

--- a/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/IteratorTestOutput.java
+++ b/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/IteratorTestOutput.java
@@ -136,11 +136,9 @@ public class IteratorTestOutput {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof IteratorTestOutput)) {
+    if (!(o instanceof IteratorTestOutput other)) {
       return false;
     }
-
-    IteratorTestOutput other = (IteratorTestOutput) o;
 
     if (outcome != other.outcome) {
       return false;

--- a/minicluster/src/main/java/org/apache/accumulo/cluster/ClusterUser.java
+++ b/minicluster/src/main/java/org/apache/accumulo/cluster/ClusterUser.java
@@ -117,8 +117,7 @@ public class ClusterUser {
       return false;
     }
 
-    if (obj instanceof ClusterUser) {
-      ClusterUser other = (ClusterUser) obj;
+    if (obj instanceof ClusterUser other) {
       if (keytab == null) {
         if (other.keytab != null) {
           return false;

--- a/minicluster/src/main/java/org/apache/accumulo/cluster/RemoteShellOptions.java
+++ b/minicluster/src/main/java/org/apache/accumulo/cluster/RemoteShellOptions.java
@@ -92,11 +92,10 @@ public class RemoteShellOptions {
 
     // Let other system properties override those in the file
     for (Entry<Object,Object> entry : System.getProperties().entrySet()) {
-      if (!(entry.getKey() instanceof String)) {
+      if (!(entry.getKey() instanceof String key)) {
         continue;
       }
 
-      String key = (String) entry.getKey();
       if (key.startsWith(SSH_PREFIX)) {
         properties.put(key, entry.getValue());
       }

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeChooserEnvironmentImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeChooserEnvironmentImpl.java
@@ -97,10 +97,9 @@ public class VolumeChooserEnvironmentImpl implements VolumeChooserEnvironment {
     if (obj == this) {
       return true;
     }
-    if (obj == null || !(obj instanceof VolumeChooserEnvironmentImpl)) {
+    if (obj == null || !(obj instanceof VolumeChooserEnvironmentImpl other)) {
       return false;
     }
-    VolumeChooserEnvironmentImpl other = (VolumeChooserEnvironmentImpl) obj;
     return getChooserScope() == other.getChooserScope()
         && Objects.equals(tableId.orElseThrow(), other.getTable().orElseThrow());
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManagerImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManagerImpl.java
@@ -530,8 +530,7 @@ public class VolumeManagerImpl implements VolumeManager {
     // for HDFS erasure coding. not checking hdfs config options
     // since that's already checked in ensureSyncIsEnabled()
     FileSystem fs = getFileSystemByPath(path);
-    if (fs instanceof DistributedFileSystem) {
-      DistributedFileSystem dfs = (DistributedFileSystem) fs;
+    if (fs instanceof DistributedFileSystem dfs) {
       try {
         ErasureCodingPolicy currEC = dfs.getErasureCodingPolicy(path);
         if (currEC != null && !currEC.isReplicationPolicy()) {

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/recovery/HadoopLogCloser.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/recovery/HadoopLogCloser.java
@@ -52,8 +52,7 @@ public class HadoopLogCloser implements LogCloser {
       }
     }
 
-    if (ns instanceof DistributedFileSystem) {
-      DistributedFileSystem dfs = (DistributedFileSystem) ns;
+    if (ns instanceof DistributedFileSystem dfs) {
       try {
         if (!dfs.recoverLease(source)) {
           log.info("Waiting for file to be closed {}", source);

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/ClientInfoProcessorFactory.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/ClientInfoProcessorFactory.java
@@ -41,11 +41,9 @@ public class ClientInfoProcessorFactory extends TProcessorFactory {
 
   @Override
   public TProcessor getProcessor(TTransport trans) {
-    if (trans instanceof TBufferedSocket) {
-      TBufferedSocket tsock = (TBufferedSocket) trans;
+    if (trans instanceof TBufferedSocket tsock) {
       clientAddress.set(tsock.getClientString());
-    } else if (trans instanceof TSocket) {
-      TSocket tsock = (TSocket) trans;
+    } else if (trans instanceof TSocket tsock) {
       clientAddress.set(
           tsock.getSocket().getInetAddress().getHostAddress() + ":" + tsock.getSocket().getPort());
     } else {

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/CustomNonBlockingServer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/CustomNonBlockingServer.java
@@ -167,8 +167,7 @@ public class CustomNonBlockingServer extends THsHaServer {
      */
     private String getClientAddress() {
       String clientAddress = null;
-      if (trans_ instanceof TNonblockingSocket) {
-        TNonblockingSocket tsock = (TNonblockingSocket) trans_;
+      if (trans_ instanceof TNonblockingSocket tsock) {
         Socket sock = tsock.getSocketChannel().socket();
         clientAddress = sock.getInetAddress().getHostAddress() + ":" + sock.getPort();
         log.trace("CustomFrameBuffer captured client address: {}", clientAddress);

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/CustomThreadedSelectorServer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/CustomThreadedSelectorServer.java
@@ -56,10 +56,9 @@ public class CustomThreadedSelectorServer extends TThreadedSelectorServer {
       try {
         TNonblockingTransport transport = getTransport(frameBuffer);
 
-        if (transport instanceof TNonblockingSocket) {
+        if (transport instanceof TNonblockingSocket tsock) {
           // This block of code makes the client address available to the server side code that
           // executes a RPC. It is made available for informational purposes.
-          TNonblockingSocket tsock = (TNonblockingSocket) transport;
           Socket sock = tsock.getSocketChannel().socket();
           TServerUtils.clientAddress
               .set(sock.getInetAddress().getHostAddress() + ":" + sock.getPort());

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/TServerUtils.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/TServerUtils.java
@@ -401,8 +401,7 @@ public class TServerUtils {
     }
 
     final ServerSocket serverSock = tServerSock.getServerSocket();
-    if (serverSock instanceof SSLServerSocket) {
-      SSLServerSocket sslServerSock = (SSLServerSocket) serverSock;
+    if (serverSock instanceof SSLServerSocket sslServerSock) {
       String[] protocols = params.getServerProtocols();
 
       // Be nice for the user and automatically remove protocols that might not exist in their JVM.

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/UGIAssumingProcessor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/UGIAssumingProcessor.java
@@ -78,10 +78,9 @@ public class UGIAssumingProcessor implements TProcessor {
   @Override
   public void process(final TProtocol inProt, final TProtocol outProt) throws TException {
     TTransport trans = inProt.getTransport();
-    if (!(trans instanceof TSaslServerTransport)) {
+    if (!(trans instanceof TSaslServerTransport saslTrans)) {
       throw new TException("Unexpected non-SASL transport " + trans.getClass() + ": " + trans);
     }
-    TSaslServerTransport saslTrans = (TSaslServerTransport) trans;
     SaslServer saslServer = saslTrans.getSaslServer();
     String endUser = saslServer.getAuthorizationID();
 

--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKAuthenticator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKAuthenticator.java
@@ -91,10 +91,9 @@ public final class ZKAuthenticator implements Authenticator {
   public void createUser(String principal, AuthenticationToken token)
       throws AccumuloSecurityException {
     try {
-      if (!(token instanceof PasswordToken)) {
+      if (!(token instanceof PasswordToken pt)) {
         throw new AccumuloSecurityException(principal, SecurityErrorCode.INVALID_TOKEN);
       }
-      PasswordToken pt = (PasswordToken) token;
       constructUser(principal, ZKSecurityTool.createPass(pt.getPassword()));
     } catch (KeeperException e) {
       if (e.code().equals(KeeperException.Code.NODEEXISTS)) {
@@ -131,10 +130,9 @@ public final class ZKAuthenticator implements Authenticator {
   @Override
   public void changePassword(String principal, AuthenticationToken token)
       throws AccumuloSecurityException {
-    if (!(token instanceof PasswordToken)) {
+    if (!(token instanceof PasswordToken pt)) {
       throw new AccumuloSecurityException(principal, SecurityErrorCode.INVALID_TOKEN);
     }
-    PasswordToken pt = (PasswordToken) token;
     if (userExists(principal)) {
       try {
         String userPath = Constants.ZUSERS + "/" + principal;
@@ -170,10 +168,9 @@ public final class ZKAuthenticator implements Authenticator {
   @Override
   public boolean authenticateUser(String principal, AuthenticationToken token)
       throws AccumuloSecurityException {
-    if (!(token instanceof PasswordToken)) {
+    if (!(token instanceof PasswordToken pt)) {
       throw new AccumuloSecurityException(principal, SecurityErrorCode.INVALID_TOKEN);
     }
-    PasswordToken pt = (PasswordToken) token;
     byte[] zkData;
     String zpath = Constants.ZUSERS + "/" + principal;
     zkData = context.getZooCache().get(zpath);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/serviceStatus/StatusSummary.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/serviceStatus/StatusSummary.java
@@ -84,10 +84,9 @@ public class StatusSummary {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof StatusSummary)) {
+    if (!(o instanceof StatusSummary that)) {
       return false;
     }
-    StatusSummary that = (StatusSummary) o;
     return serviceCount == that.serviceCount && errorCount == that.errorCount
         && serviceType == that.serviceType && Objects.equals(resourceGroups, that.resourceGroups)
         && Objects.equals(serviceByGroups, that.serviceByGroups);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/queue/ResolvedCompactionJob.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/queue/ResolvedCompactionJob.java
@@ -72,8 +72,7 @@ public class ResolvedCompactionJob implements CompactionJob {
   }
 
   public static final SizeTrackingTreeMap.Weigher<CompactionJob> WEIGHER = job -> {
-    if (job instanceof ResolvedCompactionJob) {
-      var rcj = (ResolvedCompactionJob) job;
+    if (job instanceof ResolvedCompactionJob rcj) {
       long estDataSize = 0;
       if (rcj.selectedFateId != null) {
         estDataSize += rcj.selectedFateId.canonical().length();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -779,11 +779,9 @@ public class ScanServer extends AbstractServer
   }
 
   private static Set<StoredTabletFile> getScanSessionFiles(ScanSession<?> session) {
-    if (session instanceof SingleScanSession) {
-      var sss = (SingleScanSession) session;
+    if (session instanceof SingleScanSession sss) {
       return Set.copyOf(session.getTabletResolver().getTablet(sss.extent).getDatafiles().keySet());
-    } else if (session instanceof MultiScanSession) {
-      var mss = (MultiScanSession) session;
+    } else if (session instanceof MultiScanSession mss) {
       return mss.exents.stream().flatMap(e -> {
         var tablet = mss.getTabletResolver().getTablet(e);
         if (tablet == null) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SessionManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SessionManager.java
@@ -331,8 +331,7 @@ public class SessionManager {
   private long countZombieScans(long reportTimeMillis) {
     return Stream.concat(deferredCleanupQueue.stream(), sessions.values().stream())
         .filter(session -> {
-          if (session instanceof ScanSession) {
-            var scanSession = (ScanSession<?>) session;
+          if (session instanceof ScanSession<?> scanSession) {
             synchronized (scanSession) {
               var scanTask = scanSession.getScanTask();
               if (scanTask != null && scanSession.getState() == State.REMOVED
@@ -396,12 +395,10 @@ public class SessionManager {
       ScanTask<?> nbt = null;
       TableId tableID = null;
 
-      if (session instanceof SingleScanSession) {
-        SingleScanSession ss = (SingleScanSession) session;
+      if (session instanceof SingleScanSession ss) {
         nbt = ss.getScanTask();
         tableID = ss.extent.tableId();
-      } else if (session instanceof MultiScanSession) {
-        MultiScanSession mss = (MultiScanSession) session;
+      } else if (session instanceof MultiScanSession mss) {
         nbt = mss.getScanTask();
         tableID = mss.threadPoolExtent.tableId();
       }
@@ -423,8 +420,7 @@ public class SessionManager {
     final long ct = System.currentTimeMillis();
 
     Stream.concat(sessions.values().stream(), deferredCleanupQueue.stream()).forEach(session -> {
-      if (session instanceof ScanSession) {
-        ScanSession<?> scanSession = (ScanSession<?>) session;
+      if (session instanceof ScanSession<?> scanSession) {
         boolean isSingle = session instanceof SingleScanSession;
 
         addActiveScan(activeScans, scanSession,

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ConfigCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ConfigCommand.java
@@ -289,8 +289,7 @@ public class ConfigCommand extends Command {
         try {
           acuconf = shellState.getAccumuloClient().tableOperations().getConfiguration(tableName);
         } catch (AccumuloException e) {
-          if (e.getCause() != null && e.getCause() instanceof AccumuloSecurityException) {
-            AccumuloSecurityException ase = (AccumuloSecurityException) e.getCause();
+          if (e.getCause() != null && e.getCause() instanceof AccumuloSecurityException ase) {
             if (ase.getSecurityErrorCode() == PERMISSION_DENIED) {
               Shell.log.error(
                   "User unable to retrieve {} table configuration (requires Table.ALTER_TABLE permission)",

--- a/test/src/main/java/org/apache/accumulo/harness/conf/AccumuloClusterPropertyConfiguration.java
+++ b/test/src/main/java/org/apache/accumulo/harness/conf/AccumuloClusterPropertyConfiguration.java
@@ -170,11 +170,10 @@ public abstract class AccumuloClusterPropertyConfiguration implements AccumuloCl
   protected void loadFromProperties(String desiredPrefix, Properties properties,
       Map<String,String> configuration) {
     for (Entry<Object,Object> entry : properties.entrySet()) {
-      if (!(entry.getKey() instanceof String)) {
+      if (!(entry.getKey() instanceof String key)) {
         continue;
       }
 
-      String key = (String) entry.getKey();
       if (key.startsWith(desiredPrefix)) {
         configuration.put(key, (String) entry.getValue());
       }

--- a/test/src/main/java/org/apache/accumulo/test/fate/meta/MetaFateStoreFateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/meta/MetaFateStoreFateIT.java
@@ -136,8 +136,7 @@ public class MetaFateStoreFateIT extends FateStoreITBase {
       Object currentNode) throws Exception {
     Object currentResAsObject = nodeReservation.get(currentNode);
     Optional<FateStore.FateReservation> currentReservation = Optional.empty();
-    if (currentResAsObject instanceof Optional) {
-      Optional<?> currentResAsOptional = (Optional<?>) currentResAsObject;
+    if (currentResAsObject instanceof Optional<?> currentResAsOptional) {
       if (currentResAsOptional.isPresent()
           && currentResAsOptional.orElseThrow() instanceof FateStore.FateReservation) {
         currentReservation =


### PR DESCRIPTION
use Java 17 pattern matching for `instanceof` checks, eliminating redundant casting and improving readability.

  ### Example Transformation
Before (Java 11):
  ```java
  if (obj instanceof String) {
      String str = (String) obj;
      return str.length();
  }
```

  After (Java 17):
  ```java
  if (obj instanceof String str) {
      return str.length();
  }
```

These changes were made by my IDE