### PR TITLE
Support old prop name if still user defined

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
@@ -317,6 +317,7 @@ public class ThreadPools {
           builder.enableThreadPoolMetrics();
         }
         return builder.build();
+      case MANAGER_BULK_RENAME_THREADS:
       case MANAGER_RENAME_THREADS:
         builder = getPoolBuilder(MANAGER_RENAME_POOL).numCoreThreads(conf.getCount(p));
         if (emitThreadPoolMetrics) {


### PR DESCRIPTION
The resolver code would attempt to create a threadpool with the old property name if it was defined by a user.
This would result in a IllegalArgumentException being thrown on threadpool creation.

Adding a passthrough case for the old name property name fixes this issue.