### PR TITLE
set scan executor names for meta and root

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
@@ -787,6 +787,11 @@ public class TabletServerResourceManager {
 
   }
 
+  private static final ScanDispatch ROOT_SCAN_DISPATCH =
+      ScanDispatch.builder().setExecutorName("root").build();
+  private static final ScanDispatch META_SCAN_DISPATCH =
+      ScanDispatch.builder().setExecutorName("meta").build();
+
   public void executeReadAhead(KeyExtent tablet, ScanDispatcher dispatcher, ScanSession<?> scanInfo,
       Runnable task) {
 
@@ -794,12 +799,12 @@ public class TabletServerResourceManager {
 
     if (tablet.isRootTablet()) {
       // TODO make meta dispatch??
-      scanInfo.scanParams.setScanDispatch(ScanDispatch.builder().build());
+      scanInfo.scanParams.setScanDispatch(ROOT_SCAN_DISPATCH);
       task.run();
     } else if (tablet.isMeta()) {
       // TODO make meta dispatch??
-      scanInfo.scanParams.setScanDispatch(ScanDispatch.builder().build());
-      scanExecutors.get("meta").execute(task);
+      scanInfo.scanParams.setScanDispatch(META_SCAN_DISPATCH);
+      scanExecutors.get(META_SCAN_DISPATCH.getExecutorName()).execute(task);
     } else {
       DispatchParameters params = new DispatchParamsImpl() {
 


### PR DESCRIPTION
Root and metadata table scans were not setting scan executor names.  This information will be needed by #5986