### PR TITLE
Fix nondeterministic behavior in testPrettyPrint by making iterator assertions order-independent

### DIFF
--- a/core/src/test/java/org/apache/accumulo/core/data/ConditionalMutationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/ConditionalMutationTest.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.accumulo.core.client.IteratorSetting;
@@ -193,8 +194,19 @@ public class ConditionalMutationTest {
     assertTrue(pp.contains("update: name:last value doe"));
     assertTrue(pp.contains("update: name:first value john"));
     iters = c1.getIterators();
-    assertTrue(pp.contains("condition: " + FAMILY + ":" + QUALIFIER + " value: " + VALUE
-        + " iterator: '" + iters[0] + "' '" + iters[1] + "'"));
+    assertTrue(pp.contains("condition: " + FAMILY + ":" + QUALIFIER + " value: " + VALUE));
+    String iterSection = pp.substring(pp.indexOf("iterator:"));
+    for (IteratorSetting iter : iters) {
+      Map<String,String> props = iter.getOptions();
+
+      assertTrue(iterSection.contains("name:" + iter.getName()));
+      assertTrue(iterSection.contains("class:" + iter.getIteratorClass()));
+      assertTrue(iterSection.contains("priority:" + iter.getPriority()));
+
+      for (Map.Entry<String,String> e : props.entrySet()) {
+        assertTrue(iterSection.contains(e.getKey() + "=" + e.getValue()));
+      }
+    }
 
     // all conditions together
     c1 = new Condition(FAMILY2, QUALIFIER2).setValue(VALUE).setVisibility(CVIS2)
@@ -208,8 +220,20 @@ public class ConditionalMutationTest {
     assertTrue(pp.contains("update: name:first value john"));
     iters = c1.getIterators();
     assertTrue(pp.contains("condition: " + FAMILY2 + ":" + QUALIFIER2 + " value: " + VALUE
-        + " visibility: '" + c1.getVisibility() + "' timestamp: '" + TIMESTAMP + "' iterator: '"
-        + iters[0] + "'"));
+        + " visibility: '" + c1.getVisibility() + "' timestamp: '" + TIMESTAMP));
+
+    iterSection = pp.substring(pp.indexOf("iterator:"));
+    for (IteratorSetting iter : iters) {
+      Map<String,String> props = iter.getOptions();
+
+      assertTrue(iterSection.contains("name:" + iter.getName()));
+      assertTrue(iterSection.contains("class:" + iter.getIteratorClass()));
+      assertTrue(iterSection.contains("priority:" + iter.getPriority()));
+
+      for (Map.Entry<String,String> e : props.entrySet()) {
+        assertTrue(iterSection.contains(e.getKey() + "=" + e.getValue()));
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
### **What does this PR do?**
This PR is fixing a nondeterministic test failure in ConditionalMutationTest.testPrettyPrint() when running with Nondex.

### **Problem**
The original test checked for a single concatenated string that included both iterators’ data in a specific order.  This caused nondeterministic failures under NonDex, since the order of iterators is not guaranteed.

### **Reproduce Test**
```
mvn -pl core edu.illinois:nondex-maven-plugin:2.2.1:nondex -Dtest=org.apache.accumulo.core.data.ConditionalMutationTest#testPrettyPrint
```

### **The Fix**
Instead of asserting one long expected string that assumes a fixed iterator sequence, the updated test now extracts the `iterator` section and individually checks each iterator’s:
- **name**
- **class**
- **priority**
- and **key-value options**

This ensures the test verifies the logical presence of all expected iterator properties,  
regardless of their order in the output string.
