### PR TITLE
Use TabletLogger.renamed and cleanup log messages

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/RenameCompactionFile.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/RenameCompactionFile.java
@@ -20,9 +20,12 @@ package org.apache.accumulo.manager.compaction.coordinator.commit;
 
 import java.io.IOException;
 
+import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.logging.TabletLogger;
 import org.apache.accumulo.core.metadata.ReferencedTabletFile;
+import org.apache.accumulo.core.metadata.UnreferencedTabletFile;
 import org.apache.accumulo.manager.tableOps.AbstractFateOperation;
 import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.server.tablets.TabletNameGenerator;
@@ -71,6 +74,9 @@ public class RenameCompactionFile extends AbstractFateOperation {
         if (!ctx.getVolumeManager().rename(tmpPath, newDatafile.getPath())) {
           throw new IOException("rename returned false for " + tmpPath);
         }
+        TabletLogger.renamed(KeyExtent.fromThrift(commitData.textent),
+            UnreferencedTabletFile.of(ctx.getVolumeManager().getFileSystemByPath(tmpPath), tmpPath),
+            newDatafile);
       } catch (IOException ioe) {
         // Log something in case there is an exception while doing the check, will have the original
         // exception.

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -1581,11 +1581,12 @@ public class Tablet extends TabletBase {
           }
           attemptedRename = true;
           ScanfileManager.rename(vm, tmpDatafile.getPath(), newDatafile.getPath());
+          TabletLogger.renamed(getExtent(), tmpDatafile, newDatafile);
         }
         break;
       } catch (IOException ioe) {
-        log.warn("Tablet " + getExtent() + " failed to rename " + newDatafile
-            + " after MinC, will retry in 60 secs...", ioe);
+        log.warn("Tablet {} failed to rename {} after MinC, will retry in 60 secs...", getExtent(),
+            newDatafile, ioe);
         sleepUninterruptibly(1, TimeUnit.MINUTES);
       }
     } while (true);
@@ -1630,7 +1631,7 @@ public class Tablet extends TabletBase {
               commitSession.getWALogSeq() + 2);
           break;
         } catch (IOException e) {
-          log.error("Failed to write to write-ahead log " + e.getMessage() + " will retry", e);
+          log.error("Failed to write to write-ahead log {} will retry", e.getMessage(), e);
           sleepUninterruptibly(1, TimeUnit.SECONDS);
         }
       } while (true);


### PR DESCRIPTION
Use the TabletLogger.renamed method and switch some log messages to using positional arguments.