### PR TITLE
Fix non deterministic for testDataFileCheck()

### DIFF
--- a/server/base/src/test/java/org/apache/accumulo/server/constraints/MetadataConstraintsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/constraints/MetadataConstraintsTest.java
@@ -360,8 +360,9 @@ public class MetadataConstraintsTest {
     m = new Mutation(new Text("0;foo"));
     m.put(BulkFileColumnFamily.NAME,
         new Text(StoredTabletFile.of(new Path("hdfs://1.2.3.4/accumulo/tables/2a/t-0003/someFile"))
-            .getMetadata().replaceFirst("\"path\":\".*\",\"startRow", "\"path\":\"\",\"startRow")),
+            .getMetadata().replaceFirst("\"path\":\".*\"", "\"path\":\"\"")),
         new Value(fateId1.canonical()));
+
     assertViolation(mc, m, (short) 3100);
 
     // Bad Json - test startRow key replaced with empty string so validation should fail
@@ -435,8 +436,9 @@ public class MetadataConstraintsTest {
     m = new Mutation(new Text("0;foo"));
     m.put(columnFamily,
         new Text(StoredTabletFile.of(new Path("hdfs://1.2.3.4/accumulo/tables/2a/t-0003/someFile"))
-            .getMetadata().replaceFirst("\"path\":\".*\",\"startRow", "\"path\":\"\",\"startRow")),
+            .getMetadata().replaceFirst("\"path\":\".*\"", "\"path\":\"\"")),
         value);
+
     assertViolation(mc, m, (short) 3100);
 
     // Bad Json - test startRow key replaced with empty string so validation should fail


### PR DESCRIPTION
### What does this PR do?
This PR is fixing a nondeterministic test failure in ```MetadataConstraintsTest.testDataFileCheck()``` when running with [NonDex](https://github.com/TestingResearchIllinois/NonDex)

### Problem

Within testDataFileCheck() — specifically the case "Bad Json - test path value missing" — the test previously relied on a regex replacement against the JSON string returned by:

``` StoredTabletFile.of(path).getMetadata().replaceFirst("\"path\":\".*\",\"startRow", "\"path\":\"\",\"startRow")```

When the test uses StoredTabletFile.of(Path), the constructor path eventually calls serialize(fileCq), which invokes gson.toJson(metadata) to produce the metadata JSON. Gson serializes plain Java objects (POJOs) by reflecting over their declared fields. Under the hood, it uses the JDK’s reflection APIs (such as Class.getDeclaredFields()) to discover which fields exist in a class.

The JDK specification for these APIs explicitly states:
“The elements in the array returned are not sorted and are not in any particular order.”

This means the field order returned by reflection is undefined, so Gson may serialize them in different sequences depending on the JVM or when shuffled by tools like NonDex. As a result, "path" doesn’t always come before "startRow", breaking the test’s regex and causing nondeterministic failures.

### Reproduce Test
To reproduce the failing test, Nondex can be used.

```mvn -pl server/base edu.illinois:nondex-maven-plugin:2.2.1:nondex -DnondexRuns=10 -Denforcer.skip=true -Dtest=org.apache.accumulo.server.constraints.MetadataConstraintsTest#testDataFileCheck```

### The Fix
Instead of applying a regex that assumes field order, the test now parses the JSON into a JsonObject and explicitly clears the "path" field. This ensures that the "path" field is always set to an empty string — as the test intended for the “Bad Json” case — regardless of serialization order.