### PR TITLE
Removed ResourceGroupOperations.getConfiguration

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/admin/ResourceGroupOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/ResourceGroupOperations.java
@@ -77,19 +77,6 @@ public interface ResourceGroupOperations {
   void create(final ResourceGroupId group) throws AccumuloException, AccumuloSecurityException;
 
   /**
-   * Returns the properties set for this resource group in zookeeper merged with the system
-   * configuration.
-   *
-   * @param group resource group
-   * @return Map of property keys/values
-   * @throws AccumuloException if a general error occurs
-   * @throws AccumuloSecurityException if the user does not have permission
-   * @throws ResourceGroupNotFoundException if the specified resource group doesn't exist
-   */
-  Map<String,String> getConfiguration(final ResourceGroupId group)
-      throws AccumuloException, AccumuloSecurityException, ResourceGroupNotFoundException;
-
-  /**
    * Returns the un-merged properties set for this resource group in zookeeper.
    *
    * @param group resource group

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientTabletCacheImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientTabletCacheImpl.java
@@ -51,7 +51,6 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.dataImpl.thrift.TKeyExtent;
-import org.apache.accumulo.core.lock.ServiceLockPaths.ResourceGroupPredicate;
 import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.core.metadata.SystemTables;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
@@ -676,11 +675,9 @@ public class ClientTabletCacheImpl extends ClientTabletCache {
     if (!extentsToBringOnline.isEmpty()) {
       log.debug("Requesting hosting for {} ondemand tablets for table id {}.",
           extentsToBringOnline.size(), tableId);
-      ThriftClientTypes.MANAGER
-          .executeVoid(context,
-              client -> client.requestTabletHosting(TraceUtil.traceInfo(), context.rpcCreds(),
-                  tableId.canonical(), extentsToBringOnline),
-              ResourceGroupPredicate.DEFAULT_RG_ONLY);
+      ThriftClientTypes.MANAGER.executeVoid(context,
+          client -> client.requestTabletHosting(TraceUtil.traceInfo(), context.rpcCreds(),
+              tableId.canonical(), extentsToBringOnline));
       tabletHostingRequestCount.addAndGet(extentsToBringOnline.size());
     }
   }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
@@ -106,8 +106,7 @@ public class InstanceOperationsImpl implements InstanceOperations {
           + " setting its replacement {} instead", property, replacement);
     });
     ThriftClientTypes.MANAGER.executeVoid(context, client -> client
-        .setSystemProperty(TraceUtil.traceInfo(), context.rpcCreds(), property, value),
-        ResourceGroupPredicate.DEFAULT_RG_ONLY);
+        .setSystemProperty(TraceUtil.traceInfo(), context.rpcCreds(), property, value));
     checkLocalityGroups(property);
   }
 
@@ -116,8 +115,7 @@ public class InstanceOperationsImpl implements InstanceOperations {
     checkArgument(mapMutator != null, "mapMutator is null");
 
     final TVersionedProperties vProperties = ThriftClientTypes.CLIENT.execute(context,
-        client -> client.getVersionedSystemProperties(TraceUtil.traceInfo(), context.rpcCreds()),
-        ResourceGroupPredicate.ANY);
+        client -> client.getVersionedSystemProperties(TraceUtil.traceInfo(), context.rpcCreds()));
     mapMutator.accept(vProperties.getProperties());
 
     // A reference to the map was passed to the user, maybe they still have the reference and are
@@ -141,8 +139,7 @@ public class InstanceOperationsImpl implements InstanceOperations {
 
     // Send to server
     ThriftClientTypes.MANAGER.executeVoid(context, client -> client
-        .modifySystemProperties(TraceUtil.traceInfo(), context.rpcCreds(), vProperties),
-        ResourceGroupPredicate.DEFAULT_RG_ONLY);
+        .modifySystemProperties(TraceUtil.traceInfo(), context.rpcCreds(), vProperties));
 
     return vProperties.getProperties();
   }
@@ -188,8 +185,7 @@ public class InstanceOperationsImpl implements InstanceOperations {
           + " its replacement {} and will remove that instead", property, replacement);
     });
     ThriftClientTypes.MANAGER.executeVoid(context,
-        client -> client.removeSystemProperty(TraceUtil.traceInfo(), context.rpcCreds(), property),
-        ResourceGroupPredicate.DEFAULT_RG_ONLY);
+        client -> client.removeSystemProperty(TraceUtil.traceInfo(), context.rpcCreds(), property));
     checkLocalityGroups(property);
   }
 
@@ -212,24 +208,21 @@ public class InstanceOperationsImpl implements InstanceOperations {
   public Map<String,String> getSystemConfiguration()
       throws AccumuloException, AccumuloSecurityException {
     return ThriftClientTypes.CLIENT.execute(context, client -> client
-        .getConfiguration(TraceUtil.traceInfo(), context.rpcCreds(), ConfigurationType.SYSTEM),
-        ResourceGroupPredicate.ANY);
+        .getConfiguration(TraceUtil.traceInfo(), context.rpcCreds(), ConfigurationType.SYSTEM));
   }
 
   @Override
   public Map<String,String> getSiteConfiguration()
       throws AccumuloException, AccumuloSecurityException {
     return ThriftClientTypes.CLIENT.execute(context, client -> client
-        .getConfiguration(TraceUtil.traceInfo(), context.rpcCreds(), ConfigurationType.SITE),
-        ResourceGroupPredicate.ANY);
+        .getConfiguration(TraceUtil.traceInfo(), context.rpcCreds(), ConfigurationType.SITE));
   }
 
   @Override
   public Map<String,String> getSystemProperties()
       throws AccumuloException, AccumuloSecurityException {
     return ThriftClientTypes.CLIENT.execute(context,
-        client -> client.getSystemProperties(TraceUtil.traceInfo(), context.rpcCreds()),
-        ResourceGroupPredicate.ANY);
+        client -> client.getSystemProperties(TraceUtil.traceInfo(), context.rpcCreds()));
   }
 
   @Override
@@ -331,8 +324,7 @@ public class InstanceOperationsImpl implements InstanceOperations {
   public boolean testClassLoad(final String className, final String asTypeName)
       throws AccumuloException, AccumuloSecurityException {
     return ThriftClientTypes.CLIENT.execute(context, client -> client
-        .checkClass(TraceUtil.traceInfo(), context.rpcCreds(), className, asTypeName),
-        ResourceGroupPredicate.ANY);
+        .checkClass(TraceUtil.traceInfo(), context.rpcCreds(), className, asTypeName));
   }
 
   @Override
@@ -466,8 +458,7 @@ public class InstanceOperationsImpl implements InstanceOperations {
   public void waitForBalance() throws AccumuloException {
     try {
       ThriftClientTypes.MANAGER.executeVoid(context,
-          client -> client.waitForBalance(TraceUtil.traceInfo()),
-          ResourceGroupPredicate.DEFAULT_RG_ONLY);
+          client -> client.waitForBalance(TraceUtil.traceInfo()));
     } catch (AccumuloSecurityException ex) {
       // should never happen
       throw new IllegalStateException("Unexpected exception thrown", ex);
@@ -483,8 +474,7 @@ public class InstanceOperationsImpl implements InstanceOperations {
   @Override
   public Duration getManagerTime() throws AccumuloException, AccumuloSecurityException {
     return Duration.ofNanos(ThriftClientTypes.MANAGER.execute(context,
-        client -> client.getManagerTimeNanos(TraceUtil.traceInfo(), context.rpcCreds()),
-        ResourceGroupPredicate.DEFAULT_RG_ONLY));
+        client -> client.getManagerTimeNanos(TraceUtil.traceInfo(), context.rpcCreds())));
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/NamespaceOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/NamespaceOperationsImpl.java
@@ -53,7 +53,6 @@ import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.constraints.Constraint;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
-import org.apache.accumulo.core.lock.ServiceLockPaths.ResourceGroupPredicate;
 import org.apache.accumulo.core.manager.thrift.TFateOperation;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
 import org.apache.accumulo.core.trace.TraceUtil;
@@ -207,10 +206,9 @@ public class NamespaceOperationsImpl extends NamespaceOperationsHelper {
       final Consumer<Map<String,String>> mapMutator)
       throws AccumuloException, AccumuloSecurityException, NamespaceNotFoundException {
 
-    final TVersionedProperties vProperties = ThriftClientTypes.CLIENT.execute(context,
-        client -> client.getVersionedNamespaceProperties(TraceUtil.traceInfo(), context.rpcCreds(),
-            namespace),
-        ResourceGroupPredicate.ANY);
+    final TVersionedProperties vProperties =
+        ThriftClientTypes.CLIENT.execute(context, client -> client
+            .getVersionedNamespaceProperties(TraceUtil.traceInfo(), context.rpcCreds(), namespace));
     mapMutator.accept(vProperties.getProperties());
 
     // A reference to the map was passed to the user, maybe they still have the reference and are
@@ -295,8 +293,7 @@ public class NamespaceOperationsImpl extends NamespaceOperationsHelper {
 
     try {
       return ThriftClientTypes.CLIENT.execute(context, client -> client
-          .getNamespaceConfiguration(TraceUtil.traceInfo(), context.rpcCreds(), namespace),
-          ResourceGroupPredicate.ANY);
+          .getNamespaceConfiguration(TraceUtil.traceInfo(), context.rpcCreds(), namespace));
     } catch (AccumuloSecurityException e) {
       throw e;
     } catch (AccumuloException e) {
@@ -321,8 +318,7 @@ public class NamespaceOperationsImpl extends NamespaceOperationsHelper {
 
     try {
       return ThriftClientTypes.CLIENT.execute(context, client -> client
-          .getNamespaceProperties(TraceUtil.traceInfo(), context.rpcCreds(), namespace),
-          ResourceGroupPredicate.ANY);
+          .getNamespaceProperties(TraceUtil.traceInfo(), context.rpcCreds(), namespace));
     } catch (AccumuloException e) {
       Throwable eCause = e.getCause();
       if (eCause instanceof TableNotFoundException) {
@@ -355,11 +351,9 @@ public class NamespaceOperationsImpl extends NamespaceOperationsHelper {
     checkArgument(asTypeName != null, "asTypeName is null");
 
     try {
-      return ThriftClientTypes.CLIENT
-          .execute(
-              context, client -> client.checkNamespaceClass(TraceUtil.traceInfo(),
-                  context.rpcCreds(), namespace, className, asTypeName),
-              ResourceGroupPredicate.ANY);
+      return ThriftClientTypes.CLIENT.execute(context,
+          client -> client.checkNamespaceClass(TraceUtil.traceInfo(), context.rpcCreds(), namespace,
+              className, asTypeName));
     } catch (AccumuloSecurityException e) {
       throw e;
     } catch (AccumuloException e) {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ResourceGroupOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ResourceGroupOperationsImpl.java
@@ -22,7 +22,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import java.time.Duration;
 import java.util.ConcurrentModificationException;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
@@ -34,12 +33,10 @@ import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.ResourceGroupNotFoundException;
 import org.apache.accumulo.core.client.admin.ResourceGroupOperations;
-import org.apache.accumulo.core.clientImpl.thrift.ConfigurationType;
 import org.apache.accumulo.core.clientImpl.thrift.TVersionedProperties;
 import org.apache.accumulo.core.clientImpl.thrift.ThriftResourceGroupNotExistsException;
 import org.apache.accumulo.core.conf.DeprecatedPropertyUtil;
 import org.apache.accumulo.core.data.ResourceGroupId;
-import org.apache.accumulo.core.lock.ServiceLockPaths.ResourceGroupPredicate;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
 import org.apache.accumulo.core.trace.TraceUtil;
 import org.apache.accumulo.core.util.LocalityGroupUtil;
@@ -80,24 +77,7 @@ public class ResourceGroupOperationsImpl implements ResourceGroupOperations {
   public void create(ResourceGroupId group) throws AccumuloException, AccumuloSecurityException {
     checkArgument(group != null, "group argument must be supplied");
     ThriftClientTypes.MANAGER.executeVoid(context, client -> client
-        .createResourceGroupNode(TraceUtil.traceInfo(), context.rpcCreds(), group.canonical()),
-        ResourceGroupPredicate.DEFAULT_RG_ONLY);
-  }
-
-  @Override
-  public Map<String,String> getConfiguration(ResourceGroupId group)
-      throws AccumuloException, AccumuloSecurityException, ResourceGroupNotFoundException {
-    checkArgument(group != null, "group argument must be supplied");
-    checkResourceGroupId(group.canonical());
-    Map<String,String> config = new HashMap<>();
-    config
-        .putAll(
-            ThriftClientTypes.CLIENT.execute(
-                context, client -> client.getConfiguration(TraceUtil.traceInfo(),
-                    context.rpcCreds(), ConfigurationType.PROCESS),
-                ResourceGroupPredicate.exact(group)));
-    config.putAll(getProperties(group));
-    return Map.copyOf(config);
+        .createResourceGroupNode(TraceUtil.traceInfo(), context.rpcCreds(), group.canonical()));
   }
 
   @Override
@@ -108,8 +88,7 @@ public class ResourceGroupOperationsImpl implements ResourceGroupOperations {
     try {
       TVersionedProperties rgProps = ThriftClientTypes.CLIENT.execute(context,
           client -> client.getVersionedResourceGroupProperties(TraceUtil.traceInfo(),
-              context.rpcCreds(), group.canonical()),
-          ResourceGroupPredicate.ANY);
+              context.rpcCreds(), group.canonical()));
       if (rgProps != null && rgProps.getPropertiesSize() > 0) {
         return Map.copyOf(rgProps.getProperties());
       } else {
@@ -137,10 +116,9 @@ public class ResourceGroupOperationsImpl implements ResourceGroupOperations {
           + " setting its replacement {} instead", property, replacement);
     });
     try {
-      ThriftClientTypes.MANAGER.executeVoid(
-          context, client -> client.setResourceGroupProperty(TraceUtil.traceInfo(),
-              context.rpcCreds(), group.canonical(), property, value),
-          ResourceGroupPredicate.DEFAULT_RG_ONLY);
+      ThriftClientTypes.MANAGER.executeVoid(context,
+          client -> client.setResourceGroupProperty(TraceUtil.traceInfo(), context.rpcCreds(),
+              group.canonical(), property, value));
     } catch (AccumuloException | AccumuloSecurityException e) {
       Throwable t = e.getCause();
       if (t instanceof ThriftResourceGroupNotExistsException te) {
@@ -159,8 +137,7 @@ public class ResourceGroupOperationsImpl implements ResourceGroupOperations {
     try {
       vProperties = ThriftClientTypes.CLIENT.execute(context,
           client -> client.getVersionedResourceGroupProperties(TraceUtil.traceInfo(),
-              context.rpcCreds(), group.canonical()),
-          ResourceGroupPredicate.ANY);
+              context.rpcCreds(), group.canonical()));
     } catch (AccumuloException | AccumuloSecurityException e) {
       Throwable t = e.getCause();
       if (t instanceof ThriftResourceGroupNotExistsException te) {
@@ -191,10 +168,9 @@ public class ResourceGroupOperationsImpl implements ResourceGroupOperations {
 
     // Send to server
     try {
-      ThriftClientTypes.MANAGER.executeVoid(
-          context, client -> client.modifyResourceGroupProperties(TraceUtil.traceInfo(),
-              context.rpcCreds(), group.canonical(), vProperties),
-          ResourceGroupPredicate.DEFAULT_RG_ONLY);
+      ThriftClientTypes.MANAGER.executeVoid(context,
+          client -> client.modifyResourceGroupProperties(TraceUtil.traceInfo(), context.rpcCreds(),
+              group.canonical(), vProperties));
     } catch (AccumuloException | AccumuloSecurityException e) {
       Throwable t = e.getCause();
       if (t instanceof ThriftResourceGroupNotExistsException te) {
@@ -252,10 +228,9 @@ public class ResourceGroupOperationsImpl implements ResourceGroupOperations {
           + " its replacement {} and will remove that instead", property, replacement);
     });
     try {
-      ThriftClientTypes.MANAGER.executeVoid(
-          context, client -> client.removeResourceGroupProperty(TraceUtil.traceInfo(),
-              context.rpcCreds(), group.canonical(), property),
-          ResourceGroupPredicate.DEFAULT_RG_ONLY);
+      ThriftClientTypes.MANAGER.executeVoid(context,
+          client -> client.removeResourceGroupProperty(TraceUtil.traceInfo(), context.rpcCreds(),
+              group.canonical(), property));
     } catch (AccumuloException | AccumuloSecurityException e) {
       Throwable t = e.getCause();
       if (t instanceof ThriftResourceGroupNotExistsException te) {
@@ -272,8 +247,7 @@ public class ResourceGroupOperationsImpl implements ResourceGroupOperations {
     checkArgument(group != null, "group argument must be supplied");
     try {
       ThriftClientTypes.MANAGER.executeVoid(context, client -> client
-          .removeResourceGroupNode(TraceUtil.traceInfo(), context.rpcCreds(), group.canonical()),
-          ResourceGroupPredicate.DEFAULT_RG_ONLY);
+          .removeResourceGroupNode(TraceUtil.traceInfo(), context.rpcCreds(), group.canonical()));
     } catch (AccumuloException | AccumuloSecurityException e) {
       Throwable t = e.getCause();
       if (t instanceof ThriftResourceGroupNotExistsException te) {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/SecurityOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/SecurityOperationsImpl.java
@@ -38,7 +38,6 @@ import org.apache.accumulo.core.clientImpl.thrift.ClientService;
 import org.apache.accumulo.core.clientImpl.thrift.SecurityErrorCode;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
 import org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException;
-import org.apache.accumulo.core.lock.ServiceLockPaths.ResourceGroupPredicate;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes.Exec;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes.ExecVoid;
@@ -65,8 +64,7 @@ public class SecurityOperationsImpl implements SecurityOperations {
   private void executeVoid(ExecVoid<ClientService.Client> exec)
       throws AccumuloException, AccumuloSecurityException {
     try {
-      ThriftClientTypes.CLIENT.executeVoid(context, client -> exec.execute(client),
-          ResourceGroupPredicate.ANY);
+      ThriftClientTypes.CLIENT.executeVoid(context, client -> exec.execute(client));
     } catch (AccumuloSecurityException e) {
       throw e;
     } catch (AccumuloException e) {
@@ -103,8 +101,7 @@ public class SecurityOperationsImpl implements SecurityOperations {
   private <R> R execute(Exec<R,ClientService.Client> exec)
       throws AccumuloException, AccumuloSecurityException {
     try {
-      return ThriftClientTypes.CLIENT.execute(context, client -> exec.execute(client),
-          ResourceGroupPredicate.ANY);
+      return ThriftClientTypes.CLIENT.execute(context, client -> exec.execute(client));
     } catch (AccumuloSecurityException e) {
       throw e;
     } catch (AccumuloException e) {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportPool.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportPool.java
@@ -35,24 +35,16 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
-import org.apache.accumulo.core.lock.ServiceLockData.ThriftService;
-import org.apache.accumulo.core.lock.ServiceLockPaths.AddressSelector;
-import org.apache.accumulo.core.lock.ServiceLockPaths.ResourceGroupPredicate;
-import org.apache.accumulo.core.lock.ServiceLockPaths.ServiceLockPath;
 import org.apache.accumulo.core.rpc.ThriftUtil;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
 import org.apache.accumulo.core.util.Pair;
-import org.apache.accumulo.core.util.Timer;
 import org.apache.accumulo.core.util.threads.Threads;
-import org.apache.commons.collections4.set.CompositeSet;
 import org.apache.thrift.TConfiguration;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
@@ -145,33 +137,12 @@ public class ThriftTransportPool {
     return createNewTransport(cacheKey);
   }
 
-  @SuppressWarnings("unchecked")
-  public Pair<String,TTransport> getAnyCachedTransport(ThriftClientTypes<?> type, ClientContext ctx,
-      ThriftService service, ResourceGroupPredicate rgp) {
+  public Pair<String,TTransport> getAnyCachedTransport(ThriftClientTypes<?> type) {
 
-    final Timer timer = Timer.startNew();
     final List<ThriftTransportKey> serversSet = new ArrayList<>();
 
-    Function<AddressSelector,Set<ServiceLockPath>> paths = switch (service) {
-      case CLIENT -> (selector) -> new CompositeSet<ServiceLockPath>(
-          ctx.getServerPaths().getCompactor(rgp, selector, true),
-          ctx.getServerPaths().getScanServer(rgp, selector, true),
-          ctx.getServerPaths().getTabletServer(rgp, selector, true));
-      case COMPACTOR -> (selector) -> ctx.getServerPaths().getCompactor(rgp, selector, true);
-      case MANAGER, COORDINATOR, FATE ->
-        (selector) -> Set.of(ctx.getServerPaths().getManager(true));
-      case GC -> (selector) -> Set.of(ctx.getServerPaths().getGarbageCollector(true));
-      case TABLET_SCAN -> (selector) -> new CompositeSet<ServiceLockPath>(
-          ctx.getServerPaths().getTabletServer(rgp, selector, true),
-          ctx.getServerPaths().getScanServer(rgp, selector, true));
-      case TABLET_INGEST, TABLET_MANAGEMENT, TSERV ->
-        (selector) -> ctx.getServerPaths().getTabletServer(rgp, selector, true);
-      default -> throw new IllegalArgumentException("Unhandled thrift service type: " + service);
-    };
-
     for (ThriftTransportKey ttk : connectionPool.getThriftTransportKeys()) {
-      if (ttk.getType().equals(type)
-          && !paths.apply(AddressSelector.exact(ttk.getServer())).isEmpty()) {
+      if (ttk.getType().equals(type)) {
         serversSet.add(ttk);
       }
     }
@@ -183,8 +154,7 @@ public class ThriftTransportPool {
       CachedConnection connection = connectionPool.reserveAny(ttk);
       if (connection != null) {
         final String serverAddr = ttk.getServer().toString();
-        log.trace("Took {} ms to evaluate existing connection to {}",
-            timer.elapsed(TimeUnit.MILLISECONDS), serverAddr);
+        log.trace("Using existing connection to {}", serverAddr);
         return new Pair<>(serverAddr, connection.transport);
       }
     }

--- a/core/src/main/java/org/apache/accumulo/core/rpc/clients/ClientServiceThriftClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/clients/ClientServiceThriftClient.java
@@ -25,7 +25,6 @@ import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.clientImpl.thrift.ClientService.Client;
 import org.apache.accumulo.core.lock.ServiceLockData.ThriftService;
-import org.apache.accumulo.core.lock.ServiceLockPaths.ResourceGroupPredicate;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
@@ -43,21 +42,21 @@ public class ClientServiceThriftClient extends ThriftClientTypes<Client>
 
   @Override
   public Pair<String,Client> getThriftServerConnection(ClientContext context,
-      boolean preferCachedConnections, ResourceGroupPredicate rgp) throws TTransportException {
+      boolean preferCachedConnections) throws TTransportException {
     return getThriftServerConnection(LOG, this, context, preferCachedConnections,
-        warnedAboutTServersBeingDown, ThriftService.CLIENT, rgp);
+        warnedAboutTServersBeingDown, ThriftService.CLIENT);
   }
 
   @Override
-  public <R> R execute(ClientContext context, Exec<R,Client> exec, ResourceGroupPredicate rgp)
+  public <R> R execute(ClientContext context, Exec<R,Client> exec)
       throws AccumuloException, AccumuloSecurityException {
-    return execute(LOG, context, exec, rgp);
+    return execute(LOG, context, exec);
   }
 
   @Override
-  public void executeVoid(ClientContext context, ExecVoid<Client> exec, ResourceGroupPredicate rgp)
+  public void executeVoid(ClientContext context, ExecVoid<Client> exec)
       throws AccumuloException, AccumuloSecurityException {
-    executeVoid(LOG, context, exec, rgp);
+    executeVoid(LOG, context, exec);
   }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/rpc/clients/ManagerThriftClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/clients/ManagerThriftClient.java
@@ -32,7 +32,6 @@ import org.apache.accumulo.core.clientImpl.thrift.ThriftConcurrentModificationEx
 import org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException;
 import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException;
-import org.apache.accumulo.core.lock.ServiceLockPaths.ResourceGroupPredicate;
 import org.apache.accumulo.core.manager.thrift.ManagerClientService.Client;
 import org.apache.accumulo.core.rpc.ThriftUtil;
 import org.apache.thrift.transport.TTransportException;
@@ -91,7 +90,7 @@ public class ManagerThriftClient extends ThriftClientTypes<Client>
   }
 
   @Override
-  public <R> R execute(ClientContext context, Exec<R,Client> exec, ResourceGroupPredicate rgp)
+  public <R> R execute(ClientContext context, Exec<R,Client> exec)
       throws AccumuloException, AccumuloSecurityException {
     try {
       return executeTableCommand(context, exec);
@@ -139,7 +138,7 @@ public class ManagerThriftClient extends ThriftClientTypes<Client>
   }
 
   @Override
-  public void executeVoid(ClientContext context, ExecVoid<Client> exec, ResourceGroupPredicate rgp)
+  public void executeVoid(ClientContext context, ExecVoid<Client> exec)
       throws AccumuloException, AccumuloSecurityException {
     try {
       executeVoidTableCommand(context, exec);

--- a/core/src/main/java/org/apache/accumulo/core/rpc/clients/TServerClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/clients/TServerClient.java
@@ -62,7 +62,6 @@ import com.google.common.net.HostAndPort;
 public interface TServerClient<C extends TServiceClient> {
 
   static final String DEBUG_HOST = "org.apache.accumulo.client.rpc.debug.host";
-  static final String DEBUG_RG = "org.apache.accumulo.client.rpc.debug.group";
 
   Pair<String,C> getThriftServerConnection(ClientContext context, boolean preferCachedConnections)
       throws TTransportException;

--- a/core/src/main/java/org/apache/accumulo/core/rpc/clients/TServerClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/clients/TServerClient.java
@@ -39,7 +39,6 @@ import org.apache.accumulo.core.clientImpl.AccumuloServerException;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException;
-import org.apache.accumulo.core.data.ResourceGroupId;
 import org.apache.accumulo.core.lock.ServiceLockData;
 import org.apache.accumulo.core.lock.ServiceLockData.ThriftService;
 import org.apache.accumulo.core.lock.ServiceLockPaths;
@@ -65,49 +64,20 @@ public interface TServerClient<C extends TServiceClient> {
   static final String DEBUG_HOST = "org.apache.accumulo.client.rpc.debug.host";
   static final String DEBUG_RG = "org.apache.accumulo.client.rpc.debug.group";
 
-  Pair<String,C> getThriftServerConnection(ClientContext context, boolean preferCachedConnections,
-      ResourceGroupPredicate rgp) throws TTransportException;
+  Pair<String,C> getThriftServerConnection(ClientContext context, boolean preferCachedConnections)
+      throws TTransportException;
 
   default Pair<String,C> getThriftServerConnection(Logger LOG, ThriftClientTypes<C> type,
       ClientContext context, boolean preferCachedConnections, AtomicBoolean warned,
-      ThriftService service, ResourceGroupPredicate rgp) throws TTransportException {
+      ThriftService service) throws TTransportException {
     checkArgument(context != null, "context is null");
 
     final String debugHost = System.getProperty(DEBUG_HOST, null);
     final boolean debugHostSpecified = debugHost != null;
-    final String debugRG = System.getProperty(DEBUG_RG, null);
-    final boolean debugRGSpecified = debugRG != null;
-    final ResourceGroupId debugRGid = debugRGSpecified ? ResourceGroupId.of(debugRG) : null;
 
-    if (debugHostSpecified && debugRGSpecified) {
-      LOG.warn("System properties {} and {} are both set. If set incorrectly then"
-          + " this client may not find a server to connect to.", DEBUG_HOST, DEBUG_RG);
-    }
-
-    if (debugRGSpecified) {
-      if (type == ThriftClientTypes.CLIENT || type == ThriftClientTypes.COMPACTOR
-          || type == ThriftClientTypes.SERVER_PROCESS || type == ThriftClientTypes.TABLET_INGEST
-          || type == ThriftClientTypes.TABLET_MGMT || type == ThriftClientTypes.TABLET_SCAN
-          || type == ThriftClientTypes.TABLET_SERVER) {
-        if (rgp.test(debugRGid)) {
-          // its safe to potentially narrow the predicate
-          LOG.debug("System property '{}' set to '{}' overriding predicate argument", DEBUG_RG,
-              debugRG);
-          rgp = ResourceGroupPredicate.exact(debugRGid);
-        } else {
-          LOG.warn("System property '{}' set to '{}' does not intersect with predicate argument."
-              + " Ignoring degug system property.", DEBUG_RG, debugRG);
-        }
-      } else {
-        LOG.debug(
-            "System property '{}' set to '{}' but ignored when making RPCs to management servers",
-            DEBUG_RG, debugRG);
-      }
-    }
-
-    if (preferCachedConnections && !debugHostSpecified && !debugRGSpecified) {
+    if (preferCachedConnections && !debugHostSpecified) {
       Pair<String,TTransport> cachedTransport =
-          context.getTransportPool().getAnyCachedTransport(type, context, service, rgp);
+          context.getTransportPool().getAnyCachedTransport(type);
       if (cachedTransport != null) {
         C client =
             ThriftUtil.createClient(type, cachedTransport.getSecond(), context.getInstanceID());
@@ -120,6 +90,7 @@ public interface TServerClient<C extends TServiceClient> {
     final ZooCache zc = context.getZooCache();
     final ServiceLockPaths sp = context.getServerPaths();
     final List<ServiceLockPath> serverPaths = new ArrayList<>();
+    final ResourceGroupPredicate rgp = ResourceGroupPredicate.ANY;
 
     if (type == ThriftClientTypes.CLIENT && debugHostSpecified) {
       // add all three paths to the set even though they may not be correct.
@@ -142,12 +113,7 @@ public interface TServerClient<C extends TServiceClient> {
               "There are no servers serving the {} api: check that zookeeper and accumulo are running.",
               type);
         }
-        // If the user set the system property for the resource group, then don't throw
-        // a TTransportException here. That will cause the call to be continuously retried.
-        // Instead, let this continue so that we can throw a different error below.
-        if (!debugRGSpecified) {
-          throw new TTransportException("There are no servers for type: " + type);
-        }
+        throw new TTransportException("There are no servers for type: " + type);
       }
     }
 
@@ -173,11 +139,6 @@ public interface TServerClient<C extends TServiceClient> {
                   "Error creating transport to debug host: {}. If this server is"
                       + " down, then you will need to remove or change the system property {}.",
                   debugHost, DEBUG_HOST);
-            } else if (debugRGSpecified && rgp.test(debugRGid)) {
-              LOG.error(
-                  "Error creating transport to debug group: {}. If all servers are"
-                      + " down, then you will need to remove or change the system property {}.",
-                  debugRG, DEBUG_RG);
             } else {
               LOG.trace("Error creating transport to {}", tserverClientAddress);
             }
@@ -197,22 +158,18 @@ public interface TServerClient<C extends TServiceClient> {
       throw new UncheckedIOException("Error creating transport to debug host: " + debugHost
           + ". If this server is down, then you will need to remove or change the system property "
           + DEBUG_HOST + ".", new IOException(""));
-    } else if (debugRGSpecified && rgp.test(debugRGid)) {
-      throw new UncheckedIOException("Error creating transport to debug group: " + debugRG
-          + ". If all servers are down, then you will need to remove or change the system property "
-          + DEBUG_RG + ".", new IOException(""));
     } else {
       throw new TTransportException("Failed to connect to any server for API type " + type);
     }
   }
 
-  default <R> R execute(Logger LOG, ClientContext context, Exec<R,C> exec,
-      ResourceGroupPredicate rgp) throws AccumuloException, AccumuloSecurityException {
+  default <R> R execute(Logger LOG, ClientContext context, Exec<R,C> exec)
+      throws AccumuloException, AccumuloSecurityException {
     while (true) {
       String server = null;
       C client = null;
       try {
-        Pair<String,C> pair = getThriftServerConnection(context, true, rgp);
+        Pair<String,C> pair = getThriftServerConnection(context, true);
         server = pair.getFirst();
         client = pair.getSecond();
         return exec.execute(client);
@@ -246,13 +203,13 @@ public interface TServerClient<C extends TServiceClient> {
     }
   }
 
-  default void executeVoid(Logger LOG, ClientContext context, ExecVoid<C> exec,
-      ResourceGroupPredicate rgp) throws AccumuloException, AccumuloSecurityException {
+  default void executeVoid(Logger LOG, ClientContext context, ExecVoid<C> exec)
+      throws AccumuloException, AccumuloSecurityException {
     while (true) {
       String server = null;
       C client = null;
       try {
-        Pair<String,C> pair = getThriftServerConnection(context, true, rgp);
+        Pair<String,C> pair = getThriftServerConnection(context, true);
         server = pair.getFirst();
         client = pair.getSecond();
         exec.execute(client);

--- a/core/src/main/java/org/apache/accumulo/core/rpc/clients/TabletManagementClientServiceThriftClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/clients/TabletManagementClientServiceThriftClient.java
@@ -24,7 +24,6 @@ import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.lock.ServiceLockData.ThriftService;
-import org.apache.accumulo.core.lock.ServiceLockPaths.ResourceGroupPredicate;
 import org.apache.accumulo.core.tablet.thrift.TabletManagementClientService.Client;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.thrift.transport.TTransportException;
@@ -48,21 +47,21 @@ public class TabletManagementClientServiceThriftClient extends ThriftClientTypes
 
   @Override
   public Pair<String,Client> getThriftServerConnection(ClientContext context,
-      boolean preferCachedConnections, ResourceGroupPredicate rgp) throws TTransportException {
+      boolean preferCachedConnections) throws TTransportException {
     return getThriftServerConnection(LOG, this, context, preferCachedConnections,
-        warnedAboutTServersBeingDown, ThriftService.TABLET_MANAGEMENT, rgp);
+        warnedAboutTServersBeingDown, ThriftService.TABLET_MANAGEMENT);
   }
 
   @Override
-  public <R> R execute(ClientContext context, Exec<R,Client> exec, ResourceGroupPredicate rgp)
+  public <R> R execute(ClientContext context, Exec<R,Client> exec)
       throws AccumuloException, AccumuloSecurityException {
-    return execute(LOG, context, exec, rgp);
+    return execute(LOG, context, exec);
   }
 
   @Override
-  public void executeVoid(ClientContext context, ExecVoid<Client> exec, ResourceGroupPredicate rgp)
+  public void executeVoid(ClientContext context, ExecVoid<Client> exec)
       throws AccumuloException, AccumuloSecurityException {
-    executeVoid(LOG, context, exec, rgp);
+    executeVoid(LOG, context, exec);
   }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/rpc/clients/TabletServerThriftClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/clients/TabletServerThriftClient.java
@@ -24,7 +24,6 @@ import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.lock.ServiceLockData.ThriftService;
-import org.apache.accumulo.core.lock.ServiceLockPaths.ResourceGroupPredicate;
 import org.apache.accumulo.core.tabletserver.thrift.TabletServerClientService.Client;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.thrift.transport.TTransportException;
@@ -47,21 +46,21 @@ public class TabletServerThriftClient extends ThriftClientTypes<Client>
 
   @Override
   public Pair<String,Client> getThriftServerConnection(ClientContext context,
-      boolean preferCachedConnections, ResourceGroupPredicate rgp) throws TTransportException {
+      boolean preferCachedConnections) throws TTransportException {
     return getThriftServerConnection(LOG, this, context, preferCachedConnections,
-        warnedAboutTServersBeingDown, ThriftService.TSERV, rgp);
+        warnedAboutTServersBeingDown, ThriftService.TSERV);
   }
 
   @Override
-  public <R> R execute(ClientContext context, Exec<R,Client> exec, ResourceGroupPredicate rgp)
+  public <R> R execute(ClientContext context, Exec<R,Client> exec)
       throws AccumuloException, AccumuloSecurityException {
-    return execute(LOG, context, exec, rgp);
+    return execute(LOG, context, exec);
   }
 
   @Override
-  public void executeVoid(ClientContext context, ExecVoid<Client> exec, ResourceGroupPredicate rgp)
+  public void executeVoid(ClientContext context, ExecVoid<Client> exec)
       throws AccumuloException, AccumuloSecurityException {
-    executeVoid(LOG, context, exec, rgp);
+    executeVoid(LOG, context, exec);
   }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/rpc/clients/ThriftClientTypes.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/clients/ThriftClientTypes.java
@@ -24,7 +24,6 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.clientImpl.ClientContext;
-import org.apache.accumulo.core.lock.ServiceLockPaths.ResourceGroupPredicate;
 import org.apache.thrift.TException;
 import org.apache.thrift.TServiceClient;
 import org.apache.thrift.TServiceClientFactory;
@@ -116,12 +115,12 @@ public abstract class ThriftClientTypes<C extends TServiceClient> {
     }
   }
 
-  public <R> R execute(ClientContext context, Exec<R,C> exec, ResourceGroupPredicate rgp)
+  public <R> R execute(ClientContext context, Exec<R,C> exec)
       throws AccumuloException, AccumuloSecurityException {
     throw new UnsupportedOperationException("This method has not been implemented");
   }
 
-  public void executeVoid(ClientContext context, ExecVoid<C> exec, ResourceGroupPredicate rgp)
+  public void executeVoid(ClientContext context, ExecVoid<C> exec)
       throws AccumuloException, AccumuloSecurityException {
     throw new UnsupportedOperationException("This method has not been implemented");
   }

--- a/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
@@ -62,7 +62,6 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.dataImpl.thrift.TRowRange;
 import org.apache.accumulo.core.dataImpl.thrift.TSummaries;
 import org.apache.accumulo.core.dataImpl.thrift.TSummaryRequest;
-import org.apache.accumulo.core.lock.ServiceLockPaths.ResourceGroupPredicate;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
@@ -483,7 +482,7 @@ public class Gatherer {
             tsr = client.contiuneGetSummaries(tinfo, tsr.sessionId);
           }
           return tsr;
-        }, ResourceGroupPredicate.ANY);
+        });
       } catch (AccumuloException | AccumuloSecurityException e) {
         throw new IllegalStateException(e);
       }

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
@@ -1155,8 +1155,7 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
     try (AccumuloClient c = Accumulo.newClient().from(clientProperties.get()).build()) {
       ClientContext context = (ClientContext) c;
       return ThriftClientTypes.MANAGER.execute(context,
-          client -> client.getManagerStats(TraceUtil.traceInfo(), context.rpcCreds()),
-          ResourceGroupPredicate.DEFAULT_RG_ONLY);
+          client -> client.getManagerStats(TraceUtil.traceInfo(), context.rpcCreds()));
     }
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
@@ -659,8 +659,7 @@ public class Admin implements KeywordExecutable {
       throws AccumuloException, AccumuloSecurityException {
 
     ThriftClientTypes.MANAGER.executeVoid(context,
-        client -> client.shutdown(TraceUtil.traceInfo(), context.rpcCreds(), tabletServersToo),
-        ResourceGroupPredicate.DEFAULT_RG_ONLY);
+        client -> client.shutdown(TraceUtil.traceInfo(), context.rpcCreds(), tabletServersToo));
   }
 
   private static void stopServers(final ServerContext context, List<String> servers,
@@ -777,11 +776,8 @@ public class Admin implements KeywordExecutable {
         HostAndPort address = AddressUtil.parseAddress(server, port);
         final String finalServer = qualifyWithZooKeeperSessionId(context, zc, address.toString());
         log.info("Stopping server {}", finalServer);
-        ThriftClientTypes.MANAGER
-            .executeVoid(
-                context, client -> client.shutdownTabletServer(TraceUtil.traceInfo(),
-                    context.rpcCreds(), finalServer, force),
-                ResourceGroupPredicate.DEFAULT_RG_ONLY);
+        ThriftClientTypes.MANAGER.executeVoid(context, client -> client
+            .shutdownTabletServer(TraceUtil.traceInfo(), context.rpcCreds(), finalServer, force));
       }
     }
   }
@@ -936,8 +932,8 @@ public class Admin implements KeywordExecutable {
     Path rgScript = outputDirectory.toPath().resolve(group + RG_FILE_SUFFIX);
     try (BufferedWriter nsWriter = Files.newBufferedWriter(rgScript)) {
       nsWriter.write(createRGFormat.format(new String[] {group.canonical()}));
-      Map<String,String> props = ImmutableSortedMap
-          .copyOf(accumuloClient.resourceGroupOperations().getConfiguration(group));
+      Map<String,String> props =
+          ImmutableSortedMap.copyOf(accumuloClient.resourceGroupOperations().getProperties(group));
       for (Entry<String,String> entry : props.entrySet()) {
         String defaultValue = getDefaultConfigValue(entry.getKey());
         if (defaultValue == null || !defaultValue.equals(entry.getValue())) {

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ListBulkCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ListBulkCommand.java
@@ -19,7 +19,6 @@
 package org.apache.accumulo.shell.commands;
 
 import org.apache.accumulo.core.clientImpl.ClientContext;
-import org.apache.accumulo.core.lock.ServiceLockPaths.ResourceGroupPredicate;
 import org.apache.accumulo.core.manager.thrift.ManagerMonitorInfo;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
 import org.apache.accumulo.core.trace.TraceUtil;
@@ -45,8 +44,7 @@ public class ListBulkCommand extends Command {
 
     ClientContext context = shellState.getContext();
     ManagerMonitorInfo stats = ThriftClientTypes.MANAGER.execute(context,
-        client -> client.getManagerStats(TraceUtil.traceInfo(), context.rpcCreds()),
-        ResourceGroupPredicate.DEFAULT_RG_ONLY);
+        client -> client.getManagerStats(TraceUtil.traceInfo(), context.rpcCreds()));
 
     final boolean paginate = !cl.hasOption(disablePaginationOpt.getOpt());
 

--- a/test/src/main/java/org/apache/accumulo/test/DetectDeadTabletServersIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/DetectDeadTabletServersIT.java
@@ -28,7 +28,6 @@ import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.conf.ClientProperty;
 import org.apache.accumulo.core.conf.Property;
-import org.apache.accumulo.core.lock.ServiceLockPaths.ResourceGroupPredicate;
 import org.apache.accumulo.core.manager.thrift.ManagerMonitorInfo;
 import org.apache.accumulo.core.metadata.SystemTables;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
@@ -82,8 +81,7 @@ public class DetectDeadTabletServersIT extends ConfigurableMacBase {
   private ManagerMonitorInfo getStats(AccumuloClient c) throws Exception {
     final ClientContext context = (ClientContext) c;
     return ThriftClientTypes.MANAGER.execute(context,
-        client -> client.getManagerStats(TraceUtil.traceInfo(), context.rpcCreds()),
-        ResourceGroupPredicate.DEFAULT_RG_ONLY);
+        client -> client.getManagerStats(TraceUtil.traceInfo(), context.rpcCreds()));
   }
 
 }

--- a/test/src/main/java/org/apache/accumulo/test/GetManagerStats.java
+++ b/test/src/main/java/org/apache/accumulo/test/GetManagerStats.java
@@ -23,7 +23,6 @@ import java.util.Date;
 import java.util.Map.Entry;
 
 import org.apache.accumulo.core.conf.SiteConfiguration;
-import org.apache.accumulo.core.lock.ServiceLockPaths.ResourceGroupPredicate;
 import org.apache.accumulo.core.manager.thrift.BulkImportStatus;
 import org.apache.accumulo.core.manager.thrift.DeadServer;
 import org.apache.accumulo.core.manager.thrift.ManagerMonitorInfo;
@@ -40,8 +39,7 @@ public class GetManagerStats {
     ManagerMonitorInfo stats = null;
     var context = new ServerContext(SiteConfiguration.auto());
     stats = ThriftClientTypes.MANAGER.execute(context,
-        client -> client.getManagerStats(TraceUtil.traceInfo(), context.rpcCreds()),
-        ResourceGroupPredicate.DEFAULT_RG_ONLY);
+        client -> client.getManagerStats(TraceUtil.traceInfo(), context.rpcCreds()));
     out(0, "State: " + stats.state.name());
     out(0, "Goal State: " + stats.goalState.name());
     if (stats.serversShuttingDown != null && !stats.serversShuttingDown.isEmpty()) {

--- a/test/src/main/java/org/apache/accumulo/test/TransportCachingIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TransportCachingIT.java
@@ -20,7 +20,6 @@ package org.apache.accumulo.test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.util.List;
@@ -34,9 +33,6 @@ import org.apache.accumulo.core.clientImpl.ThriftTransportKey;
 import org.apache.accumulo.core.clientImpl.ThriftTransportPool;
 import org.apache.accumulo.core.conf.ConfigurationTypeHelper;
 import org.apache.accumulo.core.conf.Property;
-import org.apache.accumulo.core.data.ResourceGroupId;
-import org.apache.accumulo.core.lock.ServiceLockData.ThriftService;
-import org.apache.accumulo.core.lock.ServiceLockPaths.ResourceGroupPredicate;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
@@ -76,62 +72,48 @@ public class TransportCachingIT extends AccumuloClusterHarness {
       ThriftTransportKey ttk = servers.get(0);
 
       ThriftTransportPool pool = context.getTransportPool();
-      TTransport first = getAnyTransport(ttk, pool, context, ThriftService.CLIENT,
-          ResourceGroupPredicate.DEFAULT_RG_ONLY, true);
+      TTransport first = getAnyTransport(ttk, pool, true);
 
       assertNotNull(first);
       // Return it to unreserve it
       pool.returnTransport(first);
 
-      TTransport second = getAnyTransport(ttk, pool, context, ThriftService.CLIENT,
-          ResourceGroupPredicate.DEFAULT_RG_ONLY, true);
+      TTransport second = getAnyTransport(ttk, pool, true);
 
       // We should get the same transport
       assertSame(first, second, "Expected the first and second to be the same instance");
       pool.returnTransport(second);
 
       // Ensure does not get cached connection just returned
-      TTransport third = getAnyTransport(ttk, pool, context, ThriftService.CLIENT,
-          ResourceGroupPredicate.DEFAULT_RG_ONLY, false);
+      TTransport third = getAnyTransport(ttk, pool, false);
       assertNotSame(second, third, "Expected second and third transport to be different instances");
 
-      TTransport fourth = getAnyTransport(ttk, pool, context, ThriftService.CLIENT,
-          ResourceGroupPredicate.DEFAULT_RG_ONLY, false);
+      TTransport fourth = getAnyTransport(ttk, pool, false);
       assertNotSame(third, fourth, "Expected third and fourth transport to be different instances");
 
       pool.returnTransport(third);
       pool.returnTransport(fourth);
 
       // The following three asserts ensure the per server queue is LIFO
-      TTransport fifth = getAnyTransport(ttk, pool, context, ThriftService.CLIENT,
-          ResourceGroupPredicate.DEFAULT_RG_ONLY, true);
+      TTransport fifth = getAnyTransport(ttk, pool, true);
       assertSame(fourth, fifth, "Expected fourth and fifth transport to be the same instance");
 
-      TTransport sixth = getAnyTransport(ttk, pool, context, ThriftService.CLIENT,
-          ResourceGroupPredicate.DEFAULT_RG_ONLY, true);
+      TTransport sixth = getAnyTransport(ttk, pool, true);
       assertSame(third, sixth, "Expected third and sixth transport to be the same instance");
 
-      TTransport seventh = getAnyTransport(ttk, pool, context, ThriftService.CLIENT,
-          ResourceGroupPredicate.DEFAULT_RG_ONLY, true);
+      TTransport seventh = getAnyTransport(ttk, pool, true);
       assertSame(second, seventh, "Expected second and seventh transport to be the same instance");
 
       pool.returnTransport(fifth);
       pool.returnTransport(sixth);
       pool.returnTransport(seventh);
-
-      Pair<String,TTransport> eigth = pool.getAnyCachedTransport(ttk.getType(), context,
-          ThriftService.CLIENT, ResourceGroupPredicate.exact(ResourceGroupId.of("FAKE")));
-      assertNull(eigth);
-
     }
   }
 
   private TTransport getAnyTransport(ThriftTransportKey ttk, ThriftTransportPool pool,
-      ClientContext context, ThriftService service, ResourceGroupPredicate rgp,
       boolean preferCached) {
     if (preferCached) {
-      Pair<String,TTransport> cached =
-          pool.getAnyCachedTransport(ttk.getType(), context, service, rgp);
+      Pair<String,TTransport> cached = pool.getAnyCachedTransport(ttk.getType());
       if (cached != null) {
         return cached.getSecond();
       }

--- a/test/src/main/java/org/apache/accumulo/test/conf/PropStoreConfigIT_SimpleSuite.java
+++ b/test/src/main/java/org/apache/accumulo/test/conf/PropStoreConfigIT_SimpleSuite.java
@@ -50,7 +50,6 @@ import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.ResourceGroupId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
-import org.apache.accumulo.core.lock.ServiceLockPaths.ResourceGroupPredicate;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
 import org.apache.accumulo.core.trace.TraceUtil;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
@@ -489,9 +488,10 @@ public class PropStoreConfigIT_SimpleSuite extends SharedMiniClusterBase {
 
   private Map<String,String> getStoredConfiguration() throws Exception {
     ServerContext ctx = getCluster().getServerContext();
-    return ThriftClientTypes.CLIENT.execute(ctx,
-        client -> client.getVersionedSystemProperties(TraceUtil.traceInfo(), ctx.rpcCreds()),
-        ResourceGroupPredicate.ANY).getProperties();
+    return ThriftClientTypes.CLIENT
+        .execute(ctx,
+            client -> client.getVersionedSystemProperties(TraceUtil.traceInfo(), ctx.rpcCreds()))
+        .getProperties();
   }
 
   interface PropertyShim {

--- a/test/src/main/java/org/apache/accumulo/test/conf/ResourceGroupConfigIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/conf/ResourceGroupConfigIT.java
@@ -361,8 +361,12 @@ public class ResourceGroupConfigIT extends SharedMiniClusterBase {
       assertEquals(Set.of(ResourceGroupId.DEFAULT, first, second, third), rgops.list());
 
       // make some changes to resource groups check if we see them
-      rgops.modifyProperties(first, (map) -> {map.clear(); map.putAll(secondProps);});
-      rgops.modifyProperties(second, (map) -> {map.clear(); map.putAll(firstProps);});
+      rgops.modifyProperties(first, (map) -> {
+        map.clear(); map.putAll(secondProps);
+      });
+      rgops.modifyProperties(second, (map) -> {
+        map.clear(); map.putAll(firstProps);
+      });
       rgops.remove(third);
 
       assertEquals(secondProps, rgops.getProperties(first));

--- a/test/src/main/java/org/apache/accumulo/test/functional/BalanceAfterCommsFailureIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BalanceAfterCommsFailureIT.java
@@ -33,7 +33,6 @@ import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.conf.Property;
-import org.apache.accumulo.core.lock.ServiceLockPaths.ResourceGroupPredicate;
 import org.apache.accumulo.core.manager.thrift.ManagerMonitorInfo;
 import org.apache.accumulo.core.manager.thrift.TableInfo;
 import org.apache.accumulo.core.manager.thrift.TabletServerStatus;
@@ -106,8 +105,7 @@ public class BalanceAfterCommsFailureIT extends ConfigurableMacBase {
     int unassignedTablets = 1;
     for (int i = 0; unassignedTablets > 0 && i < 10; i++) {
       stats = ThriftClientTypes.MANAGER.execute(context,
-          client -> client.getManagerStats(TraceUtil.traceInfo(), context.rpcCreds()),
-          ResourceGroupPredicate.DEFAULT_RG_ONLY);
+          client -> client.getManagerStats(TraceUtil.traceInfo(), context.rpcCreds()));
       unassignedTablets = stats.getUnassignedTablets();
       if (unassignedTablets > 0) {
         log.info("Found {} unassigned tablets, sleeping 3 seconds for tablet assignment",

--- a/test/src/main/java/org/apache/accumulo/test/functional/BalanceInPresenceOfOfflineTableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BalanceInPresenceOfOfflineTableIT.java
@@ -40,7 +40,6 @@ import org.apache.accumulo.core.client.admin.servers.ServerId;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.clientImpl.Credentials;
 import org.apache.accumulo.core.conf.Property;
-import org.apache.accumulo.core.lock.ServiceLockPaths.ResourceGroupPredicate;
 import org.apache.accumulo.core.manager.thrift.ManagerMonitorInfo;
 import org.apache.accumulo.core.manager.thrift.TableInfo;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
@@ -159,8 +158,7 @@ public class BalanceInPresenceOfOfflineTableIT extends AccumuloClusterHarness {
 
       ManagerMonitorInfo stats = ThriftClientTypes.MANAGER.execute((ClientContext) accumuloClient,
           client -> client.getManagerStats(TraceUtil.traceInfo(),
-              creds.toThrift(accumuloClient.instanceOperations().getInstanceId())),
-          ResourceGroupPredicate.DEFAULT_RG_ONLY);
+              creds.toThrift(accumuloClient.instanceOperations().getInstanceId())));
 
       if (stats.getTServerInfoSize() < 2) {
         log.debug("we need >= 2 servers. sleeping for {}ms", currentWait);

--- a/test/src/main/java/org/apache/accumulo/test/functional/DebugClientConnectionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/DebugClientConnectionIT.java
@@ -21,7 +21,6 @@ package org.apache.accumulo.test.functional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.UncheckedIOException;
 import java.util.Iterator;
@@ -29,17 +28,10 @@ import java.util.Set;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
-import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.admin.servers.ServerId;
-import org.apache.accumulo.core.lock.ServiceLockPaths.AddressSelector;
-import org.apache.accumulo.core.lock.ServiceLockPaths.ServiceLockPath;
-import org.apache.accumulo.core.metadata.SystemTables;
 import org.apache.accumulo.core.rpc.clients.TServerClient;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
-import org.apache.accumulo.minicluster.ServerType;
-import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
-import org.apache.accumulo.test.util.Wait;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -61,7 +53,6 @@ public class DebugClientConnectionIT extends AccumuloClusterHarness {
     assertNotNull(tservers);
     assertEquals(2, tservers.size());
     System.clearProperty(TServerClient.DEBUG_HOST);
-    System.clearProperty(TServerClient.DEBUG_RG);
   }
 
   @Test
@@ -79,52 +70,6 @@ public class DebugClientConnectionIT extends AccumuloClusterHarness {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
       assertThrows(UncheckedIOException.class,
           () -> client.instanceOperations().getSiteConfiguration());
-    }
-  }
-
-  @Test
-  public void testPreferredResourceGroup() throws Exception {
-    System.setProperty(TServerClient.DEBUG_RG, "fake");
-    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-      AccumuloException ae = assertThrows(AccumuloException.class,
-          () -> client.tableOperations().getConfiguration(SystemTables.METADATA.tableName()));
-      // TableOps wraps RuntimeExceptions with AccumuloExceptions
-      assertTrue(ae.getCause() instanceof UncheckedIOException);
-    }
-    // Set DEBUG HOST with DEBUG RG, should be no overlap with running hosts
-    Iterator<ServerId> tsi = tservers.iterator();
-    System.setProperty(TServerClient.DEBUG_HOST, tsi.next().toHostPortString());
-    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-      AccumuloException ae = assertThrows(AccumuloException.class,
-          () -> client.tableOperations().getConfiguration(SystemTables.METADATA.tableName()));
-      // TableOps wraps RuntimeExceptions with AccumuloExceptions
-      assertTrue(ae.getCause() instanceof UncheckedIOException);
-    }
-    MiniAccumuloClusterImpl mini = (MiniAccumuloClusterImpl) getCluster();
-    mini.getConfig().getClusterServerConfiguration().addTabletServerResourceGroup("fake", 1);
-    mini.getClusterControl().start(ServerType.TABLET_SERVER);
-    Wait.waitFor(() -> getCluster().getServerContext().getServerPaths()
-        .getTabletServer(r -> r.canonical().equals("fake"), AddressSelector.all(), true).size()
-        == 1);
-
-    System.clearProperty(TServerClient.DEBUG_HOST);
-    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-      assertNotNull(client.tableOperations().getConfiguration(SystemTables.METADATA.tableName()));
-    }
-    // Set DEBUG HOST with DEBUG RG, should be no overlap with running hosts
-    System.setProperty(TServerClient.DEBUG_HOST, tsi.next().toHostPortString());
-    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-      AccumuloException ae = assertThrows(AccumuloException.class,
-          () -> client.tableOperations().getConfiguration(SystemTables.METADATA.tableName()));
-      // TableOps wraps RuntimeExceptions with AccumuloExceptions
-      assertTrue(ae.getCause() instanceof UncheckedIOException);
-    }
-    // Set DEBUG_HOST and DEBUG_RG to overlap
-    Set<ServiceLockPath> fakeTservers = getCluster().getServerContext().getServerPaths()
-        .getTabletServer(r -> r.canonical().equals("fake"), AddressSelector.all(), true);
-    System.setProperty(TServerClient.DEBUG_HOST, fakeTservers.iterator().next().getServer());
-    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-      assertNotNull(client.tableOperations().getConfiguration(SystemTables.METADATA.tableName()));
     }
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/functional/ManagerApiIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ManagerApiIT.java
@@ -38,7 +38,6 @@ import org.apache.accumulo.core.clientImpl.Credentials;
 import org.apache.accumulo.core.clientImpl.thrift.TVersionedProperties;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.InstanceId;
-import org.apache.accumulo.core.lock.ServiceLockPaths.ResourceGroupPredicate;
 import org.apache.accumulo.core.manager.thrift.ManagerClientService;
 import org.apache.accumulo.core.manager.thrift.ManagerGoalState;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
@@ -267,8 +266,7 @@ public class ManagerApiIT extends SharedMiniClusterBase {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps())
         .as(rootUser.getPrincipal(), rootUser.getToken()).build()) {
       ClientContext context = (ClientContext) client;
-      ThriftClientTypes.MANAGER.execute(context, op.apply(rootUser),
-          ResourceGroupPredicate.DEFAULT_RG_ONLY);
+      ThriftClientTypes.MANAGER.execute(context, op.apply(rootUser));
     }
   }
 
@@ -305,15 +303,14 @@ public class ManagerApiIT extends SharedMiniClusterBase {
       Credentials user) throws Exception {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps())
         .as(user.getPrincipal(), user.getToken()).build()) {
-      ThriftClientTypes.MANAGER.execute((ClientContext) client, op.apply(user),
-          ResourceGroupPredicate.DEFAULT_RG_ONLY);
+      ThriftClientTypes.MANAGER.execute((ClientContext) client, op.apply(user));
     }
   }
 
   private static void expectPermissionSuccess(
       ThriftClientTypes.Exec<Void,ManagerClientService.Client> op, ClientContext context)
       throws Exception {
-    ThriftClientTypes.MANAGER.execute(context, op, ResourceGroupPredicate.DEFAULT_RG_ONLY);
+    ThriftClientTypes.MANAGER.execute(context, op);
   }
 
   private static void expectPermissionDenied(

--- a/test/src/main/java/org/apache/accumulo/test/functional/ManagerAssignmentIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ManagerAssignmentIT.java
@@ -65,7 +65,6 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.FateInstanceType;
 import org.apache.accumulo.core.lock.ServiceLock;
-import org.apache.accumulo.core.lock.ServiceLockPaths.ResourceGroupPredicate;
 import org.apache.accumulo.core.metadata.SystemTables;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
@@ -457,8 +456,7 @@ public class ManagerAssignmentIT extends SharedMiniClusterBase {
   public static List<TabletStats> getTabletStats(AccumuloClient c, String tableId)
       throws AccumuloException, AccumuloSecurityException {
     return ThriftClientTypes.TABLET_SERVER.execute((ClientContext) c, client -> client
-        .getTabletStats(TraceUtil.traceInfo(), ((ClientContext) c).rpcCreds(), tableId),
-        ResourceGroupPredicate.ANY);
+        .getTabletStats(TraceUtil.traceInfo(), ((ClientContext) c).rpcCreds(), tableId));
   }
 
   @Test
@@ -536,8 +534,7 @@ public class ManagerAssignmentIT extends SharedMiniClusterBase {
       try {
         ThriftClientTypes.MANAGER.executeVoid((ClientContext) client,
             c -> c.shutdownTabletServer(TraceUtil.traceInfo(),
-                getCluster().getServerContext().rpcCreds(), finalAddress, false),
-            ResourceGroupPredicate.DEFAULT_RG_ONLY);
+                getCluster().getServerContext().rpcCreds(), finalAddress, false));
       } catch (AccumuloException | AccumuloSecurityException e) {
         fail("Error shutting down TabletServer", e);
       }
@@ -588,8 +585,7 @@ public class ManagerAssignmentIT extends SharedMiniClusterBase {
       try {
         ThriftClientTypes.MANAGER.executeVoid((ClientContext) client,
             c -> c.shutdownTabletServer(TraceUtil.traceInfo(),
-                getCluster().getServerContext().rpcCreds(), finalAddress, false),
-            ResourceGroupPredicate.DEFAULT_RG_ONLY);
+                getCluster().getServerContext().rpcCreds(), finalAddress, false));
       } catch (AccumuloException | AccumuloSecurityException e) {
         fail("Error shutting down TabletServer", e);
       }

--- a/test/src/main/java/org/apache/accumulo/test/functional/MetadataMaxFilesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MetadataMaxFilesIT.java
@@ -31,7 +31,6 @@ import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.client.admin.TabletAvailability;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.conf.Property;
-import org.apache.accumulo.core.lock.ServiceLockPaths.ResourceGroupPredicate;
 import org.apache.accumulo.core.manager.thrift.ManagerMonitorInfo;
 import org.apache.accumulo.core.manager.thrift.TableInfo;
 import org.apache.accumulo.core.manager.thrift.TabletServerStatus;
@@ -83,8 +82,7 @@ public class MetadataMaxFilesIT extends ConfigurableMacBase {
       while (true) {
         ClientContext context = (ClientContext) c;
         ManagerMonitorInfo stats = ThriftClientTypes.MANAGER.execute(context,
-            client -> client.getManagerStats(TraceUtil.traceInfo(), context.rpcCreds()),
-            ResourceGroupPredicate.DEFAULT_RG_ONLY);
+            client -> client.getManagerStats(TraceUtil.traceInfo(), context.rpcCreds()));
         int tablets = 0;
         for (TabletServerStatus tserver : stats.tServerInfo) {
           for (Entry<String,TableInfo> entry : tserver.tableMap.entrySet()) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/SimpleBalancerFairnessIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SimpleBalancerFairnessIT.java
@@ -35,7 +35,6 @@ import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.clientImpl.Credentials;
 import org.apache.accumulo.core.conf.Property;
-import org.apache.accumulo.core.lock.ServiceLockPaths.ResourceGroupPredicate;
 import org.apache.accumulo.core.manager.thrift.ManagerMonitorInfo;
 import org.apache.accumulo.core.manager.thrift.TableInfo;
 import org.apache.accumulo.core.manager.thrift.TabletServerStatus;
@@ -88,8 +87,7 @@ public class SimpleBalancerFairnessIT extends ConfigurableMacBase {
       Wait.waitFor(() -> {
         ManagerMonitorInfo stats = ThriftClientTypes.MANAGER.execute(context,
             client -> client.getManagerStats(TraceUtil.traceInfo(),
-                creds.toThrift(c.instanceOperations().getInstanceId())),
-            ResourceGroupPredicate.DEFAULT_RG_ONLY);
+                creds.toThrift(c.instanceOperations().getInstanceId())));
         int unassignedTablets = stats.getUnassignedTablets();
         if (unassignedTablets > 0) {
           log.info("Found {} unassigned tablets, sleeping 3 seconds for tablet assignment",
@@ -104,8 +102,7 @@ public class SimpleBalancerFairnessIT extends ConfigurableMacBase {
       Wait.waitFor(() -> {
         ManagerMonitorInfo stats = ThriftClientTypes.MANAGER.execute(context,
             client -> client.getManagerStats(TraceUtil.traceInfo(),
-                creds.toThrift(c.instanceOperations().getInstanceId())),
-            ResourceGroupPredicate.DEFAULT_RG_ONLY);
+                creds.toThrift(c.instanceOperations().getInstanceId())));
 
         List<Integer> counts = new ArrayList<>();
         for (TabletServerStatus server : stats.tServerInfo) {

--- a/test/src/main/java/org/apache/accumulo/test/manager/SuspendedTabletsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/manager/SuspendedTabletsIT.java
@@ -54,7 +54,6 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.ResourceGroupId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.lock.ServiceLockPaths.ResourceGroupPredicate;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.LocationType;
@@ -311,7 +310,7 @@ public class SuspendedTabletsIT extends AccumuloClusterHarness {
           ThriftClientTypes.MANAGER.executeVoid(ctx, client -> {
             log.info("Sending shutdown command to {} via ManagerClientService", ts);
             client.shutdownTabletServer(null, ctx.rpcCreds(), ts, false);
-          }, ResourceGroupPredicate.DEFAULT_RG_ONLY);
+          });
         } catch (AccumuloSecurityException | AccumuloException e) {
           throw new RuntimeException("Error calling shutdownTabletServer for " + ts, e);
         }


### PR DESCRIPTION
Removed ResourceGroupOperations.getConfiguration added as part of #5749 to get the effective configuration of a server in a resource group. Backed out related Thrift changes added as part of #5775 to support this method.

Closes #5848