### PR TITLE
Prevent copy of iter and constraint properties to system namespace

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/DumpConfigIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/DumpConfigIT.java
@@ -55,7 +55,8 @@ public class DumpConfigIT extends ConfigurableMacBase {
   @Override
   public void configure(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
     cfg.getClusterServerConfiguration().addCompactorResourceGroup("test", 1);
-    cfg.setSiteConfig(Collections.singletonMap(Property.TABLE_FILE_BLOCK_SIZE.getKey(), "1234567"));
+    cfg.setSiteConfig(
+        Collections.singletonMap(Property.GENERAL_MAX_SCANNER_RETRY_PERIOD.getKey(), "123s"));
   }
 
   @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN",
@@ -77,8 +78,8 @@ public class DumpConfigIT extends ConfigurableMacBase {
     assertEquals(0, exec(Admin.class, "dumpConfig", "-a", "-d", folder.toString()).waitFor());
     assertTrue(Files.exists(siteFileBackup));
     String site = FunctionalTestUtils.readAll(Files.newInputStream(siteFileBackup));
-    assertTrue(site.contains(Property.TABLE_FILE_BLOCK_SIZE.getKey()));
-    assertTrue(site.contains("1234567"));
+    assertTrue(site.contains(Property.GENERAL_MAX_SCANNER_RETRY_PERIOD.getKey()));
+    assertTrue(site.contains("123s"));
     String meta = FunctionalTestUtils
         .readAll(Files.newInputStream(folder.resolve(SystemTables.METADATA.tableName() + ".cfg")));
     assertTrue(meta.contains(Property.TABLE_FILE_REPLICATION.getKey()));

--- a/test/src/main/java/org/apache/accumulo/test/functional/ChaoticBalancerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ChaoticBalancerIT.java
@@ -49,7 +49,7 @@ public class ChaoticBalancerIT extends AccumuloClusterHarness {
     Map<String,String> siteConfig = cfg.getSiteConfig();
     siteConfig.put(Property.TSERV_MAXMEM.getKey(), "10K");
     // ChaoticLoadBalancer balances across all tables
-    siteConfig.put(Property.TABLE_LOAD_BALANCER.getKey(), ChaoticLoadBalancer.class.getName());
+    siteConfig.put(Property.MANAGER_TABLET_BALANCER.getKey(), ChaoticLoadBalancer.class.getName());
     cfg.setSiteConfig(siteConfig);
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorTrashEnabledIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorTrashEnabledIT.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.admin.CompactionConfig;
+import org.apache.accumulo.core.clientImpl.Namespace;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
@@ -58,7 +59,6 @@ public class GarbageCollectorTrashEnabledIT extends GarbageCollectorTrashBase {
     cfg.setProperty(Property.GC_CYCLE_DELAY, "1");
     cfg.setProperty(Property.GC_PORT, "0");
     cfg.setProperty(Property.TSERV_MAXMEM, "5K");
-    cfg.setProperty(Property.TABLE_MAJC_RATIO, "5.0");
   }
 
   @Test
@@ -67,6 +67,8 @@ public class GarbageCollectorTrashEnabledIT extends GarbageCollectorTrashBase {
     final FileSystem fs = super.getCluster().getFileSystem();
     super.makeTrashDir(fs);
     try (AccumuloClient c = Accumulo.newClient().from(getClientProperties()).build()) {
+      c.namespaceOperations().setProperty(Namespace.DEFAULT.name(),
+          Property.TABLE_MAJC_RATIO.getKey(), "5.0");
       ArrayList<StoredTabletFile> files = super.loadData(super.getServerContext(), c, table);
       assertFalse(files.isEmpty());
       c.tableOperations().compact(table, new CompactionConfig());


### PR DESCRIPTION
Don't copy iterator or constraint table properties from the system configuration to the system namespace configuration during the upgrade. Removed code from NamespaceConfiguration that filtered out iterator and constraint properties from the system configuration as table properties are no longer allowed in the system configuration.

Closes #5901