### PR TITLE
removes setting table prop in site config in PerTableCryptoIT

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/functional/PerTableCryptoIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/PerTableCryptoIT.java
@@ -193,8 +193,6 @@ public class PerTableCryptoIT extends AccumuloClusterHarness {
               args.add(new Path(hadoopConfDir, "hdfs-site.xml").toString());
             }
             args.add("-o");
-            args.add(TABLE_SERVICE_NAME_PROP + "=" + AESCryptoService.class.getName());
-            args.add("-o");
             args.add(INSTANCE_CRYPTO_FACTORY + "=" + GenericCryptoServiceFactory.class.getName());
             log.info("Invoking PrintInfo with {}", args);
             org.apache.accumulo.core.file.rfile.PrintInfo.main(args.toArray(new String[0]));


### PR DESCRIPTION
PerTableCryptoIT was setting a table prop when it did not need to and this was failing.  Removed setting the table prop and since the test already set the general prop for the crypto service to AES the test works w/o any additional changes.

follow up for #5886