### PR TITLE
fixes creation of SiteConfig in TestAmple

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/ample/metadata/TestAmple.java
+++ b/test/src/main/java/org/apache/accumulo/test/ample/metadata/TestAmple.java
@@ -238,7 +238,8 @@ public class TestAmple {
     SiteConfiguration siteConfig;
     try {
       Map<String,String> propsMap = new HashMap<>();
-      context.getSiteConfiguration().getProperties(propsMap, x -> true);
+      // get only properties set in the site config but do not include defaults
+      context.getSiteConfiguration().getProperties(propsMap, x -> true, false);
       siteConfig = SiteConfiguration.empty().withOverrides(propsMap).build();
     } catch (Exception e) {
       throw new RuntimeException(e);


### PR DESCRIPTION
TestAmple was copying site config including defaults and creating a new site config.  After the changes in #5886 this caused multiple ITs that use TestAmple to break.  Modified TestAmple to not copy defaults as this is not needed.  The new site config it creates will automatically have defaults.