### PR TITLE
improves RG table prop test

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/conf/PropStoreConfigIT_SimpleSuite.java
+++ b/test/src/main/java/org/apache/accumulo/test/conf/PropStoreConfigIT_SimpleSuite.java
@@ -31,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.Callable;
@@ -770,19 +771,14 @@ public class PropStoreConfigIT_SimpleSuite extends SharedMiniClusterBase {
           client.resourceGroupOperations().getProperties(rgid));
 
       for (Entry<String,String> e : defaultProperties.entrySet()) {
-        AccumuloException ae =
-            assertThrows(AccumuloException.class, () -> client.resourceGroupOperations()
-                .setProperty(ResourceGroupId.DEFAULT, e.getKey(), e.getValue()));
-        assertTrue(ae.getMessage()
-            .contains("Table property " + e.getKey()
-                + " cannot be set at the system or resource group level."
-                + " Set table properties at the namespace or table level."));
-        ae = assertThrows(AccumuloException.class,
-            () -> client.resourceGroupOperations().setProperty(rgid, e.getKey(), e.getValue()));
-        assertTrue(ae.getMessage()
-            .contains("Table property " + e.getKey()
-                + " cannot be set at the system or resource group level."
-                + " Set table properties at the namespace or table level."));
+        for (var testRG : List.of(rgid, ResourceGroupId.DEFAULT)) {
+          AccumuloException ae = assertThrows(AccumuloException.class,
+              () -> client.resourceGroupOperations().setProperty(testRG, e.getKey(), e.getValue()));
+          assertTrue(ae.getMessage()
+              .contains("Table property " + e.getKey()
+                  + " cannot be set at the system or resource group level."
+                  + " Set table properties at the namespace or table level."));
+        }
       }
 
       assertEquals(Map.of(),


### PR DESCRIPTION
Added checking all resource group properties after attempted set and multiple resource groups to the test that ensures table props can not be set on a RG. Also successfully set a property in the test.  These changes cover bug cases like attempting to set a table prop corrupts existing props, setting a table prop throws an exception but still sets the prop, bugs w/ multiple RGs and table props.