### PR TITLE
Throw IllegalArgumentException for illegal mapping in NamespacePermision.getEquivalent()

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/security/NamespacePermission.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/NamespacePermission.java
@@ -125,7 +125,8 @@ public enum NamespacePermission {
       case DROP_NAMESPACE:
         return NamespacePermission.DROP_NAMESPACE;
       case GRANT:
-        return NamespacePermission.ALTER_NAMESPACE;
+        throw new IllegalArgumentException(
+            "SystemPermission.GRANT has no equivalent NamespacePermission. GRANT operations require special handling in SecurityOperation.");
       case CREATE_NAMESPACE:
       case CREATE_USER:
       case DROP_USER:


### PR DESCRIPTION
Instead of mapping SystemPermission.GRANT to NamespacePermission.ALTER_NAMESPACE, throw an IllegalArgumentException.

Fixes #5883 

This change was suggested in [this comment](https://github.com/apache/accumulo/issues/5883#issuecomment-3294169911)