### PR TITLE
Modified shell getsplits command to match against obscured extents

### DIFF
--- a/shell/src/main/java/org/apache/accumulo/shell/commands/GetSplitsCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/GetSplitsCommand.java
@@ -146,8 +146,8 @@ public class GetSplitsCommand extends Command {
     base64Opt = new Option("b64", "base64encoded", false, "encode the split points");
 
     verboseOpt =
-        new Option("v", "verbose", false, "print out the tablet information with start/end rows, "
-            + "will limit output to matching extents if match arguments are supplied");
+        new Option("v", "verbose", false, "print out the obscured tablets with start/end rows, "
+            + "will limit output to matching obscured extents if match arguments are supplied");
     verboseOpt.setOptionalArg(true);
     verboseOpt.setArgs(Option.UNLIMITED_VALUES);
     verboseOpt.setArgName("match");


### PR DESCRIPTION
This commit modifies the shell getsplits command to optionally accept 1 or more arguments to the `-v` option. When supplied, the getsplits command will only print information for the splits where the value in the first column (the obfuscated extent information) matches one of the supplied arguments. Example invocation:
```
  getsplits -t <table> -v <extent1> <extent2> ...
```

Closes #5970