### PR TITLE
Modified Fate TransactionRunner to exit normally when shut down

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
@@ -309,7 +309,7 @@ public class Fate<T> {
       ScheduledThreadPoolExecutor serverGeneralScheduledThreadPool) {
     final ThreadPoolExecutor pool = ThreadPools.getServerThreadPools().createExecutorService(conf,
         Property.MANAGER_FATE_THREADPOOL_SIZE, true);
-    log.debug("Starting Fate Transaction Running pool with {} threads", pool.getCorePoolSize());
+    log.debug("Starting Fate Transaction Runner pool with {} threads", pool.getCorePoolSize());
     ThreadPools
         .watchCriticalScheduledTask(serverGeneralScheduledThreadPool.scheduleWithFixedDelay(() -> {
           // resize the pool if the property changed

--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
@@ -214,6 +214,7 @@ public class FateIT {
 
   @BeforeEach
   public void beforeEach() throws Exception {
+    interruptedException.set(null);
     final ZooStore<Manager> zooStore = new ZooStore<>(ZK_ROOT + Constants.ZFATE, zk, zc);
     final AgeOffStore<Manager> store = new AgeOffStore<>(zooStore, 3000, System::currentTimeMillis);
 


### PR DESCRIPTION
Modified the Fate TransactionRunner threads to allow them to exit their run loop normally when an InterruptedException is raised due to Fate being shut down.

Closes #6014