### PR TITLE
Fix Flaky ClassLoaderContextCompactionIT

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/compaction/ClassLoaderContextCompactionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ClassLoaderContextCompactionIT.java
@@ -221,7 +221,7 @@ public class ClassLoaderContextCompactionIT extends AccumuloClusterHarness {
               == null);
       assertEquals(1, ExternalCompactionUtil.countCompactors(QUEUE1, (ClientContext) client));
       Wait.waitFor(() -> failures.get() == 1);
-      Wait.waitFor(() -> consecutive.get() >= 1);
+      Wait.waitFor(() -> consecutive.get() == 1);
 
       Wait.waitFor(() -> failures.get() == 0);
       client.tableOperations().compact(table1, new CompactionConfig().setWait(false));
@@ -230,7 +230,7 @@ public class ClassLoaderContextCompactionIT extends AccumuloClusterHarness {
               == null);
       assertEquals(1, ExternalCompactionUtil.countCompactors(QUEUE1, (ClientContext) client));
       Wait.waitFor(() -> failures.get() == 1);
-      Wait.waitFor(() -> consecutive.get() >= 2);
+      Wait.waitFor(() -> consecutive.get() == 2);
 
       Wait.waitFor(() -> failures.get() == 0);
       client.tableOperations().compact(table1, new CompactionConfig().setWait(false));
@@ -239,7 +239,7 @@ public class ClassLoaderContextCompactionIT extends AccumuloClusterHarness {
               == null);
       assertEquals(1, ExternalCompactionUtil.countCompactors(QUEUE1, (ClientContext) client));
       Wait.waitFor(() -> failures.get() == 1);
-      Wait.waitFor(() -> consecutive.get() >= 3);
+      Wait.waitFor(() -> consecutive.get() == 3);
 
       // Three failures have occurred, Compactor should shut down.
       Wait.waitFor(


### PR DESCRIPTION
This test tails the StatsD metrics and waited for specific values to be seen. 0's are emitted between real updates and the test reset the variable it used to 0 which means the expected value was never reached and the Wait.waitFor block timed out because of that causing the test to fail.

This PR fixes the test case by recording the highest seen value for this metric and using that