### PR TITLE
Add tableId into the log message on failure

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
@@ -177,7 +177,7 @@ public class TableManager {
         return newState.name().getBytes(UTF_8);
       });
     } catch (Exception e) {
-      log.error("FATAL Failed to transition table to state {}", newState);
+      log.error("FATAL Failed to transition table {} to state {}", tableId, newState);
       throw new RuntimeException(e);
     }
   }


### PR DESCRIPTION
Adds the tableId to the error message when table state transition fails