### PR TITLE
Fix non deterministic for LoadPlanTest.testJson()

### DIFF
--- a/core/src/test/java/org/apache/accumulo/core/data/LoadPlanTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/LoadPlanTest.java
@@ -36,6 +36,9 @@ import org.apache.accumulo.core.data.LoadPlan.RangeType;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 public class LoadPlanTest {
   @Test
   public void testBadRange1() {
@@ -112,7 +115,7 @@ public class LoadPlanTest {
   }
 
   @Test
-  public void testJson() {
+  public void testJson() throws Exception {
     var loadPlan = LoadPlan.builder().build();
     assertEquals(0, loadPlan.getDestinations().size());
     assertEquals("{\"destinations\":[]}", loadPlan.toJson());
@@ -137,7 +140,11 @@ public class LoadPlanTest {
         + "','endRow':'" + b64006 + "','rangeType':'TABLE'},{'fileName':'f3.rf','startRow':'"
         + b64binary + "','endRow':null,'rangeType':'TABLE'}]}";
 
-    assertEquals(expected.replace("'", "\""), json);
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode node1 = mapper.readTree(expected.replace("'", "\""));
+    JsonNode node2 = mapper.readTree(json);
+
+    assertEquals(node1, node2);
   }
 
   @Test


### PR DESCRIPTION
### What does this PR do?

This PR is fixing a nondeterministic test failure in `LoadPlanTest.testJson()` when running with Nondex.

### Problem

Previously, the test used:
```java
assertEquals(expected.replace("'", "\""), json);
```
This approach directly compared JSON strings. However, JSON object field order is nondeterministic, and NonDex randomizes iteration orders.
As a result, the test failed when field order in the generated JSON differed from the expected literal string, even though both represented the same structure.

### Reproduce Test

Run:
```bash
mvn edu.illinois:nondex-maven-plugin:2.2.1:nondex -pl core -Dtest=org.apache.accumulo.core.data.LoadPlanTest#testJson
```

### The Fix

Instead of comparing JSON strings directly, the test now parses both expected and actual JSON into `JsonNode` objects and asserts structural equality. This ensures the comparison is **order-independent** and validates actual JSON semantics, not textual layout.