### PR TITLE
Fix NPE in Compactor.updateCompactionFailed

### DIFF
--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -487,14 +487,14 @@ public class Compactor extends AbstractServer
    * @param exception cause of failure
    * @throws RetriesExceededException thrown when retries have been exceeded
    */
-  protected void updateCompactionFailed(TExternalCompactionJob job, Throwable exception)
+  protected void updateCompactionFailed(TExternalCompactionJob job, String exception)
       throws RetriesExceededException {
     RetryableThriftCall<String> thriftCall =
         new RetryableThriftCall<>(1000, RetryableThriftCall.MAX_WAIT_TIME, 25, () -> {
           Client coordinatorClient = getCoordinatorClient();
           try {
             coordinatorClient.compactionFailed(TraceUtil.traceInfo(), getContext().rpcCreds(),
-                job.getExternalCompactionId(), job.extent, exception.getClass().getName());
+                job.getExternalCompactionId(), job.extent, exception);
             return "";
           } finally {
             ThriftUtil.returnClient(coordinatorClient, getContext());
@@ -959,7 +959,7 @@ public class Compactor extends AbstractServer
                     TCompactionState.FAILED, "Compaction failed due to: " + err.get().getMessage(),
                     -1, -1, -1, fcr.getCompactionAge().toNanos());
                 updateCompactionState(job, update);
-                updateCompactionFailed(job, err.get());
+                updateCompactionFailed(job, err.get().getClass().getName());
                 failed.incrementAndGet();
                 errorHistory.addError(fromThriftExtent.tableId(), err.get());
               } catch (RetriesExceededException e) {

--- a/server/compactor/src/test/java/org/apache/accumulo/compactor/CompactorTest.java
+++ b/server/compactor/src/test/java/org/apache/accumulo/compactor/CompactorTest.java
@@ -272,7 +272,7 @@ public class CompactorTest {
     }
 
     @Override
-    protected void updateCompactionFailed(TExternalCompactionJob job, Throwable exception)
+    protected void updateCompactionFailed(TExternalCompactionJob job, String exception)
         throws RetriesExceededException {
       failedCalled = true;
     }


### PR DESCRIPTION
updateCompactionFailed is called from two places in Compactor.run,
one of which is passing null. This commit changes the argument type
from Throwable to String and moves the code to get the exception
class name to where the exception is non-null.