### PR TITLE
Remove uses of Thread.suspend and Thread.resume

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/zookeeper/ZooCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/zookeeper/ZooCache.java
@@ -64,7 +64,7 @@ public class ZooCache {
   private final NavigableSet<String> watchedPaths;
 
   // visible for tests
-  protected final ZCacheWatcher watcher = new ZCacheWatcher();
+  public final ZCacheWatcher watcher = new ZCacheWatcher();
   private final List<ZooCacheWatcher> externalWatchers =
       Collections.synchronizedList(new ArrayList<>());
 
@@ -85,7 +85,7 @@ public class ZooCache {
 
   private final AtomicLong zkClientTracker = new AtomicLong();
 
-  class ZCacheWatcher implements Watcher {
+  public class ZCacheWatcher implements Watcher {
     @Override
     public void process(WatchedEvent event) {
       if (log.isTraceEnabled()) {


### PR DESCRIPTION
Removes uses of deprecated Java methods: Thread.suspend() and Thread.resume(). There was only one use: in ZooCacheIT. Was being used to simulate a ZooKeeper disconnect, replaced with the Watcher instead processing a Disconnected event.

closes #5846