### PR TITLE
Migrate switch statements to Java 17 switch expression syntax

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/AccumuloSecurityException.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/AccumuloSecurityException.java
@@ -30,24 +30,26 @@ public class AccumuloSecurityException extends Exception {
   private static final long serialVersionUID = 1L;
 
   private static String getDefaultErrorMessage(final SecurityErrorCode errorcode) {
-      return switch (errorcode == null ? SecurityErrorCode.DEFAULT_SECURITY_ERROR : errorcode) {
-          case BAD_CREDENTIALS -> "Username or Password is Invalid";
-          case CONNECTION_ERROR -> "Connection Error Occurred";
-          case PERMISSION_DENIED -> "User does not have permission to perform this action";
-          case USER_DOESNT_EXIST -> "The user does not exist";
-          case USER_EXISTS -> "The user exists";
-          case GRANT_INVALID -> "The GRANT permission cannot be granted or revoked";
-          case BAD_AUTHORIZATIONS -> "The user does not have the specified authorizations assigned";
-          case UNSUPPORTED_OPERATION -> "The configured security handler does not support this operation";
-          case INVALID_TOKEN -> "The configured authenticator does not accept this type of token";
-          case AUTHENTICATOR_FAILED -> "The configured authenticator failed for some reason";
-          case AUTHORIZOR_FAILED -> "The configured authorizor failed for some reason";
-          case PERMISSIONHANDLER_FAILED -> "The configured permission handler failed for some reason";
-          case TOKEN_EXPIRED -> "The supplied token expired, please update and try again";
-          case INSUFFICIENT_PROPERTIES -> "The login properties supplied are not sufficient for authentication. "
-                  + "Please check the requested properties and try again";
-          default -> "Unknown security exception";
-      };
+    return switch (errorcode == null ? SecurityErrorCode.DEFAULT_SECURITY_ERROR : errorcode) {
+      case BAD_CREDENTIALS -> "Username or Password is Invalid";
+      case CONNECTION_ERROR -> "Connection Error Occurred";
+      case PERMISSION_DENIED -> "User does not have permission to perform this action";
+      case USER_DOESNT_EXIST -> "The user does not exist";
+      case USER_EXISTS -> "The user exists";
+      case GRANT_INVALID -> "The GRANT permission cannot be granted or revoked";
+      case BAD_AUTHORIZATIONS -> "The user does not have the specified authorizations assigned";
+      case UNSUPPORTED_OPERATION ->
+        "The configured security handler does not support this operation";
+      case INVALID_TOKEN -> "The configured authenticator does not accept this type of token";
+      case AUTHENTICATOR_FAILED -> "The configured authenticator failed for some reason";
+      case AUTHORIZOR_FAILED -> "The configured authorizor failed for some reason";
+      case PERMISSIONHANDLER_FAILED -> "The configured permission handler failed for some reason";
+      case TOKEN_EXPIRED -> "The supplied token expired, please update and try again";
+      case INSUFFICIENT_PROPERTIES ->
+        "The login properties supplied are not sufficient for authentication. "
+            + "Please check the requested properties and try again";
+      default -> "Unknown security exception";
+    };
   }
 
   private String user;

--- a/core/src/main/java/org/apache/accumulo/core/client/AccumuloSecurityException.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/AccumuloSecurityException.java
@@ -30,40 +30,24 @@ public class AccumuloSecurityException extends Exception {
   private static final long serialVersionUID = 1L;
 
   private static String getDefaultErrorMessage(final SecurityErrorCode errorcode) {
-    switch (errorcode == null ? SecurityErrorCode.DEFAULT_SECURITY_ERROR : errorcode) {
-      case BAD_CREDENTIALS:
-        return "Username or Password is Invalid";
-      case CONNECTION_ERROR:
-        return "Connection Error Occurred";
-      case PERMISSION_DENIED:
-        return "User does not have permission to perform this action";
-      case USER_DOESNT_EXIST:
-        return "The user does not exist";
-      case USER_EXISTS:
-        return "The user exists";
-      case GRANT_INVALID:
-        return "The GRANT permission cannot be granted or revoked";
-      case BAD_AUTHORIZATIONS:
-        return "The user does not have the specified authorizations assigned";
-      case UNSUPPORTED_OPERATION:
-        return "The configured security handler does not support this operation";
-      case INVALID_TOKEN:
-        return "The configured authenticator does not accept this type of token";
-      case AUTHENTICATOR_FAILED:
-        return "The configured authenticator failed for some reason";
-      case AUTHORIZOR_FAILED:
-        return "The configured authorizor failed for some reason";
-      case PERMISSIONHANDLER_FAILED:
-        return "The configured permission handler failed for some reason";
-      case TOKEN_EXPIRED:
-        return "The supplied token expired, please update and try again";
-      case INSUFFICIENT_PROPERTIES:
-        return "The login properties supplied are not sufficient for authentication. "
-            + "Please check the requested properties and try again";
-      case DEFAULT_SECURITY_ERROR:
-      default:
-        return "Unknown security exception";
-    }
+      return switch (errorcode == null ? SecurityErrorCode.DEFAULT_SECURITY_ERROR : errorcode) {
+          case BAD_CREDENTIALS -> "Username or Password is Invalid";
+          case CONNECTION_ERROR -> "Connection Error Occurred";
+          case PERMISSION_DENIED -> "User does not have permission to perform this action";
+          case USER_DOESNT_EXIST -> "The user does not exist";
+          case USER_EXISTS -> "The user exists";
+          case GRANT_INVALID -> "The GRANT permission cannot be granted or revoked";
+          case BAD_AUTHORIZATIONS -> "The user does not have the specified authorizations assigned";
+          case UNSUPPORTED_OPERATION -> "The configured security handler does not support this operation";
+          case INVALID_TOKEN -> "The configured authenticator does not accept this type of token";
+          case AUTHENTICATOR_FAILED -> "The configured authenticator failed for some reason";
+          case AUTHORIZOR_FAILED -> "The configured authorizor failed for some reason";
+          case PERMISSIONHANDLER_FAILED -> "The configured permission handler failed for some reason";
+          case TOKEN_EXPIRED -> "The supplied token expired, please update and try again";
+          case INSUFFICIENT_PROPERTIES -> "The login properties supplied are not sufficient for authentication. "
+                  + "Please check the requested properties and try again";
+          default -> "Unknown security exception";
+      };
   }
 
   private String user;

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
@@ -728,16 +728,12 @@ public class ConditionalWriterImpl implements ConditionalWriter {
   }
 
   public static Status fromThrift(TCMStatus status) {
-    switch (status) {
-      case ACCEPTED:
-        return Status.ACCEPTED;
-      case REJECTED:
-        return Status.REJECTED;
-      case VIOLATED:
-        return Status.VIOLATED;
-      default:
-        throw new IllegalArgumentException(status.toString());
-    }
+      return switch (status) {
+          case ACCEPTED -> Status.ACCEPTED;
+          case REJECTED -> Status.REJECTED;
+          case VIOLATED -> Status.VIOLATED;
+          default -> throw new IllegalArgumentException(status.toString());
+      };
   }
 
   private void convertMutations(TabletServerMutations<QCMutation> mutations, Map<Long,CMK> cmidToCm,

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
@@ -728,12 +728,12 @@ public class ConditionalWriterImpl implements ConditionalWriter {
   }
 
   public static Status fromThrift(TCMStatus status) {
-      return switch (status) {
-          case ACCEPTED -> Status.ACCEPTED;
-          case REJECTED -> Status.REJECTED;
-          case VIOLATED -> Status.VIOLATED;
-          default -> throw new IllegalArgumentException(status.toString());
-      };
+    return switch (status) {
+      case ACCEPTED -> Status.ACCEPTED;
+      case REJECTED -> Status.REJECTED;
+      case VIOLATED -> Status.VIOLATED;
+      default -> throw new IllegalArgumentException(status.toString());
+    };
   }
 
   private void convertMutations(TabletServerMutations<QCMutation> mutations, Map<Long,CMK> cmidToCm,

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/DurabilityImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/DurabilityImpl.java
@@ -24,13 +24,13 @@ import org.apache.accumulo.core.tabletingest.thrift.TDurability;
 public class DurabilityImpl {
 
   public static TDurability toThrift(Durability durability) {
-      return switch (durability) {
-          case DEFAULT -> TDurability.DEFAULT;
-          case SYNC -> TDurability.SYNC;
-          case FLUSH -> TDurability.FLUSH;
-          case LOG -> TDurability.LOG;
-          default -> TDurability.NONE;
-      };
+    return switch (durability) {
+      case DEFAULT -> TDurability.DEFAULT;
+      case SYNC -> TDurability.SYNC;
+      case FLUSH -> TDurability.FLUSH;
+      case LOG -> TDurability.LOG;
+      default -> TDurability.NONE;
+    };
   }
 
   public static Durability fromString(String value) {
@@ -41,13 +41,13 @@ public class DurabilityImpl {
     if (tdurabilty == null) {
       return Durability.DEFAULT;
     }
-      return switch (tdurabilty) {
-          case DEFAULT -> Durability.DEFAULT;
-          case SYNC -> Durability.SYNC;
-          case FLUSH -> Durability.FLUSH;
-          case LOG -> Durability.LOG;
-          default -> Durability.NONE;
-      };
+    return switch (tdurabilty) {
+      case DEFAULT -> Durability.DEFAULT;
+      case SYNC -> Durability.SYNC;
+      case FLUSH -> Durability.FLUSH;
+      case LOG -> Durability.LOG;
+      default -> Durability.NONE;
+    };
   }
 
   public static Durability resolveDurabilty(Durability durability, Durability tabletDurability) {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/DurabilityImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/DurabilityImpl.java
@@ -24,18 +24,13 @@ import org.apache.accumulo.core.tabletingest.thrift.TDurability;
 public class DurabilityImpl {
 
   public static TDurability toThrift(Durability durability) {
-    switch (durability) {
-      case DEFAULT:
-        return TDurability.DEFAULT;
-      case SYNC:
-        return TDurability.SYNC;
-      case FLUSH:
-        return TDurability.FLUSH;
-      case LOG:
-        return TDurability.LOG;
-      default:
-        return TDurability.NONE;
-    }
+      return switch (durability) {
+          case DEFAULT -> TDurability.DEFAULT;
+          case SYNC -> TDurability.SYNC;
+          case FLUSH -> TDurability.FLUSH;
+          case LOG -> TDurability.LOG;
+          default -> TDurability.NONE;
+      };
   }
 
   public static Durability fromString(String value) {
@@ -46,18 +41,13 @@ public class DurabilityImpl {
     if (tdurabilty == null) {
       return Durability.DEFAULT;
     }
-    switch (tdurabilty) {
-      case DEFAULT:
-        return Durability.DEFAULT;
-      case SYNC:
-        return Durability.SYNC;
-      case FLUSH:
-        return Durability.FLUSH;
-      case LOG:
-        return Durability.LOG;
-      default:
-        return Durability.NONE;
-    }
+      return switch (tdurabilty) {
+          case DEFAULT -> Durability.DEFAULT;
+          case SYNC -> Durability.SYNC;
+          case FLUSH -> Durability.FLUSH;
+          case LOG -> Durability.LOG;
+          default -> Durability.NONE;
+      };
   }
 
   public static Durability resolveDurabilty(Durability durability, Durability tabletDurability) {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletAvailabilityUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletAvailabilityUtil.java
@@ -25,39 +25,37 @@ import org.apache.accumulo.core.data.Value;
 public class TabletAvailabilityUtil {
 
   public static TabletAvailability fromThrift(TTabletAvailability tAvailability) {
-      return switch (tAvailability) {
-          case HOSTED -> TabletAvailability.HOSTED;
-          case UNHOSTED -> TabletAvailability.UNHOSTED;
-          case ONDEMAND -> TabletAvailability.ONDEMAND;
-          default -> throw new IllegalArgumentException("Unhandled value for TAvailability: " + tAvailability);
-      };
+    return switch (tAvailability) {
+      case HOSTED -> TabletAvailability.HOSTED;
+      case UNHOSTED -> TabletAvailability.UNHOSTED;
+      case ONDEMAND -> TabletAvailability.ONDEMAND;
+    };
   }
 
   public static TTabletAvailability toThrift(TabletAvailability tabletAvailability) {
-      return switch (tabletAvailability) {
-          case HOSTED -> TTabletAvailability.HOSTED;
-          case UNHOSTED -> TTabletAvailability.UNHOSTED;
-          case ONDEMAND -> TTabletAvailability.ONDEMAND;
-          default -> throw new IllegalArgumentException("Unhandled enum value");
-      };
+    return switch (tabletAvailability) {
+      case HOSTED -> TTabletAvailability.HOSTED;
+      case UNHOSTED -> TTabletAvailability.UNHOSTED;
+      case ONDEMAND -> TTabletAvailability.ONDEMAND;
+    };
   }
 
   public static TabletAvailability fromValue(Value value) {
-      return switch (value.toString()) {
-          case "HOSTED" -> TabletAvailability.HOSTED;
-          case "UNHOSTED" -> TabletAvailability.UNHOSTED;
-          case "ONDEMAND" -> TabletAvailability.ONDEMAND;
-          default -> throw new IllegalArgumentException("Invalid value for tablet availability: " + value);
-      };
+    return switch (value.toString()) {
+      case "HOSTED" -> TabletAvailability.HOSTED;
+      case "UNHOSTED" -> TabletAvailability.UNHOSTED;
+      case "ONDEMAND" -> TabletAvailability.ONDEMAND;
+      default ->
+        throw new IllegalArgumentException("Invalid value for tablet availability: " + value);
+    };
   }
 
   public static Value toValue(TabletAvailability tabletAvailability) {
-      return switch (tabletAvailability) {
-          case HOSTED -> new Value(TabletAvailability.HOSTED.name());
-          case UNHOSTED -> new Value(TabletAvailability.UNHOSTED.name());
-          case ONDEMAND -> new Value(TabletAvailability.ONDEMAND.name());
-          default -> throw new IllegalArgumentException("Unhandled enum value");
-      };
+    return switch (tabletAvailability) {
+      case HOSTED -> new Value(TabletAvailability.HOSTED.name());
+      case UNHOSTED -> new Value(TabletAvailability.UNHOSTED.name());
+      case ONDEMAND -> new Value(TabletAvailability.ONDEMAND.name());
+    };
   }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletAvailabilityUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletAvailabilityUtil.java
@@ -25,55 +25,39 @@ import org.apache.accumulo.core.data.Value;
 public class TabletAvailabilityUtil {
 
   public static TabletAvailability fromThrift(TTabletAvailability tAvailability) {
-    switch (tAvailability) {
-      case HOSTED:
-        return TabletAvailability.HOSTED;
-      case UNHOSTED:
-        return TabletAvailability.UNHOSTED;
-      case ONDEMAND:
-        return TabletAvailability.ONDEMAND;
-      default:
-        throw new IllegalArgumentException("Unhandled value for TAvailability: " + tAvailability);
-    }
+      return switch (tAvailability) {
+          case HOSTED -> TabletAvailability.HOSTED;
+          case UNHOSTED -> TabletAvailability.UNHOSTED;
+          case ONDEMAND -> TabletAvailability.ONDEMAND;
+          default -> throw new IllegalArgumentException("Unhandled value for TAvailability: " + tAvailability);
+      };
   }
 
   public static TTabletAvailability toThrift(TabletAvailability tabletAvailability) {
-    switch (tabletAvailability) {
-      case HOSTED:
-        return TTabletAvailability.HOSTED;
-      case UNHOSTED:
-        return TTabletAvailability.UNHOSTED;
-      case ONDEMAND:
-        return TTabletAvailability.ONDEMAND;
-      default:
-        throw new IllegalArgumentException("Unhandled enum value");
-    }
+      return switch (tabletAvailability) {
+          case HOSTED -> TTabletAvailability.HOSTED;
+          case UNHOSTED -> TTabletAvailability.UNHOSTED;
+          case ONDEMAND -> TTabletAvailability.ONDEMAND;
+          default -> throw new IllegalArgumentException("Unhandled enum value");
+      };
   }
 
   public static TabletAvailability fromValue(Value value) {
-    switch (value.toString()) {
-      case "HOSTED":
-        return TabletAvailability.HOSTED;
-      case "UNHOSTED":
-        return TabletAvailability.UNHOSTED;
-      case "ONDEMAND":
-        return TabletAvailability.ONDEMAND;
-      default:
-        throw new IllegalArgumentException("Invalid value for tablet availability: " + value);
-    }
+      return switch (value.toString()) {
+          case "HOSTED" -> TabletAvailability.HOSTED;
+          case "UNHOSTED" -> TabletAvailability.UNHOSTED;
+          case "ONDEMAND" -> TabletAvailability.ONDEMAND;
+          default -> throw new IllegalArgumentException("Invalid value for tablet availability: " + value);
+      };
   }
 
   public static Value toValue(TabletAvailability tabletAvailability) {
-    switch (tabletAvailability) {
-      case HOSTED:
-        return new Value(TabletAvailability.HOSTED.name());
-      case UNHOSTED:
-        return new Value(TabletAvailability.UNHOSTED.name());
-      case ONDEMAND:
-        return new Value(TabletAvailability.ONDEMAND.name());
-      default:
-        throw new IllegalArgumentException("Unhandled enum value");
-    }
+      return switch (tabletAvailability) {
+          case HOSTED -> new Value(TabletAvailability.HOSTED.name());
+          case UNHOSTED -> new Value(TabletAvailability.UNHOSTED.name());
+          case ONDEMAND -> new Value(TabletAvailability.ONDEMAND.name());
+          default -> throw new IllegalArgumentException("Unhandled enum value");
+      };
   }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportPool.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportPool.java
@@ -153,22 +153,23 @@ public class ThriftTransportPool {
     final List<ThriftTransportKey> serversSet = new ArrayList<>();
 
     Function<AddressSelector,Set<ServiceLockPath>> paths = switch (service) {
-        case CLIENT -> (selector) -> new CompositeSet<ServiceLockPath>(
-                ctx.getServerPaths().getCompactor(rgp, selector, true),
-                ctx.getServerPaths().getScanServer(rgp, selector, true),
-                ctx.getServerPaths().getTabletServer(rgp, selector, true));
-        case COMPACTOR -> (selector) -> ctx.getServerPaths().getCompactor(rgp, selector, true);
-        case MANAGER, COORDINATOR, FATE -> (selector) -> Set.of(ctx.getServerPaths().getManager(true));
-        case GC -> (selector) -> Set.of(ctx.getServerPaths().getGarbageCollector(true));
-        case TABLET_SCAN -> (selector) -> new CompositeSet<ServiceLockPath>(
-                ctx.getServerPaths().getTabletServer(rgp, selector, true),
-                ctx.getServerPaths().getScanServer(rgp, selector, true));
-        case TABLET_INGEST, TABLET_MANAGEMENT, TSERV ->
-                (selector) -> ctx.getServerPaths().getTabletServer(rgp, selector, true);
-        default -> throw new IllegalArgumentException("Unhandled thrift service type: " + service);
+      case CLIENT -> (selector) -> new CompositeSet<ServiceLockPath>(
+          ctx.getServerPaths().getCompactor(rgp, selector, true),
+          ctx.getServerPaths().getScanServer(rgp, selector, true),
+          ctx.getServerPaths().getTabletServer(rgp, selector, true));
+      case COMPACTOR -> (selector) -> ctx.getServerPaths().getCompactor(rgp, selector, true);
+      case MANAGER, COORDINATOR, FATE ->
+        (selector) -> Set.of(ctx.getServerPaths().getManager(true));
+      case GC -> (selector) -> Set.of(ctx.getServerPaths().getGarbageCollector(true));
+      case TABLET_SCAN -> (selector) -> new CompositeSet<ServiceLockPath>(
+          ctx.getServerPaths().getTabletServer(rgp, selector, true),
+          ctx.getServerPaths().getScanServer(rgp, selector, true));
+      case TABLET_INGEST, TABLET_MANAGEMENT, TSERV ->
+        (selector) -> ctx.getServerPaths().getTabletServer(rgp, selector, true);
+      default -> throw new IllegalArgumentException("Unhandled thrift service type: " + service);
     };
 
-      for (ThriftTransportKey ttk : connectionPool.getThriftTransportKeys()) {
+    for (ThriftTransportKey ttk : connectionPool.getThriftTransportKeys()) {
       if (ttk.getType().equals(type)
           && !paths.apply(AddressSelector.exact(ttk.getServer())).isEmpty()) {
         serversSet.add(ttk);

--- a/core/src/main/java/org/apache/accumulo/core/data/Key.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Key.java
@@ -1041,23 +1041,22 @@ public class Key implements WritableComparable<Key>, Cloneable {
    * @return true if specified parts of keys match, false otherwise
    */
   public boolean equals(Key other, PartialKey part) {
-      return switch (part) {
-          case ROW -> isEqual(row, other.row);
-          case ROW_COLFAM -> isEqual(row, other.row) && isEqual(colFamily, other.colFamily);
-          case ROW_COLFAM_COLQUAL -> isEqual(row, other.row) && isEqual(colFamily, other.colFamily)
-                  && isEqual(colQualifier, other.colQualifier);
-          case ROW_COLFAM_COLQUAL_COLVIS -> isEqual(row, other.row) && isEqual(colFamily, other.colFamily)
-                  && isEqual(colQualifier, other.colQualifier)
-                  && isEqual(colVisibility, other.colVisibility);
-          case ROW_COLFAM_COLQUAL_COLVIS_TIME -> isEqual(row, other.row) && isEqual(colFamily, other.colFamily)
-                  && isEqual(colQualifier, other.colQualifier)
-                  && isEqual(colVisibility, other.colVisibility) && timestamp == other.timestamp;
-          case ROW_COLFAM_COLQUAL_COLVIS_TIME_DEL -> isEqual(row, other.row) && isEqual(colFamily, other.colFamily)
-                  && isEqual(colQualifier, other.colQualifier)
-                  && isEqual(colVisibility, other.colVisibility) && timestamp == other.timestamp
-                  && deleted == other.deleted;
-          default -> throw new IllegalArgumentException("Unrecognized partial key specification " + part);
-      };
+    return switch (part) {
+      case ROW -> isEqual(row, other.row);
+      case ROW_COLFAM -> isEqual(row, other.row) && isEqual(colFamily, other.colFamily);
+      case ROW_COLFAM_COLQUAL -> isEqual(row, other.row) && isEqual(colFamily, other.colFamily)
+          && isEqual(colQualifier, other.colQualifier);
+      case ROW_COLFAM_COLQUAL_COLVIS -> isEqual(row, other.row)
+          && isEqual(colFamily, other.colFamily) && isEqual(colQualifier, other.colQualifier)
+          && isEqual(colVisibility, other.colVisibility);
+      case ROW_COLFAM_COLQUAL_COLVIS_TIME -> isEqual(row, other.row)
+          && isEqual(colFamily, other.colFamily) && isEqual(colQualifier, other.colQualifier)
+          && isEqual(colVisibility, other.colVisibility) && timestamp == other.timestamp;
+      case ROW_COLFAM_COLQUAL_COLVIS_TIME_DEL -> isEqual(row, other.row)
+          && isEqual(colFamily, other.colFamily) && isEqual(colQualifier, other.colQualifier)
+          && isEqual(colVisibility, other.colVisibility) && timestamp == other.timestamp
+          && deleted == other.deleted;
+    };
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/data/Key.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Key.java
@@ -1041,30 +1041,23 @@ public class Key implements WritableComparable<Key>, Cloneable {
    * @return true if specified parts of keys match, false otherwise
    */
   public boolean equals(Key other, PartialKey part) {
-    switch (part) {
-      case ROW:
-        return isEqual(row, other.row);
-      case ROW_COLFAM:
-        return isEqual(row, other.row) && isEqual(colFamily, other.colFamily);
-      case ROW_COLFAM_COLQUAL:
-        return isEqual(row, other.row) && isEqual(colFamily, other.colFamily)
-            && isEqual(colQualifier, other.colQualifier);
-      case ROW_COLFAM_COLQUAL_COLVIS:
-        return isEqual(row, other.row) && isEqual(colFamily, other.colFamily)
-            && isEqual(colQualifier, other.colQualifier)
-            && isEqual(colVisibility, other.colVisibility);
-      case ROW_COLFAM_COLQUAL_COLVIS_TIME:
-        return isEqual(row, other.row) && isEqual(colFamily, other.colFamily)
-            && isEqual(colQualifier, other.colQualifier)
-            && isEqual(colVisibility, other.colVisibility) && timestamp == other.timestamp;
-      case ROW_COLFAM_COLQUAL_COLVIS_TIME_DEL:
-        return isEqual(row, other.row) && isEqual(colFamily, other.colFamily)
-            && isEqual(colQualifier, other.colQualifier)
-            && isEqual(colVisibility, other.colVisibility) && timestamp == other.timestamp
-            && deleted == other.deleted;
-      default:
-        throw new IllegalArgumentException("Unrecognized partial key specification " + part);
-    }
+      return switch (part) {
+          case ROW -> isEqual(row, other.row);
+          case ROW_COLFAM -> isEqual(row, other.row) && isEqual(colFamily, other.colFamily);
+          case ROW_COLFAM_COLQUAL -> isEqual(row, other.row) && isEqual(colFamily, other.colFamily)
+                  && isEqual(colQualifier, other.colQualifier);
+          case ROW_COLFAM_COLQUAL_COLVIS -> isEqual(row, other.row) && isEqual(colFamily, other.colFamily)
+                  && isEqual(colQualifier, other.colQualifier)
+                  && isEqual(colVisibility, other.colVisibility);
+          case ROW_COLFAM_COLQUAL_COLVIS_TIME -> isEqual(row, other.row) && isEqual(colFamily, other.colFamily)
+                  && isEqual(colQualifier, other.colQualifier)
+                  && isEqual(colVisibility, other.colVisibility) && timestamp == other.timestamp;
+          case ROW_COLFAM_COLQUAL_COLVIS_TIME_DEL -> isEqual(row, other.row) && isEqual(colFamily, other.colFamily)
+                  && isEqual(colQualifier, other.colQualifier)
+                  && isEqual(colVisibility, other.colVisibility) && timestamp == other.timestamp
+                  && deleted == other.deleted;
+          default -> throw new IllegalArgumentException("Unrecognized partial key specification " + part);
+      };
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/data/constraints/DefaultKeySizeConstraint.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/constraints/DefaultKeySizeConstraint.java
@@ -40,12 +40,11 @@ public class DefaultKeySizeConstraint implements Constraint {
   @Override
   public String getViolationDescription(short violationCode) {
 
-    switch (violationCode) {
-      case MAX__KEY_SIZE_EXCEEDED_VIOLATION:
-        return "Key was larger than 1MB";
-    }
+      return switch (violationCode) {
+          case MAX__KEY_SIZE_EXCEEDED_VIOLATION -> "Key was larger than 1MB";
+          default -> null;
+      };
 
-    return null;
   }
 
   static final List<Short> NO_VIOLATIONS = new ArrayList<>();

--- a/core/src/main/java/org/apache/accumulo/core/data/constraints/DefaultKeySizeConstraint.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/constraints/DefaultKeySizeConstraint.java
@@ -40,10 +40,10 @@ public class DefaultKeySizeConstraint implements Constraint {
   @Override
   public String getViolationDescription(short violationCode) {
 
-      return switch (violationCode) {
-          case MAX__KEY_SIZE_EXCEEDED_VIOLATION -> "Key was larger than 1MB";
-          default -> null;
-      };
+    if (violationCode == MAX__KEY_SIZE_EXCEEDED_VIOLATION) {
+      return "Key was larger than 1MB";
+    }
+    return null;
 
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/data/constraints/VisibilityConstraint.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/constraints/VisibilityConstraint.java
@@ -47,11 +47,11 @@ public class VisibilityConstraint implements Constraint {
 
   @Override
   public String getViolationDescription(short violationCode) {
-      return switch (violationCode) {
-          case 1 -> "Malformed column visibility";
-          case 2 -> "User does not have authorization on column visibility";
-          default -> null;
-      };
+    return switch (violationCode) {
+      case 1 -> "Malformed column visibility";
+      case 2 -> "User does not have authorization on column visibility";
+      default -> null;
+    };
 
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/data/constraints/VisibilityConstraint.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/constraints/VisibilityConstraint.java
@@ -47,14 +47,12 @@ public class VisibilityConstraint implements Constraint {
 
   @Override
   public String getViolationDescription(short violationCode) {
-    switch (violationCode) {
-      case 1:
-        return "Malformed column visibility";
-      case 2:
-        return "User does not have authorization on column visibility";
-    }
+      return switch (violationCode) {
+          case 1 -> "Malformed column visibility";
+          case 2 -> "User does not have authorization on column visibility";
+          default -> null;
+      };
 
-    return null;
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/fate/FateId.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/FateId.java
@@ -140,11 +140,10 @@ public class FateId extends AbstractId<FateId> {
     FateInstanceType type;
     String txUUIDStr = tFateId.getTxUUIDStr();
 
-      type = switch (tFateId.getType()) {
-          case USER -> FateInstanceType.USER;
-          case META -> FateInstanceType.META;
-          default -> throw new IllegalArgumentException("Invalid TFateInstanceType: " + tFateId.getType());
-      };
+    type = switch (tFateId.getType()) {
+      case USER -> FateInstanceType.USER;
+      case META -> FateInstanceType.META;
+    };
 
     if (isUUID(txUUIDStr, 0)) {
       return new FateId(PREFIX + type + ":" + txUUIDStr);
@@ -160,11 +159,10 @@ public class FateId extends AbstractId<FateId> {
   public TFateId toThrift() {
     TFateInstanceType thriftType;
     FateInstanceType type = getType();
-      thriftType = switch (type) {
-          case USER -> TFateInstanceType.USER;
-          case META -> TFateInstanceType.META;
-          default -> throw new IllegalArgumentException("Invalid FateInstanceType: " + type);
-      };
+    thriftType = switch (type) {
+      case USER -> TFateInstanceType.USER;
+      case META -> TFateInstanceType.META;
+    };
     return new TFateId(thriftType, getTxUUIDStr());
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/fate/FateId.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/FateId.java
@@ -137,14 +137,12 @@ public class FateId extends AbstractId<FateId> {
    * @return the FateId equivalent of the given TFateId
    */
   public static FateId fromThrift(TFateId tFateId) {
-    FateInstanceType type;
-    String txUUIDStr = tFateId.getTxUUIDStr();
-
-    type = switch (tFateId.getType()) {
+    FateInstanceType type = switch (tFateId.getType()) {
       case USER -> FateInstanceType.USER;
       case META -> FateInstanceType.META;
     };
 
+    String txUUIDStr = tFateId.getTxUUIDStr();
     if (isUUID(txUUIDStr, 0)) {
       return new FateId(PREFIX + type + ":" + txUUIDStr);
     } else {
@@ -157,9 +155,8 @@ public class FateId extends AbstractId<FateId> {
    * @return the TFateId equivalent of the FateId
    */
   public TFateId toThrift() {
-    TFateInstanceType thriftType;
     FateInstanceType type = getType();
-    thriftType = switch (type) {
+    TFateInstanceType thriftType = switch (type) {
       case USER -> TFateInstanceType.USER;
       case META -> TFateInstanceType.META;
     };

--- a/core/src/main/java/org/apache/accumulo/core/fate/FateId.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/FateId.java
@@ -140,16 +140,11 @@ public class FateId extends AbstractId<FateId> {
     FateInstanceType type;
     String txUUIDStr = tFateId.getTxUUIDStr();
 
-    switch (tFateId.getType()) {
-      case USER:
-        type = FateInstanceType.USER;
-        break;
-      case META:
-        type = FateInstanceType.META;
-        break;
-      default:
-        throw new IllegalArgumentException("Invalid TFateInstanceType: " + tFateId.getType());
-    }
+      type = switch (tFateId.getType()) {
+          case USER -> FateInstanceType.USER;
+          case META -> FateInstanceType.META;
+          default -> throw new IllegalArgumentException("Invalid TFateInstanceType: " + tFateId.getType());
+      };
 
     if (isUUID(txUUIDStr, 0)) {
       return new FateId(PREFIX + type + ":" + txUUIDStr);
@@ -165,16 +160,11 @@ public class FateId extends AbstractId<FateId> {
   public TFateId toThrift() {
     TFateInstanceType thriftType;
     FateInstanceType type = getType();
-    switch (type) {
-      case USER:
-        thriftType = TFateInstanceType.USER;
-        break;
-      case META:
-        thriftType = TFateInstanceType.META;
-        break;
-      default:
-        throw new IllegalArgumentException("Invalid FateInstanceType: " + type);
-    }
+      thriftType = switch (type) {
+          case USER -> TFateInstanceType.USER;
+          case META -> TFateInstanceType.META;
+          default -> throw new IllegalArgumentException("Invalid FateInstanceType: " + type);
+      };
     return new TFateId(thriftType, getTxUUIDStr());
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/fate/FateInstanceType.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/FateInstanceType.java
@@ -32,25 +32,19 @@ public enum FateInstanceType {
   }
 
   public TFateInstanceType toThrift() {
-    switch (this) {
-      case USER:
-        return TFateInstanceType.USER;
-      case META:
-        return TFateInstanceType.META;
-      default:
-        throw new IllegalStateException("Unknown FateInstance type " + this);
-    }
+      return switch (this) {
+          case USER -> TFateInstanceType.USER;
+          case META -> TFateInstanceType.META;
+          default -> throw new IllegalStateException("Unknown FateInstance type " + this);
+      };
   }
 
   public static FateInstanceType fromThrift(TFateInstanceType tfit) {
-    switch (tfit) {
-      case USER:
-        return FateInstanceType.USER;
-      case META:
-        return FateInstanceType.META;
-      default:
-        throw new IllegalStateException("Unknown type " + tfit);
-    }
+      return switch (tfit) {
+          case USER -> FateInstanceType.USER;
+          case META -> FateInstanceType.META;
+          default -> throw new IllegalStateException("Unknown type " + tfit);
+      };
   }
 
   public static FateInstanceType fromTableId(TableId tableId) {

--- a/core/src/main/java/org/apache/accumulo/core/fate/FateInstanceType.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/FateInstanceType.java
@@ -32,19 +32,17 @@ public enum FateInstanceType {
   }
 
   public TFateInstanceType toThrift() {
-      return switch (this) {
-          case USER -> TFateInstanceType.USER;
-          case META -> TFateInstanceType.META;
-          default -> throw new IllegalStateException("Unknown FateInstance type " + this);
-      };
+    return switch (this) {
+      case USER -> TFateInstanceType.USER;
+      case META -> TFateInstanceType.META;
+    };
   }
 
   public static FateInstanceType fromThrift(TFateInstanceType tfit) {
-      return switch (tfit) {
-          case USER -> FateInstanceType.USER;
-          case META -> FateInstanceType.META;
-          default -> throw new IllegalStateException("Unknown type " + tfit);
-      };
+    return switch (tfit) {
+      case USER -> FateInstanceType.USER;
+      case META -> FateInstanceType.META;
+    };
   }
 
   public static FateInstanceType fromTableId(TableId tableId) {

--- a/core/src/main/java/org/apache/accumulo/core/fate/FateKey.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/FateKey.java
@@ -153,28 +153,20 @@ public class FateKey {
 
   private static Optional<KeyExtent> deserializeKeyExtent(FateKeyType type, DataInputBuffer buffer)
       throws IOException {
-    switch (type) {
-      case SPLIT:
-      case MERGE:
-        return Optional.of(KeyExtent.readFrom(buffer));
-      case COMPACTION_COMMIT:
-        return Optional.empty();
-      default:
-        throw new IllegalStateException("Unexpected FateInstanceType found " + type);
-    }
+      return switch (type) {
+          case SPLIT, MERGE -> Optional.of(KeyExtent.readFrom(buffer));
+          case COMPACTION_COMMIT -> Optional.empty();
+          default -> throw new IllegalStateException("Unexpected FateInstanceType found " + type);
+      };
   }
 
   private static Optional<ExternalCompactionId> deserializeCompactionId(FateKeyType type,
       DataInputBuffer buffer) throws IOException {
-    switch (type) {
-      case SPLIT:
-      case MERGE:
-        return Optional.empty();
-      case COMPACTION_COMMIT:
-        return Optional.of(ExternalCompactionId.of(buffer.readUTF()));
-      default:
-        throw new IllegalStateException("Unexpected FateInstanceType found " + type);
-    }
+      return switch (type) {
+          case SPLIT, MERGE -> Optional.empty();
+          case COMPACTION_COMMIT -> Optional.of(ExternalCompactionId.of(buffer.readUTF()));
+          default -> throw new IllegalStateException("Unexpected FateInstanceType found " + type);
+      };
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/fate/FateKey.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/FateKey.java
@@ -153,20 +153,18 @@ public class FateKey {
 
   private static Optional<KeyExtent> deserializeKeyExtent(FateKeyType type, DataInputBuffer buffer)
       throws IOException {
-      return switch (type) {
-          case SPLIT, MERGE -> Optional.of(KeyExtent.readFrom(buffer));
-          case COMPACTION_COMMIT -> Optional.empty();
-          default -> throw new IllegalStateException("Unexpected FateInstanceType found " + type);
-      };
+    return switch (type) {
+      case SPLIT, MERGE -> Optional.of(KeyExtent.readFrom(buffer));
+      case COMPACTION_COMMIT -> Optional.empty();
+    };
   }
 
   private static Optional<ExternalCompactionId> deserializeCompactionId(FateKeyType type,
       DataInputBuffer buffer) throws IOException {
-      return switch (type) {
-          case SPLIT, MERGE -> Optional.empty();
-          case COMPACTION_COMMIT -> Optional.of(ExternalCompactionId.of(buffer.readUTF()));
-          default -> throw new IllegalStateException("Unexpected FateInstanceType found " + type);
-      };
+    return switch (type) {
+      case SPLIT, MERGE -> Optional.empty();
+      case COMPACTION_COMMIT -> Optional.of(ExternalCompactionId.of(buffer.readUTF()));
+    };
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/FateMutatorImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/FateMutatorImpl.java
@@ -244,18 +244,14 @@ public class FateMutatorImpl<T> implements FateMutator<T> {
         try {
           ConditionalWriter.Result result = writer.get().write(mutation);
 
-          switch (result.getStatus()) {
-            case ACCEPTED:
-              return Status.ACCEPTED;
-            case REJECTED:
-              return Status.REJECTED;
-            case UNKNOWN:
-              return Status.UNKNOWN;
-            default:
-              // do not expect other statuses
-              throw new IllegalStateException(
-                  "Unhandled status for mutation " + result.getStatus());
-          }
+            // do not expect other statuses
+            return switch (result.getStatus()) {
+                case ACCEPTED -> Status.ACCEPTED;
+                case REJECTED -> Status.REJECTED;
+                case UNKNOWN -> Status.UNKNOWN;
+                default -> throw new IllegalStateException(
+                        "Unhandled status for mutation " + result.getStatus());
+            };
 
         } catch (AccumuloException | AccumuloSecurityException e) {
           throw new RuntimeException(e);

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/FateMutatorImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/FateMutatorImpl.java
@@ -244,14 +244,14 @@ public class FateMutatorImpl<T> implements FateMutator<T> {
         try {
           ConditionalWriter.Result result = writer.get().write(mutation);
 
+          return switch (result.getStatus()) {
+            case ACCEPTED -> Status.ACCEPTED;
+            case REJECTED -> Status.REJECTED;
+            case UNKNOWN -> Status.UNKNOWN;
             // do not expect other statuses
-            return switch (result.getStatus()) {
-                case ACCEPTED -> Status.ACCEPTED;
-                case REJECTED -> Status.REJECTED;
-                case UNKNOWN -> Status.UNKNOWN;
-                default -> throw new IllegalStateException(
-                        "Unhandled status for mutation " + result.getStatus());
-            };
+            default -> throw new IllegalStateException(
+                "Unhandled status for mutation " + result.getStatus());
+          };
 
         } catch (AccumuloException | AccumuloSecurityException e) {
           throw new RuntimeException(e);

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/UserFateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/UserFateStore.java
@@ -569,14 +569,13 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
         scanner.setRange(getRow(fateId));
 
         final ColumnFQ cq = switch (txInfo) {
-            case FATE_OP -> TxAdminColumnFamily.FATE_OP_COLUMN;
-            case AUTO_CLEAN -> TxInfoColumnFamily.AUTO_CLEAN_COLUMN;
-            case EXCEPTION -> TxInfoColumnFamily.EXCEPTION_COLUMN;
-            case RETURN_VALUE -> TxInfoColumnFamily.RETURN_VALUE_COLUMN;
-            case TX_AGEOFF -> TxInfoColumnFamily.TX_AGEOFF_COLUMN;
-            default -> throw new IllegalArgumentException("Unexpected TxInfo type " + txInfo);
+          case FATE_OP -> TxAdminColumnFamily.FATE_OP_COLUMN;
+          case AUTO_CLEAN -> TxInfoColumnFamily.AUTO_CLEAN_COLUMN;
+          case EXCEPTION -> TxInfoColumnFamily.EXCEPTION_COLUMN;
+          case RETURN_VALUE -> TxInfoColumnFamily.RETURN_VALUE_COLUMN;
+          case TX_AGEOFF -> TxInfoColumnFamily.TX_AGEOFF_COLUMN;
         };
-          scanner.fetchColumn(cq.getColumnFamily(), cq.getColumnQualifier());
+        scanner.fetchColumn(cq.getColumnFamily(), cq.getColumnQualifier());
 
         return scanner.stream().map(e -> deserializeTxInfo(txInfo, e.getValue().get())).findFirst()
             .orElse(null);

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/UserFateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/UserFateStore.java
@@ -568,27 +568,15 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
       try (Scanner scanner = context.createScanner(tableName, Authorizations.EMPTY)) {
         scanner.setRange(getRow(fateId));
 
-        final ColumnFQ cq;
-        switch (txInfo) {
-          case FATE_OP:
-            cq = TxAdminColumnFamily.FATE_OP_COLUMN;
-            break;
-          case AUTO_CLEAN:
-            cq = TxInfoColumnFamily.AUTO_CLEAN_COLUMN;
-            break;
-          case EXCEPTION:
-            cq = TxInfoColumnFamily.EXCEPTION_COLUMN;
-            break;
-          case RETURN_VALUE:
-            cq = TxInfoColumnFamily.RETURN_VALUE_COLUMN;
-            break;
-          case TX_AGEOFF:
-            cq = TxInfoColumnFamily.TX_AGEOFF_COLUMN;
-            break;
-          default:
-            throw new IllegalArgumentException("Unexpected TxInfo type " + txInfo);
-        }
-        scanner.fetchColumn(cq.getColumnFamily(), cq.getColumnQualifier());
+        final ColumnFQ cq = switch (txInfo) {
+            case FATE_OP -> TxAdminColumnFamily.FATE_OP_COLUMN;
+            case AUTO_CLEAN -> TxInfoColumnFamily.AUTO_CLEAN_COLUMN;
+            case EXCEPTION -> TxInfoColumnFamily.EXCEPTION_COLUMN;
+            case RETURN_VALUE -> TxInfoColumnFamily.RETURN_VALUE_COLUMN;
+            case TX_AGEOFF -> TxInfoColumnFamily.TX_AGEOFF_COLUMN;
+            default -> throw new IllegalArgumentException("Unexpected TxInfo type " + txInfo);
+        };
+          scanner.fetchColumn(cq.getColumnFamily(), cq.getColumnQualifier());
 
         return scanner.stream().map(e -> deserializeTxInfo(txInfo, e.getValue().get())).findFirst()
             .orElse(null);

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/DistributedReadWriteLock.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/DistributedReadWriteLock.java
@@ -231,12 +231,12 @@ public class DistributedReadWriteLock implements java.util.concurrent.locks.Read
       case 1:
         var entry = entries.entrySet().iterator().next();
         FateLockEntry lockEntry = entry.getValue().get();
-          return switch (lockEntry.getLockType()) {
-              case READ -> new ReadLock(qlock, lockEntry.getFateId(), lockEntry.getRange(), entry.getKey());
-              case WRITE -> new WriteLock(qlock, lockEntry.getFateId(), lockEntry.getRange(),
-                      entry.getKey());
-              default -> throw new IllegalStateException("Unknown lock type " + lockEntry.getLockType());
-          };
+        return switch (lockEntry.getLockType()) {
+          case READ ->
+            new ReadLock(qlock, lockEntry.getFateId(), lockEntry.getRange(), entry.getKey());
+          case WRITE ->
+            new WriteLock(qlock, lockEntry.getFateId(), lockEntry.getRange(), entry.getKey());
+        };
       default:
         throw new IllegalStateException("Found more than one lock node " + entries);
     }

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/DistributedReadWriteLock.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/DistributedReadWriteLock.java
@@ -231,15 +231,12 @@ public class DistributedReadWriteLock implements java.util.concurrent.locks.Read
       case 1:
         var entry = entries.entrySet().iterator().next();
         FateLockEntry lockEntry = entry.getValue().get();
-        switch (lockEntry.getLockType()) {
-          case READ:
-            return new ReadLock(qlock, lockEntry.getFateId(), lockEntry.getRange(), entry.getKey());
-          case WRITE:
-            return new WriteLock(qlock, lockEntry.getFateId(), lockEntry.getRange(),
-                entry.getKey());
-          default:
-            throw new IllegalStateException("Unknown lock type " + lockEntry.getLockType());
-        }
+          return switch (lockEntry.getLockType()) {
+              case READ -> new ReadLock(qlock, lockEntry.getFateId(), lockEntry.getRange(), entry.getKey());
+              case WRITE -> new WriteLock(qlock, lockEntry.getFateId(), lockEntry.getRange(),
+                      entry.getKey());
+              default -> throw new IllegalStateException("Unknown lock type " + lockEntry.getLockType());
+          };
       default:
         throw new IllegalStateException("Found more than one lock node " + entries);
     }

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/impl/BlockCacheConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/impl/BlockCacheConfiguration.java
@@ -68,12 +68,11 @@ public class BlockCacheConfiguration implements Configuration {
 
   @Override
   public long getMaxSize(CacheType type) {
-      return switch (type) {
-          case INDEX -> indexMaxSize;
-          case DATA -> dataMaxSize;
-          case SUMMARY -> summaryMaxSize;
-          default -> throw new IllegalArgumentException("Unknown block cache type");
-      };
+    return switch (type) {
+      case INDEX -> indexMaxSize;
+      case DATA -> dataMaxSize;
+      case SUMMARY -> summaryMaxSize;
+    };
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/impl/BlockCacheConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/impl/BlockCacheConfiguration.java
@@ -68,16 +68,12 @@ public class BlockCacheConfiguration implements Configuration {
 
   @Override
   public long getMaxSize(CacheType type) {
-    switch (type) {
-      case INDEX:
-        return indexMaxSize;
-      case DATA:
-        return dataMaxSize;
-      case SUMMARY:
-        return summaryMaxSize;
-      default:
-        throw new IllegalArgumentException("Unknown block cache type");
-    }
+      return switch (type) {
+          case INDEX -> indexMaxSize;
+          case DATA -> dataMaxSize;
+          case SUMMARY -> summaryMaxSize;
+          default -> throw new IllegalArgumentException("Unknown block cache type");
+      };
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/bcfile/Utils.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/bcfile/Utils.java
@@ -185,24 +185,25 @@ public final class Utils {
       return firstByte;
     }
 
-      return switch ((firstByte + 128) / 8) {
-          case 11, 10, 9, 8, 7 -> ((firstByte + 52L) << 8) | in.readUnsignedByte();
-          case 6, 5, 4, 3 -> ((firstByte + 88L) << 16) | in.readUnsignedShort();
-          case 2, 1 -> ((firstByte + 112L) << 24) | (in.readUnsignedShort() << 8) | in.readUnsignedByte();
-          case 0 -> {
-              int len = firstByte + 129;
-              yield switch (len) {
-                  case 4 -> in.readInt();
-                  case 5 -> ((long) in.readInt()) << 8 | in.readUnsignedByte();
-                  case 6 -> ((long) in.readInt()) << 16 | in.readUnsignedShort();
-                  case 7 -> ((long) in.readInt()) << 24 | (in.readUnsignedShort() << 8)
-                          | in.readUnsignedByte();
-                  case 8 -> in.readLong();
-                  default -> throw new IOException("Corrupted VLong encoding");
-              };
-          }
-          default -> throw new IllegalStateException("Internal error");
-      };
+    return switch ((firstByte + 128) / 8) {
+      case 11, 10, 9, 8, 7 -> ((firstByte + 52L) << 8) | in.readUnsignedByte();
+      case 6, 5, 4, 3 -> ((firstByte + 88L) << 16) | in.readUnsignedShort();
+      case 2, 1 ->
+        ((firstByte + 112L) << 24) | (in.readUnsignedShort() << 8) | in.readUnsignedByte();
+      case 0 -> {
+        int len = firstByte + 129;
+        yield switch (len) {
+          case 4 -> in.readInt();
+          case 5 -> ((long) in.readInt()) << 8 | in.readUnsignedByte();
+          case 6 -> ((long) in.readInt()) << 16 | in.readUnsignedShort();
+          case 7 ->
+            ((long) in.readInt()) << 24 | (in.readUnsignedShort() << 8) | in.readUnsignedByte();
+          case 8 -> in.readLong();
+          default -> throw new IOException("Corrupted VLong encoding");
+        };
+      }
+      default -> throw new IllegalStateException("Internal error");
+    };
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/bcfile/Utils.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/bcfile/Utils.java
@@ -185,41 +185,24 @@ public final class Utils {
       return firstByte;
     }
 
-    switch ((firstByte + 128) / 8) {
-      case 11:
-      case 10:
-      case 9:
-      case 8:
-      case 7:
-        return ((firstByte + 52L) << 8) | in.readUnsignedByte();
-      case 6:
-      case 5:
-      case 4:
-      case 3:
-        return ((firstByte + 88L) << 16) | in.readUnsignedShort();
-      case 2:
-      case 1:
-        return ((firstByte + 112L) << 24) | (in.readUnsignedShort() << 8) | in.readUnsignedByte();
-      case 0:
-        int len = firstByte + 129;
-        switch (len) {
-          case 4:
-            return in.readInt();
-          case 5:
-            return ((long) in.readInt()) << 8 | in.readUnsignedByte();
-          case 6:
-            return ((long) in.readInt()) << 16 | in.readUnsignedShort();
-          case 7:
-            return ((long) in.readInt()) << 24 | (in.readUnsignedShort() << 8)
-                | in.readUnsignedByte();
-          case 8:
-            return in.readLong();
-          default:
-            throw new IOException("Corrupted VLong encoding");
-        }
-      default:
-        throw new IllegalStateException("Internal error");
-    }
+      return switch ((firstByte + 128) / 8) {
+          case 11, 10, 9, 8, 7 -> ((firstByte + 52L) << 8) | in.readUnsignedByte();
+          case 6, 5, 4, 3 -> ((firstByte + 88L) << 16) | in.readUnsignedShort();
+          case 2, 1 -> ((firstByte + 112L) << 24) | (in.readUnsignedShort() << 8) | in.readUnsignedByte();
+          case 0 -> {
+              int len = firstByte + 129;
+              yield switch (len) {
+                  case 4 -> in.readInt();
+                  case 5 -> ((long) in.readInt()) << 8 | in.readUnsignedByte();
+                  case 6 -> ((long) in.readInt()) << 16 | in.readUnsignedShort();
+                  case 7 -> ((long) in.readInt()) << 24 | (in.readUnsignedShort() << 8)
+                          | in.readUnsignedByte();
+                  case 8 -> in.readLong();
+                  default -> throw new IOException("Corrupted VLong encoding");
+              };
+          }
+          default -> throw new IllegalStateException("Internal error");
+      };
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/TransformingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/TransformingIterator.java
@@ -510,19 +510,20 @@ public abstract class TransformingIterator extends WrappingIterator implements O
    */
   protected boolean isSetAfterPart(Key key, PartialKey part) {
     if (key != null) {
-        return switch (part) {
-            case ROW -> key.getColumnFamilyData().length() > 0 || key.getColumnQualifierData().length() > 0
-                    || key.getColumnVisibilityData().length() > 0 || key.getTimestamp() < Long.MAX_VALUE
-                    || key.isDeleted();
-            case ROW_COLFAM -> key.getColumnQualifierData().length() > 0
-                    || key.getColumnVisibilityData().length() > 0 || key.getTimestamp() < Long.MAX_VALUE
-                    || key.isDeleted();
-            case ROW_COLFAM_COLQUAL -> key.getColumnVisibilityData().length() > 0 || key.getTimestamp() < Long.MAX_VALUE
-                    || key.isDeleted();
-            case ROW_COLFAM_COLQUAL_COLVIS -> key.getTimestamp() < Long.MAX_VALUE || key.isDeleted();
-            case ROW_COLFAM_COLQUAL_COLVIS_TIME -> key.isDeleted();
-            case ROW_COLFAM_COLQUAL_COLVIS_TIME_DEL -> false;
-        };
+      return switch (part) {
+        case ROW ->
+          key.getColumnFamilyData().length() > 0 || key.getColumnQualifierData().length() > 0
+              || key.getColumnVisibilityData().length() > 0 || key.getTimestamp() < Long.MAX_VALUE
+              || key.isDeleted();
+        case ROW_COLFAM ->
+          key.getColumnQualifierData().length() > 0 || key.getColumnVisibilityData().length() > 0
+              || key.getTimestamp() < Long.MAX_VALUE || key.isDeleted();
+        case ROW_COLFAM_COLQUAL -> key.getColumnVisibilityData().length() > 0
+            || key.getTimestamp() < Long.MAX_VALUE || key.isDeleted();
+        case ROW_COLFAM_COLQUAL_COLVIS -> key.getTimestamp() < Long.MAX_VALUE || key.isDeleted();
+        case ROW_COLFAM_COLQUAL_COLVIS_TIME -> key.isDeleted();
+        case ROW_COLFAM_COLQUAL_COLVIS_TIME_DEL -> false;
+      };
     }
     return false;
   }
@@ -538,16 +539,17 @@ public abstract class TransformingIterator extends WrappingIterator implements O
    */
   protected Key copyPartialKey(Key key, PartialKey part) {
     Key keyCopy = switch (part) {
-        case ROW -> new Key(key.getRow());
-        case ROW_COLFAM -> new Key(key.getRow(), key.getColumnFamily());
-        case ROW_COLFAM_COLQUAL -> new Key(key.getRow(), key.getColumnFamily(), key.getColumnQualifier());
-        case ROW_COLFAM_COLQUAL_COLVIS -> new Key(key.getRow(), key.getColumnFamily(), key.getColumnQualifier(),
-                key.getColumnVisibility());
-        case ROW_COLFAM_COLQUAL_COLVIS_TIME -> new Key(key.getRow(), key.getColumnFamily(), key.getColumnQualifier(),
-                key.getColumnVisibility(), key.getTimestamp());
-        default -> throw new IllegalArgumentException("Unsupported key part: " + part);
+      case ROW -> new Key(key.getRow());
+      case ROW_COLFAM -> new Key(key.getRow(), key.getColumnFamily());
+      case ROW_COLFAM_COLQUAL ->
+        new Key(key.getRow(), key.getColumnFamily(), key.getColumnQualifier());
+      case ROW_COLFAM_COLQUAL_COLVIS -> new Key(key.getRow(), key.getColumnFamily(),
+          key.getColumnQualifier(), key.getColumnVisibility());
+      case ROW_COLFAM_COLQUAL_COLVIS_TIME -> new Key(key.getRow(), key.getColumnFamily(),
+          key.getColumnQualifier(), key.getColumnVisibility(), key.getTimestamp());
+      default -> throw new IllegalArgumentException("Unsupported key part: " + part);
     };
-      return keyCopy;
+    return keyCopy;
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/TransformingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/TransformingIterator.java
@@ -510,25 +510,19 @@ public abstract class TransformingIterator extends WrappingIterator implements O
    */
   protected boolean isSetAfterPart(Key key, PartialKey part) {
     if (key != null) {
-      switch (part) {
-        case ROW:
-          return key.getColumnFamilyData().length() > 0 || key.getColumnQualifierData().length() > 0
-              || key.getColumnVisibilityData().length() > 0 || key.getTimestamp() < Long.MAX_VALUE
-              || key.isDeleted();
-        case ROW_COLFAM:
-          return key.getColumnQualifierData().length() > 0
-              || key.getColumnVisibilityData().length() > 0 || key.getTimestamp() < Long.MAX_VALUE
-              || key.isDeleted();
-        case ROW_COLFAM_COLQUAL:
-          return key.getColumnVisibilityData().length() > 0 || key.getTimestamp() < Long.MAX_VALUE
-              || key.isDeleted();
-        case ROW_COLFAM_COLQUAL_COLVIS:
-          return key.getTimestamp() < Long.MAX_VALUE || key.isDeleted();
-        case ROW_COLFAM_COLQUAL_COLVIS_TIME:
-          return key.isDeleted();
-        case ROW_COLFAM_COLQUAL_COLVIS_TIME_DEL:
-          return false;
-      }
+        return switch (part) {
+            case ROW -> key.getColumnFamilyData().length() > 0 || key.getColumnQualifierData().length() > 0
+                    || key.getColumnVisibilityData().length() > 0 || key.getTimestamp() < Long.MAX_VALUE
+                    || key.isDeleted();
+            case ROW_COLFAM -> key.getColumnQualifierData().length() > 0
+                    || key.getColumnVisibilityData().length() > 0 || key.getTimestamp() < Long.MAX_VALUE
+                    || key.isDeleted();
+            case ROW_COLFAM_COLQUAL -> key.getColumnVisibilityData().length() > 0 || key.getTimestamp() < Long.MAX_VALUE
+                    || key.isDeleted();
+            case ROW_COLFAM_COLQUAL_COLVIS -> key.getTimestamp() < Long.MAX_VALUE || key.isDeleted();
+            case ROW_COLFAM_COLQUAL_COLVIS_TIME -> key.isDeleted();
+            case ROW_COLFAM_COLQUAL_COLVIS_TIME_DEL -> false;
+        };
     }
     return false;
   }
@@ -543,29 +537,17 @@ public abstract class TransformingIterator extends WrappingIterator implements O
    * @return the new key containing {@code part} of {@code key}
    */
   protected Key copyPartialKey(Key key, PartialKey part) {
-    Key keyCopy;
-    switch (part) {
-      case ROW:
-        keyCopy = new Key(key.getRow());
-        break;
-      case ROW_COLFAM:
-        keyCopy = new Key(key.getRow(), key.getColumnFamily());
-        break;
-      case ROW_COLFAM_COLQUAL:
-        keyCopy = new Key(key.getRow(), key.getColumnFamily(), key.getColumnQualifier());
-        break;
-      case ROW_COLFAM_COLQUAL_COLVIS:
-        keyCopy = new Key(key.getRow(), key.getColumnFamily(), key.getColumnQualifier(),
-            key.getColumnVisibility());
-        break;
-      case ROW_COLFAM_COLQUAL_COLVIS_TIME:
-        keyCopy = new Key(key.getRow(), key.getColumnFamily(), key.getColumnQualifier(),
-            key.getColumnVisibility(), key.getTimestamp());
-        break;
-      default:
-        throw new IllegalArgumentException("Unsupported key part: " + part);
-    }
-    return keyCopy;
+    Key keyCopy = switch (part) {
+        case ROW -> new Key(key.getRow());
+        case ROW_COLFAM -> new Key(key.getRow(), key.getColumnFamily());
+        case ROW_COLFAM_COLQUAL -> new Key(key.getRow(), key.getColumnFamily(), key.getColumnQualifier());
+        case ROW_COLFAM_COLQUAL_COLVIS -> new Key(key.getRow(), key.getColumnFamily(), key.getColumnQualifier(),
+                key.getColumnVisibility());
+        case ROW_COLFAM_COLQUAL_COLVIS_TIME -> new Key(key.getRow(), key.getColumnFamily(), key.getColumnQualifier(),
+                key.getColumnVisibility(), key.getTimestamp());
+        default -> throw new IllegalArgumentException("Unsupported key part: " + part);
+    };
+      return keyCopy;
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/IteratorConfigUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/IteratorConfigUtil.java
@@ -62,16 +62,12 @@ public class IteratorConfigUtil {
    */
   public static Property getProperty(IteratorScope scope) {
     requireNonNull(scope);
-    switch (scope) {
-      case scan:
-        return Property.TABLE_ITERATOR_SCAN_PREFIX;
-      case minc:
-        return Property.TABLE_ITERATOR_MINC_PREFIX;
-      case majc:
-        return Property.TABLE_ITERATOR_MAJC_PREFIX;
-      default:
-        throw new IllegalStateException("Could not find configuration property for IteratorScope");
-    }
+      return switch (scope) {
+          case scan -> Property.TABLE_ITERATOR_SCAN_PREFIX;
+          case minc -> Property.TABLE_ITERATOR_MINC_PREFIX;
+          case majc -> Property.TABLE_ITERATOR_MAJC_PREFIX;
+          default -> throw new IllegalStateException("Could not find configuration property for IteratorScope");
+      };
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/IteratorConfigUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/IteratorConfigUtil.java
@@ -62,12 +62,11 @@ public class IteratorConfigUtil {
    */
   public static Property getProperty(IteratorScope scope) {
     requireNonNull(scope);
-      return switch (scope) {
-          case scan -> Property.TABLE_ITERATOR_SCAN_PREFIX;
-          case minc -> Property.TABLE_ITERATOR_MINC_PREFIX;
-          case majc -> Property.TABLE_ITERATOR_MAJC_PREFIX;
-          default -> throw new IllegalStateException("Could not find configuration property for IteratorScope");
-      };
+    return switch (scope) {
+      case scan -> Property.TABLE_ITERATOR_SCAN_PREFIX;
+      case minc -> Property.TABLE_ITERATOR_MINC_PREFIX;
+      case majc -> Property.TABLE_ITERATOR_MAJC_PREFIX;
+    };
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/DeletingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/DeletingIterator.java
@@ -116,23 +116,20 @@ public class DeletingIterator extends ServerWrappingIterator {
 
   public static SortedKeyValueIterator<Key,Value> wrap(SortedKeyValueIterator<Key,Value> source,
       boolean propagateDeletes, Behavior behavior) {
-    switch (behavior) {
-      case PROCESS:
-        return new DeletingIterator(source, propagateDeletes);
-      case FAIL:
-        return new ServerWrappingIterator(source) {
-          @Override
-          public Key getTopKey() {
-            Key top = source.getTopKey();
-            if (top.isDeleted()) {
-              throw new IllegalStateException("Saw unexpected delete " + top);
-            }
-            return top;
-          }
-        };
-      default:
-        throw new IllegalArgumentException("Unknown behavior " + behavior);
-    }
+      return switch (behavior) {
+          case PROCESS -> new DeletingIterator(source, propagateDeletes);
+          case FAIL -> new ServerWrappingIterator(source) {
+              @Override
+              public Key getTopKey() {
+                  Key top = source.getTopKey();
+                  if (top.isDeleted()) {
+                      throw new IllegalStateException("Saw unexpected delete " + top);
+                  }
+                  return top;
+              }
+          };
+          default -> throw new IllegalArgumentException("Unknown behavior " + behavior);
+      };
   }
 
   public static Behavior getBehavior(AccumuloConfiguration conf) {

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/DeletingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/DeletingIterator.java
@@ -116,20 +116,19 @@ public class DeletingIterator extends ServerWrappingIterator {
 
   public static SortedKeyValueIterator<Key,Value> wrap(SortedKeyValueIterator<Key,Value> source,
       boolean propagateDeletes, Behavior behavior) {
-      return switch (behavior) {
-          case PROCESS -> new DeletingIterator(source, propagateDeletes);
-          case FAIL -> new ServerWrappingIterator(source) {
-              @Override
-              public Key getTopKey() {
-                  Key top = source.getTopKey();
-                  if (top.isDeleted()) {
-                      throw new IllegalStateException("Saw unexpected delete " + top);
-                  }
-                  return top;
-              }
-          };
-          default -> throw new IllegalArgumentException("Unknown behavior " + behavior);
+    return switch (behavior) {
+      case PROCESS -> new DeletingIterator(source, propagateDeletes);
+      case FAIL -> new ServerWrappingIterator(source) {
+        @Override
+        public Key getTopKey() {
+          Key top = source.getTopKey();
+          if (top.isDeleted()) {
+            throw new IllegalStateException("Saw unexpected delete " + top);
+          }
+          return top;
+        }
       };
+    };
   }
 
   public static Behavior getBehavior(AccumuloConfiguration conf) {

--- a/core/src/main/java/org/apache/accumulo/core/lock/ServiceLockPaths.java
+++ b/core/src/main/java/org/apache/accumulo/core/lock/ServiceLockPaths.java
@@ -216,18 +216,13 @@ public class ServiceLockPaths {
             "Unhandled zookeeper service path : " + path);
         final String server = pathParts[pathParts.length - 1];
         final String resourceGroup = pathParts[pathParts.length - 2];
-        switch (type) {
-          case Constants.ZMINI_LOCK:
-            return new ServiceLockPath(type, server);
-          case Constants.ZCOMPACTORS:
-          case Constants.ZSSERVERS:
-          case Constants.ZTSERVERS:
-          case Constants.ZDEADTSERVERS:
-            return new ServiceLockPath(type, ResourceGroupId.of(resourceGroup),
-                HostAndPort.fromString(server));
-          default:
-            throw new IllegalArgumentException("Unhandled zookeeper service path : " + path);
-        }
+          return switch (type) {
+              case Constants.ZMINI_LOCK -> new ServiceLockPath(type, server);
+              case Constants.ZCOMPACTORS, Constants.ZSSERVERS, Constants.ZTSERVERS, Constants.ZDEADTSERVERS ->
+                      new ServiceLockPath(type, ResourceGroupId.of(resourceGroup),
+                              HostAndPort.fromString(server));
+              default -> throw new IllegalArgumentException("Unhandled zookeeper service path : " + path);
+          };
       }
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/lock/ServiceLockPaths.java
+++ b/core/src/main/java/org/apache/accumulo/core/lock/ServiceLockPaths.java
@@ -216,13 +216,15 @@ public class ServiceLockPaths {
             "Unhandled zookeeper service path : " + path);
         final String server = pathParts[pathParts.length - 1];
         final String resourceGroup = pathParts[pathParts.length - 2];
-          return switch (type) {
-              case Constants.ZMINI_LOCK -> new ServiceLockPath(type, server);
-              case Constants.ZCOMPACTORS, Constants.ZSSERVERS, Constants.ZTSERVERS, Constants.ZDEADTSERVERS ->
-                      new ServiceLockPath(type, ResourceGroupId.of(resourceGroup),
-                              HostAndPort.fromString(server));
-              default -> throw new IllegalArgumentException("Unhandled zookeeper service path : " + path);
-          };
+        return switch (type) {
+          case Constants.ZMINI_LOCK -> new ServiceLockPath(type, server);
+          case Constants.ZCOMPACTORS, Constants.ZSSERVERS, Constants.ZTSERVERS,
+              Constants.ZDEADTSERVERS ->
+            new ServiceLockPath(type, ResourceGroupId.of(resourceGroup),
+                HostAndPort.fromString(server));
+          default ->
+            throw new IllegalArgumentException("Unhandled zookeeper service path : " + path);
+        };
       }
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataTime.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataTime.java
@@ -58,23 +58,23 @@ public final class MetadataTime implements Comparable<MetadataTime> {
    * @return a TimeType {@link TimeType} represented by code.
    */
   public static TimeType getType(char code) {
-      return switch (code) {
-          case 'M' -> TimeType.MILLIS;
-          case 'L' -> TimeType.LOGICAL;
-          default -> throw new IllegalArgumentException("Unknown time type code : " + code);
-      };
+    return switch (code) {
+      case 'M' -> TimeType.MILLIS;
+      case 'L' -> TimeType.LOGICAL;
+      default -> throw new IllegalArgumentException("Unknown time type code : " + code);
+    };
   }
 
   /**
    * @return the single char code of this objects timeType
    */
   public static char getCode(TimeType type) {
-      // this should never happen
-      return switch (type) {
-          case MILLIS -> 'M';
-          case LOGICAL -> 'L';
-          default -> throw new IllegalArgumentException("Unknown time type: " + type);
-      };
+    // this should never happen
+    return switch (type) {
+      case MILLIS -> 'M';
+      case LOGICAL -> 'L';
+      default -> throw new IllegalArgumentException("Unknown time type: " + type);
+    };
   }
 
   public char getCode() {

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataTime.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataTime.java
@@ -58,28 +58,23 @@ public final class MetadataTime implements Comparable<MetadataTime> {
    * @return a TimeType {@link TimeType} represented by code.
    */
   public static TimeType getType(char code) {
-    switch (code) {
-      case 'M':
-        return TimeType.MILLIS;
-      case 'L':
-        return TimeType.LOGICAL;
-      default:
-        throw new IllegalArgumentException("Unknown time type code : " + code);
-    }
+      return switch (code) {
+          case 'M' -> TimeType.MILLIS;
+          case 'L' -> TimeType.LOGICAL;
+          default -> throw new IllegalArgumentException("Unknown time type code : " + code);
+      };
   }
 
   /**
    * @return the single char code of this objects timeType
    */
   public static char getCode(TimeType type) {
-    switch (type) {
-      case MILLIS:
-        return 'M';
-      case LOGICAL:
-        return 'L';
-      default: // this should never happen
-        throw new IllegalArgumentException("Unknown time type: " + type);
-    }
+      // this should never happen
+      return switch (type) {
+          case MILLIS -> 'M';
+          case LOGICAL -> 'L';
+          default -> throw new IllegalArgumentException("Unknown time type: " + type);
+      };
   }
 
   public char getCode() {

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataTime.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataTime.java
@@ -69,11 +69,9 @@ public final class MetadataTime implements Comparable<MetadataTime> {
    * @return the single char code of this objects timeType
    */
   public static char getCode(TimeType type) {
-    // this should never happen
     return switch (type) {
       case MILLIS -> 'M';
       case LOGICAL -> 'L';
-      default -> throw new IllegalArgumentException("Unknown time type: " + type);
     };
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMutatorBase.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMutatorBase.java
@@ -153,21 +153,19 @@ public abstract class TabletMutatorBase<T extends Ample.TabletUpdates<T>>
   }
 
   protected String getLocationFamily(LocationType type) {
-      return switch (type) {
-          case CURRENT -> CurrentLocationColumnFamily.STR_NAME;
-          case FUTURE -> FutureLocationColumnFamily.STR_NAME;
-          case LAST -> LastLocationColumnFamily.STR_NAME;
-          default -> throw new IllegalArgumentException();
-      };
+    return switch (type) {
+      case CURRENT -> CurrentLocationColumnFamily.STR_NAME;
+      case FUTURE -> FutureLocationColumnFamily.STR_NAME;
+      case LAST -> LastLocationColumnFamily.STR_NAME;
+    };
   }
 
   protected Text getLocationFamilyText(LocationType type) {
-      return switch (type) {
-          case CURRENT -> CurrentLocationColumnFamily.NAME;
-          case FUTURE -> FutureLocationColumnFamily.NAME;
-          case LAST -> LastLocationColumnFamily.NAME;
-          default -> throw new IllegalArgumentException();
-      };
+    return switch (type) {
+      case CURRENT -> CurrentLocationColumnFamily.NAME;
+      case FUTURE -> FutureLocationColumnFamily.NAME;
+      case LAST -> LastLocationColumnFamily.NAME;
+    };
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMutatorBase.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMutatorBase.java
@@ -153,29 +153,21 @@ public abstract class TabletMutatorBase<T extends Ample.TabletUpdates<T>>
   }
 
   protected String getLocationFamily(LocationType type) {
-    switch (type) {
-      case CURRENT:
-        return CurrentLocationColumnFamily.STR_NAME;
-      case FUTURE:
-        return FutureLocationColumnFamily.STR_NAME;
-      case LAST:
-        return LastLocationColumnFamily.STR_NAME;
-      default:
-        throw new IllegalArgumentException();
-    }
+      return switch (type) {
+          case CURRENT -> CurrentLocationColumnFamily.STR_NAME;
+          case FUTURE -> FutureLocationColumnFamily.STR_NAME;
+          case LAST -> LastLocationColumnFamily.STR_NAME;
+          default -> throw new IllegalArgumentException();
+      };
   }
 
   protected Text getLocationFamilyText(LocationType type) {
-    switch (type) {
-      case CURRENT:
-        return CurrentLocationColumnFamily.NAME;
-      case FUTURE:
-        return FutureLocationColumnFamily.NAME;
-      case LAST:
-        return LastLocationColumnFamily.NAME;
-      default:
-        throw new IllegalArgumentException();
-    }
+      return switch (type) {
+          case CURRENT -> CurrentLocationColumnFamily.NAME;
+          case FUTURE -> FutureLocationColumnFamily.NAME;
+          case LAST -> LastLocationColumnFamily.NAME;
+          default -> throw new IllegalArgumentException();
+      };
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/security/NamespacePermission.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/NamespacePermission.java
@@ -93,28 +93,28 @@ public enum NamespacePermission {
   }
 
   public static NamespacePermission getEquivalent(TablePermission permission) {
-      return switch (permission) {
-          case READ -> NamespacePermission.READ;
-          case WRITE -> NamespacePermission.WRITE;
-          case ALTER_TABLE -> NamespacePermission.ALTER_TABLE;
-          case GRANT -> NamespacePermission.GRANT;
-          case DROP_TABLE -> NamespacePermission.DROP_TABLE;
-          case BULK_IMPORT -> NamespacePermission.BULK_IMPORT;
-          default -> null;
-      };
+    return switch (permission) {
+      case READ -> NamespacePermission.READ;
+      case WRITE -> NamespacePermission.WRITE;
+      case ALTER_TABLE -> NamespacePermission.ALTER_TABLE;
+      case GRANT -> NamespacePermission.GRANT;
+      case DROP_TABLE -> NamespacePermission.DROP_TABLE;
+      case BULK_IMPORT -> NamespacePermission.BULK_IMPORT;
+      default -> null;
+    };
 
   }
 
   public static NamespacePermission getEquivalent(SystemPermission permission) {
-      return switch (permission) {
-          case CREATE_TABLE -> NamespacePermission.CREATE_TABLE;
-          case DROP_TABLE -> NamespacePermission.DROP_TABLE;
-          case ALTER_TABLE -> NamespacePermission.ALTER_TABLE;
-          case ALTER_NAMESPACE -> NamespacePermission.ALTER_NAMESPACE;
-          case DROP_NAMESPACE -> NamespacePermission.DROP_NAMESPACE;
-          case GRANT -> NamespacePermission.ALTER_NAMESPACE;
-          default -> null;
-      };
+    return switch (permission) {
+      case CREATE_TABLE -> NamespacePermission.CREATE_TABLE;
+      case DROP_TABLE -> NamespacePermission.DROP_TABLE;
+      case ALTER_TABLE -> NamespacePermission.ALTER_TABLE;
+      case ALTER_NAMESPACE -> NamespacePermission.ALTER_NAMESPACE;
+      case DROP_NAMESPACE -> NamespacePermission.DROP_NAMESPACE;
+      case GRANT -> NamespacePermission.ALTER_NAMESPACE;
+      default -> null;
+    };
   }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/security/NamespacePermission.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/NamespacePermission.java
@@ -93,47 +93,28 @@ public enum NamespacePermission {
   }
 
   public static NamespacePermission getEquivalent(TablePermission permission) {
-    switch (permission) {
-      case READ:
-        return NamespacePermission.READ;
-      case WRITE:
-        return NamespacePermission.WRITE;
-      case ALTER_TABLE:
-        return NamespacePermission.ALTER_TABLE;
-      case GRANT:
-        return NamespacePermission.GRANT;
-      case DROP_TABLE:
-        return NamespacePermission.DROP_TABLE;
-      case BULK_IMPORT:
-        return NamespacePermission.BULK_IMPORT;
-      default:
-        return null;
-    }
+      return switch (permission) {
+          case READ -> NamespacePermission.READ;
+          case WRITE -> NamespacePermission.WRITE;
+          case ALTER_TABLE -> NamespacePermission.ALTER_TABLE;
+          case GRANT -> NamespacePermission.GRANT;
+          case DROP_TABLE -> NamespacePermission.DROP_TABLE;
+          case BULK_IMPORT -> NamespacePermission.BULK_IMPORT;
+          default -> null;
+      };
 
   }
 
   public static NamespacePermission getEquivalent(SystemPermission permission) {
-    switch (permission) {
-      case CREATE_TABLE:
-        return NamespacePermission.CREATE_TABLE;
-      case DROP_TABLE:
-        return NamespacePermission.DROP_TABLE;
-      case ALTER_TABLE:
-        return NamespacePermission.ALTER_TABLE;
-      case ALTER_NAMESPACE:
-        return NamespacePermission.ALTER_NAMESPACE;
-      case DROP_NAMESPACE:
-        return NamespacePermission.DROP_NAMESPACE;
-      case GRANT:
-        return NamespacePermission.ALTER_NAMESPACE;
-      case CREATE_NAMESPACE:
-      case CREATE_USER:
-      case DROP_USER:
-      case ALTER_USER:
-      case SYSTEM:
-      default:
-        return null;
-    }
+      return switch (permission) {
+          case CREATE_TABLE -> NamespacePermission.CREATE_TABLE;
+          case DROP_TABLE -> NamespacePermission.DROP_TABLE;
+          case ALTER_TABLE -> NamespacePermission.ALTER_TABLE;
+          case ALTER_NAMESPACE -> NamespacePermission.ALTER_NAMESPACE;
+          case DROP_NAMESPACE -> NamespacePermission.DROP_NAMESPACE;
+          case GRANT -> NamespacePermission.ALTER_NAMESPACE;
+          default -> null;
+      };
   }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/spi/crypto/AESCryptoService.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/crypto/AESCryptoService.java
@@ -151,18 +151,17 @@ public class AESCryptoService implements CryptoService {
       return DISABLED;
     }
     CryptoModule cm;
-    switch (environment.getScope()) {
-      case WAL:
-        cm = new AESCBCCryptoModule(this.encryptingKek, this.keyLocation, this.keyManager);
-        return cm.getEncrypter();
-
-      case TABLE:
-        cm = new AESGCMCryptoModule(this.encryptingKek, this.keyLocation, this.keyManager);
-        return cm.getEncrypter();
-
-      default:
-        throw new CryptoException("Unknown scope: " + environment.getScope());
-    }
+      return switch (environment.getScope()) {
+          case WAL -> {
+              cm = new AESCBCCryptoModule(this.encryptingKek, this.keyLocation, this.keyManager);
+              yield cm.getEncrypter();
+          }
+          case TABLE -> {
+              cm = new AESGCMCryptoModule(this.encryptingKek, this.keyLocation, this.keyManager);
+              yield cm.getEncrypter();
+          }
+          default -> throw new CryptoException("Unknown scope: " + environment.getScope());
+      };
   }
 
   @Override
@@ -177,17 +176,18 @@ public class AESCryptoService implements CryptoService {
     ParsedCryptoParameters parsed = parseCryptoParameters(decryptionParams.orElseThrow());
     Key kek = loadDecryptionKek(parsed);
     Key fek = unwrapKey(parsed.getEncFek(), kek);
-    switch (parsed.getCryptoServiceVersion()) {
-      case AESCBCCryptoModule.VERSION:
-        cm = new AESCBCCryptoModule(this.encryptingKek, this.keyLocation, this.keyManager);
-        return cm.getDecrypter(fek);
-      case AESGCMCryptoModule.VERSION:
-        cm = new AESGCMCryptoModule(this.encryptingKek, this.keyLocation, this.keyManager);
-        return cm.getDecrypter(fek);
-      default:
-        throw new CryptoException(
-            "Unknown crypto module version: " + parsed.getCryptoServiceVersion());
-    }
+      return switch (parsed.getCryptoServiceVersion()) {
+          case AESCBCCryptoModule.VERSION -> {
+              cm = new AESCBCCryptoModule(this.encryptingKek, this.keyLocation, this.keyManager);
+              yield cm.getDecrypter(fek);
+          }
+          case AESGCMCryptoModule.VERSION -> {
+              cm = new AESGCMCryptoModule(this.encryptingKek, this.keyLocation, this.keyManager);
+              yield cm.getDecrypter(fek);
+          }
+          default -> throw new CryptoException(
+                  "Unknown crypto module version: " + parsed.getCryptoServiceVersion());
+      };
   }
 
   private static boolean checkNoCrypto(byte[] params) {
@@ -288,13 +288,10 @@ public class AESCryptoService implements CryptoService {
       return this.decryptingKeys.get(keyTag);
     }
 
-    switch (params.keyManagerVersion) {
-      case URI:
-        ret = loadKekFromUri(params.kekId);
-        break;
-      default:
-        throw new CryptoException("Unable to load kek: " + params.kekId);
-    }
+      ret = switch (params.keyManagerVersion) {
+          case URI -> loadKekFromUri(params.kekId);
+          default -> throw new CryptoException("Unable to load kek: " + params.kekId);
+      };
 
     this.decryptingKeys.put(keyTag, ret);
 

--- a/core/src/main/java/org/apache/accumulo/core/spi/crypto/AESCryptoService.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/crypto/AESCryptoService.java
@@ -151,17 +151,17 @@ public class AESCryptoService implements CryptoService {
       return DISABLED;
     }
     CryptoModule cm;
-      return switch (environment.getScope()) {
-          case WAL -> {
-              cm = new AESCBCCryptoModule(this.encryptingKek, this.keyLocation, this.keyManager);
-              yield cm.getEncrypter();
-          }
-          case TABLE -> {
-              cm = new AESGCMCryptoModule(this.encryptingKek, this.keyLocation, this.keyManager);
-              yield cm.getEncrypter();
-          }
-          default -> throw new CryptoException("Unknown scope: " + environment.getScope());
-      };
+    return switch (environment.getScope()) {
+      case WAL -> {
+        cm = new AESCBCCryptoModule(this.encryptingKek, this.keyLocation, this.keyManager);
+        yield cm.getEncrypter();
+      }
+      case TABLE -> {
+        cm = new AESGCMCryptoModule(this.encryptingKek, this.keyLocation, this.keyManager);
+        yield cm.getEncrypter();
+      }
+      default -> throw new CryptoException("Unknown scope: " + environment.getScope());
+    };
   }
 
   @Override
@@ -176,18 +176,18 @@ public class AESCryptoService implements CryptoService {
     ParsedCryptoParameters parsed = parseCryptoParameters(decryptionParams.orElseThrow());
     Key kek = loadDecryptionKek(parsed);
     Key fek = unwrapKey(parsed.getEncFek(), kek);
-      return switch (parsed.getCryptoServiceVersion()) {
-          case AESCBCCryptoModule.VERSION -> {
-              cm = new AESCBCCryptoModule(this.encryptingKek, this.keyLocation, this.keyManager);
-              yield cm.getDecrypter(fek);
-          }
-          case AESGCMCryptoModule.VERSION -> {
-              cm = new AESGCMCryptoModule(this.encryptingKek, this.keyLocation, this.keyManager);
-              yield cm.getDecrypter(fek);
-          }
-          default -> throw new CryptoException(
-                  "Unknown crypto module version: " + parsed.getCryptoServiceVersion());
-      };
+    return switch (parsed.getCryptoServiceVersion()) {
+      case AESCBCCryptoModule.VERSION -> {
+        cm = new AESCBCCryptoModule(this.encryptingKek, this.keyLocation, this.keyManager);
+        yield cm.getDecrypter(fek);
+      }
+      case AESGCMCryptoModule.VERSION -> {
+        cm = new AESGCMCryptoModule(this.encryptingKek, this.keyLocation, this.keyManager);
+        yield cm.getDecrypter(fek);
+      }
+      default -> throw new CryptoException(
+          "Unknown crypto module version: " + parsed.getCryptoServiceVersion());
+    };
   }
 
   private static boolean checkNoCrypto(byte[] params) {
@@ -288,10 +288,11 @@ public class AESCryptoService implements CryptoService {
       return this.decryptingKeys.get(keyTag);
     }
 
-      ret = switch (params.keyManagerVersion) {
-          case URI -> loadKekFromUri(params.kekId);
-          default -> throw new CryptoException("Unable to load kek: " + params.kekId);
-      };
+    if (params.keyManagerVersion.equals(URI)) {
+      ret = loadKekFromUri(params.kekId);
+    } else {
+      throw new CryptoException("Unable to load kek: " + params.kekId);
+    }
 
     this.decryptingKeys.put(keyTag, ret);
 

--- a/core/src/main/java/org/apache/accumulo/core/spi/scan/SimpleScanDispatcher.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/scan/SimpleScanDispatcher.java
@@ -152,11 +152,10 @@ public class SimpleScanDispatcher implements ScanDispatcher {
       }
     }
 
-      return switch (scanInfo.getScanType()) {
-          case MULTI -> multiDispatch;
-          case SINGLE -> singleDispatch;
-          default -> throw new IllegalArgumentException("Unexpected scan type " + scanInfo.getScanType());
-      };
+    return switch (scanInfo.getScanType()) {
+      case MULTI -> multiDispatch;
+      case SINGLE -> singleDispatch;
+    };
 
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/spi/scan/SimpleScanDispatcher.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/scan/SimpleScanDispatcher.java
@@ -152,14 +152,11 @@ public class SimpleScanDispatcher implements ScanDispatcher {
       }
     }
 
-    switch (scanInfo.getScanType()) {
-      case MULTI:
-        return multiDispatch;
-      case SINGLE:
-        return singleDispatch;
-      default:
-        throw new IllegalArgumentException("Unexpected scan type " + scanInfo.getScanType());
-    }
+      return switch (scanInfo.getScanType()) {
+          case MULTI -> multiDispatch;
+          case SINGLE -> singleDispatch;
+          default -> throw new IllegalArgumentException("Unexpected scan type " + scanInfo.getScanType());
+      };
 
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
@@ -384,16 +384,12 @@ public class MultiThreadedRFileTest {
 
   private String pad(int val) {
     String valStr = String.valueOf(val);
-    switch (valStr.length()) {
-      case 1:
-        return "000" + valStr;
-      case 2:
-        return "00" + valStr;
-      case 3:
-        return "0" + valStr;
-      default:
-        return valStr;
-    }
+      return switch (valStr.length()) {
+          case 1 -> "000" + valStr;
+          case 2 -> "00" + valStr;
+          case 3 -> "0" + valStr;
+          default -> valStr;
+      };
   }
 
   private Value getValue(int index) {

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
@@ -384,12 +384,12 @@ public class MultiThreadedRFileTest {
 
   private String pad(int val) {
     String valStr = String.valueOf(val);
-      return switch (valStr.length()) {
-          case 1 -> "000" + valStr;
-          case 2 -> "00" + valStr;
-          case 3 -> "0" + valStr;
-          default -> valStr;
-      };
+    return switch (valStr.length()) {
+      case 1 -> "000" + valStr;
+      case 2 -> "00" + valStr;
+      case 3 -> "0" + valStr;
+      default -> valStr;
+    };
   }
 
   private Value getValue(int index) {

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
@@ -1776,19 +1776,19 @@ public class RFileTest extends AbstractRFileTest {
 
   private Key newKey(int r, int c) {
     String row = String.format("r%06d", r);
-      return switch (c) {
-          case 0 -> new Key(row, "user", "addr");
-          case 1 -> new Key(row, "user", "name");
-          default -> throw new IllegalArgumentException();
-      };
+    return switch (c) {
+      case 0 -> new Key(row, "user", "addr");
+      case 1 -> new Key(row, "user", "name");
+      default -> throw new IllegalArgumentException();
+    };
   }
 
   private Value newValue(int r, int c) {
-      return switch (c) {
-          case 0 -> new Value("123" + r + " west st");
-          case 1 -> new Value("bob" + r);
-          default -> throw new IllegalArgumentException();
-      };
+    return switch (c) {
+      case 0 -> new Value("123" + r + " west st");
+      case 1 -> new Value("bob" + r);
+      default -> throw new IllegalArgumentException();
+    };
   }
 
   private static void hash(Hasher hasher, Key key, Value val) {

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
@@ -1776,25 +1776,19 @@ public class RFileTest extends AbstractRFileTest {
 
   private Key newKey(int r, int c) {
     String row = String.format("r%06d", r);
-    switch (c) {
-      case 0:
-        return new Key(row, "user", "addr");
-      case 1:
-        return new Key(row, "user", "name");
-      default:
-        throw new IllegalArgumentException();
-    }
+      return switch (c) {
+          case 0 -> new Key(row, "user", "addr");
+          case 1 -> new Key(row, "user", "name");
+          default -> throw new IllegalArgumentException();
+      };
   }
 
   private Value newValue(int r, int c) {
-    switch (c) {
-      case 0:
-        return new Value("123" + r + " west st");
-      case 1:
-        return new Value("bob" + r);
-      default:
-        throw new IllegalArgumentException();
-    }
+      return switch (c) {
+          case 0 -> new Value("123" + r + " west st");
+          case 1 -> new Value("bob" + r);
+          default -> throw new IllegalArgumentException();
+      };
   }
 
   private static void hash(Hasher hasher, Key key, Value val) {

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/FileOutputConfigurator.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/FileOutputConfigurator.java
@@ -60,16 +60,11 @@ public class FileOutputConfigurator extends ConfiguratorBase {
    * @since 1.6.0
    */
   protected static Boolean isSupportedAccumuloProperty(Property property) {
-    switch (property) {
-      case TABLE_FILE_COMPRESSION_TYPE:
-      case TABLE_FILE_COMPRESSED_BLOCK_SIZE:
-      case TABLE_FILE_BLOCK_SIZE:
-      case TABLE_FILE_COMPRESSED_BLOCK_SIZE_INDEX:
-      case TABLE_FILE_REPLICATION:
-        return true;
-      default:
-        return false;
-    }
+      return switch (property) {
+          case TABLE_FILE_COMPRESSION_TYPE, TABLE_FILE_COMPRESSED_BLOCK_SIZE, TABLE_FILE_BLOCK_SIZE,
+               TABLE_FILE_COMPRESSED_BLOCK_SIZE_INDEX, TABLE_FILE_REPLICATION -> true;
+          default -> false;
+      };
   }
 
   /**

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/FileOutputConfigurator.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/FileOutputConfigurator.java
@@ -60,11 +60,12 @@ public class FileOutputConfigurator extends ConfiguratorBase {
    * @since 1.6.0
    */
   protected static Boolean isSupportedAccumuloProperty(Property property) {
-      return switch (property) {
-          case TABLE_FILE_COMPRESSION_TYPE, TABLE_FILE_COMPRESSED_BLOCK_SIZE, TABLE_FILE_BLOCK_SIZE,
-               TABLE_FILE_COMPRESSED_BLOCK_SIZE_INDEX, TABLE_FILE_REPLICATION -> true;
-          default -> false;
-      };
+    return switch (property) {
+      case TABLE_FILE_COMPRESSION_TYPE, TABLE_FILE_COMPRESSED_BLOCK_SIZE, TABLE_FILE_BLOCK_SIZE,
+          TABLE_FILE_COMPRESSED_BLOCK_SIZE_INDEX, TABLE_FILE_REPLICATION ->
+        true;
+      default -> false;
+    };
   }
 
   /**

--- a/minicluster/src/main/java/org/apache/accumulo/cluster/standalone/StandaloneClusterControl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/cluster/standalone/StandaloneClusterControl.java
@@ -309,18 +309,13 @@ public class StandaloneClusterControl implements ClusterControl {
   }
 
   protected String getProcessString(ServerType server) {
-    switch (server) {
-      case TABLET_SERVER:
-        return "tserver";
-      case GARBAGE_COLLECTOR:
-        return "gc";
-      case MANAGER:
-        return "manager";
-      case MONITOR:
-        return "monitor";
-      default:
-        throw new UnsupportedOperationException("Unhandled ServerType " + server);
-    }
+      return switch (server) {
+          case TABLET_SERVER -> "tserver";
+          case GARBAGE_COLLECTOR -> "gc";
+          case MANAGER -> "manager";
+          case MONITOR -> "monitor";
+          default -> throw new UnsupportedOperationException("Unhandled ServerType " + server);
+      };
   }
 
   @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN",

--- a/minicluster/src/main/java/org/apache/accumulo/cluster/standalone/StandaloneClusterControl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/cluster/standalone/StandaloneClusterControl.java
@@ -309,13 +309,13 @@ public class StandaloneClusterControl implements ClusterControl {
   }
 
   protected String getProcessString(ServerType server) {
-      return switch (server) {
-          case TABLET_SERVER -> "tserver";
-          case GARBAGE_COLLECTOR -> "gc";
-          case MANAGER -> "manager";
-          case MONITOR -> "monitor";
-          default -> throw new UnsupportedOperationException("Unhandled ServerType " + server);
-      };
+    return switch (server) {
+      case TABLET_SERVER -> "tserver";
+      case GARBAGE_COLLECTOR -> "gc";
+      case MANAGER -> "manager";
+      case MONITOR -> "monitor";
+      default -> throw new UnsupportedOperationException("Unhandled ServerType " + server);
+    };
   }
 
   @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN",

--- a/server/base/src/main/java/org/apache/accumulo/server/AccumuloDataVersion.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/AccumuloDataVersion.java
@@ -103,11 +103,11 @@ public class AccumuloDataVersion {
   }
 
   private static String dataVersionToReleaseName(final int version) {
-      return switch (version) {
-          case ROOT_TABLET_META_CHANGES -> "2.1.0";
-          case REMOVE_DEPRECATIONS_FOR_VERSION_3 -> "3.0.0";
-          case FILE_JSON_ENCODING_ONDEMAND_TABLETSFOR_VERSION_4 -> "4.0.0";
-          default -> throw new IllegalArgumentException("Unsupported data version " + version);
-      };
+    return switch (version) {
+      case ROOT_TABLET_META_CHANGES -> "2.1.0";
+      case REMOVE_DEPRECATIONS_FOR_VERSION_3 -> "3.0.0";
+      case FILE_JSON_ENCODING_ONDEMAND_TABLETSFOR_VERSION_4 -> "4.0.0";
+      default -> throw new IllegalArgumentException("Unsupported data version " + version);
+    };
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/AccumuloDataVersion.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/AccumuloDataVersion.java
@@ -103,14 +103,11 @@ public class AccumuloDataVersion {
   }
 
   private static String dataVersionToReleaseName(final int version) {
-    switch (version) {
-      case ROOT_TABLET_META_CHANGES:
-        return "2.1.0";
-      case REMOVE_DEPRECATIONS_FOR_VERSION_3:
-        return "3.0.0";
-      case FILE_JSON_ENCODING_ONDEMAND_TABLETSFOR_VERSION_4:
-        return "4.0.0";
-    }
-    throw new IllegalArgumentException("Unsupported data version " + version);
+      return switch (version) {
+          case ROOT_TABLET_META_CHANGES -> "2.1.0";
+          case REMOVE_DEPRECATIONS_FOR_VERSION_3 -> "3.0.0";
+          case FILE_JSON_ENCODING_ONDEMAND_TABLETSFOR_VERSION_4 -> "4.0.0";
+          default -> throw new IllegalArgumentException("Unsupported data version " + version);
+      };
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/client/ClientServiceHandler.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/client/ClientServiceHandler.java
@@ -333,18 +333,15 @@ public class ClientServiceHandler implements ClientService.Iface {
   public Map<String,String> getConfiguration(TInfo tinfo, TCredentials credentials,
       ConfigurationType type) throws TException {
     checkSystemPermission(credentials);
-    switch (type) {
-      case PROCESS:
-        return conf(credentials, context.getConfiguration());
-      case SYSTEM:
-        context.getPropStore().getCache().remove(SystemPropKey.of());
-        return conf(credentials, context.getSystemConfiguration());
-      case SITE:
-        return conf(credentials, context.getSiteConfiguration());
-      case DEFAULT:
-        return conf(credentials, context.getDefaultConfiguration());
-    }
-    throw new IllegalArgumentException("Unexpected configuration type " + type);
+      return switch (type) {
+          case PROCESS -> conf(credentials, context.getConfiguration());
+          case SYSTEM -> {
+              context.getPropStore().getCache().remove(SystemPropKey.of());
+              yield conf(credentials, context.getSystemConfiguration());
+          }
+          case SITE -> conf(credentials, context.getSiteConfiguration());
+          case DEFAULT -> conf(credentials, context.getDefaultConfiguration());
+      };
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/client/ClientServiceHandler.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/client/ClientServiceHandler.java
@@ -333,15 +333,15 @@ public class ClientServiceHandler implements ClientService.Iface {
   public Map<String,String> getConfiguration(TInfo tinfo, TCredentials credentials,
       ConfigurationType type) throws TException {
     checkSystemPermission(credentials);
-      return switch (type) {
-          case PROCESS -> conf(credentials, context.getConfiguration());
-          case SYSTEM -> {
-              context.getPropStore().getCache().remove(SystemPropKey.of());
-              yield conf(credentials, context.getSystemConfiguration());
-          }
-          case SITE -> conf(credentials, context.getSiteConfiguration());
-          case DEFAULT -> conf(credentials, context.getDefaultConfiguration());
-      };
+    return switch (type) {
+      case PROCESS -> conf(credentials, context.getConfiguration());
+      case SYSTEM -> {
+        context.getPropStore().getCache().remove(SystemPropKey.of());
+        yield conf(credentials, context.getSystemConfiguration());
+      }
+      case SITE -> conf(credentials, context.getSiteConfiguration());
+      case DEFAULT -> conf(credentials, context.getDefaultConfiguration());
+    };
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
@@ -265,29 +265,29 @@ public class MetadataConstraints implements Constraint {
 
   @Override
   public String getViolationDescription(short violationCode) {
-      return switch (violationCode) {
-          case 1 -> "data file size must be a non-negative integer";
-          case 2 -> "Invalid column name given.";
-          case 3 -> "Prev end row is greater than or equal to end row.";
-          case 4 -> "Invalid metadata row format";
-          case 5 -> "Row can not be less than " + SystemTables.METADATA.tableId();
-          case 6 -> "Empty values are not allowed for any " + SystemTables.METADATA.tableName()
-                  + " column";
-          case 7 -> "Lock not held in zookeeper by writer";
-          case 8 -> "Bulk load mutation contains either inconsistent files or multiple fateTX ids";
-          case 3100 -> "Invalid data file metadata format";
-          case 3101 -> "Suspended timestamp is not valid";
-          case 3102 -> "Invalid directory column value";
-          case 4000 -> "Malformed operation id";
-          case 4001 -> "Malformed file selection value";
-          case 4002 -> "Invalid compacted column";
-          case 4003 -> "Invalid user compaction requested column";
-          case 4004 -> "Invalid unsplittable column";
-          case 4005 -> "Malformed availability value";
-          case 4006 -> "Malformed mergeability value";
-          case 4007 -> "Malformed migration value";
-          default -> null;
-      };
+    return switch (violationCode) {
+      case 1 -> "data file size must be a non-negative integer";
+      case 2 -> "Invalid column name given.";
+      case 3 -> "Prev end row is greater than or equal to end row.";
+      case 4 -> "Invalid metadata row format";
+      case 5 -> "Row can not be less than " + SystemTables.METADATA.tableId();
+      case 6 ->
+        "Empty values are not allowed for any " + SystemTables.METADATA.tableName() + " column";
+      case 7 -> "Lock not held in zookeeper by writer";
+      case 8 -> "Bulk load mutation contains either inconsistent files or multiple fateTX ids";
+      case 3100 -> "Invalid data file metadata format";
+      case 3101 -> "Suspended timestamp is not valid";
+      case 3102 -> "Invalid directory column value";
+      case 4000 -> "Malformed operation id";
+      case 4001 -> "Malformed file selection value";
+      case 4002 -> "Invalid compacted column";
+      case 4003 -> "Invalid user compaction requested column";
+      case 4004 -> "Invalid unsplittable column";
+      case 4005 -> "Malformed availability value";
+      case 4006 -> "Malformed mergeability value";
+      case 4007 -> "Malformed migration value";
+      default -> null;
+    };
   }
 
   private void validateColValLen(ArrayList<Short> violations, ColumnUpdate columnUpdate) {

--- a/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
@@ -265,49 +265,29 @@ public class MetadataConstraints implements Constraint {
 
   @Override
   public String getViolationDescription(short violationCode) {
-    switch (violationCode) {
-      case 1:
-        return "data file size must be a non-negative integer";
-      case 2:
-        return "Invalid column name given.";
-      case 3:
-        return "Prev end row is greater than or equal to end row.";
-      case 4:
-        return "Invalid metadata row format";
-      case 5:
-        return "Row can not be less than " + SystemTables.METADATA.tableId();
-      case 6:
-        return "Empty values are not allowed for any " + SystemTables.METADATA.tableName()
-            + " column";
-      case 7:
-        return "Lock not held in zookeeper by writer";
-      case 8:
-        return "Bulk load mutation contains either inconsistent files or multiple fateTX ids";
-      case 3100:
-        return "Invalid data file metadata format";
-      case 3101:
-        return "Suspended timestamp is not valid";
-      case 3102:
-        return "Invalid directory column value";
-      case 4000:
-        return "Malformed operation id";
-      case 4001:
-        return "Malformed file selection value";
-      case 4002:
-        return "Invalid compacted column";
-      case 4003:
-        return "Invalid user compaction requested column";
-      case 4004:
-        return "Invalid unsplittable column";
-      case 4005:
-        return "Malformed availability value";
-      case 4006:
-        return "Malformed mergeability value";
-      case 4007:
-        return "Malformed migration value";
-
-    }
-    return null;
+      return switch (violationCode) {
+          case 1 -> "data file size must be a non-negative integer";
+          case 2 -> "Invalid column name given.";
+          case 3 -> "Prev end row is greater than or equal to end row.";
+          case 4 -> "Invalid metadata row format";
+          case 5 -> "Row can not be less than " + SystemTables.METADATA.tableId();
+          case 6 -> "Empty values are not allowed for any " + SystemTables.METADATA.tableName()
+                  + " column";
+          case 7 -> "Lock not held in zookeeper by writer";
+          case 8 -> "Bulk load mutation contains either inconsistent files or multiple fateTX ids";
+          case 3100 -> "Invalid data file metadata format";
+          case 3101 -> "Suspended timestamp is not valid";
+          case 3102 -> "Invalid directory column value";
+          case 4000 -> "Malformed operation id";
+          case 4001 -> "Malformed file selection value";
+          case 4002 -> "Invalid compacted column";
+          case 4003 -> "Invalid user compaction requested column";
+          case 4004 -> "Invalid unsplittable column";
+          case 4005 -> "Malformed availability value";
+          case 4006 -> "Malformed mergeability value";
+          case 4007 -> "Malformed migration value";
+          default -> null;
+      };
   }
 
   private void validateColValLen(ArrayList<Short> violations, ColumnUpdate columnUpdate) {

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletGoalState.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletGoalState.java
@@ -177,24 +177,22 @@ public enum TabletGoalState {
 
   private static TabletGoalState getSystemGoalState(TabletMetadata tm,
       TabletManagementParameters params) {
-      return switch (params.getManagerState()) {
-          case NORMAL -> HOSTED; // fall-through intended
-          // fall-through intended
-          case HAVE_LOCK, INITIAL, SAFE_MODE -> {
-              if (tm.getExtent().isMeta()) {
-                  yield HOSTED;
-              }
-              yield TabletGoalState.UNASSIGNED;
-          }
-          case UNLOAD_METADATA_TABLETS -> {
-              if (tm.getExtent().isRootTablet()) {
-                  yield HOSTED;
-              }
-              yield UNASSIGNED;
-          }
-          case UNLOAD_ROOT_TABLET, STOP -> UNASSIGNED;
-          default -> throw new IllegalStateException("Unknown Manager State");
-      };
+    return switch (params.getManagerState()) {
+      case NORMAL -> HOSTED;
+      case HAVE_LOCK, INITIAL, SAFE_MODE -> {
+        if (tm.getExtent().isMeta()) {
+          yield HOSTED;
+        }
+        yield TabletGoalState.UNASSIGNED;
+      }
+      case UNLOAD_METADATA_TABLETS -> {
+        if (tm.getExtent().isRootTablet()) {
+          yield HOSTED;
+        }
+        yield UNASSIGNED;
+      }
+      case UNLOAD_ROOT_TABLET, STOP -> UNASSIGNED;
+    };
   }
 
   private static TabletGoalState trace(TabletGoalState tabletGoalState, TabletMetadata tm,

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletGoalState.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletGoalState.java
@@ -177,27 +177,24 @@ public enum TabletGoalState {
 
   private static TabletGoalState getSystemGoalState(TabletMetadata tm,
       TabletManagementParameters params) {
-    switch (params.getManagerState()) {
-      case NORMAL:
-        return HOSTED;
-      case HAVE_LOCK: // fall-through intended
-      case INITIAL: // fall-through intended
-      case SAFE_MODE:
-        if (tm.getExtent().isMeta()) {
-          return HOSTED;
-        }
-        return TabletGoalState.UNASSIGNED;
-      case UNLOAD_METADATA_TABLETS:
-        if (tm.getExtent().isRootTablet()) {
-          return HOSTED;
-        }
-        return UNASSIGNED;
-      case UNLOAD_ROOT_TABLET:
-      case STOP:
-        return UNASSIGNED;
-      default:
-        throw new IllegalStateException("Unknown Manager State");
-    }
+      return switch (params.getManagerState()) {
+          case NORMAL -> HOSTED; // fall-through intended
+          // fall-through intended
+          case HAVE_LOCK, INITIAL, SAFE_MODE -> {
+              if (tm.getExtent().isMeta()) {
+                  yield HOSTED;
+              }
+              yield TabletGoalState.UNASSIGNED;
+          }
+          case UNLOAD_METADATA_TABLETS -> {
+              if (tm.getExtent().isRootTablet()) {
+                  yield HOSTED;
+              }
+              yield UNASSIGNED;
+          }
+          case UNLOAD_ROOT_TABLET, STOP -> UNASSIGNED;
+          default -> throw new IllegalStateException("Unknown Manager State");
+      };
   }
 
   private static TabletGoalState trace(TabletGoalState tabletGoalState, TabletMetadata tm,

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementIterator.java
@@ -145,16 +145,12 @@ public class TabletManagementIterator extends WholeRowIterator {
           tm.getOperationId());
     }
 
-    switch (goalState) {
-      case HOSTED:
-        return state != TabletState.HOSTED;
-      case SUSPENDED:
-        return state != TabletState.SUSPENDED;
-      case UNASSIGNED:
-        return state != TabletState.UNASSIGNED;
-      default:
-        throw new IllegalStateException("unknown goal state " + goalState);
-    }
+      return switch (goalState) {
+          case HOSTED -> state != TabletState.HOSTED;
+          case SUSPENDED -> state != TabletState.SUSPENDED;
+          case UNASSIGNED -> state != TabletState.UNASSIGNED;
+          default -> throw new IllegalStateException("unknown goal state " + goalState);
+      };
   }
 
   public static void configureScanner(AccumuloConfiguration conf, final ScannerBase scanner,

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletManagementIterator.java
@@ -145,12 +145,11 @@ public class TabletManagementIterator extends WholeRowIterator {
           tm.getOperationId());
     }
 
-      return switch (goalState) {
-          case HOSTED -> state != TabletState.HOSTED;
-          case SUSPENDED -> state != TabletState.SUSPENDED;
-          case UNASSIGNED -> state != TabletState.UNASSIGNED;
-          default -> throw new IllegalStateException("unknown goal state " + goalState);
-      };
+    return switch (goalState) {
+      case HOSTED -> state != TabletState.HOSTED;
+      case SUSPENDED -> state != TabletState.SUSPENDED;
+      case UNASSIGNED -> state != TabletState.UNASSIGNED;
+    };
   }
 
   public static void configureScanner(AccumuloConfiguration conf, final ScannerBase scanner,

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletStateStore.java
@@ -125,12 +125,11 @@ public interface TabletStateStore {
   public static TabletStateStore getStoreForLevel(DataLevel level, ServerContext context) {
 
     TabletStateStore tss = switch (level) {
-        case ROOT -> new ZooTabletStateStore(level, context);
-        case METADATA -> new RootTabletStateStore(level, context);
-        case USER -> new MetaDataStateStore(level, context);
-        default -> throw new IllegalArgumentException("Unknown level " + level);
+      case ROOT -> new ZooTabletStateStore(level, context);
+      case METADATA -> new RootTabletStateStore(level, context);
+      case USER -> new MetaDataStateStore(level, context);
     };
 
-      return new LoggingTabletStateStore(tss);
+    return new LoggingTabletStateStore(tss);
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletStateStore.java
@@ -124,21 +124,13 @@ public interface TabletStateStore {
 
   public static TabletStateStore getStoreForLevel(DataLevel level, ServerContext context) {
 
-    TabletStateStore tss;
-    switch (level) {
-      case ROOT:
-        tss = new ZooTabletStateStore(level, context);
-        break;
-      case METADATA:
-        tss = new RootTabletStateStore(level, context);
-        break;
-      case USER:
-        tss = new MetaDataStateStore(level, context);
-        break;
-      default:
-        throw new IllegalArgumentException("Unknown level " + level);
-    }
+    TabletStateStore tss = switch (level) {
+        case ROOT -> new ZooTabletStateStore(level, context);
+        case METADATA -> new RootTabletStateStore(level, context);
+        case USER -> new MetaDataStateStore(level, context);
+        default -> throw new IllegalArgumentException("Unknown level " + level);
+    };
 
-    return new LoggingTabletStateStore(tss);
+      return new LoggingTabletStateStore(tss);
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/mem/LowMemoryDetector.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/mem/LowMemoryDetector.java
@@ -80,12 +80,11 @@ public class LowMemoryDetector {
       Supplier<Boolean> isUserTable, Action action) {
     if (isUserTable.get()) {
       Property p = switch (scope) {
-          case SCAN -> Property.GENERAL_LOW_MEM_SCAN_PROTECTION;
-          case MINC -> Property.GENERAL_LOW_MEM_MINC_PROTECTION;
-          case MAJC -> Property.GENERAL_LOW_MEM_MAJC_PROTECTION;
-          default -> throw new IllegalArgumentException("Unknown scope: " + scope);
+        case SCAN -> Property.GENERAL_LOW_MEM_SCAN_PROTECTION;
+        case MINC -> Property.GENERAL_LOW_MEM_MINC_PROTECTION;
+        case MAJC -> Property.GENERAL_LOW_MEM_MAJC_PROTECTION;
       };
-        boolean isEnabled = context.getConfiguration().getBoolean(p);
+      boolean isEnabled = context.getConfiguration().getBoolean(p);
       // Only incur the penalty of accessing the volatile variable when enabled for this scope
       if (isEnabled && state.get().runningLowOnMemory) {
         action.execute();

--- a/server/base/src/main/java/org/apache/accumulo/server/mem/LowMemoryDetector.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/mem/LowMemoryDetector.java
@@ -79,21 +79,13 @@ public class LowMemoryDetector {
   public boolean isRunningLowOnMemory(ServerContext context, DetectionScope scope,
       Supplier<Boolean> isUserTable, Action action) {
     if (isUserTable.get()) {
-      Property p;
-      switch (scope) {
-        case SCAN:
-          p = Property.GENERAL_LOW_MEM_SCAN_PROTECTION;
-          break;
-        case MINC:
-          p = Property.GENERAL_LOW_MEM_MINC_PROTECTION;
-          break;
-        case MAJC:
-          p = Property.GENERAL_LOW_MEM_MAJC_PROTECTION;
-          break;
-        default:
-          throw new IllegalArgumentException("Unknown scope: " + scope);
-      }
-      boolean isEnabled = context.getConfiguration().getBoolean(p);
+      Property p = switch (scope) {
+          case SCAN -> Property.GENERAL_LOW_MEM_SCAN_PROTECTION;
+          case MINC -> Property.GENERAL_LOW_MEM_MINC_PROTECTION;
+          case MAJC -> Property.GENERAL_LOW_MEM_MAJC_PROTECTION;
+          default -> throw new IllegalArgumentException("Unknown scope: " + scope);
+      };
+        boolean isEnabled = context.getConfiguration().getBoolean(p);
       // Only incur the penalty of accessing the volatile variable when enabled for this scope
       if (isEnabled && state.get().runningLowOnMemory) {
         action.execute();

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ConditionalTabletsMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ConditionalTabletsMutatorImpl.java
@@ -222,15 +222,12 @@ public class ConditionalTabletsMutatorImpl implements Ample.ConditionalTabletsMu
       throw new IllegalStateException(e);
     }
 
-    switch (status) {
-      case REJECTED:
-        return Ample.ConditionalResult.Status.REJECTED;
-      case ACCEPTED:
-        return Ample.ConditionalResult.Status.ACCEPTED;
-      default:
-        throw new IllegalStateException(
-            "Unexpected conditional mutation status : " + extent + " " + status);
-    }
+      return switch (status) {
+          case REJECTED -> Ample.ConditionalResult.Status.REJECTED;
+          case ACCEPTED -> Ample.ConditionalResult.Status.ACCEPTED;
+          default -> throw new IllegalStateException(
+                  "Unexpected conditional mutation status : " + extent + " " + status);
+      };
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ConditionalTabletsMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ConditionalTabletsMutatorImpl.java
@@ -222,12 +222,12 @@ public class ConditionalTabletsMutatorImpl implements Ample.ConditionalTabletsMu
       throw new IllegalStateException(e);
     }
 
-      return switch (status) {
-          case REJECTED -> Ample.ConditionalResult.Status.REJECTED;
-          case ACCEPTED -> Ample.ConditionalResult.Status.ACCEPTED;
-          default -> throw new IllegalStateException(
-                  "Unexpected conditional mutation status : " + extent + " " + status);
-      };
+    return switch (status) {
+      case REJECTED -> Ample.ConditionalResult.Status.REJECTED;
+      case ACCEPTED -> Ample.ConditionalResult.Status.ACCEPTED;
+      default -> throw new IllegalStateException(
+          "Unexpected conditional mutation status : " + extent + " " + status);
+    };
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/TServerUtils.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/TServerUtils.java
@@ -609,39 +609,37 @@ public class TServerUtils {
     ServerAddress serverAddress = null;
     for (HostAndPort address : addresses) {
       try {
-        switch (serverType) {
-          case SSL:
-            log.debug("Instantiating SSL Thrift server");
-            serverAddress = createSslThreadPoolServer(address, processor, protocolFactory,
-                serverSocketTimeout, sslParams, serverName, numThreads, threadTimeOut, conf,
-                timeBetweenThreadChecks);
-            break;
-          case SASL:
-            log.debug("Instantiating SASL Thrift server");
-            serverAddress = createSaslThreadPoolServer(address, processor, protocolFactory,
-                serverSocketTimeout, saslParams, serverName, numThreads, threadTimeOut, conf,
-                timeBetweenThreadChecks, backlog);
-            break;
-          case THREADPOOL:
-            log.debug("Instantiating unsecure TThreadPool Thrift server");
-            serverAddress =
-                createBlockingServer(address, processor, protocolFactory, maxMessageSize,
-                    serverName, numThreads, threadTimeOut, conf, timeBetweenThreadChecks, backlog);
-            break;
-          case THREADED_SELECTOR:
-            log.debug("Instantiating default, unsecure Threaded selector Thrift server");
-            serverAddress = createThreadedSelectorServer(address, processor, protocolFactory,
-                serverName, numThreads, threadTimeOut, conf, timeBetweenThreadChecks,
-                maxMessageSize, backlog);
-            break;
-          case CUSTOM_HS_HA:
-            log.debug("Instantiating unsecure custom half-async Thrift server");
-            serverAddress = createNonBlockingServer(address, processor, protocolFactory, serverName,
-                numThreads, threadTimeOut, conf, timeBetweenThreadChecks, maxMessageSize, backlog);
-            break;
-          default:
-            throw new IllegalArgumentException("Unknown server type " + serverType);
-        }
+          serverAddress = switch (serverType) {
+              case SSL -> {
+                  log.debug("Instantiating SSL Thrift server");
+                  yield createSslThreadPoolServer(address, processor, protocolFactory,
+                          serverSocketTimeout, sslParams, serverName, numThreads, threadTimeOut, conf,
+                          timeBetweenThreadChecks);
+              }
+              case SASL -> {
+                  log.debug("Instantiating SASL Thrift server");
+                  yield createSaslThreadPoolServer(address, processor, protocolFactory,
+                          serverSocketTimeout, saslParams, serverName, numThreads, threadTimeOut, conf,
+                          timeBetweenThreadChecks, backlog);
+              }
+              case THREADPOOL -> {
+                  log.debug("Instantiating unsecure TThreadPool Thrift server");
+                  yield createBlockingServer(address, processor, protocolFactory, maxMessageSize,
+                          serverName, numThreads, threadTimeOut, conf, timeBetweenThreadChecks, backlog);
+              }
+              case THREADED_SELECTOR -> {
+                  log.debug("Instantiating default, unsecure Threaded selector Thrift server");
+                  yield createThreadedSelectorServer(address, processor, protocolFactory,
+                          serverName, numThreads, threadTimeOut, conf, timeBetweenThreadChecks,
+                          maxMessageSize, backlog);
+              }
+              case CUSTOM_HS_HA -> {
+                  log.debug("Instantiating unsecure custom half-async Thrift server");
+                  yield createNonBlockingServer(address, processor, protocolFactory, serverName,
+                          numThreads, threadTimeOut, conf, timeBetweenThreadChecks, maxMessageSize, backlog);
+              }
+              default -> throw new IllegalArgumentException("Unknown server type " + serverType);
+          };
         break;
       } catch (TTransportException e) {
         if (portSearch) {

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/TServerUtils.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/TServerUtils.java
@@ -609,37 +609,35 @@ public class TServerUtils {
     ServerAddress serverAddress = null;
     for (HostAndPort address : addresses) {
       try {
-          serverAddress = switch (serverType) {
-              case SSL -> {
-                  log.debug("Instantiating SSL Thrift server");
-                  yield createSslThreadPoolServer(address, processor, protocolFactory,
-                          serverSocketTimeout, sslParams, serverName, numThreads, threadTimeOut, conf,
-                          timeBetweenThreadChecks);
-              }
-              case SASL -> {
-                  log.debug("Instantiating SASL Thrift server");
-                  yield createSaslThreadPoolServer(address, processor, protocolFactory,
-                          serverSocketTimeout, saslParams, serverName, numThreads, threadTimeOut, conf,
-                          timeBetweenThreadChecks, backlog);
-              }
-              case THREADPOOL -> {
-                  log.debug("Instantiating unsecure TThreadPool Thrift server");
-                  yield createBlockingServer(address, processor, protocolFactory, maxMessageSize,
-                          serverName, numThreads, threadTimeOut, conf, timeBetweenThreadChecks, backlog);
-              }
-              case THREADED_SELECTOR -> {
-                  log.debug("Instantiating default, unsecure Threaded selector Thrift server");
-                  yield createThreadedSelectorServer(address, processor, protocolFactory,
-                          serverName, numThreads, threadTimeOut, conf, timeBetweenThreadChecks,
-                          maxMessageSize, backlog);
-              }
-              case CUSTOM_HS_HA -> {
-                  log.debug("Instantiating unsecure custom half-async Thrift server");
-                  yield createNonBlockingServer(address, processor, protocolFactory, serverName,
-                          numThreads, threadTimeOut, conf, timeBetweenThreadChecks, maxMessageSize, backlog);
-              }
-              default -> throw new IllegalArgumentException("Unknown server type " + serverType);
-          };
+        serverAddress = switch (serverType) {
+          case SSL -> {
+            log.debug("Instantiating SSL Thrift server");
+            yield createSslThreadPoolServer(address, processor, protocolFactory,
+                serverSocketTimeout, sslParams, serverName, numThreads, threadTimeOut, conf,
+                timeBetweenThreadChecks);
+          }
+          case SASL -> {
+            log.debug("Instantiating SASL Thrift server");
+            yield createSaslThreadPoolServer(address, processor, protocolFactory,
+                serverSocketTimeout, saslParams, serverName, numThreads, threadTimeOut, conf,
+                timeBetweenThreadChecks, backlog);
+          }
+          case THREADPOOL -> {
+            log.debug("Instantiating unsecure TThreadPool Thrift server");
+            yield createBlockingServer(address, processor, protocolFactory, maxMessageSize,
+                serverName, numThreads, threadTimeOut, conf, timeBetweenThreadChecks, backlog);
+          }
+          case THREADED_SELECTOR -> {
+            log.debug("Instantiating default, unsecure Threaded selector Thrift server");
+            yield createThreadedSelectorServer(address, processor, protocolFactory, serverName,
+                numThreads, threadTimeOut, conf, timeBetweenThreadChecks, maxMessageSize, backlog);
+          }
+          case CUSTOM_HS_HA -> {
+            log.debug("Instantiating unsecure custom half-async Thrift server");
+            yield createNonBlockingServer(address, processor, protocolFactory, serverName,
+                numThreads, threadTimeOut, conf, timeBetweenThreadChecks, maxMessageSize, backlog);
+          }
+        };
         break;
       } catch (TTransportException e) {
         if (portSearch) {

--- a/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
@@ -111,17 +111,15 @@ public class TableManager {
         }
 
         boolean transition = switch (currState) {
-            case NEW -> (newState == TableState.OFFLINE || newState == TableState.ONLINE); // fall-through intended
-            // fall through intended
-            case ONLINE, UNKNOWN, OFFLINE -> (newState != TableState.NEW);
-            case DELETING ->
-                // Can't transition to any state from DELETING
-                    false;
+          // +--------+
+          // v |
+          // NEW -> (ONLINE|OFFLINE)+--- DELETING
+          case NEW -> (newState == TableState.OFFLINE || newState == TableState.ONLINE);
+          case ONLINE, UNKNOWN, OFFLINE -> (newState != TableState.NEW);
+          case DELETING -> false;// Can't transition to any state from DELETING
         };
-        // +--------+
-        // v |
-        // NEW -> (ONLINE|OFFLINE)+--- DELETING
-          if (!transition || !expectedCurrStates.contains(currState)) {
+
+        if (!transition || !expectedCurrStates.contains(currState)) {
           throw new IllegalTableTransitionException(currState, newState);
         }
         log.debug("Transitioning state for table {} from {} to {}", tableId, currState, newState);

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/ExtCEnv.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/ExtCEnv.java
@@ -114,14 +114,11 @@ public class ExtCEnv implements CompactionEnv {
 
   @Override
   public TCompactionReason getReason() {
-    switch (job.getKind()) {
-      case USER:
-        return TCompactionReason.USER;
-      case SYSTEM:
-        return TCompactionReason.SYSTEM;
-      default:
-        throw new IllegalStateException("Unknown compaction kind " + job.getKind());
-    }
+      return switch (job.getKind()) {
+          case USER -> TCompactionReason.USER;
+          case SYSTEM -> TCompactionReason.SYSTEM;
+          default -> throw new IllegalStateException("Unknown compaction kind " + job.getKind());
+      };
   }
 
 }

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/ExtCEnv.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/ExtCEnv.java
@@ -114,11 +114,10 @@ public class ExtCEnv implements CompactionEnv {
 
   @Override
   public TCompactionReason getReason() {
-      return switch (job.getKind()) {
-          case USER -> TCompactionReason.USER;
-          case SYSTEM -> TCompactionReason.SYSTEM;
-          default -> throw new IllegalStateException("Unknown compaction kind " + job.getKind());
-      };
+    return switch (job.getKind()) {
+      case USER -> TCompactionReason.USER;
+      case SYSTEM -> TCompactionReason.SYSTEM;
+    };
   }
 
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -648,18 +648,12 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener {
   private class StatusThread implements Runnable {
 
     private boolean goodStats() {
-      int start;
-      switch (getManagerState()) {
-        case UNLOAD_METADATA_TABLETS:
-          start = 1;
-          break;
-        case UNLOAD_ROOT_TABLET:
-          start = 2;
-          break;
-        default:
-          start = 0;
-      }
-      for (int i = start; i < watchers.size(); i++) {
+      int start = switch (getManagerState()) {
+          case UNLOAD_METADATA_TABLETS -> 1;
+          case UNLOAD_ROOT_TABLET -> 2;
+          default -> 0;
+      };
+        for (int i = start; i < watchers.size(); i++) {
         TabletGroupWatcher watcher = watchers.get(i);
         if (watcher.stats.getLastManagerState() != getManagerState()) {
           log.debug("{}: {} != {}", watcher.getName(), watcher.stats.getLastManagerState(),

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -649,11 +649,11 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener {
 
     private boolean goodStats() {
       int start = switch (getManagerState()) {
-          case UNLOAD_METADATA_TABLETS -> 1;
-          case UNLOAD_ROOT_TABLET -> 2;
-          default -> 0;
+        case UNLOAD_METADATA_TABLETS -> 1;
+        case UNLOAD_ROOT_TABLET -> 2;
+        default -> 0;
       };
-        for (int i = start; i < watchers.size(); i++) {
+      for (int i = start; i < watchers.size(); i++) {
         TabletGroupWatcher watcher = watchers.get(i);
         if (watcher.stats.getLastManagerState() != getManagerState()) {
           log.debug("{}: {} != {}", watcher.getName(), watcher.stats.getLastManagerState(),

--- a/server/manager/src/main/java/org/apache/accumulo/manager/merge/FindMergeableRangeTask.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/merge/FindMergeableRangeTask.java
@@ -178,18 +178,13 @@ public class FindMergeableRangeTask implements Runnable {
         Optional.of(TABLET_MERGEABILITY);
 
     public Optional<UnmergeableReason> optional() {
-      switch (this) {
-        case NOT_CONTIGUOUS:
-          return NOT_CONTIGUOUS_OPT;
-        case MAX_FILE_COUNT:
-          return MAX_FILE_COUNT_OPT;
-        case MAX_TOTAL_SIZE:
-          return MAX_TOTAL_SIZE_OPT;
-        case TABLET_MERGEABILITY:
-          return TABLET_MERGEABILITY_OPT;
-        default:
-          throw new IllegalArgumentException("Unexpected enum type");
-      }
+        return switch (this) {
+            case NOT_CONTIGUOUS -> NOT_CONTIGUOUS_OPT;
+            case MAX_FILE_COUNT -> MAX_FILE_COUNT_OPT;
+            case MAX_TOTAL_SIZE -> MAX_TOTAL_SIZE_OPT;
+            case TABLET_MERGEABILITY -> TABLET_MERGEABILITY_OPT;
+            default -> throw new IllegalArgumentException("Unexpected enum type");
+        };
     }
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/merge/FindMergeableRangeTask.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/merge/FindMergeableRangeTask.java
@@ -178,13 +178,12 @@ public class FindMergeableRangeTask implements Runnable {
         Optional.of(TABLET_MERGEABILITY);
 
     public Optional<UnmergeableReason> optional() {
-        return switch (this) {
-            case NOT_CONTIGUOUS -> NOT_CONTIGUOUS_OPT;
-            case MAX_FILE_COUNT -> MAX_FILE_COUNT_OPT;
-            case MAX_TOTAL_SIZE -> MAX_TOTAL_SIZE_OPT;
-            case TABLET_MERGEABILITY -> TABLET_MERGEABILITY_OPT;
-            default -> throw new IllegalArgumentException("Unexpected enum type");
-        };
+      return switch (this) {
+        case NOT_CONTIGUOUS -> NOT_CONTIGUOUS_OPT;
+        case MAX_FILE_COUNT -> MAX_FILE_COUNT_OPT;
+        case MAX_TOTAL_SIZE -> MAX_TOTAL_SIZE_OPT;
+        case TABLET_MERGEABILITY -> TABLET_MERGEABILITY_OPT;
+      };
     }
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
@@ -297,16 +297,11 @@ public class Utils {
       }
     } else {
       DistributedReadWriteLock locker = new DistributedReadWriteLock(qlock, fateId, range);
-      switch (lockType) {
-        case WRITE:
-          lock = locker.writeLock();
-          break;
-        case READ:
-          lock = locker.readLock();
-          break;
-        default:
-          throw new IllegalStateException("Unexpected LockType: " + lockType);
-      }
+        lock = switch (lockType) {
+            case WRITE -> locker.writeLock();
+            case READ -> locker.readLock();
+            default -> throw new IllegalStateException("Unexpected LockType: " + lockType);
+        };
     }
     return lock;
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
@@ -297,11 +297,10 @@ public class Utils {
       }
     } else {
       DistributedReadWriteLock locker = new DistributedReadWriteLock(qlock, fateId, range);
-        lock = switch (lockType) {
-            case WRITE -> locker.writeLock();
-            case READ -> locker.readLock();
-            default -> throw new IllegalStateException("Unexpected LockType: " + lockType);
-        };
+      lock = switch (lockType) {
+        case WRITE -> locker.writeLock();
+        case READ -> locker.readLock();
+      };
     }
     return lock;
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/CountFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/CountFiles.java
@@ -81,11 +81,11 @@ public class CountFiles extends ManagerRepo {
     if (totalFiles >= maxFiles) {
       return new UnreserveAndError(data, totalFiles, maxFiles);
     } else {
-        return switch (data.op) {
-            case MERGE -> new MergeTablets(data);
-            case DELETE -> new DeleteRows(data);
-            default -> throw new IllegalStateException("Unknown op " + data.op);
-        };
+      return switch (data.op) {
+        case MERGE -> new MergeTablets(data);
+        case DELETE -> new DeleteRows(data);
+        default -> throw new IllegalStateException("Unknown op " + data.op);
+      };
     }
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/CountFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/CountFiles.java
@@ -81,14 +81,11 @@ public class CountFiles extends ManagerRepo {
     if (totalFiles >= maxFiles) {
       return new UnreserveAndError(data, totalFiles, maxFiles);
     } else {
-      switch (data.op) {
-        case MERGE:
-          return new MergeTablets(data);
-        case DELETE:
-          return new DeleteRows(data);
-        default:
-          throw new IllegalStateException("Unknown op " + data.op);
-      }
+        return switch (data.op) {
+            case MERGE -> new MergeTablets(data);
+            case DELETE -> new DeleteRows(data);
+            default -> throw new IllegalStateException("Unknown op " + data.op);
+        };
     }
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/ReserveTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/ReserveTablets.java
@@ -128,10 +128,9 @@ public class ReserveTablets extends ManagerRepo {
 
   @Override
   public Repo<Manager> call(FateId fateId, Manager environment) throws Exception {
-      return switch (data.op) {
-          case SYSTEM_MERGE -> new VerifyMergeability(data);
-          case MERGE, DELETE -> new CountFiles(data);
-          default -> throw new IllegalStateException("Unknown op " + data.op);
-      };
+    return switch (data.op) {
+      case SYSTEM_MERGE -> new VerifyMergeability(data);
+      case MERGE, DELETE -> new CountFiles(data);
+    };
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/ReserveTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/ReserveTablets.java
@@ -128,14 +128,10 @@ public class ReserveTablets extends ManagerRepo {
 
   @Override
   public Repo<Manager> call(FateId fateId, Manager environment) throws Exception {
-    switch (data.op) {
-      case SYSTEM_MERGE:
-        return new VerifyMergeability(data);
-      case MERGE:
-      case DELETE:
-        return new CountFiles(data);
-      default:
-        throw new IllegalStateException("Unknown op " + data.op);
-    }
+      return switch (data.op) {
+          case SYSTEM_MERGE -> new VerifyMergeability(data);
+          case MERGE, DELETE -> new CountFiles(data);
+          default -> throw new IllegalStateException("Unknown op " + data.op);
+      };
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/UnreserveSystemMerge.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/UnreserveSystemMerge.java
@@ -59,19 +59,20 @@ public class UnreserveSystemMerge extends ManagerRepo {
   }
 
   private String formatReason() {
-      return switch (reason) {
-          case MAX_FILE_COUNT ->
-                  "Aborted merge because it would produce a tablet with more files than the configured limit of "
-                          + maxFileCount;
-          case MAX_TOTAL_SIZE ->
-                  "Aborted merge because it would produce a tablet with a file size larger than the configured limit of "
-                          + maxTotalSize;
-          // This state should not happen as VerifyMergeability repo checks consistency but adding it
-          // just in case
-          case TABLET_MERGEABILITY -> "Aborted merge because one ore more tablets in the merge range are unmergeable.";
-          case NOT_CONTIGUOUS -> "Aborted merge because the tablets in a range do not form a linked list.";
-          default -> throw new IllegalArgumentException("Unknown Reason");
-      };
+    return switch (reason) {
+      case MAX_FILE_COUNT ->
+        "Aborted merge because it would produce a tablet with more files than the configured limit of "
+            + maxFileCount;
+      case MAX_TOTAL_SIZE ->
+        "Aborted merge because it would produce a tablet with a file size larger than the configured limit of "
+            + maxTotalSize;
+      // This state should not happen as VerifyMergeability repo checks consistency but adding it
+      // just in case
+      case TABLET_MERGEABILITY ->
+        "Aborted merge because one ore more tablets in the merge range are unmergeable.";
+      case NOT_CONTIGUOUS ->
+        "Aborted merge because the tablets in a range do not form a linked list.";
+    };
 
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/UnreserveSystemMerge.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/UnreserveSystemMerge.java
@@ -59,22 +59,19 @@ public class UnreserveSystemMerge extends ManagerRepo {
   }
 
   private String formatReason() {
-    switch (reason) {
-      case MAX_FILE_COUNT:
-        return "Aborted merge because it would produce a tablet with more files than the configured limit of "
-            + maxFileCount;
-      case MAX_TOTAL_SIZE:
-        return "Aborted merge because it would produce a tablet with a file size larger than the configured limit of "
-            + maxTotalSize;
-      // This state should not happen as VerifyMergeability repo checks consistency but adding it
-      // just in case
-      case TABLET_MERGEABILITY:
-        return "Aborted merge because one ore more tablets in the merge range are unmergeable.";
-      case NOT_CONTIGUOUS:
-        return "Aborted merge because the tablets in a range do not form a linked list.";
-      default:
-        throw new IllegalArgumentException("Unknown Reason");
-    }
+      return switch (reason) {
+          case MAX_FILE_COUNT ->
+                  "Aborted merge because it would produce a tablet with more files than the configured limit of "
+                          + maxFileCount;
+          case MAX_TOTAL_SIZE ->
+                  "Aborted merge because it would produce a tablet with a file size larger than the configured limit of "
+                          + maxTotalSize;
+          // This state should not happen as VerifyMergeability repo checks consistency but adding it
+          // just in case
+          case TABLET_MERGEABILITY -> "Aborted merge because one ore more tablets in the merge range are unmergeable.";
+          case NOT_CONTIGUOUS -> "Aborted merge because the tablets in a range do not form a linked list.";
+          default -> throw new IllegalArgumentException("Unknown Reason");
+      };
 
   }
 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
@@ -238,14 +238,14 @@ public class LogFileKey implements WritableComparable<LogFileKey> {
 
   @Override
   public String toString() {
-      return switch (event) {
-          case OPEN -> String.format("OPEN %s", tserverSession);
-          case COMPACTION_FINISH -> String.format("COMPACTION_FINISH %d %d", tabletId, seq);
-          case COMPACTION_START -> String.format("COMPACTION_START %d %d %s", tabletId, seq, filename);
-          case MUTATION -> String.format("MUTATION %d %d", tabletId, seq);
-          case MANY_MUTATIONS -> String.format("MANY_MUTATIONS %d %d", tabletId, seq);
-          case DEFINE_TABLET -> String.format("DEFINE_TABLET %d %d %s", tabletId, seq, tablet);
-      };
+    return switch (event) {
+      case OPEN -> String.format("OPEN %s", tserverSession);
+      case COMPACTION_FINISH -> String.format("COMPACTION_FINISH %d %d", tabletId, seq);
+      case COMPACTION_START -> String.format("COMPACTION_START %d %d %s", tabletId, seq, filename);
+      case MUTATION -> String.format("MUTATION %d %d", tabletId, seq);
+      case MANY_MUTATIONS -> String.format("MANY_MUTATIONS %d %d", tabletId, seq);
+      case DEFINE_TABLET -> String.format("DEFINE_TABLET %d %d %s", tabletId, seq, tablet);
+    };
   }
 
   /**

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
@@ -238,21 +238,14 @@ public class LogFileKey implements WritableComparable<LogFileKey> {
 
   @Override
   public String toString() {
-    switch (event) {
-      case OPEN:
-        return String.format("OPEN %s", tserverSession);
-      case COMPACTION_FINISH:
-        return String.format("COMPACTION_FINISH %d %d", tabletId, seq);
-      case COMPACTION_START:
-        return String.format("COMPACTION_START %d %d %s", tabletId, seq, filename);
-      case MUTATION:
-        return String.format("MUTATION %d %d", tabletId, seq);
-      case MANY_MUTATIONS:
-        return String.format("MANY_MUTATIONS %d %d", tabletId, seq);
-      case DEFINE_TABLET:
-        return String.format("DEFINE_TABLET %d %d %s", tabletId, seq, tablet);
-    }
-    throw new RuntimeException("Unknown type of entry: " + event);
+      return switch (event) {
+          case OPEN -> String.format("OPEN %s", tserverSession);
+          case COMPACTION_FINISH -> String.format("COMPACTION_FINISH %d %d", tabletId, seq);
+          case COMPACTION_START -> String.format("COMPACTION_START %d %d %s", tabletId, seq, filename);
+          case MUTATION -> String.format("MUTATION %d %d", tabletId, seq);
+          case MANY_MUTATIONS -> String.format("MANY_MUTATIONS %d %d", tabletId, seq);
+          case DEFINE_TABLET -> String.format("DEFINE_TABLET %d %d %s", tabletId, seq, tablet);
+      };
   }
 
   /**

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/scan/ScanTask.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/scan/ScanTask.java
@@ -149,13 +149,12 @@ public abstract class ScanTask<T> implements Runnable {
   }
 
   private String stateString(int state) {
-    String stateStr = switch (state) {
-        case ADDED -> "ADDED";
-        case CANCELED -> "CANCELED";
-        case INITIAL -> "INITIAL";
-        default -> "UNKNOWN";
+    return switch (state) {
+      case ADDED -> "ADDED";
+      case CANCELED -> "CANCELED";
+      case INITIAL -> "INITIAL";
+      default -> "UNKNOWN";
     };
-      return stateStr;
   }
 
   /**

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/scan/ScanTask.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/scan/ScanTask.java
@@ -149,22 +149,13 @@ public abstract class ScanTask<T> implements Runnable {
   }
 
   private String stateString(int state) {
-    String stateStr;
-    switch (state) {
-      case ADDED:
-        stateStr = "ADDED";
-        break;
-      case CANCELED:
-        stateStr = "CANCELED";
-        break;
-      case INITIAL:
-        stateStr = "INITIAL";
-        break;
-      default:
-        stateStr = "UNKNOWN";
-        break;
-    }
-    return stateStr;
+    String stateStr = switch (state) {
+        case ADDED -> "ADDED";
+        case CANCELED -> "CANCELED";
+        case INITIAL -> "INITIAL";
+        default -> "UNKNOWN";
+    };
+      return stateStr;
   }
 
   /**

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinCEnv.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinCEnv.java
@@ -66,14 +66,10 @@ public class MinCEnv implements FileCompactor.CompactionEnv {
 
   @Override
   public TCompactionReason getReason() {
-    switch (reason) {
-      case USER:
-        return TCompactionReason.USER;
-      case CLOSE:
-        return TCompactionReason.CLOSE;
-      case SYSTEM:
-      default:
-        return TCompactionReason.SYSTEM;
-    }
+      return switch (reason) {
+          case USER -> TCompactionReason.USER;
+          case CLOSE -> TCompactionReason.CLOSE;
+          default -> TCompactionReason.SYSTEM;
+      };
   }
 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinCEnv.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinCEnv.java
@@ -66,10 +66,10 @@ public class MinCEnv implements FileCompactor.CompactionEnv {
 
   @Override
   public TCompactionReason getReason() {
-      return switch (reason) {
-          case USER -> TCompactionReason.USER;
-          case CLOSE -> TCompactionReason.CLOSE;
-          default -> TCompactionReason.SYSTEM;
-      };
+    return switch (reason) {
+      case USER -> TCompactionReason.USER;
+      case CLOSE -> TCompactionReason.CLOSE;
+      default -> TCompactionReason.SYSTEM;
+    };
   }
 }

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ActiveCompactionHelper.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ActiveCompactionHelper.java
@@ -87,12 +87,12 @@ class ActiveCompactionHelper {
     }
 
     String hostSuffix = switch (ac.getServerId().getType()) {
-        case TABLET_SERVER -> "";
-        case COMPACTOR -> " (ext)";
-        default -> ac.getServerId().getType().name();
+      case TABLET_SERVER -> "";
+      case COMPACTOR -> " (ext)";
+      default -> ac.getServerId().getType().name();
     };
 
-      String host = ac.getServerId().toHostPortString() + hostSuffix;
+    String host = ac.getServerId().toHostPortString() + hostSuffix;
 
     try {
       var dur = new DurationFormat(ac.getAge(), "");

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ActiveCompactionHelper.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ActiveCompactionHelper.java
@@ -86,20 +86,13 @@ class ActiveCompactionHelper {
       iterOpts.put(is.getName(), is.getOptions());
     }
 
-    String hostSuffix;
-    switch (ac.getServerId().getType()) {
-      case TABLET_SERVER:
-        hostSuffix = "";
-        break;
-      case COMPACTOR:
-        hostSuffix = " (ext)";
-        break;
-      default:
-        hostSuffix = ac.getServerId().getType().name();
-        break;
-    }
+    String hostSuffix = switch (ac.getServerId().getType()) {
+        case TABLET_SERVER -> "";
+        case COMPACTOR -> " (ext)";
+        default -> ac.getServerId().getType().name();
+    };
 
-    String host = ac.getServerId().toHostPortString() + hostSuffix;
+      String host = ac.getServerId().toHostPortString() + hostSuffix;
 
     try {
       var dur = new DurationFormat(ac.getAge(), "");

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/CreateTableCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/CreateTableCommand.java
@@ -124,18 +124,12 @@ public class CreateTableCommand extends Command {
     if (cl.hasOption(createTableOptInitialTabletAvailability.getOpt())) {
       String tabletAvailability =
           cl.getOptionValue(createTableOptInitialTabletAvailability.getOpt()).toUpperCase();
-      TabletAvailability initialTabletAvailability;
-      switch (tabletAvailability) {
-        case "HOSTED":
-          initialTabletAvailability = TabletAvailability.HOSTED;
-          break;
-        case "UNHOSTED":
-          initialTabletAvailability = TabletAvailability.UNHOSTED;
-          break;
-        default:
-          initialTabletAvailability = TabletAvailability.ONDEMAND;
-      }
-      ntc = ntc.withInitialTabletAvailability(initialTabletAvailability);
+      TabletAvailability initialTabletAvailability = switch (tabletAvailability) {
+          case "HOSTED" -> TabletAvailability.HOSTED;
+          case "UNHOSTED" -> TabletAvailability.UNHOSTED;
+          default -> TabletAvailability.ONDEMAND;
+      };
+        ntc = ntc.withInitialTabletAvailability(initialTabletAvailability);
     }
 
     TimeType timeType = TimeType.MILLIS;

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/CreateTableCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/CreateTableCommand.java
@@ -125,11 +125,11 @@ public class CreateTableCommand extends Command {
       String tabletAvailability =
           cl.getOptionValue(createTableOptInitialTabletAvailability.getOpt()).toUpperCase();
       TabletAvailability initialTabletAvailability = switch (tabletAvailability) {
-          case "HOSTED" -> TabletAvailability.HOSTED;
-          case "UNHOSTED" -> TabletAvailability.UNHOSTED;
-          default -> TabletAvailability.ONDEMAND;
+        case "HOSTED" -> TabletAvailability.HOSTED;
+        case "UNHOSTED" -> TabletAvailability.UNHOSTED;
+        default -> TabletAvailability.ONDEMAND;
       };
-        ntc = ntc.withInitialTabletAvailability(initialTabletAvailability);
+      ntc = ntc.withInitialTabletAvailability(initialTabletAvailability);
     }
 
     TimeType timeType = TimeType.MILLIS;

--- a/test/src/main/java/org/apache/accumulo/harness/AccumuloClusterHarness.java
+++ b/test/src/main/java/org/apache/accumulo/harness/AccumuloClusterHarness.java
@@ -263,20 +263,19 @@ public abstract class AccumuloClusterHarness extends AccumuloITBase
 
   @Override
   public ClusterUser getAdminUser() {
-    switch (type) {
-      case MINI:
-        if (krb == null) {
-          PasswordToken passwordToken = (PasswordToken) getAdminToken();
-          return new ClusterUser(getAdminPrincipal(),
-              new String(passwordToken.getPassword(), UTF_8));
-        }
-        return krb.getRootUser();
-      case STANDALONE:
-        return new ClusterUser(getAdminPrincipal(),
-            ((StandaloneAccumuloClusterConfiguration) clusterConf).getAdminKeytab());
-      default:
-        throw new RuntimeException("Unknown cluster type");
-    }
+      return switch (type) {
+          case MINI -> {
+              if (krb == null) {
+                  PasswordToken passwordToken = (PasswordToken) getAdminToken();
+                  yield new ClusterUser(getAdminPrincipal(),
+                          new String(passwordToken.getPassword(), UTF_8));
+              }
+              yield krb.getRootUser();
+          }
+          case STANDALONE -> new ClusterUser(getAdminPrincipal(),
+                  ((StandaloneAccumuloClusterConfiguration) clusterConf).getAdminKeytab());
+          default -> throw new RuntimeException("Unknown cluster type");
+      };
   }
 
   @Override

--- a/test/src/main/java/org/apache/accumulo/harness/AccumuloClusterHarness.java
+++ b/test/src/main/java/org/apache/accumulo/harness/AccumuloClusterHarness.java
@@ -263,19 +263,18 @@ public abstract class AccumuloClusterHarness extends AccumuloITBase
 
   @Override
   public ClusterUser getAdminUser() {
-      return switch (type) {
-          case MINI -> {
-              if (krb == null) {
-                  PasswordToken passwordToken = (PasswordToken) getAdminToken();
-                  yield new ClusterUser(getAdminPrincipal(),
-                          new String(passwordToken.getPassword(), UTF_8));
-              }
-              yield krb.getRootUser();
-          }
-          case STANDALONE -> new ClusterUser(getAdminPrincipal(),
-                  ((StandaloneAccumuloClusterConfiguration) clusterConf).getAdminKeytab());
-          default -> throw new RuntimeException("Unknown cluster type");
-      };
+    return switch (type) {
+      case MINI -> {
+        if (krb == null) {
+          PasswordToken passwordToken = (PasswordToken) getAdminToken();
+          yield new ClusterUser(getAdminPrincipal(),
+              new String(passwordToken.getPassword(), UTF_8));
+        }
+        yield krb.getRootUser();
+      }
+      case STANDALONE -> new ClusterUser(getAdminPrincipal(),
+          ((StandaloneAccumuloClusterConfiguration) clusterConf).getAdminKeytab());
+    };
   }
 
   @Override

--- a/test/src/main/java/org/apache/accumulo/harness/conf/AccumuloClusterPropertyConfiguration.java
+++ b/test/src/main/java/org/apache/accumulo/harness/conf/AccumuloClusterPropertyConfiguration.java
@@ -117,12 +117,11 @@ public abstract class AccumuloClusterPropertyConfiguration implements AccumuloCl
     requireNonNull(type);
 
     String prefix = switch (type) {
-        case MINI -> ACCUMULO_MINI_PREFIX;
-        case STANDALONE -> ACCUMULO_STANDALONE_PREFIX;
-        default -> throw new IllegalArgumentException("Unknown ClusterType: " + type);
+      case MINI -> ACCUMULO_MINI_PREFIX;
+      case STANDALONE -> ACCUMULO_STANDALONE_PREFIX;
     };
 
-      Map<String,String> configuration = new HashMap<>();
+    Map<String,String> configuration = new HashMap<>();
 
     String propertyFile = System.getProperty(ACCUMULO_IT_PROPERTIES_FILE);
 

--- a/test/src/main/java/org/apache/accumulo/harness/conf/AccumuloClusterPropertyConfiguration.java
+++ b/test/src/main/java/org/apache/accumulo/harness/conf/AccumuloClusterPropertyConfiguration.java
@@ -116,19 +116,13 @@ public abstract class AccumuloClusterPropertyConfiguration implements AccumuloCl
   public Map<String,String> getConfiguration(ClusterType type) {
     requireNonNull(type);
 
-    String prefix;
-    switch (type) {
-      case MINI:
-        prefix = ACCUMULO_MINI_PREFIX;
-        break;
-      case STANDALONE:
-        prefix = ACCUMULO_STANDALONE_PREFIX;
-        break;
-      default:
-        throw new IllegalArgumentException("Unknown ClusterType: " + type);
-    }
+    String prefix = switch (type) {
+        case MINI -> ACCUMULO_MINI_PREFIX;
+        case STANDALONE -> ACCUMULO_STANDALONE_PREFIX;
+        default -> throw new IllegalArgumentException("Unknown ClusterType: " + type);
+    };
 
-    Map<String,String> configuration = new HashMap<>();
+      Map<String,String> configuration = new HashMap<>();
 
     String propertyFile = System.getProperty(ACCUMULO_IT_PROPERTIES_FILE);
 

--- a/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
@@ -1245,11 +1245,11 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
 
       NewTableConfiguration ntc = new NewTableConfiguration();
 
-        ntc = switch (RANDOM.get().nextInt(3)) {
-            case 1 -> ntc.withSplits(nss("4"));
-            case 2 -> ntc.withSplits(nss("3", "5"));
-            default -> ntc;
-        };
+      ntc = switch (RANDOM.get().nextInt(3)) {
+        case 1 -> ntc.withSplits(nss("4"));
+        case 2 -> ntc.withSplits(nss("3", "5"));
+        default -> ntc;
+      };
 
       client.tableOperations().create(tableName, ntc);
 

--- a/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
@@ -1245,14 +1245,11 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
 
       NewTableConfiguration ntc = new NewTableConfiguration();
 
-      switch (RANDOM.get().nextInt(3)) {
-        case 1:
-          ntc = ntc.withSplits(nss("4"));
-          break;
-        case 2:
-          ntc = ntc.withSplits(nss("3", "5"));
-          break;
-      }
+        ntc = switch (RANDOM.get().nextInt(3)) {
+            case 1 -> ntc.withSplits(nss("4"));
+            case 2 -> ntc.withSplits(nss("3", "5"));
+            default -> ntc;
+        };
 
       client.tableOperations().create(tableName, ntc);
 

--- a/test/src/main/java/org/apache/accumulo/test/ThriftServerBindsBeforeZooKeeperLockIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ThriftServerBindsBeforeZooKeeperLockIT.java
@@ -245,22 +245,22 @@ public class ThriftServerBindsBeforeZooKeeperLockIT extends AccumuloClusterHarne
       throws IOException {
     final Property property;
     final Class<?> service = switch (serverType) {
-        case MONITOR -> {
-            property = Property.MONITOR_PORT;
-            yield Monitor.class;
-        }
-        case MANAGER -> {
-            property = Property.MANAGER_CLIENTPORT;
-            yield Manager.class;
-        }
-        case GARBAGE_COLLECTOR -> {
-            property = Property.GC_PORT;
-            yield SimpleGarbageCollector.class;
-        }
-        default -> throw new IllegalArgumentException("Irrelevant server type for test");
+      case MONITOR -> {
+        property = Property.MONITOR_PORT;
+        yield Monitor.class;
+      }
+      case MANAGER -> {
+        property = Property.MANAGER_CLIENTPORT;
+        yield Manager.class;
+      }
+      case GARBAGE_COLLECTOR -> {
+        property = Property.GC_PORT;
+        yield SimpleGarbageCollector.class;
+      }
+      default -> throw new IllegalArgumentException("Irrelevant server type for test");
     };
 
-      return cluster._exec(service, serverType, Map.of(property.getKey(), Integer.toString(port)))
+    return cluster._exec(service, serverType, Map.of(property.getKey(), Integer.toString(port)))
         .getProcess();
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/ThriftServerBindsBeforeZooKeeperLockIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ThriftServerBindsBeforeZooKeeperLockIT.java
@@ -244,25 +244,23 @@ public class ThriftServerBindsBeforeZooKeeperLockIT extends AccumuloClusterHarne
   private Process startProcess(MiniAccumuloClusterImpl cluster, ServerType serverType, int port)
       throws IOException {
     final Property property;
-    final Class<?> service;
-    switch (serverType) {
-      case MONITOR:
-        property = Property.MONITOR_PORT;
-        service = Monitor.class;
-        break;
-      case MANAGER:
-        property = Property.MANAGER_CLIENTPORT;
-        service = Manager.class;
-        break;
-      case GARBAGE_COLLECTOR:
-        property = Property.GC_PORT;
-        service = SimpleGarbageCollector.class;
-        break;
-      default:
-        throw new IllegalArgumentException("Irrelevant server type for test");
-    }
+    final Class<?> service = switch (serverType) {
+        case MONITOR -> {
+            property = Property.MONITOR_PORT;
+            yield Monitor.class;
+        }
+        case MANAGER -> {
+            property = Property.MANAGER_CLIENTPORT;
+            yield Manager.class;
+        }
+        case GARBAGE_COLLECTOR -> {
+            property = Property.GC_PORT;
+            yield SimpleGarbageCollector.class;
+        }
+        default -> throw new IllegalArgumentException("Irrelevant server type for test");
+    };
 
-    return cluster._exec(service, serverType, Map.of(property.getKey(), Integer.toString(port)))
+      return cluster._exec(service, serverType, Map.of(property.getKey(), Integer.toString(port)))
         .getProcess();
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/constraints/AlphaNumKeyConstraint.java
+++ b/test/src/main/java/org/apache/accumulo/test/constraints/AlphaNumKeyConstraint.java
@@ -87,12 +87,12 @@ public class AlphaNumKeyConstraint implements Constraint {
   @Override
   public String getViolationDescription(short violationCode) {
 
-      return switch (violationCode) {
-          case NON_ALPHA_NUM_ROW -> ROW_VIOLATION_MESSAGE;
-          case NON_ALPHA_NUM_COLF -> COLF_VIOLATION_MESSAGE;
-          case NON_ALPHA_NUM_COLQ -> COLQ_VIOLATION_MESSAGE;
-          default -> null;
-      };
+    return switch (violationCode) {
+      case NON_ALPHA_NUM_ROW -> ROW_VIOLATION_MESSAGE;
+      case NON_ALPHA_NUM_COLF -> COLF_VIOLATION_MESSAGE;
+      case NON_ALPHA_NUM_COLQ -> COLQ_VIOLATION_MESSAGE;
+      default -> null;
+    };
 
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/constraints/AlphaNumKeyConstraint.java
+++ b/test/src/main/java/org/apache/accumulo/test/constraints/AlphaNumKeyConstraint.java
@@ -87,16 +87,13 @@ public class AlphaNumKeyConstraint implements Constraint {
   @Override
   public String getViolationDescription(short violationCode) {
 
-    switch (violationCode) {
-      case NON_ALPHA_NUM_ROW:
-        return ROW_VIOLATION_MESSAGE;
-      case NON_ALPHA_NUM_COLF:
-        return COLF_VIOLATION_MESSAGE;
-      case NON_ALPHA_NUM_COLQ:
-        return COLQ_VIOLATION_MESSAGE;
-    }
+      return switch (violationCode) {
+          case NON_ALPHA_NUM_ROW -> ROW_VIOLATION_MESSAGE;
+          case NON_ALPHA_NUM_COLF -> COLF_VIOLATION_MESSAGE;
+          case NON_ALPHA_NUM_COLQ -> COLQ_VIOLATION_MESSAGE;
+          default -> null;
+      };
 
-    return null;
   }
 
 }

--- a/test/src/main/java/org/apache/accumulo/test/constraints/NumericValueConstraint.java
+++ b/test/src/main/java/org/apache/accumulo/test/constraints/NumericValueConstraint.java
@@ -65,10 +65,10 @@ public class NumericValueConstraint implements Constraint {
   @Override
   public String getViolationDescription(short violationCode) {
 
-      return switch (violationCode) {
-          case NON_NUMERIC_VALUE -> "Value is not numeric";
-          default -> null;
-      };
+    return switch (violationCode) {
+      case NON_NUMERIC_VALUE -> "Value is not numeric";
+      default -> null;
+    };
 
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/constraints/NumericValueConstraint.java
+++ b/test/src/main/java/org/apache/accumulo/test/constraints/NumericValueConstraint.java
@@ -65,12 +65,11 @@ public class NumericValueConstraint implements Constraint {
   @Override
   public String getViolationDescription(short violationCode) {
 
-    switch (violationCode) {
-      case NON_NUMERIC_VALUE:
-        return "Value is not numeric";
-    }
+      return switch (violationCode) {
+          case NON_NUMERIC_VALUE -> "Value is not numeric";
+          default -> null;
+      };
 
-    return null;
   }
 
 }

--- a/test/src/main/java/org/apache/accumulo/test/functional/BloomFilterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BloomFilterIT.java
@@ -206,20 +206,18 @@ public class BloomFilterIT extends AccumuloClusterHarness {
         expected.add(k);
       }
 
-      switch (depth) {
-        case 1:
-          range = new Range(new Text(key));
-          break;
-        case 2:
-          acuKey = new Key(row, key, cq);
-          range = new Range(acuKey, true, acuKey.followingKey(PartialKey.ROW_COLFAM), false);
-          break;
-        case 3:
-          acuKey = new Key(row, cf, key);
-          range =
-              new Range(acuKey, true, acuKey.followingKey(PartialKey.ROW_COLFAM_COLQUAL), false);
-          break;
-      }
+        range = switch (depth) {
+            case 1 -> new Range(new Text(key));
+            case 2 -> {
+                acuKey = new Key(row, key, cq);
+                yield new Range(acuKey, true, acuKey.followingKey(PartialKey.ROW_COLFAM), false);
+            }
+            case 3 -> {
+                acuKey = new Key(row, cf, key);
+                yield new Range(acuKey, true, acuKey.followingKey(PartialKey.ROW_COLFAM_COLQUAL), false);
+            }
+            default -> range;
+        };
 
       ranges.add(range);
     }

--- a/test/src/main/java/org/apache/accumulo/test/functional/BloomFilterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BloomFilterIT.java
@@ -206,18 +206,18 @@ public class BloomFilterIT extends AccumuloClusterHarness {
         expected.add(k);
       }
 
-        range = switch (depth) {
-            case 1 -> new Range(new Text(key));
-            case 2 -> {
-                acuKey = new Key(row, key, cq);
-                yield new Range(acuKey, true, acuKey.followingKey(PartialKey.ROW_COLFAM), false);
-            }
-            case 3 -> {
-                acuKey = new Key(row, cf, key);
-                yield new Range(acuKey, true, acuKey.followingKey(PartialKey.ROW_COLFAM_COLQUAL), false);
-            }
-            default -> range;
-        };
+      range = switch (depth) {
+        case 1 -> new Range(new Text(key));
+        case 2 -> {
+          acuKey = new Key(row, key, cq);
+          yield new Range(acuKey, true, acuKey.followingKey(PartialKey.ROW_COLFAM), false);
+        }
+        case 3 -> {
+          acuKey = new Key(row, cf, key);
+          yield new Range(acuKey, true, acuKey.followingKey(PartialKey.ROW_COLFAM_COLQUAL), false);
+        }
+        default -> range;
+      };
 
       ranges.add(range);
     }

--- a/test/src/main/java/org/apache/accumulo/test/functional/ExitCodesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ExitCodesIT.java
@@ -265,25 +265,13 @@ public class ExitCodesIT extends SharedMiniClusterBase {
     Map<String,String> properties = new HashMap<>();
     properties.put(PROXY_METHOD_BEHAVIOR, behavior.name());
     getCluster().getConfig().setSystemProperties(properties);
-    Class<?> serverClass = null;
-    switch (server) {
-      case COMPACTOR:
-        serverClass = ExitCompactor.class;
-        break;
-      case SCAN_SERVER:
-        serverClass = ExitScanServer.class;
-        break;
-      case TABLET_SERVER:
-        serverClass = ExitTabletServer.class;
-        break;
-      case GARBAGE_COLLECTOR:
-      case MANAGER:
-      case MONITOR:
-      case ZOOKEEPER:
-      default:
-        throw new IllegalArgumentException("Unhandled type");
-    }
-    ProcessInfo pi = getCluster()._exec(serverClass, server, Map.of(), new String[] {});
+    Class<?> serverClass = switch (server) {
+        case COMPACTOR -> ExitCompactor.class;
+        case SCAN_SERVER -> ExitScanServer.class;
+        case TABLET_SERVER -> ExitTabletServer.class;
+        default -> throw new IllegalArgumentException("Unhandled type");
+    };
+      ProcessInfo pi = getCluster()._exec(serverClass, server, Map.of(), new String[] {});
     Wait.waitFor(() -> !pi.getProcess().isAlive(), 120_000);
     int exitValue = pi.getProcess().exitValue();
     assertEquals(behavior == TerminalBehavior.SHUTDOWN ? 0 : 1, exitValue);

--- a/test/src/main/java/org/apache/accumulo/test/functional/ExitCodesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ExitCodesIT.java
@@ -266,12 +266,12 @@ public class ExitCodesIT extends SharedMiniClusterBase {
     properties.put(PROXY_METHOD_BEHAVIOR, behavior.name());
     getCluster().getConfig().setSystemProperties(properties);
     Class<?> serverClass = switch (server) {
-        case COMPACTOR -> ExitCompactor.class;
-        case SCAN_SERVER -> ExitScanServer.class;
-        case TABLET_SERVER -> ExitTabletServer.class;
-        default -> throw new IllegalArgumentException("Unhandled type");
+      case COMPACTOR -> ExitCompactor.class;
+      case SCAN_SERVER -> ExitScanServer.class;
+      case TABLET_SERVER -> ExitTabletServer.class;
+      default -> throw new IllegalArgumentException("Unhandled type");
     };
-      ProcessInfo pi = getCluster()._exec(serverClass, server, Map.of(), new String[] {});
+    ProcessInfo pi = getCluster()._exec(serverClass, server, Map.of(), new String[] {});
     Wait.waitFor(() -> !pi.getProcess().isAlive(), 120_000);
     int exitValue = pi.getProcess().exitValue();
     assertEquals(behavior == TerminalBehavior.SHUTDOWN ? 0 : 1, exitValue);

--- a/test/src/main/java/org/apache/accumulo/test/server/security/SystemCredentialsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/server/security/SystemCredentialsIT.java
@@ -67,12 +67,13 @@ public class SystemCredentialsIT extends ConfigurableMacBase {
       if (args.length < 2) {
         throw new RuntimeException("Incorrect usage; expected to be run by test only");
       }
-        creds = switch (args[0]) {
-            case "bad" -> SystemCredentials.get(badInstanceID, siteConfig);
-            case "good" -> SystemCredentials.get(context.getInstanceID(), siteConfig);
-            case "bad_password" -> new SystemCredentials(badInstanceID, "!SYSTEM", new PasswordToken("fake"));
-            default -> throw new RuntimeException("Incorrect usage; expected to be run by test only");
-        };
+      creds = switch (args[0]) {
+        case "bad" -> SystemCredentials.get(badInstanceID, siteConfig);
+        case "good" -> SystemCredentials.get(context.getInstanceID(), siteConfig);
+        case "bad_password" ->
+          new SystemCredentials(badInstanceID, "!SYSTEM", new PasswordToken("fake"));
+        default -> throw new RuntimeException("Incorrect usage; expected to be run by test only");
+      };
       try (AccumuloClient client = Accumulo.newClient().from(context.properties())
           .as(creds.getPrincipal(), creds.getToken()).build()) {
         client.securityOperations().authenticateUser(creds.getPrincipal(), creds.getToken());

--- a/test/src/main/java/org/apache/accumulo/test/server/security/SystemCredentialsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/server/security/SystemCredentialsIT.java
@@ -67,19 +67,12 @@ public class SystemCredentialsIT extends ConfigurableMacBase {
       if (args.length < 2) {
         throw new RuntimeException("Incorrect usage; expected to be run by test only");
       }
-      switch (args[0]) {
-        case "bad":
-          creds = SystemCredentials.get(badInstanceID, siteConfig);
-          break;
-        case "good":
-          creds = SystemCredentials.get(context.getInstanceID(), siteConfig);
-          break;
-        case "bad_password":
-          creds = new SystemCredentials(badInstanceID, "!SYSTEM", new PasswordToken("fake"));
-          break;
-        default:
-          throw new RuntimeException("Incorrect usage; expected to be run by test only");
-      }
+        creds = switch (args[0]) {
+            case "bad" -> SystemCredentials.get(badInstanceID, siteConfig);
+            case "good" -> SystemCredentials.get(context.getInstanceID(), siteConfig);
+            case "bad_password" -> new SystemCredentials(badInstanceID, "!SYSTEM", new PasswordToken("fake"));
+            default -> throw new RuntimeException("Incorrect usage; expected to be run by test only");
+        };
       try (AccumuloClient client = Accumulo.newClient().from(context.properties())
           .as(creds.getPrincipal(), creds.getToken()).build()) {
         client.securityOperations().authenticateUser(creds.getPrincipal(), creds.getToken());


### PR DESCRIPTION
* 1cde73b8dcff6f220b8fb9c058b36d6fbc272808 are the changes that happened when running an automatic migration in my IDE. I restored the auto generated files (thrift) after that ran and also formatted the code before committing.
* 748620049ffb5bb8ca5aa833c65aa9f5ffb821cf I looked through the places that were changed in the step above and corrected comments that got rearranged, converted to an if statement if there were too few cases to make switch worth it, and removed the default case in the scenarios where it was redundant