### PR TITLE
Narrow table lock range for set tablet availability fate operation

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
@@ -86,6 +86,12 @@ public class Utils {
     }
   }
 
+  /**
+   * Finds the single tablet extent that contains the provided row.
+   *
+   * @throws NullPointerException if row is null
+   * @throws java.util.NoSuchElementException if no tablet contains the row
+   */
   public static KeyExtent findContaining(Ample ample, TableId tableId, Text row) {
     Objects.requireNonNull(row);
     try (var tablets = ample.readTablets().forTable(tableId).overlapping(row, true, row)

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/availability/LockTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/availability/LockTable.java
@@ -84,6 +84,9 @@ public class LockTable extends AbstractFateOperation {
    * be converted to a RowRange, an infinite LockRange is returned.
    */
   private LockRange getLockRange(FateEnv env) {
+    if (tRange.infiniteStartKey && tRange.infiniteStopKey) {
+      return LockRange.infinite();
+    }
     Range range = new Range(tRange);
 
     try {


### PR DESCRIPTION
Fixes #5788 

The main change here is to use the version of `Utils.reserveTable()` that allows us to pass a range to only lock that portion.