### PR TITLE
Fixes bug where monitor appender does not notice monitor died

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooCache.java
@@ -82,6 +82,11 @@ public class ZooCache {
       return ephemeralOwner;
     }
 
+    public void clear() {
+      this.ephemeralOwner = 0;
+      this.mzxid = 0;
+    }
+
     private void set(ZcStat cachedStat) {
       this.ephemeralOwner = cachedStat.ephemeralOwner;
       this.mzxid = cachedStat.mzxid;


### PR DESCRIPTION
When the monitor process died the monitor appender did not notice because it kept using the same stat which does not change on absence. Also reusing the stat object may not be thread safe.  Made the stat object a thread local to avoid object allocation and use by multiple threads.