### PR TITLE
improves searchability of bulk import logging

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/logging/BulkLogger.java
+++ b/core/src/main/java/org/apache/accumulo/core/logging/BulkLogger.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.logging;
+
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.fate.FateId;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BulkLogger {
+  private static final Logger log = LoggerFactory.getLogger(Logging.PREFIX + "bulk");
+
+  public static void initiating(FateId fateId, TableId tableId, boolean setTime, String sourceDir,
+      String destinationDir) {
+    // Log the key pieces of information about a bulk import in a single log message to tie them all
+    // together.
+    log.info("{} initiating bulk import, tableId:{} setTime:{} source:{} destination:{}", fateId,
+        tableId, setTime, sourceDir, destinationDir);
+  }
+
+  public static void renamed(FateId fateId, Path source, Path destination) {
+    // The initiating message logged the full directory paths, so do not need to repeat that
+    // information here. Log the bulk destination directory as it is unique and easy to search for.
+    log.debug("{} renamed {} to {}/{}", fateId, source.getName(), destination.getParent().getName(),
+        destination.getName());
+  }
+}

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/BulkImportMove.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/BulkImportMove.java
@@ -28,6 +28,7 @@ import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
+import org.apache.accumulo.core.logging.BulkLogger;
 import org.apache.accumulo.core.manager.thrift.BulkImportState;
 import org.apache.accumulo.manager.tableOps.AbstractFateOperation;
 import org.apache.accumulo.manager.tableOps.FateEnv;
@@ -102,6 +103,7 @@ class BulkImportMove extends AbstractFateOperation {
     }
     try {
       fs.bulkRename(oldToNewMap, env.getRenamePool(), fateId);
+      oldToNewMap.forEach((oldName, newName) -> BulkLogger.renamed(fateId, oldName, newName));
     } catch (IOException ioe) {
       throw new AcceptableThriftTableOperationException(bulkInfo.tableId.canonical(), null,
           TableOperation.BULK_IMPORT, TableOperationExceptionType.OTHER,

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/PrepBulkImport.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/PrepBulkImport.java
@@ -47,6 +47,7 @@ import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock;
 import org.apache.accumulo.core.fate.zookeeper.LockRange;
 import org.apache.accumulo.core.file.FilePrefix;
+import org.apache.accumulo.core.logging.BulkLogger;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.core.util.PeekingIterator;
@@ -268,6 +269,10 @@ public class PrepBulkImport extends AbstractFateOperation {
     List<FileStatus> files = BulkImport.filterInvalid(fs.listStatus(sourceDir));
 
     Path bulkDir = createNewBulkDir(env.getContext(), fs, bulkInfo.tableId);
+
+    BulkLogger.initiating(fateId, bulkInfo.tableId, bulkInfo.setTime, bulkInfo.sourceDir,
+        bulkDir.toString());
+
     Path mappingFile = new Path(sourceDir, Constants.BULK_LOAD_MAPPING);
 
     Map<String,String> oldToNewNameMap = new HashMap<>();


### PR DESCRIPTION
Compared to bulkV1, the bulkV2 logging is more sparse and its difficult to track the key pieces of information about a bulk import in the logs. Added some logging that ties together all the important information about a bulk import into a single log message that contains the table id, fate id, source dir, and dest dir.