### PR TITLE
Make Mini Accumulo hardcoded JVM options mutable

### DIFF
--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
@@ -348,22 +348,15 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
     String javaBin = javaHome + File.separator + "bin" + File.separator + "java";
 
     var basicArgs = Stream.of(javaBin, "-Dproc=" + clazz.getSimpleName());
-    var jvmOptions = config.getJvmOptions().stream();
-    var jvmArgs = extraJvmOpts.stream();
-    var propsArgs = config.getSystemProperties().entrySet().stream()
+    var jvmOptions = Stream.concat(config.getJvmOptions().stream(), extraJvmOpts.stream());
+    var systemProps = config.getSystemProperties().entrySet().stream()
         .map(e -> String.format("-D%s=%s", e.getKey(), e.getValue()));
 
-    // @formatter:off
-    var hardcodedArgs = Stream.of(
-        "-Dapple.awt.UIElement=true",
-        "-Djava.net.preferIPv4Stack=true",
-        Main.class.getName(), clazz.getName());
-    // @formatter:on
+    var classArgs = Stream.of(Main.class.getName(), clazz.getName());
 
     // concatenate all the args sources into a single list of args
-    var argList =
-        Stream.of(basicArgs, jvmOptions, jvmArgs, propsArgs, hardcodedArgs, Stream.of(args))
-            .flatMap(Function.identity()).collect(toList());
+    var argList = Stream.of(basicArgs, jvmOptions, systemProps, classArgs, Stream.of(args))
+        .flatMap(Function.identity()).collect(toList());
     ProcessBuilder builder = new ProcessBuilder(argList);
 
     final String classpath = getClasspath();

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
@@ -88,8 +88,8 @@ public class MiniAccumuloConfigImpl {
           MONITOR, Monitor.class, ZOOKEEPER, ZooKeeperServerMain.class, TABLET_SERVER,
           TabletServer.class, SCAN_SERVER, ScanServer.class, COMPACTOR, Compactor.class));
   private boolean jdwpEnabled = false;
-  private Map<String,String> systemProperties = new HashMap<>();
-  private Set<String> jvmOptions = new HashSet<>();
+  private final Map<String,String> systemProperties = new HashMap<>();
+  private final Set<String> jvmOptions = new HashSet<>();
 
   private String instanceName = "miniInstance";
   private String rootUserName = "root";
@@ -137,6 +137,8 @@ public class MiniAccumuloConfigImpl {
     // Set default options
     this.jvmOptions.add("-XX:+PerfDisableSharedMem");
     this.jvmOptions.add("-XX:+AlwaysPreTouch");
+    this.systemProperties.put("-Dapple.awt.UIElement", "true");
+    this.systemProperties.put("-Djava.net.preferIPv4Stack", "true");
   }
 
   /**
@@ -675,7 +677,7 @@ public class MiniAccumuloConfigImpl {
    * @since 1.6.0
    */
   public void setSystemProperties(Map<String,String> systemProperties) {
-    this.systemProperties = new HashMap<>(systemProperties);
+    this.systemProperties.putAll(systemProperties);
   }
 
   /**
@@ -699,7 +701,8 @@ public class MiniAccumuloConfigImpl {
   }
 
   /**
-   * Remove an option from the set of JVM options
+   * Remove an option from the set of JVM options. Only options that match the {@code option}
+   * exactly will be removed.
    *
    * @param option JVM option
    * @return true if removed, false if not removed


### PR DESCRIPTION
Processes spawned by MiniAccumuloCluster have a pre-configured, but not mutable, set of JVM options. Specifically they are '-XX:+PerfDisableSharedMem' and '-XX:+AlwaysPreTouch'. This change makes the set of JVM options configurable.