### PR TITLE
shortens help description for accumulo upgrade

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/util/UpgradeUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/UpgradeUtil.java
@@ -80,7 +80,7 @@ public class UpgradeUtil implements KeywordExecutable {
     @Parameter(names = "--start",
         description = """
             Start an upgrade of an Accumulo instance. The 'start' step is intended to be run on the \
-            instance with the new version of software before any server processes are started.  Server processes \
+            instance with the new version of software before any server processes are started. Server processes \
             should fail to start if this step is not run. This will check that 'accumulo upgrade --prepare' \
             was run on the instance after it was shut down, perform pre-upgrade validation, and perform any \
             upgrade steps that need to occur before the Manager is started. Finally, it creates a mandatory \

--- a/server/base/src/main/java/org/apache/accumulo/server/util/UpgradeUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/UpgradeUtil.java
@@ -78,10 +78,12 @@ public class UpgradeUtil implements KeywordExecutable {
     boolean prepare = false;
 
     @Parameter(names = "--start",
-        description = "Start an upgrade of an Accumulo instance. This will check that 'accumulo upgrade --prepare'"
+        description = "Start an upgrade of an Accumulo instance. The 'start' step is intended to be run on the "
+            + "instance with the new version of software before any server processes are started.  Server processes "
+            +  "should fail to start if this step is not run. This will check that 'accumulo upgrade --prepare'"
             + " was run on the instance after it was shut down, perform pre-upgrade validation, and perform any"
             + " upgrade steps that need to occur before the Manager is started. Finally, it creates a mandatory"
-            + " marker in ZooKeeper that enables the Manager to perform an upgrade.")
+            + " marker in ZooKeeper that enables the Manager to complete an upgrade.")
     boolean start = false;
 
     @Parameter(names = "--force",
@@ -96,13 +98,7 @@ public class UpgradeUtil implements KeywordExecutable {
 
   @Override
   public String description() {
-    return "utility used to perform various upgrade steps for an Accumulo instance. The 'prepare'"
-        + " step is intended to be run using the old version of software after an instance has"
-        + " been shut down. The 'start' step is intended to be run on the instance with the new"
-        + " version of software. Server processes should fail to start after the 'prepare' step"
-        + " has been run due to the existence of a node in ZooKeeper. When the 'start' step"
-        + " completes successfully it will remove this node allowing the user to start the"
-        + " Manager to complete the instance upgrade process.";
+    return "utility used to perform various upgrade steps for an Accumulo instance.";
   }
 
   private void prepare(final ServerContext context) {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/UpgradeUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/UpgradeUtil.java
@@ -80,7 +80,7 @@ public class UpgradeUtil implements KeywordExecutable {
     @Parameter(names = "--start",
         description = "Start an upgrade of an Accumulo instance. The 'start' step is intended to be run on the "
             + "instance with the new version of software before any server processes are started.  Server processes "
-            +  "should fail to start if this step is not run. This will check that 'accumulo upgrade --prepare'"
+            + "should fail to start if this step is not run. This will check that 'accumulo upgrade --prepare'"
             + " was run on the instance after it was shut down, perform pre-upgrade validation, and perform any"
             + " upgrade steps that need to occur before the Manager is started. Finally, it creates a mandatory"
             + " marker in ZooKeeper that enables the Manager to complete an upgrade.")

--- a/server/base/src/main/java/org/apache/accumulo/server/util/UpgradeUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/UpgradeUtil.java
@@ -83,8 +83,8 @@ public class UpgradeUtil implements KeywordExecutable {
             instance with the new version of software before any server processes are started. Server processes \
             should fail to start if this step is not run. This will check that 'accumulo upgrade --prepare' \
             was run on the instance after it was shut down, perform pre-upgrade validation, and perform any \
-            upgrade steps that need to occur before the Manager is started. Finally, it creates a mandatory \
-            marker in ZooKeeper that enables the Manager to complete an upgrade.""")
+            upgrade steps that need to occur before the Manager is started. After successfully completing this \
+            step, start the server processes to complete the upgrade.""")
     boolean start = false;
 
     @Parameter(names = "--force",

--- a/server/base/src/main/java/org/apache/accumulo/server/util/UpgradeUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/UpgradeUtil.java
@@ -78,12 +78,13 @@ public class UpgradeUtil implements KeywordExecutable {
     boolean prepare = false;
 
     @Parameter(names = "--start",
-        description = "Start an upgrade of an Accumulo instance. The 'start' step is intended to be run on the "
-            + "instance with the new version of software before any server processes are started.  Server processes "
-            + "should fail to start if this step is not run. This will check that 'accumulo upgrade --prepare'"
-            + " was run on the instance after it was shut down, perform pre-upgrade validation, and perform any"
-            + " upgrade steps that need to occur before the Manager is started. Finally, it creates a mandatory"
-            + " marker in ZooKeeper that enables the Manager to complete an upgrade.")
+        description = """
+            Start an upgrade of an Accumulo instance. The 'start' step is intended to be run on the \
+            instance with the new version of software before any server processes are started.  Server processes \
+            should fail to start if this step is not run. This will check that 'accumulo upgrade --prepare' \
+            was run on the instance after it was shut down, perform pre-upgrade validation, and perform any \
+            upgrade steps that need to occur before the Manager is started. Finally, it creates a mandatory \
+            marker in ZooKeeper that enables the Manager to complete an upgrade.""")
     boolean start = false;
 
     @Parameter(names = "--force",


### PR DESCRIPTION
When running `accumulo -help` the description of the upgrade command is really long compared to other commands.  Shortened the description by moving information into the options so that the more detailed information is displayed when running `accumulo upgrade --help`.  Some of the information in the description was redundant w/ the existing help for `--prepare` and did not need to be moved.