### PR TITLE
Made unique IT directories conditional on a system property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,7 @@ under the License.
     <!-- used for filtering the java source with the current version -->
     <accumulo.build.release.version>${project.version}</accumulo.build.release.version>
     <accumulo.build.unitTestMemSize>-Xmx1G</accumulo.build.unitTestMemSize>
+    <accumulo.it.uniq.test.dir>false</accumulo.it.uniq.test.dir>
     <!-- avoid error shutting down built-in ForkJoinPool.commonPool() during exec:java tasks -->
     <exec.cleanupDaemonThreads>false</exec.cleanupDaemonThreads>
     <failsafe.excludedGroups />
@@ -141,7 +142,6 @@ under the License.
     <failsafe.forkCount>1</failsafe.forkCount>
     <failsafe.groups />
     <failsafe.reuseForks>false</failsafe.reuseForks>
-    <failsafe.unique.accumulo.test.dirs>false</failsafe.unique.accumulo.test.dirs>
     <!-- prevent introduction of new compiler warnings -->
     <maven.compiler.failOnWarning>true</maven.compiler.failOnWarning>
     <maven.compiler.target>17</maven.compiler.target>
@@ -851,7 +851,7 @@ under the License.
             <excludedGroups>${failsafe.excludedGroups}</excludedGroups>
             <groups>${failsafe.groups}</groups>
             <systemPropertyVariables combine.children="append">
-              <accumulo.it.uniq.test.dir>${failsafe.unique.accumulo.test.dirs}</accumulo.it.uniq.test.dir>
+              <accumulo.it.uniq.test.dir>${accumulo.it.uniq.test.dir}</accumulo.it.uniq.test.dir>
               <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
             </systemPropertyVariables>
             <argLine>${accumulo.build.extraTestArgs}</argLine>
@@ -1755,7 +1755,7 @@ under the License.
         </property>
       </activation>
       <properties>
-        <failsafe.unique.accumulo.test.dirs>true</failsafe.unique.accumulo.test.dirs>
+        <accumulo.it.uniq.test.dir>true</accumulo.it.uniq.test.dir>
       </properties>
     </profile>
   </profiles>

--- a/test/src/main/java/org/apache/accumulo/harness/AccumuloITBase.java
+++ b/test/src/main/java/org/apache/accumulo/harness/AccumuloITBase.java
@@ -93,9 +93,11 @@ public class AccumuloITBase extends WithTestNames {
       return baseDir;
     }
 
-    String uniqueName = System.getProperty(UNIQUE_TEST_DIR_SYS_PROPERTY).equalsIgnoreCase("false")
-        ? name : String.format("%s-%d-%d", name, System.currentTimeMillis(),
-            RANDOM.get().nextInt(Short.MAX_VALUE));
+    String uniqueName =
+        System.getProperty(UNIQUE_TEST_DIR_SYS_PROPERTY, "").equalsIgnoreCase("true")
+            ? String.format("%s-%d-%d", name, System.currentTimeMillis(),
+                RANDOM.get().nextInt(Short.MAX_VALUE))
+            : name;
     File testDir = baseDir.toPath().resolve(uniqueName).toFile();
     FileUtils.deleteQuietly(testDir);
     assertTrue(testDir.mkdir());


### PR DESCRIPTION
Modified the logic added in #5676 such that the unique directory is disabled by default and can be enabled with by setting the system property accumulo.it.uniq.test.dir to true. Added the Maven profile uniq-test-dirs to enable this during the Maven build.

Closes #5739