### PR TITLE
replaces Manager with new FateEnv interface in fate code

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/EventCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/EventCoordinator.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 
-public class EventCoordinator {
+public class EventCoordinator implements Events {
 
   private static final Logger log = LoggerFactory.getLogger(EventCoordinator.class);
 
@@ -108,26 +108,31 @@ public class EventCoordinator {
     }
   }
 
+  @Override
   public void event(String msg, Object... args) {
     log.info(String.format(msg, args));
     publish(new Event());
   }
 
+  @Override
   public void event(Ample.DataLevel level, String msg, Object... args) {
     log.info(String.format(msg, args));
     publish(new Event(EventScope.DATA_LEVEL, level));
   }
 
+  @Override
   public void event(TableId tableId, String msg, Object... args) {
     log.info(String.format(msg, args));
     publish(new Event(EventScope.TABLE, tableId));
   }
 
+  @Override
   public void event(KeyExtent extent, String msg, Object... args) {
     log.debug(String.format(msg, args));
     publish(new Event(EventScope.TABLE_RANGE, extent));
   }
 
+  @Override
   public void event(Collection<KeyExtent> extents, String msg, Object... args) {
     if (!extents.isEmpty()) {
       log.debug(String.format(msg, args));

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Events.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Events.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.manager;
+
+import java.util.Collection;
+
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.core.metadata.schema.Ample;
+
+public interface Events {
+  void event(String msg, Object... args);
+
+  void event(Ample.DataLevel level, String msg, Object... args);
+
+  void event(TableId tableId, String msg, Object... args);
+
+  void event(KeyExtent extent, String msg, Object... args);
+
+  void event(Collection<KeyExtent> extents, String msg, Object... args);
+}

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
@@ -137,6 +137,7 @@ import org.apache.accumulo.manager.compaction.coordinator.commit.RenameCompactio
 import org.apache.accumulo.manager.compaction.queue.CompactionJobPriorityQueue;
 import org.apache.accumulo.manager.compaction.queue.CompactionJobQueues;
 import org.apache.accumulo.manager.compaction.queue.ResolvedCompactionJob;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.ServiceEnvironmentImpl;
 import org.apache.accumulo.server.compaction.CompactionConfigStorage;
@@ -270,7 +271,7 @@ public class CompactionCoordinator
   private final ServerContext ctx;
   private final AuditedSecurityOperation security;
   private final CompactionJobQueues jobQueues;
-  private final AtomicReference<Map<FateInstanceType,Fate<Manager>>> fateInstances;
+  private final AtomicReference<Map<FateInstanceType,Fate<FateEnv>>> fateInstances;
   // Exposed for tests
   protected final CountDownLatch shutdown = new CountDownLatch(1);
 
@@ -290,7 +291,7 @@ public class CompactionCoordinator
   private final Set<String> activeCompactorReservationRequest = ConcurrentHashMap.newKeySet();
 
   public CompactionCoordinator(Manager manager,
-      AtomicReference<Map<FateInstanceType,Fate<Manager>>> fateInstances) {
+      AtomicReference<Map<FateInstanceType,Fate<FateEnv>>> fateInstances) {
     this.ctx = manager.getContext();
     this.security = ctx.getSecurityOperation();
     this.manager = Objects.requireNonNull(manager);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/DeadCompactionDetector.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/DeadCompactionDetector.java
@@ -45,7 +45,7 @@ import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.core.metadata.schema.filters.HasExternalCompactionsFilter;
 import org.apache.accumulo.core.util.compaction.ExternalCompactionUtil;
 import org.apache.accumulo.core.util.threads.ThreadPools;
-import org.apache.accumulo.manager.Manager;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.util.FindCompactionTmpFiles;
 import org.apache.accumulo.server.util.FindCompactionTmpFiles.DeleteStats;
@@ -62,11 +62,11 @@ public class DeadCompactionDetector {
   private final ScheduledThreadPoolExecutor schedExecutor;
   private final ConcurrentHashMap<ExternalCompactionId,Long> deadCompactions;
   private final Set<TableId> tablesWithUnreferencedTmpFiles = new HashSet<>();
-  private final AtomicReference<Map<FateInstanceType,Fate<Manager>>> fateInstances;
+  private final AtomicReference<Map<FateInstanceType,Fate<FateEnv>>> fateInstances;
 
   public DeadCompactionDetector(ServerContext context, CompactionCoordinator coordinator,
       ScheduledThreadPoolExecutor stpe,
-      AtomicReference<Map<FateInstanceType,Fate<Manager>>> fateInstances) {
+      AtomicReference<Map<FateInstanceType,Fate<FateEnv>>> fateInstances) {
     this.context = context;
     this.coordinator = coordinator;
     this.schedExecutor = stpe;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/PutGcCandidates.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/PutGcCandidates.java
@@ -21,10 +21,10 @@ package org.apache.accumulo.manager.compaction.coordinator.commit;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 
-public class PutGcCandidates extends ManagerRepo {
+public class PutGcCandidates extends AbstractRepo {
   private static final long serialVersionUID = 1L;
   private final CompactionCommitData commitData;
   private final String refreshLocation;
@@ -35,14 +35,13 @@ public class PutGcCandidates extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager manager) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
 
     // add the GC candidates
-    manager.getContext().getAmple().putGcCandidates(commitData.getTableId(),
-        commitData.getJobFiles());
+    env.getContext().getAmple().putGcCandidates(commitData.getTableId(), commitData.getJobFiles());
 
     if (refreshLocation == null) {
-      manager.getCompactionCoordinator().recordCompletion(ExternalCompactionId.of(commitData.ecid));
+      env.recordCompletion(ExternalCompactionId.of(commitData.ecid));
       return null;
     }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/RenameCompactionFile.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/RenameCompactionFile.java
@@ -23,14 +23,14 @@ import java.io.IOException;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.metadata.ReferencedTabletFile;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.server.tablets.TabletNameGenerator;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class RenameCompactionFile extends ManagerRepo {
+public class RenameCompactionFile extends AbstractRepo {
   private static final Logger log = LoggerFactory.getLogger(RenameCompactionFile.class);
   private static final long serialVersionUID = 1L;
   private final CompactionCommitData commitData;
@@ -40,9 +40,9 @@ public class RenameCompactionFile extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager manager) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
     ReferencedTabletFile newDatafile = null;
-    var ctx = manager.getContext();
+    var ctx = env.getContext();
 
     var tmpPath = new Path(commitData.outputTmpPath);
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/metrics/ManagerMetrics.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/metrics/ManagerMetrics.java
@@ -40,6 +40,7 @@ import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.metrics.fate.FateMetrics;
 import org.apache.accumulo.manager.metrics.fate.meta.MetaFateMetrics;
 import org.apache.accumulo.manager.metrics.fate.user.UserFateMetrics;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -54,7 +55,7 @@ public class ManagerMetrics implements MetricsProducer {
   private final AtomicInteger compactionConfigurationError = new AtomicInteger(0);
 
   public void configureFateMetrics(final AccumuloConfiguration conf, final Manager manager,
-      Map<FateInstanceType,Fate<Manager>> fateRefs) {
+      Map<FateInstanceType,Fate<FateEnv>> fateRefs) {
     requireNonNull(conf, "AccumuloConfiguration must not be null");
     requireNonNull(conf, "Manager must not be null");
     fateMetrics = List.of(

--- a/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/FateMetrics.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/FateMetrics.java
@@ -36,7 +36,7 @@ import org.apache.accumulo.core.fate.ReadOnlyFateStore;
 import org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus;
 import org.apache.accumulo.core.metrics.MetricsProducer;
 import org.apache.accumulo.core.util.threads.ThreadPools;
-import org.apache.accumulo.manager.Manager;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.server.ServerContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,14 +58,14 @@ public abstract class FateMetrics<T extends FateMetricValues> implements Metrics
   protected final ServerContext context;
   protected final ReadOnlyFateStore<FateMetrics<T>> readOnlyFateStore;
   protected final long refreshDelay;
-  private final Set<FateExecutor<Manager>> fateExecutors;
+  private final Set<FateExecutor<FateEnv>> fateExecutors;
   private MeterRegistry registry;
 
   protected final AtomicLong totalCurrentOpsCount = new AtomicLong(0);
   private final EnumMap<TStatus,AtomicLong> txStatusCounters = new EnumMap<>(TStatus.class);
 
   public FateMetrics(final ServerContext context, final long minimumRefreshDelay,
-      Set<FateExecutor<Manager>> fateExecutors) {
+      Set<FateExecutor<FateEnv>> fateExecutors) {
     this.context = context;
     this.refreshDelay = Math.max(DEFAULT_MIN_REFRESH_DELAY, minimumRefreshDelay);
     this.readOnlyFateStore = Objects.requireNonNull(buildReadOnlyStore(context));

--- a/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/meta/MetaFateMetrics.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/meta/MetaFateMetrics.java
@@ -28,8 +28,8 @@ import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.fate.FateExecutor;
 import org.apache.accumulo.core.fate.ReadOnlyFateStore;
 import org.apache.accumulo.core.fate.zookeeper.MetaFateStore;
-import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.metrics.fate.FateMetrics;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.zookeeper.KeeperException;
 
@@ -42,7 +42,7 @@ public class MetaFateMetrics extends FateMetrics<MetaFateMetricValues> {
   private final AtomicLong fateErrorsGauge = new AtomicLong(0);
 
   public MetaFateMetrics(ServerContext context, long minimumRefreshDelay,
-      Set<FateExecutor<Manager>> fateExecutors) {
+      Set<FateExecutor<FateEnv>> fateExecutors) {
     super(context, minimumRefreshDelay, fateExecutors);
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/user/UserFateMetrics.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/user/UserFateMetrics.java
@@ -24,14 +24,14 @@ import org.apache.accumulo.core.fate.FateExecutor;
 import org.apache.accumulo.core.fate.ReadOnlyFateStore;
 import org.apache.accumulo.core.fate.user.UserFateStore;
 import org.apache.accumulo.core.metadata.SystemTables;
-import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.metrics.fate.FateMetrics;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.server.ServerContext;
 
 public class UserFateMetrics extends FateMetrics<UserFateMetricValues> {
 
   public UserFateMetrics(ServerContext context, long minimumRefreshDelay,
-      Set<FateExecutor<Manager>> fateExecutors) {
+      Set<FateExecutor<FateEnv>> fateExecutors) {
     super(context, minimumRefreshDelay, fateExecutors);
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/AbstractRepo.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/AbstractRepo.java
@@ -20,19 +20,16 @@ package org.apache.accumulo.manager.tableOps;
 
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
-import org.apache.accumulo.manager.Manager;
 
-public abstract class ManagerRepo implements Repo<Manager> {
+public abstract class AbstractRepo implements Repo<FateEnv> {
 
   private static final long serialVersionUID = 1L;
 
-  @Override
-  public long isReady(FateId fateId, Manager environment) throws Exception {
+  public long isReady(FateId fateId, FateEnv environment) throws Exception {
     return 0;
   }
 
-  @Override
-  public void undo(FateId fateId, Manager environment) throws Exception {}
+  public void undo(FateId fateId, FateEnv environment) throws Exception {}
 
   @Override
   public String getName() {
@@ -44,7 +41,6 @@ public abstract class ManagerRepo implements Repo<Manager> {
     return null;
   }
 
-  @Override
-  public abstract Repo<Manager> call(FateId fateId, Manager environment) throws Exception;
+  public abstract Repo<FateEnv> call(FateId fateId, FateEnv environment) throws Exception;
 
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/ChangeTableState.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/ChangeTableState.java
@@ -28,10 +28,9 @@ import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.fate.zookeeper.LockRange;
 import org.apache.accumulo.core.manager.state.tables.TableState;
-import org.apache.accumulo.manager.Manager;
 import org.slf4j.LoggerFactory;
 
-public class ChangeTableState extends ManagerRepo {
+public class ChangeTableState extends AbstractRepo {
 
   private static final long serialVersionUID = 1L;
   private final TableId tableId;
@@ -52,7 +51,7 @@ public class ChangeTableState extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager env) throws Exception {
+  public long isReady(FateId fateId, FateEnv env) throws Exception {
     // reserve the table so that this op does not run concurrently with create, clone, or delete
     // table
     return Utils.reserveNamespace(env.getContext(), namespaceId, fateId, LockType.READ, true, top)
@@ -61,7 +60,7 @@ public class ChangeTableState extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager env) {
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) {
     TableState ts = TableState.ONLINE;
     if (top == TableOperation.OFFLINE) {
       ts = TableState.OFFLINE;
@@ -71,12 +70,12 @@ public class ChangeTableState extends ManagerRepo {
     Utils.unreserveNamespace(env.getContext(), namespaceId, fateId, LockType.READ);
     Utils.unreserveTable(env.getContext(), tableId, fateId, LockType.WRITE);
     LoggerFactory.getLogger(ChangeTableState.class).debug("Changed table state {} {}", tableId, ts);
-    env.getEventCoordinator().event(tableId, "Set table state of %s to %s", tableId, ts);
+    env.getEvents().event(tableId, "Set table state of %s to %s", tableId, ts);
     return null;
   }
 
   @Override
-  public void undo(FateId fateId, Manager env) {
+  public void undo(FateId fateId, FateEnv env) {
     Utils.unreserveNamespace(env.getContext(), namespaceId, fateId, LockType.READ);
     Utils.unreserveTable(env.getContext(), tableId, fateId, LockType.WRITE);
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/FateEnv.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/FateEnv.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.manager.tableOps;
+
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+
+import org.apache.accumulo.core.lock.ServiceLock;
+import org.apache.accumulo.core.manager.thrift.BulkImportState;
+import org.apache.accumulo.core.metadata.TServerInstance;
+import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
+import org.apache.accumulo.core.util.time.SteadyTime;
+import org.apache.accumulo.manager.Events;
+import org.apache.accumulo.manager.split.Splitter;
+import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.fs.VolumeManager;
+import org.apache.accumulo.server.tables.TableManager;
+
+public interface FateEnv {
+  ServerContext getContext();
+
+  Events getEvents();
+
+  void recordCompletion(ExternalCompactionId ecid);
+
+  Set<TServerInstance> onlineTabletServers();
+
+  TableManager getTableManager();
+
+  VolumeManager getVolumeManager();
+
+  void updateBulkImportStatus(String string, BulkImportState bulkImportState);
+
+  void removeBulkImportStatus(String sourceDir);
+
+  // TODO rename
+  ServiceLock getManagerLock();
+
+  SteadyTime getSteadyTime();
+
+  ExecutorService getTabletRefreshThreadPool();
+
+  Splitter getSplitter();
+
+  ExecutorService getRenamePool();
+
+}

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/TraceRepo.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/TraceRepo.java
@@ -22,7 +22,6 @@ import org.apache.accumulo.core.clientImpl.thrift.TInfo;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.trace.TraceUtil;
-import org.apache.accumulo.manager.Manager;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Scope;
@@ -111,9 +110,9 @@ public class TraceRepo<T> implements Repo<T> {
   /**
    * @return string version of Repo that is suitable for logging
    */
-  public static String toLogString(Repo<Manager> repo) {
+  public static String toLogString(Repo<FateEnv> repo) {
     if (repo instanceof TraceRepo) {
-      repo = ((TraceRepo<Manager>) repo).repo;
+      repo = ((TraceRepo<FateEnv>) repo).repo;
     }
 
     return repo.getClass() + " " + repo.getName();

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/availability/LockTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/availability/LockTable.java
@@ -26,11 +26,11 @@ import org.apache.accumulo.core.dataImpl.thrift.TRange;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.Utils;
 
-public class LockTable extends ManagerRepo {
+public class LockTable extends AbstractRepo {
   private static final long serialVersionUID = 1L;
 
   private final TableId tableId;
@@ -47,23 +47,23 @@ public class LockTable extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager manager) throws Exception {
-    return Utils.reserveNamespace(manager.getContext(), namespaceId, fateId,
+  public long isReady(FateId fateId, FateEnv env) throws Exception {
+    return Utils.reserveNamespace(env.getContext(), namespaceId, fateId,
         DistributedReadWriteLock.LockType.READ, true, TableOperation.SET_TABLET_AVAILABILITY)
-        + Utils.reserveTable(manager.getContext(), tableId, fateId,
+        + Utils.reserveTable(env.getContext(), tableId, fateId,
             DistributedReadWriteLock.LockType.WRITE, true, TableOperation.SET_TABLET_AVAILABILITY);
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager manager) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
     return new SetTabletAvailability(tableId, namespaceId, tRange, tabletAvailability);
   }
 
   @Override
-  public void undo(FateId fateId, Manager manager) throws Exception {
-    Utils.unreserveNamespace(manager.getContext(), namespaceId, fateId,
+  public void undo(FateId fateId, FateEnv env) throws Exception {
+    Utils.unreserveNamespace(env.getContext(), namespaceId, fateId,
         DistributedReadWriteLock.LockType.READ);
-    Utils.unreserveTable(manager.getContext(), tableId, fateId,
+    Utils.unreserveTable(env.getContext(), tableId, fateId,
         DistributedReadWriteLock.LockType.WRITE);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/availability/SetTabletAvailability.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/availability/SetTabletAvailability.java
@@ -43,14 +43,14 @@ import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.core.util.Timer;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SetTabletAvailability extends ManagerRepo {
+public class SetTabletAvailability extends AbstractRepo {
 
   private static final long serialVersionUID = 1L;
   private static final Logger LOG = LoggerFactory.getLogger(SetTabletAvailability.class);
@@ -69,9 +69,9 @@ public class SetTabletAvailability extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager manager) throws Exception {
+  public long isReady(FateId fateId, FateEnv env) throws Exception {
 
-    if (manager.getContext().getTableState(tableId) != TableState.ONLINE) {
+    if (env.getContext().getTableState(tableId) != TableState.ONLINE) {
       throw new AcceptableThriftTableOperationException(tableId.canonical(), null,
           TableOperation.COMPACT, TableOperationExceptionType.OFFLINE, "The table is not online.");
     }
@@ -101,10 +101,10 @@ public class SetTabletAvailability extends ManagerRepo {
 
     var start = Timer.startNew();
     try (
-        TabletsMetadata m = manager.getContext().getAmple().readTablets().forTable(tableId)
+        TabletsMetadata m = env.getContext().getAmple().readTablets().forTable(tableId)
             .overlapping(scanRangeStart, true, null).build();
         Ample.AsyncConditionalTabletsMutator mutator =
-            manager.getContext().getAmple().conditionallyMutateTablets(resultsConsumer)) {
+            env.getContext().getAmple().conditionallyMutateTablets(resultsConsumer)) {
       for (TabletMetadata tm : m) {
         final KeyExtent tabletExtent = tm.getExtent();
         LOG.trace("Evaluating tablet {} against range {}", tabletExtent, range);
@@ -149,9 +149,9 @@ public class SetTabletAvailability extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager manager) throws Exception {
-    Utils.unreserveNamespace(manager.getContext(), namespaceId, fateId, LockType.READ);
-    Utils.unreserveTable(manager.getContext(), tableId, fateId, LockType.WRITE);
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
+    Utils.unreserveNamespace(env.getContext(), namespaceId, fateId, LockType.READ);
+    Utils.unreserveTable(env.getContext(), tableId, fateId, LockType.WRITE);
     return null;
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/CleanUpBulkImport.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/CleanUpBulkImport.java
@@ -37,15 +37,15 @@ import org.apache.accumulo.core.metadata.schema.Ample.ConditionalResult.Status;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.accumulo.core.util.Retry;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class CleanUpBulkImport extends ManagerRepo {
+public class CleanUpBulkImport extends AbstractRepo {
 
   private static final long serialVersionUID = 1L;
 
@@ -58,10 +58,10 @@ public class CleanUpBulkImport extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager manager) throws Exception {
-    manager.updateBulkImportStatus(info.sourceDir, BulkImportState.CLEANUP);
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
+    env.updateBulkImportStatus(info.sourceDir, BulkImportState.CLEANUP);
     log.debug("{} removing the bulkDir processing flag file in {}", fateId, info.bulkDir);
-    Ample ample = manager.getContext().getAmple();
+    Ample ample = env.getContext().getAmple();
     Path bulkDir = new Path(info.bulkDir);
     ample.removeBulkLoadInProgressFlag(
         "/" + bulkDir.getParent().getName() + "/" + bulkDir.getName());
@@ -75,20 +75,20 @@ public class CleanUpBulkImport extends ManagerRepo {
         firstSplit, lastSplit);
     removeBulkLoadEntries(ample, info.tableId, fateId, firstSplit, lastSplit);
 
-    Utils.unreserveHdfsDirectory(manager.getContext(), info.sourceDir, fateId);
-    Utils.getReadLock(manager.getContext(), info.tableId, fateId, LockRange.infinite()).unlock();
+    Utils.unreserveHdfsDirectory(env.getContext(), info.sourceDir, fateId);
+    Utils.getReadLock(env.getContext(), info.tableId, fateId, LockRange.infinite()).unlock();
     // delete json renames and mapping files
     Path renamingFile = new Path(bulkDir, Constants.BULK_RENAME_FILE);
     Path mappingFile = new Path(bulkDir, Constants.BULK_LOAD_MAPPING);
     try {
-      manager.getVolumeManager().delete(renamingFile);
-      manager.getVolumeManager().delete(mappingFile);
+      env.getVolumeManager().delete(renamingFile);
+      env.getVolumeManager().delete(mappingFile);
     } catch (IOException ioe) {
       log.debug("{} Failed to delete renames and/or loadmap", fateId, ioe);
     }
 
     log.debug("completing bulkDir import transaction " + fateId);
-    manager.removeBulkImportStatus(info.sourceDir);
+    env.removeBulkImportStatus(info.sourceDir);
     return null;
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/ComputeBulkRange.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/ComputeBulkRange.java
@@ -26,15 +26,15 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ComputeBulkRange extends ManagerRepo {
+public class ComputeBulkRange extends AbstractRepo {
   private static final long serialVersionUID = 1L;
 
   private static final Logger log = LoggerFactory.getLogger(ComputeBulkRange.class);
@@ -50,9 +50,9 @@ public class ComputeBulkRange extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager manager) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
 
-    VolumeManager fs = manager.getVolumeManager();
+    VolumeManager fs = env.getVolumeManager();
     final Path bulkDir = new Path(bulkInfo.sourceDir);
 
     try (LoadMappingIterator lmi =

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
@@ -66,8 +66,8 @@ import org.apache.accumulo.core.tabletserver.thrift.TabletServerClientService;
 import org.apache.accumulo.core.trace.TraceUtil;
 import org.apache.accumulo.core.util.PeekingIterator;
 import org.apache.accumulo.core.util.Timer;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.tablets.TabletTime;
 import org.apache.hadoop.fs.Path;
@@ -83,7 +83,7 @@ import com.google.common.net.HostAndPort;
  * Make asynchronous load calls to each overlapping Tablet. This RepO does its work on the isReady
  * and will return a linear sleep value based on the largest number of Tablets on a TabletServer.
  */
-class LoadFiles extends ManagerRepo {
+class LoadFiles extends AbstractRepo {
 
   // visible for testing
   interface TabletsMetadataFactory {
@@ -103,44 +103,44 @@ class LoadFiles extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager manager) throws Exception {
+  public long isReady(FateId fateId, FateEnv env) throws Exception {
     log.info("Starting for {} (tid = {})", bulkInfo.sourceDir, fateId);
-    if (manager.onlineTabletServers().isEmpty()) {
+    if (env.onlineTabletServers().isEmpty()) {
       log.warn("There are no tablet server to process bulkDir import, waiting (fateId = " + fateId
           + ")");
       return 100;
     }
-    VolumeManager fs = manager.getVolumeManager();
+    VolumeManager fs = env.getVolumeManager();
     final Path bulkDir = new Path(bulkInfo.bulkDir);
-    manager.updateBulkImportStatus(bulkInfo.sourceDir, BulkImportState.LOADING);
+    env.updateBulkImportStatus(bulkInfo.sourceDir, BulkImportState.LOADING);
     try (LoadMappingIterator lmi =
         BulkSerialize.getUpdatedLoadMapping(bulkDir.toString(), bulkInfo.tableId, fs::open)) {
 
-      Loader loader = new Loader(manager, bulkInfo.tableId);
+      Loader loader = new Loader(env, bulkInfo.tableId);
 
       List<ColumnType> fetchCols = new ArrayList<>(List.of(PREV_ROW, LOCATION, LOADED, TIME));
       if (loader.pauseLimit > 0) {
         fetchCols.add(FILES);
       }
 
-      TabletsMetadataFactory tmf = (startRow) -> TabletsMetadata.builder(manager.getContext())
+      TabletsMetadataFactory tmf = (startRow) -> TabletsMetadata.builder(env.getContext())
           .forTable(bulkInfo.tableId).overlapping(startRow, null).checkConsistency()
           .fetch(fetchCols.toArray(new ColumnType[0])).build();
 
-      int skip = manager.getContext().getTableConfiguration(bulkInfo.tableId)
+      int skip = env.getContext().getTableConfiguration(bulkInfo.tableId)
           .getCount(Property.TABLE_BULK_SKIP_THRESHOLD);
-      return loadFiles(loader, bulkInfo, bulkDir, lmi, tmf, manager, fateId, skip);
+      return loadFiles(loader, bulkInfo, bulkDir, lmi, tmf, fateId, skip);
     }
   }
 
   @Override
-  public Repo<Manager> call(final FateId fateId, final Manager manager) {
+  public Repo<FateEnv> call(final FateId fateId, final FateEnv env) {
     return new RefreshTablets(bulkInfo);
   }
 
   // visible for testing
   public static class Loader {
-    private final Manager manager;
+    private final FateEnv env;
     private final long pauseLimit;
 
     private Path bulkDir;
@@ -150,20 +150,19 @@ class LoadFiles extends ManagerRepo {
     private Map<KeyExtent,List<TabletFile>> loadingFiles;
     private long skipped = 0;
 
-    public Loader(Manager manager, TableId tableId) {
-      Objects.requireNonNull(manager, "Manager must be supplied");
+    public Loader(FateEnv env, TableId tableId) {
+      Objects.requireNonNull(env, "Fate env must be supplied");
       Objects.requireNonNull(tableId, "Table ID must be supplied");
-      this.manager = manager;
+      this.env = env;
       this.pauseLimit =
-          manager.getContext().getTableConfiguration(tableId).getCount(Property.TABLE_FILE_PAUSE);
+          env.getContext().getTableConfiguration(tableId).getCount(Property.TABLE_FILE_PAUSE);
     }
 
-    void start(Path bulkDir, Manager manager, TableId tableId, FateId fateId, boolean setTime)
-        throws Exception {
+    void start(Path bulkDir, TableId tableId, FateId fateId, boolean setTime) throws Exception {
       this.bulkDir = bulkDir;
       this.fateId = fateId;
       this.setTime = setTime;
-      conditionalMutator = manager.getContext().getAmple().conditionallyMutateTablets();
+      conditionalMutator = env.getContext().getAmple().conditionallyMutateTablets();
       this.skipped = 0;
       this.loadingFiles = new HashMap<>();
     }
@@ -315,7 +314,7 @@ class LoadFiles extends ManagerRepo {
     private Map<KeyExtent,Long> allocateTimestamps(HostAndPort server, List<TKeyExtent> extents,
         int numStamps) {
       TabletServerClientService.Client client = null;
-      var context = manager.getContext();
+      var context = env.getContext();
       try {
 
         log.trace("{} sending allocate timestamps request to {} for {} extents", fateId, server,
@@ -352,7 +351,7 @@ class LoadFiles extends ManagerRepo {
         if (condResult.getStatus() == Status.ACCEPTED) {
           loadingFiles.get(extent).forEach(file -> TabletLogger.bulkImported(extent, file));
           // Trigger a check for compaction now that new files were added via bulk load
-          manager.getEventCoordinator().event(extent, "Bulk load completed on tablet %s", extent);
+          env.getEvents().event(extent, "Bulk load completed on tablet %s", extent);
         } else {
           seenFailure.set(true);
           var metadata = condResult.readMetadata();
@@ -393,8 +392,8 @@ class LoadFiles extends ManagerRepo {
    */
   // visible for testing
   static long loadFiles(Loader loader, BulkInfo bulkInfo, Path bulkDir,
-      LoadMappingIterator loadMapIter, TabletsMetadataFactory factory, Manager manager,
-      FateId fateId, int skipDistance) throws Exception {
+      LoadMappingIterator loadMapIter, TabletsMetadataFactory factory, FateId fateId,
+      int skipDistance) throws Exception {
     PeekingIterator<Map.Entry<KeyExtent,Bulk.Files>> lmi = new PeekingIterator<>(loadMapIter);
     Map.Entry<KeyExtent,Bulk.Files> loadMapEntry = lmi.peek();
 
@@ -403,7 +402,7 @@ class LoadFiles extends ManagerRepo {
     String fmtTid = fateId.getTxUUIDStr();
     log.trace("{}: Started loading files at row: {}", fmtTid, startRow);
 
-    loader.start(bulkDir, manager, bulkInfo.tableId, fateId, bulkInfo.setTime);
+    loader.start(bulkDir, bulkInfo.tableId, fateId, bulkInfo.setTime);
 
     ImportTimingStats importTimingStats = new ImportTimingStats();
     Timer timer = Timer.startNew();

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/PrepBulkImport.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/PrepBulkImport.java
@@ -50,8 +50,8 @@ import org.apache.accumulo.core.file.FilePrefix;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.core.util.PeekingIterator;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.fs.VolumeManager;
@@ -74,7 +74,7 @@ import com.google.common.annotations.VisibleForTesting;
  *
  * @since 2.0.0
  */
-public class PrepBulkImport extends ManagerRepo {
+public class PrepBulkImport extends AbstractRepo {
 
   private static final long serialVersionUID = 1L;
 
@@ -87,19 +87,19 @@ public class PrepBulkImport extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager manager) throws Exception {
-    long wait = Utils.reserveTable(manager.getContext(), bulkInfo.tableId, fateId,
+  public long isReady(FateId fateId, FateEnv env) throws Exception {
+    long wait = Utils.reserveTable(env.getContext(), bulkInfo.tableId, fateId,
         DistributedReadWriteLock.LockType.READ, true, TableOperation.BULK_IMPORT,
         LockRange.of(bulkInfo.firstSplit, bulkInfo.lastSplit));
     if (wait > 0) {
       return wait;
     }
 
-    if (manager.onlineTabletServers().isEmpty()) {
+    if (env.onlineTabletServers().isEmpty()) {
       return 500;
     }
 
-    return Utils.reserveHdfsDirectory(manager.getContext(), bulkInfo.sourceDir, fateId);
+    return Utils.reserveHdfsDirectory(env.getContext(), bulkInfo.sourceDir, fateId);
   }
 
   @VisibleForTesting
@@ -220,15 +220,15 @@ public class PrepBulkImport extends ManagerRepo {
     }
   }
 
-  private void checkForMerge(final Manager manager, final FateId fateId) throws Exception {
+  private void checkForMerge(final ServerContext ctx, final FateId fateId) throws Exception {
 
-    VolumeManager fs = manager.getVolumeManager();
+    VolumeManager fs = ctx.getVolumeManager();
     final Path bulkDir = new Path(bulkInfo.sourceDir);
 
-    int maxTablets = manager.getContext().getTableConfiguration(bulkInfo.tableId)
-        .getCount(Property.TABLE_BULK_MAX_TABLETS);
-    int maxFilesPerTablet = manager.getContext().getTableConfiguration(bulkInfo.tableId)
-        .getCount(Property.TABLE_BULK_MAX_TABLET_FILES);
+    int maxTablets =
+        ctx.getTableConfiguration(bulkInfo.tableId).getCount(Property.TABLE_BULK_MAX_TABLETS);
+    int maxFilesPerTablet =
+        ctx.getTableConfiguration(bulkInfo.tableId).getCount(Property.TABLE_BULK_MAX_TABLET_FILES);
 
     try (LoadMappingIterator lmi =
         BulkSerialize.readLoadMapping(bulkDir.toString(), bulkInfo.tableId, fs::open)) {
@@ -239,8 +239,8 @@ public class PrepBulkImport extends ManagerRepo {
 
         @Override
         public Iterator<KeyExtent> newTabletIter(Text startRow) {
-          tm = TabletsMetadata.builder(manager.getContext()).forTable(bulkInfo.tableId)
-              .overlapping(startRow, null).checkConsistency().fetch(PREV_ROW).build();
+          tm = TabletsMetadata.builder(ctx).forTable(bulkInfo.tableId).overlapping(startRow, null)
+              .checkConsistency().fetch(PREV_ROW).build();
           return tm.stream().map(TabletMetadata::getExtent).iterator();
         }
 
@@ -252,24 +252,24 @@ public class PrepBulkImport extends ManagerRepo {
         }
       };
 
-      int skip = manager.getContext().getTableConfiguration(bulkInfo.tableId)
-          .getCount(Property.TABLE_BULK_SKIP_THRESHOLD);
+      int skip =
+          ctx.getTableConfiguration(bulkInfo.tableId).getCount(Property.TABLE_BULK_SKIP_THRESHOLD);
       validateLoadMapping(bulkInfo.tableId.canonical(), lmi, tabletIterFactory, maxTablets,
           maxFilesPerTablet, fateId, skip);
     }
   }
 
   @Override
-  public Repo<Manager> call(final FateId fateId, final Manager manager) throws Exception {
+  public Repo<FateEnv> call(final FateId fateId, final FateEnv env) throws Exception {
     // now that table lock is acquired check that all splits in load mapping exists in table
-    checkForMerge(manager, fateId);
+    checkForMerge(env.getContext(), fateId);
 
-    VolumeManager fs = manager.getVolumeManager();
-    final UniqueNameAllocator namer = manager.getContext().getUniqueNameAllocator();
+    VolumeManager fs = env.getVolumeManager();
+    final UniqueNameAllocator namer = env.getContext().getUniqueNameAllocator();
     Path sourceDir = new Path(bulkInfo.sourceDir);
     List<FileStatus> files = BulkImport.filterInvalid(fs.listStatus(sourceDir));
 
-    Path bulkDir = createNewBulkDir(manager.getContext(), fs, bulkInfo.tableId);
+    Path bulkDir = createNewBulkDir(env.getContext(), fs, bulkInfo.tableId);
     Path mappingFile = new Path(sourceDir, Constants.BULK_LOAD_MAPPING);
 
     Map<String,String> oldToNewNameMap = new HashMap<>();
@@ -317,7 +317,7 @@ public class PrepBulkImport extends ManagerRepo {
   }
 
   @Override
-  public void undo(FateId fateId, Manager environment) throws Exception {
+  public void undo(FateId fateId, FateEnv environment) throws Exception {
     // unreserve sourceDir/error directories
     Utils.unreserveHdfsDirectory(environment.getContext(), bulkInfo.sourceDir, fateId);
     Utils.getReadLock(environment.getContext(), bulkInfo.tableId, fateId, LockRange.infinite())

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/RefreshTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/RefreshTablets.java
@@ -20,8 +20,8 @@ package org.apache.accumulo.manager.tableOps.bulkVer2;
 
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 
 /**
  * This Repo asks hosted tablets that were bulk loaded into to refresh their metadata. It works by
@@ -30,7 +30,7 @@ import org.apache.accumulo.manager.tableOps.ManagerRepo;
  * location its ok. That means the tablet either unloaded before of after the snapshot. In either
  * case the tablet will see the bulk files the next time its hosted somewhere.
  */
-public class RefreshTablets extends ManagerRepo {
+public class RefreshTablets extends AbstractRepo {
 
   private static final long serialVersionUID = 1L;
 
@@ -41,15 +41,15 @@ public class RefreshTablets extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager manager) throws Exception {
+  public long isReady(FateId fateId, FateEnv env) throws Exception {
     return 0;
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager manager) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
 
-    TabletRefresher.refresh(manager, fateId, bulkInfo.tableId, bulkInfo.firstSplit,
-        bulkInfo.lastSplit, tabletMetadata -> tabletMetadata.getLoaded().containsValue(fateId));
+    TabletRefresher.refresh(env, fateId, bulkInfo.tableId, bulkInfo.firstSplit, bulkInfo.lastSplit,
+        tabletMetadata -> tabletMetadata.getLoaded().containsValue(fateId));
 
     return new CleanUpBulkImport(bulkInfo);
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneMetadata.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneMetadata.java
@@ -20,12 +20,12 @@ package org.apache.accumulo.manager.tableOps.clone;
 
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.server.util.MetadataTableUtil;
 import org.slf4j.LoggerFactory;
 
-class CloneMetadata extends ManagerRepo {
+class CloneMetadata extends AbstractRepo {
 
   private static final long serialVersionUID = 1L;
   private final CloneInfo cloneInfo;
@@ -35,12 +35,12 @@ class CloneMetadata extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager environment) {
+  public long isReady(FateId fateId, FateEnv environment) {
     return 0;
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager environment) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv environment) throws Exception {
     LoggerFactory.getLogger(CloneMetadata.class)
         .info(String.format("Cloning %s with tableId %s from srcTableId %s",
             cloneInfo.getTableName(), cloneInfo.getTableId(), cloneInfo.getSrcTableId()));
@@ -54,7 +54,7 @@ class CloneMetadata extends ManagerRepo {
   }
 
   @Override
-  public void undo(FateId fateId, Manager environment) throws Exception {
+  public void undo(FateId fateId, FateEnv environment) throws Exception {
     MetadataTableUtil.deleteTable(cloneInfo.getTableId(), false, environment.getContext(),
         environment.getManagerLock());
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/ClonePermissions.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/ClonePermissions.java
@@ -26,11 +26,11 @@ import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.security.TablePermission;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.slf4j.LoggerFactory;
 
-class ClonePermissions extends ManagerRepo {
+class ClonePermissions extends AbstractRepo {
 
   private static final long serialVersionUID = 1L;
 
@@ -41,12 +41,12 @@ class ClonePermissions extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager environment) {
+  public long isReady(FateId fateId, FateEnv environment) {
     return 0;
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager environment) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv environment) throws Exception {
     // give all table permissions to the creator
     for (TablePermission permission : TablePermission.values()) {
       try {
@@ -72,7 +72,7 @@ class ClonePermissions extends ManagerRepo {
   }
 
   @Override
-  public void undo(FateId fateId, Manager environment) throws Exception {
+  public void undo(FateId fateId, FateEnv environment) throws Exception {
     environment.getContext().getSecurityOperation().deleteTable(environment.getContext().rpcCreds(),
         cloneInfo.getTableId(), cloneInfo.getNamespaceId());
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneTable.java
@@ -27,11 +27,11 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.Utils;
 
-public class CloneTable extends ManagerRepo {
+public class CloneTable extends AbstractRepo {
 
   private static final long serialVersionUID = 1L;
   private final CloneInfo cloneInfo;
@@ -44,7 +44,7 @@ public class CloneTable extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager environment) throws Exception {
+  public long isReady(FateId fateId, FateEnv environment) throws Exception {
     long val = Utils.reserveNamespace(environment.getContext(), cloneInfo.getNamespaceId(), fateId,
         LockType.READ, true, TableOperation.CLONE);
     val += Utils.reserveTable(environment.getContext(), cloneInfo.getSrcTableId(), fateId,
@@ -53,7 +53,7 @@ public class CloneTable extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager environment) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv environment) throws Exception {
 
     cloneInfo.setTableId(
         Utils.getNextId(cloneInfo.getTableName(), environment.getContext(), TableId::of));
@@ -61,7 +61,7 @@ public class CloneTable extends ManagerRepo {
   }
 
   @Override
-  public void undo(FateId fateId, Manager environment) {
+  public void undo(FateId fateId, FateEnv environment) {
     Utils.unreserveNamespace(environment.getContext(), cloneInfo.getNamespaceId(), fateId,
         LockType.READ);
     Utils.unreserveTable(environment.getContext(), cloneInfo.getSrcTableId(), fateId,

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneZookeeper.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneZookeeper.java
@@ -24,11 +24,11 @@ import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.Utils;
 
-class CloneZookeeper extends ManagerRepo {
+class CloneZookeeper extends AbstractRepo {
 
   private static final long serialVersionUID = 1L;
 
@@ -40,7 +40,7 @@ class CloneZookeeper extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager environment) throws Exception {
+  public long isReady(FateId fateId, FateEnv environment) throws Exception {
     long val = 0;
     if (!cloneInfo.getSrcNamespaceId().equals(cloneInfo.getNamespaceId())) {
       val += Utils.reserveNamespace(environment.getContext(), cloneInfo.getNamespaceId(), fateId,
@@ -52,7 +52,7 @@ class CloneZookeeper extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager environment) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv environment) throws Exception {
     var context = environment.getContext();
     // write tableName & tableId, first to Table Mapping and then to Zookeeper
     context.getTableMapping(cloneInfo.getNamespaceId()).put(cloneInfo.getTableId(),
@@ -66,7 +66,7 @@ class CloneZookeeper extends ManagerRepo {
   }
 
   @Override
-  public void undo(FateId fateId, Manager environment) throws Exception {
+  public void undo(FateId fateId, FateEnv environment) throws Exception {
     environment.getTableManager().removeTable(cloneInfo.getTableId(), cloneInfo.getNamespaceId());
     if (!cloneInfo.getSrcNamespaceId().equals(cloneInfo.getNamespaceId())) {
       Utils.unreserveNamespace(environment.getContext(), cloneInfo.getNamespaceId(), fateId,

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/FinishCloneTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/FinishCloneTable.java
@@ -24,12 +24,12 @@ import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.manager.state.tables.TableState;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.slf4j.LoggerFactory;
 
-class FinishCloneTable extends ManagerRepo {
+class FinishCloneTable extends AbstractRepo {
 
   private static final long serialVersionUID = 1L;
   private final CloneInfo cloneInfo;
@@ -39,12 +39,12 @@ class FinishCloneTable extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager environment) {
+  public long isReady(FateId fateId, FateEnv environment) {
     return 0;
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager environment) {
+  public Repo<FateEnv> call(FateId fateId, FateEnv environment) {
     // directories are intentionally not created.... this is done because directories should be
     // unique
     // because they occupy a different namespace than normal tablet directories... also some clones
@@ -72,7 +72,7 @@ class FinishCloneTable extends ManagerRepo {
         LockType.READ);
     Utils.unreserveTable(environment.getContext(), cloneInfo.getTableId(), fateId, LockType.WRITE);
 
-    environment.getEventCoordinator().event(cloneInfo.getTableId(), "Cloned table %s from %s",
+    environment.getEvents().event(cloneInfo.getTableId(), "Cloned table %s from %s",
         cloneInfo.getTableName(), cloneInfo.getSrcTableId());
 
     LoggerFactory.getLogger(FinishCloneTable.class)
@@ -83,6 +83,6 @@ class FinishCloneTable extends ManagerRepo {
   }
 
   @Override
-  public void undo(FateId fateId, Manager environment) {}
+  public void undo(FateId fateId, FateEnv environment) {}
 
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CleanUp.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CleanUp.java
@@ -34,14 +34,14 @@ import org.apache.accumulo.core.fate.zookeeper.LockRange;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.Ample.ConditionalResult.Status;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.accumulo.server.compaction.CompactionConfigStorage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class CleanUp extends ManagerRepo {
+public class CleanUp extends AbstractRepo {
 
   private static final Logger log = LoggerFactory.getLogger(CleanUp.class);
 
@@ -60,9 +60,9 @@ public class CleanUp extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager manager) throws Exception {
+  public long isReady(FateId fateId, FateEnv env) throws Exception {
 
-    var ample = manager.getContext().getAmple();
+    var ample = env.getContext().getAmple();
 
     AtomicLong rejectedCount = new AtomicLong(0);
     Consumer<Ample.ConditionalResult> resultConsumer = result -> {
@@ -119,10 +119,10 @@ public class CleanUp extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager manager) throws Exception {
-    CompactionConfigStorage.deleteConfig(manager.getContext(), fateId);
-    Utils.getReadLock(manager.getContext(), tableId, fateId, LockRange.infinite()).unlock();
-    Utils.getReadLock(manager.getContext(), namespaceId, fateId, LockRange.infinite()).unlock();
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
+    CompactionConfigStorage.deleteConfig(env.getContext(), fateId);
+    Utils.getReadLock(env.getContext(), tableId, fateId, LockRange.infinite()).unlock();
+    Utils.getReadLock(env.getContext(), namespaceId, fateId, LockRange.infinite()).unlock();
     return null;
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactRange.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactRange.java
@@ -34,8 +34,8 @@ import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.fate.zookeeper.LockRange;
 import org.apache.accumulo.core.util.TextUtil;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.accumulo.server.compaction.CompactionConfigStorage;
 import org.apache.hadoop.io.Text;
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 
-public class CompactRange extends ManagerRepo {
+public class CompactRange extends AbstractRepo {
 
   private static final Logger log = LoggerFactory.getLogger(CompactRange.class);
 
@@ -80,7 +80,7 @@ public class CompactRange extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager env) throws Exception {
+  public long isReady(FateId fateId, FateEnv env) throws Exception {
     return Utils.reserveNamespace(env.getContext(), namespaceId, fateId, LockType.READ, true,
         TableOperation.COMPACT)
         + Utils.reserveTable(env.getContext(), tableId, fateId, LockType.READ, true,
@@ -88,7 +88,7 @@ public class CompactRange extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(final FateId fateId, Manager env) throws Exception {
+  public Repo<FateEnv> call(final FateId fateId, FateEnv env) throws Exception {
     CompactionConfigStorage.setConfig(env.getContext(), fateId, config);
     var extent = new KeyExtent(tableId, endRow == null ? null : new Text(endRow),
         startRow == null ? null : new Text(startRow));
@@ -106,7 +106,7 @@ public class CompactRange extends ManagerRepo {
   }
 
   @Override
-  public void undo(FateId fateId, Manager env) throws Exception {
+  public void undo(FateId fateId, FateEnv env) throws Exception {
     try {
       CompactionConfigStorage.deleteConfig(env.getContext(), fateId);
     } finally {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/RefreshTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/RefreshTablets.java
@@ -23,11 +23,11 @@ import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.bulkVer2.TabletRefresher;
 
-public class RefreshTablets extends ManagerRepo {
+public class RefreshTablets extends AbstractRepo {
 
   private static final long serialVersionUID = 1L;
 
@@ -44,8 +44,8 @@ public class RefreshTablets extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager manager) throws Exception {
-    TabletRefresher.refresh(manager, fateId, tableId, startRow, endRow, tabletMetadata -> true);
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
+    TabletRefresher.refresh(env, fateId, tableId, startRow, endRow, tabletMetadata -> true);
 
     return new CleanUp(tableId, namespaceId, startRow, endRow);
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/cancel/CancelCompactions.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/cancel/CancelCompactions.java
@@ -24,14 +24,14 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.accumulo.server.compaction.CompactionConfigStorage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class CancelCompactions extends ManagerRepo {
+public class CancelCompactions extends AbstractRepo {
 
   private static final long serialVersionUID = 1L;
   private final TableId tableId;
@@ -45,8 +45,7 @@ public class CancelCompactions extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager env) throws Exception {
-
+  public long isReady(FateId fateId, FateEnv env) throws Exception {
     return Utils.reserveNamespace(env.getContext(), namespaceId, fateId, LockType.READ, true,
         TableOperation.COMPACT_CANCEL)
         + Utils.reserveTable(env.getContext(), tableId, fateId, LockType.READ, true,
@@ -54,7 +53,7 @@ public class CancelCompactions extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager environment) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv environment) throws Exception {
     var idsToCancel =
         CompactionConfigStorage.getAllConfig(environment.getContext(), tableId::equals).keySet();
 
@@ -66,7 +65,7 @@ public class CancelCompactions extends ManagerRepo {
   }
 
   @Override
-  public void undo(FateId fateId, Manager env) {
+  public void undo(FateId fateId, FateEnv env) {
     Utils.unreserveTable(env.getContext(), tableId, fateId, LockType.READ);
     Utils.unreserveNamespace(env.getContext(), namespaceId, fateId, LockType.READ);
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/cancel/FinishCancelCompaction.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/cancel/FinishCancelCompaction.java
@@ -23,11 +23,11 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.Utils;
 
-class FinishCancelCompaction extends ManagerRepo {
+class FinishCancelCompaction extends AbstractRepo {
   private static final long serialVersionUID = 1L;
   private final TableId tableId;
   private final NamespaceId namespaceId;
@@ -38,14 +38,14 @@ class FinishCancelCompaction extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager environment) {
+  public Repo<FateEnv> call(FateId fateId, FateEnv environment) {
     Utils.unreserveTable(environment.getContext(), tableId, fateId, LockType.READ);
     Utils.unreserveNamespace(environment.getContext(), namespaceId, fateId, LockType.READ);
     return null;
   }
 
   @Override
-  public void undo(FateId fateId, Manager environment) {
+  public void undo(FateId fateId, FateEnv environment) {
 
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/ChooseDir.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/ChooseDir.java
@@ -30,8 +30,8 @@ import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.admin.TabletMergeability;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.TableInfo;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.accumulo.server.ServerContext;
@@ -43,7 +43,7 @@ import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class ChooseDir extends ManagerRepo {
+class ChooseDir extends AbstractRepo {
   private static final long serialVersionUID = 1L;
 
   private final TableInfo tableInfo;
@@ -54,26 +54,26 @@ class ChooseDir extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager environment) {
+  public long isReady(FateId fateId, FateEnv environment) {
     return 0;
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager manager) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
     if (tableInfo.getInitialSplitSize() > 0) {
-      createTableDirectoriesInfo(manager.getContext());
+      createTableDirectoriesInfo(env.getContext());
     }
     return new PopulateMetadata(tableInfo);
   }
 
   @Override
-  public void undo(FateId fateId, Manager manager) throws Exception {
+  public void undo(FateId fateId, FateEnv env) throws Exception {
     // Clean up split files if ChooseDir operation fails
     Path p = null;
     try {
       if (tableInfo.getInitialSplitSize() > 0) {
         p = tableInfo.getSplitDirsPath();
-        FileSystem fs = p.getFileSystem(manager.getContext().getHadoopConf());
+        FileSystem fs = p.getFileSystem(env.getContext().getHadoopConf());
         fs.delete(p, true);
       }
     } catch (IOException e) {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/CreateTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/CreateTable.java
@@ -31,8 +31,8 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.TableInfo;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.hadoop.fs.FileSystem;
@@ -40,7 +40,7 @@ import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class CreateTable extends ManagerRepo {
+public class CreateTable extends AbstractRepo {
   private static final long serialVersionUID = 1L;
   private static final Logger log = LoggerFactory.getLogger(CreateTable.class);
 
@@ -65,7 +65,7 @@ public class CreateTable extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager environment) throws Exception {
+  public long isReady(FateId fateId, FateEnv environment) throws Exception {
     // reserve the table's namespace to make sure it doesn't change while the table is created
     return Utils.reserveNamespace(environment.getContext(), tableInfo.getNamespaceId(), fateId,
         LockType.READ, true, TableOperation.CREATE);
@@ -73,20 +73,17 @@ public class CreateTable extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager manager) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
     // first step is to reserve a table id.. if the machine fails during this step
     // it is ok to retry... the only side effect is that a table id may not be used
     // or skipped
-
-    // assuming only the manager process is creating tables
-
     String tName = tableInfo.getTableName();
-    tableInfo.setTableId(Utils.getNextId(tName, manager.getContext(), TableId::of));
+    tableInfo.setTableId(Utils.getNextId(tName, env.getContext(), TableId::of));
     return new SetupPermissions(tableInfo);
   }
 
   @Override
-  public void undo(FateId fateId, Manager env) throws IOException {
+  public void undo(FateId fateId, FateEnv env) throws IOException {
     // Clean up split files if create table operation fails
     Path p = null;
     try {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/FinishCreateTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/FinishCreateTable.java
@@ -26,8 +26,8 @@ import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.manager.state.tables.TableState;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.TableInfo;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.accumulo.server.ServerContext;
@@ -36,7 +36,7 @@ import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class FinishCreateTable extends ManagerRepo {
+class FinishCreateTable extends AbstractRepo {
 
   private static final long serialVersionUID = 1L;
   private static final Logger log = LoggerFactory.getLogger(FinishCreateTable.class);
@@ -48,12 +48,12 @@ class FinishCreateTable extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager environment) {
+  public long isReady(FateId fateId, FateEnv environment) {
     return 0;
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager env) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
     final EnumSet<TableState> expectedCurrStates = EnumSet.of(TableState.NEW);
 
     if (tableInfo.getInitialTableState() == InitialTableState.OFFLINE) {
@@ -67,8 +67,7 @@ class FinishCreateTable extends ManagerRepo {
     Utils.unreserveNamespace(env.getContext(), tableInfo.getNamespaceId(), fateId, LockType.READ);
     Utils.unreserveTable(env.getContext(), tableInfo.getTableId(), fateId, LockType.WRITE);
 
-    env.getEventCoordinator().event(tableInfo.getTableId(), "Created table %s ",
-        tableInfo.getTableName());
+    env.getEvents().event(tableInfo.getTableId(), "Created table %s ", tableInfo.getTableName());
 
     if (tableInfo.getInitialSplitSize() > 0) {
       cleanupSplitFiles(env.getContext());
@@ -95,6 +94,6 @@ class FinishCreateTable extends ManagerRepo {
   }
 
   @Override
-  public void undo(FateId fateId, Manager env) {}
+  public void undo(FateId fateId, FateEnv env) {}
 
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/PopulateMetadata.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/PopulateMetadata.java
@@ -36,8 +36,8 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.Se
 import org.apache.accumulo.core.metadata.schema.MetadataTime;
 import org.apache.accumulo.core.metadata.schema.TabletMergeabilityMetadata;
 import org.apache.accumulo.core.util.time.SteadyTime;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.TableInfo;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.accumulo.server.ServerContext;
@@ -46,7 +46,7 @@ import org.apache.hadoop.io.Text;
 
 import com.google.common.base.Preconditions;
 
-class PopulateMetadata extends ManagerRepo {
+class PopulateMetadata extends AbstractRepo {
 
   private static final long serialVersionUID = 1L;
 
@@ -57,12 +57,12 @@ class PopulateMetadata extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager environment) {
+  public long isReady(FateId fateId, FateEnv environment) {
     return 0;
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager env) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
     SortedMap<Text,TabletMergeability> splits;
     Map<Text,Text> splitDirMap;
 
@@ -113,7 +113,7 @@ class PopulateMetadata extends ManagerRepo {
   }
 
   @Override
-  public void undo(FateId fateId, Manager environment) throws Exception {
+  public void undo(FateId fateId, FateEnv environment) throws Exception {
     MetadataTableUtil.deleteTable(tableInfo.getTableId(), false, environment.getContext(),
         environment.getManagerLock());
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/PopulateZookeeper.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/PopulateZookeeper.java
@@ -24,14 +24,14 @@ import org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.TableInfo;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.accumulo.server.conf.store.TablePropKey;
 import org.apache.accumulo.server.util.PropUtil;
 
-class PopulateZookeeper extends ManagerRepo {
+class PopulateZookeeper extends AbstractRepo {
 
   private static final long serialVersionUID = 1L;
 
@@ -42,20 +42,20 @@ class PopulateZookeeper extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager environment) throws Exception {
+  public long isReady(FateId fateId, FateEnv environment) throws Exception {
     return Utils.reserveTable(environment.getContext(), tableInfo.getTableId(), fateId,
         LockType.WRITE, false, TableOperation.CREATE);
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager manager) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
     // reserve the table name in zookeeper or fail
 
-    var context = manager.getContext();
+    var context = env.getContext();
     // write tableName & tableId, first to Table Mapping and then to Zookeeper
     context.getTableMapping(tableInfo.getNamespaceId()).put(tableInfo.getTableId(),
         tableInfo.getTableName(), TableOperation.CREATE);
-    manager.getTableManager().addTable(tableInfo.getTableId(), tableInfo.getNamespaceId(),
+    env.getTableManager().addTable(tableInfo.getTableId(), tableInfo.getNamespaceId(),
         tableInfo.getTableName());
 
     try {
@@ -72,10 +72,10 @@ class PopulateZookeeper extends ManagerRepo {
   }
 
   @Override
-  public void undo(FateId fateId, Manager manager) throws Exception {
-    manager.getTableManager().removeTable(tableInfo.getTableId(), tableInfo.getNamespaceId());
-    Utils.unreserveTable(manager.getContext(), tableInfo.getTableId(), fateId, LockType.WRITE);
-    manager.getContext().clearTableListCache();
+  public void undo(FateId fateId, FateEnv env) throws Exception {
+    env.getTableManager().removeTable(tableInfo.getTableId(), tableInfo.getNamespaceId());
+    Utils.unreserveTable(env.getContext(), tableInfo.getTableId(), fateId, LockType.WRITE);
+    env.getContext().clearTableListCache();
   }
 
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/SetupPermissions.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/SetupPermissions.java
@@ -22,12 +22,12 @@ import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.security.TablePermission;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.TableInfo;
 import org.slf4j.LoggerFactory;
 
-class SetupPermissions extends ManagerRepo {
+class SetupPermissions extends AbstractRepo {
 
   private static final long serialVersionUID = 1L;
 
@@ -38,7 +38,7 @@ class SetupPermissions extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager env) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
     // give all table permissions to the creator
     var security = env.getContext().getSecurityOperation();
     if (!tableInfo.getUser().equals(env.getContext().getCredentials().getPrincipal())) {
@@ -61,7 +61,7 @@ class SetupPermissions extends ManagerRepo {
   }
 
   @Override
-  public void undo(FateId fateId, Manager env) throws Exception {
+  public void undo(FateId fateId, FateEnv env) throws Exception {
     env.getContext().getSecurityOperation().deleteTable(env.getContext().rpcCreds(),
         tableInfo.getTableId(), tableInfo.getNamespaceId());
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/DeleteTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/DeleteTable.java
@@ -27,11 +27,11 @@ import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.manager.state.tables.TableState;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.Utils;
 
-public class DeleteTable extends ManagerRepo {
+public class DeleteTable extends AbstractRepo {
 
   private static final long serialVersionUID = 1L;
 
@@ -44,7 +44,7 @@ public class DeleteTable extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager env) throws Exception {
+  public long isReady(FateId fateId, FateEnv env) throws Exception {
     return Utils.reserveNamespace(env.getContext(), namespaceId, fateId, LockType.READ, false,
         TableOperation.DELETE)
         + Utils.reserveTable(env.getContext(), tableId, fateId, LockType.WRITE, true,
@@ -52,16 +52,16 @@ public class DeleteTable extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager env) {
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) {
     final EnumSet<TableState> expectedCurrStates =
         EnumSet.of(TableState.ONLINE, TableState.OFFLINE);
     env.getTableManager().transitionTableState(tableId, TableState.DELETING, expectedCurrStates);
-    env.getEventCoordinator().event(tableId, "deleting table %s %s", tableId, fateId);
+    env.getEvents().event(tableId, "deleting table %s %s", tableId, fateId);
     return new ReserveTablets(tableId, namespaceId);
   }
 
   @Override
-  public void undo(FateId fateId, Manager env) {
+  public void undo(FateId fateId, FateEnv env) {
     Utils.unreserveTable(env.getContext(), tableId, fateId, LockType.WRITE);
     Utils.unreserveNamespace(env.getContext(), namespaceId, fateId, LockType.READ);
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/PreDeleteTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/PreDeleteTable.java
@@ -28,14 +28,14 @@ import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil.NodeExistsPolicy;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.compaction.CompactionConfigStorage;
 import org.apache.zookeeper.KeeperException;
 
-public class PreDeleteTable extends ManagerRepo {
+public class PreDeleteTable extends AbstractRepo {
 
   public static String createDeleteMarkerPath(InstanceId instanceId, TableId tableId) {
     return Constants.ZTABLES + "/" + tableId.canonical() + Constants.ZTABLE_DELETE_MARKER;
@@ -52,7 +52,7 @@ public class PreDeleteTable extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager env) throws Exception {
+  public long isReady(FateId fateId, FateEnv env) throws Exception {
     return Utils.reserveNamespace(env.getContext(), namespaceId, fateId, LockType.READ, true,
         TableOperation.DELETE)
         + Utils.reserveTable(env.getContext(), tableId, fateId, LockType.READ, true,
@@ -67,7 +67,7 @@ public class PreDeleteTable extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager environment) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv environment) throws Exception {
     try {
       preventFutureCompactions(environment.getContext());
 
@@ -85,7 +85,7 @@ public class PreDeleteTable extends ManagerRepo {
   }
 
   @Override
-  public void undo(FateId fateId, Manager env) {
+  public void undo(FateId fateId, FateEnv env) {
     Utils.unreserveTable(env.getContext(), tableId, fateId, LockType.READ);
     Utils.unreserveNamespace(env.getContext(), namespaceId, fateId, LockType.READ);
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/ReserveTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/ReserveTablets.java
@@ -32,12 +32,12 @@ import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.TabletOperationId;
 import org.apache.accumulo.core.metadata.schema.TabletOperationType;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ReserveTablets extends ManagerRepo {
+public class ReserveTablets extends AbstractRepo {
 
   private static final Logger log = LoggerFactory.getLogger(ReserveTablets.class);
 
@@ -52,7 +52,7 @@ public class ReserveTablets extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager manager) throws Exception {
+  public long isReady(FateId fateId, FateEnv env) throws Exception {
 
     var opid = TabletOperationId.from(TabletOperationType.DELETING, fateId);
 
@@ -72,10 +72,10 @@ public class ReserveTablets extends ManagerRepo {
     long tabletsSeen = 0;
 
     try (
-        var tablets = manager.getContext().getAmple().readTablets().forTable(tableId)
+        var tablets = env.getContext().getAmple().readTablets().forTable(tableId)
             .fetch(OPID, PREV_ROW, LOCATION).checkConsistency().build();
         var conditionalMutator =
-            manager.getContext().getAmple().conditionallyMutateTablets(resultsConsumer)) {
+            env.getContext().getAmple().conditionallyMutateTablets(resultsConsumer)) {
 
       for (var tabletMeta : tablets) {
         tabletsSeen++;
@@ -117,7 +117,7 @@ public class ReserveTablets extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager manager) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
     return new CleanUp(tableId, namespaceId);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/CountFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/CountFiles.java
@@ -24,14 +24,14 @@ import static org.apache.accumulo.manager.tableOps.merge.MergeInfo.Operation.SYS
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 
-public class CountFiles extends ManagerRepo {
+public class CountFiles extends AbstractRepo {
   private static final Logger log = LoggerFactory.getLogger(CountFiles.class);
   private static final long serialVersionUID = 1L;
   private final MergeInfo data;
@@ -41,7 +41,7 @@ public class CountFiles extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager env) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
     // SYSTEM_MERGE should be executing VerifyMergeability repo, which already
     // will count files
     Preconditions.checkState(data.op != SYSTEM_MERGE, "Unexpected op %s", SYSTEM_MERGE);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/DeleteTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/DeleteTablets.java
@@ -29,8 +29,8 @@ import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.TabletOperationId;
 import org.apache.accumulo.core.metadata.schema.TabletOperationType;
 import org.apache.accumulo.core.util.TextUtil;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,7 +40,7 @@ import com.google.common.base.Preconditions;
 /**
  * Delete tablets that were merged into another tablet.
  */
-public class DeleteTablets extends ManagerRepo {
+public class DeleteTablets extends AbstractRepo {
 
   private static final long serialVersionUID = 1L;
 
@@ -56,7 +56,7 @@ public class DeleteTablets extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager manager) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
 
     KeyExtent range = data.getMergeExtent();
     log.debug("{} Deleting tablets for {}", fateId, range);
@@ -77,11 +77,10 @@ public class DeleteTablets extends ManagerRepo {
     long submitted = 0;
 
     try (
-        var tabletsMetadata =
-            manager.getContext().getAmple().readTablets().forTable(range.tableId())
-                .overlapping(range.prevEndRow(), range.endRow()).saveKeyValues().build();
+        var tabletsMetadata = env.getContext().getAmple().readTablets().forTable(range.tableId())
+            .overlapping(range.prevEndRow(), range.endRow()).saveKeyValues().build();
         var tabletsMutator =
-            manager.getContext().getAmple().conditionallyMutateTablets(resultConsumer)) {
+            env.getContext().getAmple().conditionallyMutateTablets(resultConsumer)) {
 
       var lastEndRow = lastTabletEndRow == null ? null : new Text(lastTabletEndRow);
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/FinishTableRangeOp.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/FinishTableRangeOp.java
@@ -32,15 +32,15 @@ import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.TabletOperationId;
 import org.apache.accumulo.core.metadata.schema.TabletOperationType;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 
-class FinishTableRangeOp extends ManagerRepo {
+class FinishTableRangeOp extends AbstractRepo {
   private static final Logger log = LoggerFactory.getLogger(FinishTableRangeOp.class);
 
   private static final long serialVersionUID = 1L;
@@ -52,15 +52,15 @@ class FinishTableRangeOp extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager manager) throws Exception {
-    removeOperationIds(log, data, fateId, manager);
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
+    removeOperationIds(log, data, fateId, env);
 
-    Utils.unreserveTable(manager.getContext(), data.tableId, fateId, LockType.WRITE);
-    Utils.unreserveNamespace(manager.getContext(), data.namespaceId, fateId, LockType.READ);
+    Utils.unreserveTable(env.getContext(), data.tableId, fateId, LockType.WRITE);
+    Utils.unreserveNamespace(env.getContext(), data.namespaceId, fateId, LockType.READ);
     return null;
   }
 
-  static void removeOperationIds(Logger log, MergeInfo data, FateId fateId, Manager manager) {
+  static void removeOperationIds(Logger log, MergeInfo data, FateId fateId, FateEnv env) {
     KeyExtent range = data.getReserveExtent();
     var opid = TabletOperationId.from(TabletOperationType.MERGING, fateId);
     log.debug("{} unreserving tablet in range {}", fateId, range);
@@ -80,10 +80,10 @@ class FinishTableRangeOp extends ManagerRepo {
     int submitted = 0;
     int count = 0;
 
-    try (var tablets = manager.getContext().getAmple().readTablets().forTable(data.tableId)
+    try (var tablets = env.getContext().getAmple().readTablets().forTable(data.tableId)
         .overlapping(range.prevEndRow(), range.endRow()).fetch(PREV_ROW, LOCATION, OPID).build();
         var tabletsMutator =
-            manager.getContext().getAmple().conditionallyMutateTablets(resultConsumer)) {
+            env.getContext().getAmple().conditionallyMutateTablets(resultConsumer)) {
 
       for (var tabletMeta : tablets) {
         if (opid.equals(tabletMeta.getOperationId())) {
@@ -100,7 +100,7 @@ class FinishTableRangeOp extends ManagerRepo {
     log.debug("{} deleted {}/{} opids out of {} tablets", fateId, acceptedCount.get(), submitted,
         count);
 
-    manager.getEventCoordinator().event(range, "Merge or deleterows completed %s", fateId);
+    env.getEvents().event(range, "Merge or deleterows completed %s", fateId);
 
     Preconditions.checkState(acceptedCount.get() == submitted && rejectedCount.get() == 0,
         "Failed to delete tablets accepted:%s != %s rejected:%s", acceptedCount.get(), submitted,

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/ReserveTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/ReserveTablets.java
@@ -34,14 +34,14 @@ import org.apache.accumulo.core.metadata.schema.Ample.ConditionalResult.Status;
 import org.apache.accumulo.core.metadata.schema.TabletOperationId;
 import org.apache.accumulo.core.metadata.schema.TabletOperationType;
 import org.apache.accumulo.core.util.Timer;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 
-public class ReserveTablets extends ManagerRepo {
+public class ReserveTablets extends AbstractRepo {
 
   private static final Logger log = LoggerFactory.getLogger(ReserveTablets.class);
 
@@ -54,7 +54,7 @@ public class ReserveTablets extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager env) throws Exception {
+  public long isReady(FateId fateId, FateEnv env) throws Exception {
     var range = data.getReserveExtent();
     log.debug("{} reserving tablets in range {}", fateId, range);
     var opid = TabletOperationId.from(TabletOperationType.MERGING, fateId);
@@ -115,8 +115,8 @@ public class ReserveTablets extends ManagerRepo {
     if (locations > 0 && opsAccepted.get() > 0) {
       // operation ids were set and tablets have locations, so lets send a signal to get them
       // unassigned
-      env.getEventCoordinator().event(range, "Tablets %d were reserved for merge %s",
-          opsAccepted.get(), fateId);
+      env.getEvents().event(range, "Tablets %d were reserved for merge %s", opsAccepted.get(),
+          fateId);
     }
 
     long sleepTime = Math.min(Math.max(1000, count), maxSleepTime);
@@ -131,7 +131,7 @@ public class ReserveTablets extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager environment) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv environment) throws Exception {
     return switch (data.op) {
       case SYSTEM_MERGE -> new VerifyMergeability(data);
       case MERGE, DELETE -> new CountFiles(data);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/TableRangeOp.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/TableRangeOp.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.merge;
 
+import static org.apache.accumulo.manager.ManagerClientServiceHandler.mustBeOnline;
+
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
@@ -27,14 +29,14 @@ import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType
 import org.apache.accumulo.core.fate.zookeeper.LockRange;
 import org.apache.accumulo.core.metadata.SystemTables;
 import org.apache.accumulo.core.util.TextUtil;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class TableRangeOp extends ManagerRepo {
+public class TableRangeOp extends AbstractRepo {
   private static final Logger log = LoggerFactory.getLogger(TableRangeOp.class);
 
   private static final long serialVersionUID = 1L;
@@ -42,7 +44,7 @@ public class TableRangeOp extends ManagerRepo {
   private final MergeInfo data;
 
   @Override
-  public long isReady(FateId fateId, Manager env) throws Exception {
+  public long isReady(FateId fateId, FateEnv env) throws Exception {
     return Utils.reserveNamespace(env.getContext(), data.namespaceId, fateId, LockType.READ, true,
         TableOperation.MERGE)
         + Utils.reserveTable(env.getContext(), data.tableId, fateId, LockType.WRITE, true,
@@ -57,14 +59,14 @@ public class TableRangeOp extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager env) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
 
     if (SystemTables.ROOT.tableId().equals(data.tableId) && data.op.isMergeOp()) {
       log.warn("Attempt to merge tablets for {} does nothing. It is not splittable.",
           SystemTables.ROOT.tableName());
     }
 
-    env.mustBeOnline(data.tableId);
+    mustBeOnline(env.getContext(), data.tableId);
 
     data.validate();
 
@@ -72,7 +74,7 @@ public class TableRangeOp extends ManagerRepo {
   }
 
   @Override
-  public void undo(FateId fateId, Manager env) throws Exception {
+  public void undo(FateId fateId, FateEnv env) throws Exception {
     Utils.unreserveNamespace(env.getContext(), data.namespaceId, fateId, LockType.READ);
     Utils.unreserveTable(env.getContext(), data.tableId, fateId, LockType.WRITE);
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/UnreserveAndError.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/UnreserveAndError.java
@@ -23,12 +23,12 @@ import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class UnreserveAndError extends ManagerRepo {
+public class UnreserveAndError extends AbstractRepo {
   private static final long serialVersionUID = 1L;
   private static final Logger log = LoggerFactory.getLogger(UnreserveAndError.class);
   private final MergeInfo mergeInfo;
@@ -42,7 +42,7 @@ public class UnreserveAndError extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager environment) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv environment) throws Exception {
     FinishTableRangeOp.removeOperationIds(log, mergeInfo, fateId, environment);
     throw new AcceptableThriftTableOperationException(mergeInfo.tableId.toString(), null,
         mergeInfo.op == MergeInfo.Operation.MERGE ? TableOperation.MERGE

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/UnreserveSystemMerge.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/UnreserveSystemMerge.java
@@ -23,13 +23,13 @@ import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
-import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.merge.FindMergeableRangeTask.UnmergeableReason;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class UnreserveSystemMerge extends ManagerRepo {
+public class UnreserveSystemMerge extends AbstractRepo {
 
   private static final long serialVersionUID = 1L;
   private static final Logger log = LoggerFactory.getLogger(UnreserveSystemMerge.class);
@@ -47,7 +47,7 @@ public class UnreserveSystemMerge extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager environment) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv environment) throws Exception {
     FinishTableRangeOp.removeOperationIds(log, mergeInfo, fateId, environment);
     throw new AcceptableThriftTableOperationException(mergeInfo.tableId.toString(), null,
         mergeInfo.op.isMergeOp() ? TableOperation.MERGE : TableOperation.DELETE_RANGE,

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/VerifyMergeability.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/VerifyMergeability.java
@@ -24,16 +24,16 @@ import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
-import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.merge.FindMergeableRangeTask.MergeableRange;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.merge.MergeInfo.Operation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 
-public class VerifyMergeability extends ManagerRepo {
+public class VerifyMergeability extends AbstractRepo {
   private static final Logger log = LoggerFactory.getLogger(VerifyMergeability.class);
   private static final long serialVersionUID = 1L;
   private final MergeInfo data;
@@ -44,7 +44,7 @@ public class VerifyMergeability extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager env) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
 
     var range = data.getReserveExtent();
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/CreateNamespace.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/CreateNamespace.java
@@ -23,11 +23,11 @@ import java.util.Map;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.Utils;
 
-public class CreateNamespace extends ManagerRepo {
+public class CreateNamespace extends AbstractRepo {
   private static final long serialVersionUID = 1L;
 
   private final NamespaceInfo namespaceInfo;
@@ -40,12 +40,12 @@ public class CreateNamespace extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager environment) {
+  public long isReady(FateId fateId, FateEnv environment) {
     return 0;
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager manager) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv manager) throws Exception {
     namespaceInfo.namespaceId =
         Utils.getNextId(namespaceInfo.namespaceName, manager.getContext(), NamespaceId::of);
     return new SetupNamespacePermissions(namespaceInfo);
@@ -53,7 +53,7 @@ public class CreateNamespace extends ManagerRepo {
   }
 
   @Override
-  public void undo(FateId fateId, Manager env) {
+  public void undo(FateId fateId, FateEnv env) {
     // nothing to do, the namespace id was allocated!
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/FinishCreateNamespace.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/FinishCreateNamespace.java
@@ -21,12 +21,12 @@ package org.apache.accumulo.manager.tableOps.namespace.create;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.slf4j.LoggerFactory;
 
-class FinishCreateNamespace extends ManagerRepo {
+class FinishCreateNamespace extends AbstractRepo {
 
   private static final long serialVersionUID = 1L;
 
@@ -37,16 +37,16 @@ class FinishCreateNamespace extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager environment) {
+  public long isReady(FateId fateId, FateEnv environment) {
     return 0;
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager env) {
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) {
 
     Utils.unreserveNamespace(env.getContext(), namespaceInfo.namespaceId, fateId, LockType.WRITE);
 
-    env.getEventCoordinator().event("Created namespace %s ", namespaceInfo.namespaceName);
+    env.getEvents().event("Created namespace %s ", namespaceInfo.namespaceName);
 
     LoggerFactory.getLogger(FinishCreateNamespace.class)
         .debug("Created table " + namespaceInfo.namespaceId + " " + namespaceInfo.namespaceName);
@@ -60,6 +60,6 @@ class FinishCreateNamespace extends ManagerRepo {
   }
 
   @Override
-  public void undo(FateId fateId, Manager env) {}
+  public void undo(FateId fateId, FateEnv env) {}
 
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/PopulateZookeeperWithNamespace.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/PopulateZookeeperWithNamespace.java
@@ -23,13 +23,13 @@ import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil.NodeExistsPolicy;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.accumulo.server.conf.store.NamespacePropKey;
 import org.apache.accumulo.server.util.PropUtil;
 
-class PopulateZookeeperWithNamespace extends ManagerRepo {
+class PopulateZookeeperWithNamespace extends AbstractRepo {
 
   private static final long serialVersionUID = 1L;
 
@@ -40,16 +40,15 @@ class PopulateZookeeperWithNamespace extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager environment) throws Exception {
+  public long isReady(FateId fateId, FateEnv environment) throws Exception {
     return Utils.reserveNamespace(environment.getContext(), namespaceInfo.namespaceId, fateId,
         LockType.WRITE, false, TableOperation.CREATE);
-
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager manager) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
 
-    var context = manager.getContext();
+    var context = env.getContext();
     context.getNamespaceMapping().put(namespaceInfo.namespaceId, namespaceInfo.namespaceName);
     context.getTableManager().prepareNewNamespaceState(namespaceInfo.namespaceId,
         namespaceInfo.namespaceName, NodeExistsPolicy.OVERWRITE);
@@ -63,11 +62,10 @@ class PopulateZookeeperWithNamespace extends ManagerRepo {
   }
 
   @Override
-  public void undo(FateId fateId, Manager manager) throws Exception {
-    manager.getTableManager().removeNamespace(namespaceInfo.namespaceId);
-    manager.getContext().clearTableListCache();
-    Utils.unreserveNamespace(manager.getContext(), namespaceInfo.namespaceId, fateId,
-        LockType.WRITE);
+  public void undo(FateId fateId, FateEnv env) throws Exception {
+    env.getTableManager().removeNamespace(namespaceInfo.namespaceId);
+    env.getContext().clearTableListCache();
+    Utils.unreserveNamespace(env.getContext(), namespaceInfo.namespaceId, fateId, LockType.WRITE);
   }
 
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/SetupNamespacePermissions.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/SetupNamespacePermissions.java
@@ -22,11 +22,11 @@ import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.security.NamespacePermission;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.slf4j.LoggerFactory;
 
-class SetupNamespacePermissions extends ManagerRepo {
+class SetupNamespacePermissions extends AbstractRepo {
 
   private static final long serialVersionUID = 1L;
 
@@ -37,7 +37,7 @@ class SetupNamespacePermissions extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fate, Manager env) throws Exception {
+  public Repo<FateEnv> call(FateId fate, FateEnv env) throws Exception {
     // give all namespace permissions to the creator
     var security = env.getContext().getSecurityOperation();
     if (!namespaceInfo.user.equals(env.getContext().getCredentials().getPrincipal())) {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/delete/DeleteNamespace.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/delete/DeleteNamespace.java
@@ -23,11 +23,11 @@ import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.Utils;
 
-public class DeleteNamespace extends ManagerRepo {
+public class DeleteNamespace extends AbstractRepo {
 
   private static final long serialVersionUID = 1L;
 
@@ -38,20 +38,19 @@ public class DeleteNamespace extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager environment) throws Exception {
+  public long isReady(FateId fateId, FateEnv environment) throws Exception {
     return Utils.reserveNamespace(environment.getContext(), namespaceId, fateId, LockType.WRITE,
         true, TableOperation.DELETE);
-
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager environment) {
-    environment.getEventCoordinator().event("deleting namespace %s ", namespaceId);
+  public Repo<FateEnv> call(FateId fateId, FateEnv environment) {
+    environment.getEvents().event("deleting namespace %s ", namespaceId);
     return new NamespaceCleanUp(namespaceId);
   }
 
   @Override
-  public void undo(FateId fateId, Manager environment) {
+  public void undo(FateId fateId, FateEnv environment) {
     Utils.unreserveNamespace(environment.getContext(), namespaceId, fateId, LockType.WRITE);
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/delete/NamespaceCleanUp.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/delete/NamespaceCleanUp.java
@@ -23,13 +23,13 @@ import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class NamespaceCleanUp extends ManagerRepo {
+class NamespaceCleanUp extends AbstractRepo {
 
   private static final Logger log = LoggerFactory.getLogger(NamespaceCleanUp.class);
 
@@ -42,30 +42,30 @@ class NamespaceCleanUp extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager manager) {
+  public long isReady(FateId fateId, FateEnv env) {
     return 0;
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager manager) {
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) {
 
     // remove from zookeeper
     try {
-      manager.getTableManager().removeNamespace(namespaceId);
+      env.getTableManager().removeNamespace(namespaceId);
     } catch (Exception e) {
       log.error("Failed to find namespace in zookeeper", e);
     }
-    manager.getContext().clearTableListCache();
+    env.getContext().clearTableListCache();
 
     // remove any permissions associated with this namespace
     try {
-      manager.getContext().getSecurityOperation().deleteNamespace(manager.getContext().rpcCreds(),
+      env.getContext().getSecurityOperation().deleteNamespace(env.getContext().rpcCreds(),
           namespaceId);
     } catch (ThriftSecurityException e) {
       log.error("{}", e.getMessage(), e);
     }
 
-    Utils.unreserveNamespace(manager.getContext(), namespaceId, fateId, LockType.WRITE);
+    Utils.unreserveNamespace(env.getContext(), namespaceId, fateId, LockType.WRITE);
 
     log.debug("Deleted namespace " + namespaceId);
 
@@ -73,7 +73,7 @@ class NamespaceCleanUp extends ManagerRepo {
   }
 
   @Override
-  public void undo(FateId fateId, Manager environment) {
+  public void undo(FateId fateId, FateEnv environment) {
     // nothing to do
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/rename/RenameTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/rename/RenameTable.java
@@ -27,12 +27,12 @@ import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.core.util.tables.TableNameUtil;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.slf4j.LoggerFactory;
 
-public class RenameTable extends ManagerRepo {
+public class RenameTable extends AbstractRepo {
 
   private static final long serialVersionUID = 1L;
   private final TableId tableId;
@@ -41,7 +41,7 @@ public class RenameTable extends ManagerRepo {
   private final String newTableName;
 
   @Override
-  public long isReady(FateId fateId, Manager env) throws Exception {
+  public long isReady(FateId fateId, FateEnv env) throws Exception {
     return Utils.reserveNamespace(env.getContext(), namespaceId, fateId, LockType.READ, true,
         TableOperation.RENAME)
         + Utils.reserveTable(env.getContext(), tableId, fateId, LockType.WRITE, true,
@@ -57,11 +57,11 @@ public class RenameTable extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager manager) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
     Pair<String,String> qualifiedOldTableName = TableNameUtil.qualify(oldTableName);
     // the namespace name was already checked before starting the fate operation
     String newSimpleTableName = TableNameUtil.qualify(newTableName).getSecond();
-    var context = manager.getContext();
+    var context = env.getContext();
 
     try {
       context.getTableMapping(namespaceId).rename(tableId, qualifiedOldTableName.getSecond(),
@@ -69,8 +69,8 @@ public class RenameTable extends ManagerRepo {
 
       context.clearTableListCache();
     } finally {
-      Utils.unreserveTable(manager.getContext(), tableId, fateId, LockType.WRITE);
-      Utils.unreserveNamespace(manager.getContext(), namespaceId, fateId, LockType.READ);
+      Utils.unreserveTable(env.getContext(), tableId, fateId, LockType.WRITE);
+      Utils.unreserveNamespace(env.getContext(), namespaceId, fateId, LockType.READ);
     }
 
     LoggerFactory.getLogger(RenameTable.class).debug("Renamed table {} {} {}", tableId,
@@ -80,7 +80,7 @@ public class RenameTable extends ManagerRepo {
   }
 
   @Override
-  public void undo(FateId fateId, Manager env) {
+  public void undo(FateId fateId, FateEnv env) {
     Utils.unreserveTable(env.getContext(), tableId, fateId, LockType.WRITE);
     Utils.unreserveNamespace(env.getContext(), namespaceId, fateId, LockType.READ);
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/DeleteOperationIds.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/DeleteOperationIds.java
@@ -28,10 +28,10 @@ import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.Ample.ConditionalResult.Status;
 import org.apache.accumulo.core.metadata.schema.TabletOperationId;
 import org.apache.accumulo.core.metadata.schema.TabletOperationType;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 
-public class DeleteOperationIds extends ManagerRepo {
+public class DeleteOperationIds extends AbstractRepo {
   private static final long serialVersionUID = 1L;
   private final SplitInfo splitInfo;
 
@@ -40,11 +40,11 @@ public class DeleteOperationIds extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager manager) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
 
     var opid = TabletOperationId.from(TabletOperationType.SPLITTING, fateId);
 
-    try (var tabletsMutator = manager.getContext().getAmple().conditionallyMutateTablets()) {
+    try (var tabletsMutator = env.getContext().getAmple().conditionallyMutateTablets()) {
 
       // As long as the operation is not our operation id, then this step can be considered
       // successful in the case of rejection. If this repo is running for a second time and has
@@ -69,7 +69,7 @@ public class DeleteOperationIds extends ManagerRepo {
       }
 
       // Get the tablets hosted ASAP if necessary.
-      manager.getEventCoordinator().event(splitInfo.getOriginal(), "Added %d splits to %s",
+      env.getEvents().event(splitInfo.getOriginal(), "Added %d splits to %s",
           splitInfo.getSplits().size(), splitInfo.getOriginal());
 
       TabletLogger.split(splitInfo.getOriginal(), splitInfo.getSplits().navigableKeySet());

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/FindSplits.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/FindSplits.java
@@ -33,14 +33,14 @@ import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.core.metadata.schema.Ample.ConditionalResult;
 import org.apache.accumulo.core.metadata.schema.Ample.ConditionalResult.Status;
 import org.apache.accumulo.core.metadata.schema.UnSplittableMetadata;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.server.split.SplitUtils;
 import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class FindSplits extends ManagerRepo {
+public class FindSplits extends AbstractRepo {
 
   private static final long serialVersionUID = 1L;
 
@@ -52,9 +52,9 @@ public class FindSplits extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager manager) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
     var extent = splitInfo.getOriginal();
-    var ample = manager.getContext().getAmple();
+    var ample = env.getContext().getAmple();
     var tabletMetadata = ample.readTablet(extent);
     Optional<UnSplittableMetadata> computedUnsplittable = Optional.empty();
 
@@ -73,7 +73,7 @@ public class FindSplits extends ManagerRepo {
     // as unsplittable and the metadata hasn't changed so check that the metadata is different
     if (tabletMetadata.getUnSplittable() != null) {
       computedUnsplittable =
-          Optional.of(SplitUtils.toUnSplittable(manager.getContext(), tabletMetadata));
+          Optional.of(SplitUtils.toUnSplittable(env.getContext(), tabletMetadata));
       if (tabletMetadata.getUnSplittable().equals(computedUnsplittable.orElseThrow())) {
         log.debug("Not splitting {} because unsplittable metadata is present and did not change",
             extent);
@@ -90,13 +90,13 @@ public class FindSplits extends ManagerRepo {
       return null;
     }
 
-    if (manager.getContext().getTableState(extent.tableId()) != TableState.ONLINE) {
+    if (env.getContext().getTableState(extent.tableId()) != TableState.ONLINE) {
       // The table is offline, do not bother finding splits
       log.debug("Not splitting {} because the table is not online", tabletMetadata.getExtent());
       return null;
     }
 
-    SortedSet<Text> splits = SplitUtils.findSplits(manager.getContext(), tabletMetadata);
+    SortedSet<Text> splits = SplitUtils.findSplits(env.getContext(), tabletMetadata);
 
     if (extent.endRow() != null) {
       splits.remove(extent.endRow());
@@ -117,7 +117,7 @@ public class FindSplits extends ManagerRepo {
         // Case 1: If a split is needed then set the unsplittable marker as no split
         // points could be found so that we don't keep trying again until the
         // split metadata is changed
-        final var context = manager.getContext();
+        final var context = env.getContext();
         if (SplitUtils.needsSplit(context, tabletMetadata)) {
           log.info("Tablet {} needs to split, but no split points could be found.",
               tabletMetadata.getExtent());

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableExport/ExportTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableExport/ExportTable.java
@@ -22,12 +22,12 @@ import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.hadoop.fs.Path;
 
-public class ExportTable extends ManagerRepo {
+public class ExportTable extends AbstractRepo {
   private static final long serialVersionUID = 1L;
 
   private final ExportInfo tableInfo;
@@ -41,18 +41,18 @@ public class ExportTable extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager environment) throws Exception {
+  public long isReady(FateId fateId, FateEnv environment) throws Exception {
     return Utils.reserveHdfsDirectory(environment.getContext(),
         new Path(tableInfo.exportDir).toString(), fateId);
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager env) {
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) {
     return new WriteExportFiles(tableInfo);
   }
 
   @Override
-  public void undo(FateId fateId, Manager env) throws Exception {
+  public void undo(FateId fateId, FateEnv env) throws Exception {
     String directory = new Path(tableInfo.exportDir).toString();
     Utils.unreserveHdfsDirectory(env.getContext(), directory, fateId);
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/CreateImportDir.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/CreateImportDir.java
@@ -25,15 +25,15 @@ import java.util.Set;
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.tablets.UniqueNameAllocator;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class CreateImportDir extends ManagerRepo {
+class CreateImportDir extends AbstractRepo {
   private static final Logger log = LoggerFactory.getLogger(CreateImportDir.class);
   private static final long serialVersionUID = 1L;
 
@@ -44,11 +44,11 @@ class CreateImportDir extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager manager) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
 
-    Set<String> tableDirs = manager.getContext().getTablesDirs();
+    Set<String> tableDirs = env.getContext().getTablesDirs();
 
-    create(tableDirs, manager.getContext());
+    create(tableDirs, env.getContext());
 
     return new MapImportFileNames(tableInfo);
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/FinishImportTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/FinishImportTable.java
@@ -26,13 +26,13 @@ import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
 import org.apache.accumulo.core.manager.state.tables.TableState;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.LoggerFactory;
 
-class FinishImportTable extends ManagerRepo {
+class FinishImportTable extends AbstractRepo {
 
   private static final long serialVersionUID = 1L;
 
@@ -43,12 +43,12 @@ class FinishImportTable extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager environment) {
+  public long isReady(FateId fateId, FateEnv environment) {
     return 0;
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager env) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
 
     if (!tableInfo.keepMappings) {
       for (ImportedTableInfo.DirectoryMapping dm : tableInfo.directories) {
@@ -67,7 +67,7 @@ class FinishImportTable extends ManagerRepo {
       Utils.unreserveHdfsDirectory(env.getContext(), new Path(dm.exportDir).toString(), fateId);
     }
 
-    env.getEventCoordinator().event(tableInfo.tableId, "Imported table %s ", tableInfo.tableName);
+    env.getEvents().event(tableInfo.tableId, "Imported table %s ", tableInfo.tableName);
 
     LoggerFactory.getLogger(FinishImportTable.class)
         .debug("Imported table " + tableInfo.tableId + " " + tableInfo.tableName);
@@ -81,6 +81,6 @@ class FinishImportTable extends ManagerRepo {
   }
 
   @Override
-  public void undo(FateId fateId, Manager env) {}
+  public void undo(FateId fateId, FateEnv env) {}
 
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportPopulateZookeeper.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportPopulateZookeeper.java
@@ -28,8 +28,8 @@ import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.accumulo.server.conf.store.TablePropKey;
 import org.apache.accumulo.server.fs.VolumeManager;
@@ -37,7 +37,7 @@ import org.apache.accumulo.server.util.PropUtil;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
-class ImportPopulateZookeeper extends ManagerRepo {
+class ImportPopulateZookeeper extends AbstractRepo {
 
   private static final long serialVersionUID = 1L;
 
@@ -48,7 +48,7 @@ class ImportPopulateZookeeper extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager environment) throws Exception {
+  public long isReady(FateId fateId, FateEnv environment) throws Exception {
     return Utils.reserveTable(environment.getContext(), tableInfo.tableId, fateId, LockType.WRITE,
         false, TableOperation.IMPORT);
   }
@@ -68,7 +68,7 @@ class ImportPopulateZookeeper extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager env) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
 
     var context = env.getContext();
     // write tableName & tableId, first to Table Mapping and then to Zookeeper
@@ -92,7 +92,7 @@ class ImportPopulateZookeeper extends ManagerRepo {
   }
 
   @Override
-  public void undo(FateId fateId, Manager env) throws Exception {
+  public void undo(FateId fateId, FateEnv env) throws Exception {
     var context = env.getContext();
     env.getTableManager().removeTable(tableInfo.tableId, tableInfo.namespaceId);
     Utils.unreserveTable(env.getContext(), tableInfo.tableId, fateId, LockType.WRITE);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportSetupPermissions.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportSetupPermissions.java
@@ -22,11 +22,11 @@ import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.security.TablePermission;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.slf4j.LoggerFactory;
 
-class ImportSetupPermissions extends ManagerRepo {
+class ImportSetupPermissions extends AbstractRepo {
 
   private static final long serialVersionUID = 1L;
 
@@ -37,12 +37,12 @@ class ImportSetupPermissions extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager environment) {
+  public long isReady(FateId fateId, FateEnv environment) {
     return 0;
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager env) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
     // give all table permissions to the creator
     var security = env.getContext().getSecurityOperation();
     for (TablePermission permission : TablePermission.values()) {
@@ -62,7 +62,7 @@ class ImportSetupPermissions extends ManagerRepo {
   }
 
   @Override
-  public void undo(FateId fateId, Manager env) throws Exception {
+  public void undo(FateId fateId, FateEnv env) throws Exception {
     env.getContext().getSecurityOperation().deleteTable(env.getContext().rpcCreds(),
         tableInfo.tableId, tableInfo.namespaceId);
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportTable.java
@@ -42,8 +42,8 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.accumulo.manager.tableOps.tableExport.ExportTable;
 import org.apache.accumulo.server.AccumuloDataVersion;
@@ -57,7 +57,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 /**
  * Serialization updated for supporting multiple volumes in import table from 1L to 2L.
  */
-public class ImportTable extends ManagerRepo {
+public class ImportTable extends AbstractRepo {
   private static final Logger log = LoggerFactory.getLogger(ImportTable.class);
 
   private static final long serialVersionUID = 2L;
@@ -76,7 +76,7 @@ public class ImportTable extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager environment) throws Exception {
+  public long isReady(FateId fateId, FateEnv environment) throws Exception {
     long result = 0;
     for (ImportedTableInfo.DirectoryMapping dm : tableInfo.directories) {
       result += Utils.reserveHdfsDirectory(environment.getContext(),
@@ -88,7 +88,7 @@ public class ImportTable extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager env) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
     checkVersions(env.getContext());
 
     // first step is to reserve a table id.. if the machine fails during this step
@@ -156,7 +156,7 @@ public class ImportTable extends ManagerRepo {
   }
 
   @Override
-  public void undo(FateId fateId, Manager env) throws Exception {
+  public void undo(FateId fateId, FateEnv env) throws Exception {
     for (ImportedTableInfo.DirectoryMapping dm : tableInfo.directories) {
       Utils.unreserveHdfsDirectory(env.getContext(), new Path(dm.exportDir).toString(), fateId);
     }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/MapImportFileNames.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/MapImportFileNames.java
@@ -32,8 +32,8 @@ import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FilePrefix;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.tablets.UniqueNameAllocator;
 import org.apache.hadoop.fs.FileStatus;
@@ -41,7 +41,7 @@ import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class MapImportFileNames extends ManagerRepo {
+class MapImportFileNames extends AbstractRepo {
   private static final Logger log = LoggerFactory.getLogger(MapImportFileNames.class);
 
   private static final long serialVersionUID = 1L;
@@ -53,7 +53,7 @@ class MapImportFileNames extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager environment) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv environment) throws Exception {
 
     for (ImportedTableInfo.DirectoryMapping dm : tableInfo.directories) {
       Path path = new Path(dm.importDir, IMPORT_MAPPINGS_FILE);
@@ -119,7 +119,7 @@ class MapImportFileNames extends ManagerRepo {
   }
 
   @Override
-  public void undo(FateId fateId, Manager env) throws Exception {
+  public void undo(FateId fateId, FateEnv env) throws Exception {
     // TODO: will this be OK for partially complete operations?
     for (ImportedTableInfo.DirectoryMapping dm : tableInfo.directories) {
       env.getVolumeManager().deleteRecursively(new Path(dm.importDir));

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/MoveExportedFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/MoveExportedFiles.java
@@ -33,8 +33,8 @@ import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Sets;
 
-class MoveExportedFiles extends ManagerRepo {
+class MoveExportedFiles extends AbstractRepo {
   private static final Logger log = LoggerFactory.getLogger(MoveExportedFiles.class);
 
   private static final long serialVersionUID = 1L;
@@ -55,8 +55,8 @@ class MoveExportedFiles extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager manager) throws Exception {
-    VolumeManager fs = manager.getVolumeManager();
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
+    VolumeManager fs = env.getVolumeManager();
     Map<Path,Path> oldToNewPaths = new HashMap<>();
 
     for (ImportedTableInfo.DirectoryMapping dm : tableInfo.directories) {
@@ -108,7 +108,7 @@ class MoveExportedFiles extends ManagerRepo {
       }
     }
     try {
-      fs.bulkRename(oldToNewPaths, manager.getRenamePool(), fateId);
+      fs.bulkRename(oldToNewPaths, env.getRenamePool(), fateId);
     } catch (IOException ioe) {
       throw new AcceptableThriftTableOperationException(tableInfo.tableId.canonical(), null,
           TableOperation.IMPORT, TableOperationExceptionType.OTHER, ioe.getCause().getMessage());

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/PopulateMetadataTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/PopulateMetadataTable.java
@@ -52,8 +52,8 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.Da
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.util.FastFormat;
-import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.util.MetadataTableUtil;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -62,7 +62,7 @@ import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class PopulateMetadataTable extends ManagerRepo {
+class PopulateMetadataTable extends AbstractRepo {
   private static final Logger log = LoggerFactory.getLogger(PopulateMetadataTable.class);
 
   private static final long serialVersionUID = 1L;
@@ -96,14 +96,13 @@ class PopulateMetadataTable extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager manager) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
 
     Path path = new Path(tableInfo.exportFile);
 
-    VolumeManager fs = manager.getVolumeManager();
+    VolumeManager fs = env.getVolumeManager();
 
-    try (
-        BatchWriter mbw = manager.getContext().createBatchWriter(SystemTables.METADATA.tableName());
+    try (BatchWriter mbw = env.getContext().createBatchWriter(SystemTables.METADATA.tableName());
         FSDataInputStream fsDataInputStream = fs.open(path);
         ZipInputStream zis = new ZipInputStream(fsDataInputStream)) {
 
@@ -212,7 +211,7 @@ class PopulateMetadataTable extends ManagerRepo {
   }
 
   @Override
-  public void undo(FateId fateId, Manager environment) throws Exception {
+  public void undo(FateId fateId, FateEnv environment) throws Exception {
     MetadataTableUtil.deleteTable(tableInfo.tableId, false, environment.getContext(),
         environment.getManagerLock());
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tserverOps/ShutdownTServer.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tserverOps/ShutdownTServer.java
@@ -29,7 +29,8 @@ import org.apache.accumulo.core.lock.ServiceLock;
 import org.apache.accumulo.core.manager.thrift.TabletServerStatus;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.manager.Manager;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.server.manager.LiveTServerSet.TServerConnection;
 import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
@@ -37,7 +38,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.net.HostAndPort;
 
-public class ShutdownTServer extends ManagerRepo {
+public class ShutdownTServer extends AbstractRepo {
 
   private static final long serialVersionUID = 2L;
   private static final Logger log = LoggerFactory.getLogger(ShutdownTServer.class);
@@ -54,7 +55,7 @@ public class ShutdownTServer extends ManagerRepo {
   }
 
   @Override
-  public long isReady(FateId fateId, Manager manager) {
+  public long isReady(FateId fateId, FateEnv env) {
     TServerInstance server = new TServerInstance(hostAndPort, serverSession);
     // suppress assignment of tablets to the server
     if (force) {
@@ -62,6 +63,7 @@ public class ShutdownTServer extends ManagerRepo {
     }
 
     // Inform the manager that we want this server to shutdown
+    Manager manager = (Manager) env; // TODO
     manager.shutdownTServer(server);
 
     if (manager.onlineTabletServers().contains(server)) {
@@ -95,15 +97,15 @@ public class ShutdownTServer extends ManagerRepo {
   }
 
   @Override
-  public Repo<Manager> call(FateId fateId, Manager manager) throws Exception {
+  public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
     // suppress assignment of tablets to the server
     if (force) {
-      ZooReaderWriter zoo = manager.getContext().getZooSession().asReaderWriter();
+      ZooReaderWriter zoo = env.getContext().getZooSession().asReaderWriter();
       var path =
-          manager.getContext().getServerPaths().createTabletServerPath(resourceGroup, hostAndPort);
+          env.getContext().getServerPaths().createTabletServerPath(resourceGroup, hostAndPort);
       ServiceLock.deleteLock(zoo, path);
-      path = manager.getContext().getServerPaths().createDeadTabletServerPath(resourceGroup,
-          hostAndPort);
+      path =
+          env.getContext().getServerPaths().createDeadTabletServerPath(resourceGroup, hostAndPort);
       zoo.putPersistentData(path.toString(), "forced down".getBytes(UTF_8),
           NodeExistsPolicy.OVERWRITE);
     }
@@ -112,5 +114,5 @@ public class ShutdownTServer extends ManagerRepo {
   }
 
   @Override
-  public void undo(FateId fateId, Manager m) {}
+  public void undo(FateId fateId, FateEnv m) {}
 }

--- a/server/manager/src/test/java/org/apache/accumulo/manager/compaction/CompactionCoordinatorTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/compaction/CompactionCoordinatorTest.java
@@ -78,6 +78,7 @@ import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.compaction.coordinator.CompactionCoordinator;
 import org.apache.accumulo.manager.compaction.queue.CompactionJobPriorityQueue;
 import org.apache.accumulo.manager.compaction.queue.ResolvedCompactionJob;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.conf.TableConfiguration;
 import org.apache.accumulo.server.security.AuditedSecurityOperation;
@@ -93,7 +94,7 @@ import com.google.common.net.HostAndPort;
 public class CompactionCoordinatorTest {
 
   // Need a non-null fateInstances reference for CompactionCoordinator.compactionCompleted
-  private static final AtomicReference<Map<FateInstanceType,Fate<Manager>>> fateInstances =
+  private static final AtomicReference<Map<FateInstanceType,Fate<FateEnv>>> fateInstances =
       new AtomicReference<>(Map.of());
 
   private static final ResourceGroupId GROUP_ID = ResourceGroupId.of("R2DQ");

--- a/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/ShutdownTServerTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/ShutdownTServerTest.java
@@ -29,7 +29,6 @@ import java.util.UUID;
 import org.apache.accumulo.core.data.ResourceGroupId;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.FateInstanceType;
-import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.manager.thrift.TableInfo;
 import org.apache.accumulo.core.manager.thrift.TabletServerStatus;
 import org.apache.accumulo.core.metadata.TServerInstance;
@@ -92,7 +91,7 @@ public class ShutdownTServerTest {
     wait = op.isReady(fateId, manager);
     assertEquals(0, wait, "Expected wait to be 0");
 
-    Repo<Manager> op2 = op.call(fateId, manager);
+    var op2 = op.call(fateId, manager);
     assertNull(op2, "Expected no follow on step");
 
     EasyMock.verify(tserverCnxn, manager);

--- a/test/src/main/java/org/apache/accumulo/test/fate/FlakyFateManager.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FlakyFateManager.java
@@ -24,6 +24,7 @@ import org.apache.accumulo.core.cli.ConfigOpts;
 import org.apache.accumulo.core.fate.Fate;
 import org.apache.accumulo.core.fate.FateStore;
 import org.apache.accumulo.manager.Manager;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.TraceRepo;
 import org.apache.accumulo.server.ServerContext;
 import org.slf4j.LoggerFactory;
@@ -34,7 +35,7 @@ public class FlakyFateManager extends Manager {
   }
 
   @Override
-  protected Fate<Manager> initializeFateInstance(ServerContext context, FateStore<Manager> store) {
+  protected Fate<FateEnv> initializeFateInstance(ServerContext context, FateStore<FateEnv> store) {
     LoggerFactory.getLogger(FlakyFateManager.class).info("Creating Flaky Fate for {}",
         store.type());
     return new FlakyFate<>(this, store, TraceRepo::toLogString, getConfiguration());

--- a/test/src/main/java/org/apache/accumulo/test/fate/ManagerRepoIT_SimpleSuite.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/ManagerRepoIT_SimpleSuite.java
@@ -77,7 +77,7 @@ import org.apache.accumulo.core.util.time.SteadyTime;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.merge.FindMergeableRangeTask.UnmergeableReason;
-import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.AbstractRepo;
 import org.apache.accumulo.manager.tableOps.compact.CompactionDriver;
 import org.apache.accumulo.manager.tableOps.merge.DeleteRows;
 import org.apache.accumulo.manager.tableOps.merge.MergeInfo;
@@ -149,10 +149,10 @@ public class ManagerRepoIT_SimpleSuite extends SharedMiniClusterBase {
       // condition
       final MergeInfo mergeInfo = new MergeInfo(tableId,
           manager.getContext().getNamespaceId(tableId), null, null, operation);
-      final ManagerRepo repo =
+      final AbstractRepo repo =
           operation == Operation.MERGE ? new MergeTablets(mergeInfo) : new DeleteRows(mergeInfo);
       // Also test ReserveTablets isReady()
-      final ManagerRepo reserve = new ReserveTablets(mergeInfo);
+      final AbstractRepo reserve = new ReserveTablets(mergeInfo);
 
       // First, check no errors with the default case
       assertEquals(0, reserve.isReady(fateId, manager));
@@ -466,7 +466,7 @@ public class ManagerRepoIT_SimpleSuite extends SharedMiniClusterBase {
       var ctx = manager.getContext();
 
       // Create the CompactionDriver to test with the given range passed into the method
-      final ManagerRepo repo = new CompactionDriver(ctx.getNamespaceId(tableId), tableId,
+      final AbstractRepo repo = new CompactionDriver(ctx.getNamespaceId(tableId), tableId,
           !range.isInfiniteStartKey() ? range.getStartKey().getRow().getBytes() : null,
           !range.isInfiniteStopKey() ? range.getEndKey().getRow().getBytes() : null);
 

--- a/test/src/main/java/org/apache/accumulo/test/fate/SlowFateSplitManager.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/SlowFateSplitManager.java
@@ -24,6 +24,7 @@ import org.apache.accumulo.core.cli.ConfigOpts;
 import org.apache.accumulo.core.fate.Fate;
 import org.apache.accumulo.core.fate.FateStore;
 import org.apache.accumulo.manager.Manager;
+import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.TraceRepo;
 import org.apache.accumulo.server.ServerContext;
 import org.slf4j.Logger;
@@ -44,7 +45,7 @@ public class SlowFateSplitManager extends Manager {
   }
 
   @Override
-  protected Fate<Manager> initializeFateInstance(ServerContext context, FateStore<Manager> store) {
+  protected Fate<FateEnv> initializeFateInstance(ServerContext context, FateStore<FateEnv> store) {
     log.info("Creating Slow Split Fate for {}", store.type());
     return new SlowFateSplit<>(this, store, TraceRepo::toLogString, getConfiguration());
   }


### PR DESCRIPTION
Added a FateEnv interface that replaces direct usage of the Manager type in fate operations. This refactoring could support changes to run fate operations outside of the Manager process.