### PR TITLE
removes newlines in default fate config json

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -472,14 +472,14 @@ public enum Property {
       "1.9.3"),
   MANAGER_FATE_USER_CONFIG("manager.fate.user.config",
       """
-          {
+          {\
             'general': {'TABLE_CREATE,TABLE_DELETE,TABLE_RENAME,TABLE_ONLINE,TABLE_OFFLINE,NAMESPACE_CREATE,\
           NAMESPACE_DELETE,NAMESPACE_RENAME,TABLE_TABLET_AVAILABILITY,SHUTDOWN_TSERVER,\
           TABLE_BULK_IMPORT2,TABLE_COMPACT,TABLE_CANCEL_COMPACT,TABLE_MERGE,TABLE_DELETE_RANGE,\
-          TABLE_SPLIT,TABLE_CLONE,TABLE_IMPORT,TABLE_EXPORT,SYSTEM_MERGE': 4},
-            'commit': {'COMMIT_COMPACTION': 4},
-            'split': {'SYSTEM_SPLIT': 4}
-          }
+          TABLE_SPLIT,TABLE_CLONE,TABLE_IMPORT,TABLE_EXPORT,SYSTEM_MERGE': 4},\
+            'commit': {'COMMIT_COMPACTION': 4},\
+            'split': {'SYSTEM_SPLIT': 4}\
+          }\
           """,
       PropertyType.FATE_USER_CONFIG, """
           The number of threads used to run fault-tolerant executions (FATE) on user \
@@ -490,14 +490,14 @@ public enum Property {
           """, "4.0.0"),
   MANAGER_FATE_META_CONFIG("manager.fate.meta.config",
       """
-          {
+          {\
             'general': {'TABLE_CREATE,TABLE_DELETE,TABLE_RENAME,TABLE_ONLINE,TABLE_OFFLINE,NAMESPACE_CREATE,\
           NAMESPACE_DELETE,NAMESPACE_RENAME,TABLE_TABLET_AVAILABILITY,SHUTDOWN_TSERVER,\
           TABLE_BULK_IMPORT2,TABLE_COMPACT,TABLE_CANCEL_COMPACT,TABLE_MERGE,TABLE_DELETE_RANGE,\
-          TABLE_SPLIT,TABLE_CLONE,TABLE_IMPORT,TABLE_EXPORT,SYSTEM_MERGE': 4},
-            'commit': {'COMMIT_COMPACTION': 4},
-            'split': {'SYSTEM_SPLIT': 4}
-          }
+          TABLE_SPLIT,TABLE_CLONE,TABLE_IMPORT,TABLE_EXPORT,SYSTEM_MERGE': 4},\
+            'commit': {'COMMIT_COMPACTION': 4},\
+            'split': {'SYSTEM_SPLIT': 4}\
+          }\
           """,
       PropertyType.FATE_META_CONFIG, """
           The number of threads used to run fault-tolerant executions (FATE) on Accumulo system \

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -74,8 +74,7 @@ public enum Property {
   COMPACTION_SERVICE_DEFAULT_MAX_OPEN(COMPACTION_SERVICE_DEFAULT_PLANNER + ".opts.maxOpen", "10",
       PropertyType.COUNT, "The maximum number of files a compaction will open.", "4.0.0"),
   COMPACTION_SERVICE_DEFAULT_GROUPS(COMPACTION_SERVICE_DEFAULT_PLANNER + ".opts.groups", """
-      [{"group": "default"}]
-      """, PropertyType.JSON,
+      [{"group": "default"}]""", PropertyType.JSON,
       "See {% jlink -f org.apache.accumulo.core.spi.compaction.RatioBasedCompactionPlanner %}.",
       "4.0.0"),
   COMPACTION_WARN_TIME(COMPACTION_PREFIX + "warn.time", "10m", PropertyType.TIMEDURATION,
@@ -479,8 +478,7 @@ public enum Property {
           TABLE_SPLIT,TABLE_CLONE,TABLE_IMPORT,TABLE_EXPORT,SYSTEM_MERGE': 4},\
             'commit': {'COMMIT_COMPACTION': 4},\
             'split': {'SYSTEM_SPLIT': 4}\
-          }\
-          """,
+          }""",
       PropertyType.FATE_USER_CONFIG, """
           The number of threads used to run fault-tolerant executions (FATE) on user \
           tables. These are primarily table operations like merge. The property value is JSON. \
@@ -497,8 +495,7 @@ public enum Property {
           TABLE_SPLIT,TABLE_CLONE,TABLE_IMPORT,TABLE_EXPORT,SYSTEM_MERGE': 4},\
             'commit': {'COMMIT_COMPACTION': 4},\
             'split': {'SYSTEM_SPLIT': 4}\
-          }\
-          """,
+          }""",
       PropertyType.FATE_META_CONFIG, """
           The number of threads used to run fault-tolerant executions (FATE) on Accumulo system \
           tables. These are primarily table operations like merge. The property value is JSON. \

--- a/core/src/test/java/org/apache/accumulo/core/conf/PropertyTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/PropertyTest.java
@@ -61,8 +61,21 @@ public class PropertyTest {
         assertNull(prop.getDefaultValue(),
             "PREFIX property " + prop.name() + " has unexpected non-null default value.");
       } else {
+        // default values shouldn't be null, but they can be an empty string
+        assertNotNull(prop.getDefaultValue());
+        // default values shouldn't start or end with whitespace
+        assertEquals(prop.getDefaultValue().strip(), prop.getDefaultValue(),
+            "Property " + prop.name() + " starts or ends with whitespace");
+        // default values shouldn't contain newline characters or tabs
+        assertFalse(prop.getDefaultValue().contains("\t"),
+            "Property " + prop.name() + " contains a tab character");
+        assertFalse(prop.getDefaultValue().contains("\n"),
+            "Property " + prop.name() + " contains a newline (\\n) character");
+        assertFalse(prop.getDefaultValue().contains("\r"),
+            "Property " + prop.name() + " contains a return (\\r) character");
+
         assertTrue(Property.isValidProperty(prop.getKey(), prop.getDefaultValue()),
-            "Property " + prop + " has invalid default value " + prop.getDefaultValue()
+            "Property " + prop.name() + " has invalid default value " + prop.getDefaultValue()
                 + " for type " + prop.getType());
       }
 


### PR DESCRIPTION
ExistingMacIT was failing w/ the following error.  Seemed that a newline in the default fate config json was causing apache commons config to only see up to the first newline for the value.  Removed the newlines in the default config to fix the issue.

```
org.apache.accumulo.core.conf.ConfigCheckUtil$ConfigCheckException: BAD CONFIG improperly formatted value for key (manager.fate.user.config, type=fate user config) : { for site config
	at org.apache.accumulo.core.conf.ConfigCheckUtil.fatal(ConfigCheckUtil.java:150)
	at org.apache.accumulo.core.conf.ConfigCheckUtil.validate(ConfigCheckUtil.java:62)
	at org.apache.accumulo.core.conf.SiteConfiguration.<init>(SiteConfiguration.java:206)
	at org.apache.accumulo.core.conf.SiteConfiguration$Builder.build(SiteConfiguration.java:171)
	at org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl.<init>(MiniAccumuloClusterImpl.java:271)
	at org.apache.accumulo.test.ExistingMacIT.testExistingInstance(ExistingMacIT.java:138)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
```