### PR TITLE
avoids unneeded meta index read

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/CachableBlockFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/CachableBlockFile.java
@@ -179,13 +179,14 @@ public class CachableBlockFile {
       }
     }
 
-    private BCFile.Reader getBCFile(byte[] serializedMetadata) throws IOException {
+    private BCFile.Reader getBCFile(Supplier<byte[]> cachedMetadataSupplier) throws IOException {
 
       BCFile.Reader reader = bcfr.get();
       if (reader == null) {
         RateLimitedInputStream fsIn =
             new RateLimitedInputStream((InputStream & Seekable) inputSupplier.get(), readLimiter);
         BCFile.Reader tmpReader = null;
+        byte[] serializedMetadata = cachedMetadataSupplier.get();
         if (serializedMetadata == null) {
           if (fileLenCache == null) {
             tmpReader = new BCFile.Reader(fsIn, lengthSupplier.get(), conf, cryptoService);
@@ -221,15 +222,19 @@ public class CachableBlockFile {
     }
 
     private BCFile.Reader getBCFile() throws IOException {
-      BlockCache _iCache = cacheProvider.getIndexCache();
-      if (_iCache != null) {
-        CacheEntry mce = _iCache.getBlock(cacheId + ROOT_BLOCK_NAME, new BCFileLoader());
-        if (mce != null) {
-          return getBCFile(mce.getBuffer());
-        }
-      }
 
-      return getBCFile(null);
+      Supplier<byte[]> cachedMetadataSupplier = () -> {
+        BlockCache _iCache = cacheProvider.getIndexCache();
+        if (_iCache != null) {
+          CacheEntry mce = _iCache.getBlock(cacheId + ROOT_BLOCK_NAME, new BCFileLoader());
+          if (mce != null) {
+            return mce.getBuffer();
+          }
+        }
+        return null;
+      };
+
+      return getBCFile(cachedMetadataSupplier);
     }
 
     private class BCFileLoader implements Loader {
@@ -242,7 +247,7 @@ public class CachableBlockFile {
       @Override
       public byte[] load(int maxSize, Map<String,byte[]> dependencies) {
         try {
-          return getBCFile(null).serializeMetadata(maxSize);
+          return getBCFile(() -> null).serializeMetadata(maxSize);
         } catch (IOException e) {
           throw new UncheckedIOException(e);
         }
@@ -348,7 +353,7 @@ public class CachableBlockFile {
           if (reader == null) {
             if (loadingMetaBlock) {
               byte[] serializedMetadata = dependencies.get(cacheId + ROOT_BLOCK_NAME);
-              reader = getBCFile(serializedMetadata);
+              reader = getBCFile(() -> serializedMetadata);
             } else {
               reader = getBCFile();
             }
@@ -407,7 +412,7 @@ public class CachableBlockFile {
         }
       }
 
-      BlockReader _currBlock = getBCFile(null).getMetaBlock(blockName);
+      BlockReader _currBlock = getBCFile(() -> null).getMetaBlock(blockName);
       incrementCacheBypass(CacheType.INDEX);
       return new CachedBlockRead(_currBlock);
     }
@@ -424,7 +429,7 @@ public class CachableBlockFile {
         }
       }
 
-      BlockReader _currBlock = getBCFile(null).getDataBlock(offset, compressedSize, rawSize);
+      BlockReader _currBlock = getBCFile(() -> null).getDataBlock(offset, compressedSize, rawSize);
       incrementCacheBypass(CacheType.INDEX);
       return new CachedBlockRead(_currBlock);
     }

--- a/test/src/main/java/org/apache/accumulo/test/tracing/ScanTracingIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/tracing/ScanTracingIT.java
@@ -94,14 +94,17 @@ class ScanTracingIT extends ConfigurableMacBase {
 
   @Test
   public void test() throws Exception {
-    var names = getUniqueNames(7);
+    var names = getUniqueNames(8);
     runTest(names[0], 0, false, false, -1, -1, -1);
     runTest(names[1], 10, false, false, -1, -1, -1);
-    runTest(names[2], 0, true, false, -1, -1, -1);
-    runTest(names[3], 0, false, false, -1, -1, 2);
-    runTest(names[4], 0, false, false, 32, 256, -1);
-    runTest(names[5], 0, true, true, 32, 256, -1);
-    runTest(names[6], 0, true, false, -1, -1, 2);
+    // when the tables tablets are spread across two tablet servers, then all the tables data will
+    // fit in cache
+    runTest(names[2], 10, true, true, -1, -1, -1);
+    runTest(names[3], 0, true, false, -1, -1, -1);
+    runTest(names[4], 0, false, false, -1, -1, 2);
+    runTest(names[5], 0, false, false, 32, 256, -1);
+    runTest(names[6], 0, true, true, 32, 256, -1);
+    runTest(names[7], 0, true, false, -1, -1, 2);
   }
 
   private void runTest(String tableName, int numSplits, boolean cacheData,
@@ -239,15 +242,14 @@ class ScanTracingIT extends ConfigurableMacBase {
         if (stats.getFileBytesRead() == 0) {
           assertEquals(0L, stats.getDataCacheMisses(), stats::toString);
         }
-        // When caching data, does not seem to hit the cache much
-        var cacheSum = stats.getIndexCacheHits() + stats.getIndexCacheMisses();
-        assertTrue(cacheSum == 0 || cacheSum == 1, stats::toString);
       } else {
         assertEquals(0, stats.getDataCacheHits(), stats::toString);
         assertEquals(0, stats.getDataCacheMisses(), stats::toString);
         assertTrue(stats.getDataCacheBypasses() > stats.getSeeks(), stats::toString);
-        assertClose(stats.getDataCacheBypasses(), stats.getIndexCacheHits(), .05);
       }
+      // May see rfile metadata reads for each tablet
+      var cacheSum = stats.getIndexCacheHits() + stats.getIndexCacheMisses();
+      assertTrue(cacheSum <= (numSplits + 1) * 2L, stats::toString);
       assertEquals(0, stats.getIndexCacheBypasses(), stats::toString);
     }
 


### PR DESCRIPTION
CachableBlockFile.Reader.getBCFile() always read the RFile root block from the index cache even if would not use it. Modified the method to only read from the index cache when the data is actually needed. Noticed this while working on #6010, saw for every data block read from a rfile it would also read from the index cache.

Adjusted ScanTracingIT because before this change there was an rfile index cache read per rfile data block read.  After this change the number of rfile index reads align w/ the number of rfiles opened, which in this case aligns with the number of tablets in the test tables.

The existing behavior was likely not a performance problem if the data was in cache, but could potentially cause thread contention and extra CPU usage. So its probably good to fix, also nice to make the tracing stats align better w/ expectations.