### PR TITLE
Add multi-range Tablet info API

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
@@ -1079,9 +1079,9 @@ public interface TableOperations {
   }
 
   /**
-   * @param ranges the ranges of tablets to scan. Ranges can overlap and an attempt will be made to
-   *        merge this list. An empty list returns an empty stream; use {@code List.of(new Range())}
-   *        to scan all tablets.
+   * @param ranges the row ranges of tablets to scan. Ranges can overlap and an attempt will be made
+   *        to merge this list. An empty list returns an empty stream; use
+   *        {@code List.of(RowRange.all())} to scan all tablets.
    * @param fields can optionally narrow the data retrieved per tablet, which can speed up streaming
    *        over tablets. If this list is empty then all fields are fetched.
    * @return a stream of tablet information for tablets that fall in the specified ranges. The
@@ -1090,7 +1090,8 @@ public interface TableOperations {
    * @since 4.0.0
    */
   default Stream<TabletInformation> getTabletInformation(final String tableName,
-      final List<Range> ranges, TabletInformation.Field... fields) throws TableNotFoundException {
+      final List<RowRange> ranges, TabletInformation.Field... fields)
+      throws TableNotFoundException {
     throw new UnsupportedOperationException();
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
@@ -1079,24 +1079,14 @@ public interface TableOperations {
   }
 
   /**
-   * @param fields can optionally narrow the data retrieved per tablet, which can speed up streaming
-   *        over tablets. If this list is empty then all fields are fetched.
-   * @return a stream of tablet information for tablets that fall in the specified range. The stream
-   *         may be backed by a scanner, so it's best to close the stream.
-   * @since 4.0.0
-   */
-  default Stream<TabletInformation> getTabletInformation(final String tableName, final Range range,
-      TabletInformation.Field... fields) throws TableNotFoundException {
-    throw new UnsupportedOperationException();
-  }
-
-  /**
    * @param ranges the ranges of tablets to scan. Ranges can overlap and an attempt will be made to
-   *        merge this list
+   *        merge this list. An empty list returns an empty stream; use {@code List.of(new Range())}
+   *        to scan all tablets.
    * @param fields can optionally narrow the data retrieved per tablet, which can speed up streaming
    *        over tablets. If this list is empty then all fields are fetched.
    * @return a stream of tablet information for tablets that fall in the specified ranges. The
-   *         stream may be backed by a scanner, so it's best to close the stream.
+   *         stream may be backed by a scanner, so it's best to close the stream. The stream has no
+   *         defined ordering.
    * @since 4.0.0
    */
   default Stream<TabletInformation> getTabletInformation(final String tableName,

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
@@ -1091,6 +1091,20 @@ public interface TableOperations {
   }
 
   /**
+   * @param ranges the ranges of tablets to scan. Ranges can overlap and an attempt will be made to
+   *        merge this list
+   * @param fields can optionally narrow the data retrieved per tablet, which can speed up streaming
+   *        over tablets. If this list is empty then all fields are fetched.
+   * @return a stream of tablet information for tablets that fall in the specified ranges. The
+   *         stream may be backed by a scanner, so it's best to close the stream.
+   * @since 4.0.0
+   */
+  default Stream<TabletInformation> getTabletInformation(final String tableName,
+      final List<Range> ranges, TabletInformation.Field... fields) throws TableNotFoundException {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
    * Returns the namespace for the given table name
    *
    * @param table fully qualified table name

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/TabletInformation.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/TabletInformation.java
@@ -18,9 +18,9 @@
  */
 package org.apache.accumulo.core.client.admin;
 
+import java.util.List;
 import java.util.Optional;
 
-import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TabletId;
 
 /**
@@ -30,7 +30,7 @@ public interface TabletInformation {
 
   /**
    * Used to limit what information is obtained per tablet when calling
-   * {@link TableOperations#getTabletInformation(String, Range, Field...)}
+   * {@link TableOperations#getTabletInformation(String, List, Field...)}
    *
    * @since 4.0.0
    */

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -2244,12 +2244,6 @@ public class TableOperationsImpl extends TableOperationsHelper {
   }
 
   @Override
-  public Stream<TabletInformation> getTabletInformation(final String tableName, final Range range,
-      TabletInformation.Field... fields) throws TableNotFoundException {
-    return getTabletInformation(tableName, List.of(range), fields);
-  }
-
-  @Override
   public Stream<TabletInformation> getTabletInformation(final String tableName,
       final List<Range> ranges, TabletInformation.Field... fields) throws TableNotFoundException {
     EXISTING_TABLE_NAME.validate(tableName);

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -26,17 +26,11 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.AVAILABILITY;
-import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.DIR;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.ECOMP;
-import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.FILES;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.HOSTING_REQUESTED;
-import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LAST;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LOCATION;
-import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LOGS;
-import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.MERGEABILITY;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.OPID;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.PREV_ROW;
-import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.SUSPEND;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.TIME;
 import static org.apache.accumulo.core.util.LazySingletons.RANDOM;
 import static org.apache.accumulo.core.util.Validators.EXISTING_TABLE_NAME;
@@ -128,8 +122,6 @@ import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.ByteSequence;
-import org.apache.accumulo.core.data.Key;
-import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.RowRange;
 import org.apache.accumulo.core.data.TableId;
@@ -151,8 +143,6 @@ import org.apache.accumulo.core.manager.thrift.TFateId;
 import org.apache.accumulo.core.manager.thrift.TFateInstanceType;
 import org.apache.accumulo.core.manager.thrift.TFateOperation;
 import org.apache.accumulo.core.metadata.SystemTables;
-import org.apache.accumulo.core.metadata.TServerInstance;
-import org.apache.accumulo.core.metadata.TabletState;
 import org.apache.accumulo.core.metadata.schema.TabletDeletedException;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
@@ -186,7 +176,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Suppliers;
 
 public class TableOperationsImpl extends TableOperationsHelper {
 
@@ -2257,55 +2246,21 @@ public class TableOperationsImpl extends TableOperationsHelper {
   @Override
   public Stream<TabletInformation> getTabletInformation(final String tableName, final Range range,
       TabletInformation.Field... fields) throws TableNotFoundException {
-    EXISTING_TABLE_NAME.validate(tableName);
+    return getTabletInformation(tableName, List.of(range), fields);
+  }
 
-    final Text scanRangeStart = (range.getStartKey() == null) ? null : range.getStartKey().getRow();
+  @Override
+  public Stream<TabletInformation> getTabletInformation(final String tableName,
+      final List<Range> ranges, TabletInformation.Field... fields) throws TableNotFoundException {
+    EXISTING_TABLE_NAME.validate(tableName);
+    Objects.requireNonNull(ranges, "ranges is null");
+
+    EnumSet<TabletInformation.Field> fieldSet = fields.length == 0
+        ? EnumSet.allOf(TabletInformation.Field.class) : EnumSet.copyOf(Arrays.asList(fields));
+
     TableId tableId = context.getTableId(tableName);
 
-    List<TabletMetadata.ColumnType> columns = new ArrayList<>();
-    EnumSet<TabletInformation.Field> fieldSet =
-        fields.length == 0 ? EnumSet.allOf(TabletInformation.Field.class)
-            : EnumSet.noneOf(TabletInformation.Field.class);
-    Collections.addAll(fieldSet, fields);
-    if (fieldSet.contains(TabletInformation.Field.FILES)) {
-      Collections.addAll(columns, DIR, FILES, LOGS);
-    }
-    if (fieldSet.contains(TabletInformation.Field.LOCATION)) {
-      Collections.addAll(columns, LOCATION, LAST, SUSPEND);
-    }
-    if (fieldSet.contains(TabletInformation.Field.AVAILABILITY)) {
-      Collections.addAll(columns, AVAILABILITY);
-    }
-    if (fieldSet.contains(TabletInformation.Field.MERGEABILITY)) {
-      Collections.addAll(columns, MERGEABILITY);
-    }
-    columns.add(PREV_ROW);
-
-    TabletsMetadata tabletsMetadata =
-        context.getAmple().readTablets().forTable(tableId).overlapping(scanRangeStart, true, null)
-            .fetch(columns.toArray(new TabletMetadata.ColumnType[0])).checkConsistency().build();
-
-    Set<TServerInstance> liveTserverSet = TabletMetadata.getLiveTServers(context);
-
-    var currentTime = Suppliers.memoize(() -> {
-      try {
-        return Duration.ofNanos(ThriftClientTypes.MANAGER.execute(context,
-            client -> client.getManagerTimeNanos(TraceUtil.traceInfo(), context.rpcCreds())));
-      } catch (AccumuloException | AccumuloSecurityException e) {
-        throw new IllegalStateException(e);
-      }
-    });
-
-    return tabletsMetadata.stream().onClose(tabletsMetadata::close).peek(tm -> {
-      if (scanRangeStart != null && tm.getEndRow() != null
-          && tm.getEndRow().compareTo(scanRangeStart) < 0) {
-        log.debug("tablet {} is before scan start range: {}", tm.getExtent(), scanRangeStart);
-        throw new RuntimeException("Bug in ample or this code.");
-      }
-    }).takeWhile(tm -> tm.getPrevEndRow() == null
-        || !range.afterEndKey(new Key(tm.getPrevEndRow()).followingKey(PartialKey.ROW)))
-        .map(tm -> new TabletInformationImpl(tm,
-            () -> TabletState.compute(tm, liveTserverSet).toString(), currentTime));
+    return TabletInformationCollector.getTabletInformation(context, tableId, ranges, fieldSet);
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -2245,7 +2245,8 @@ public class TableOperationsImpl extends TableOperationsHelper {
 
   @Override
   public Stream<TabletInformation> getTabletInformation(final String tableName,
-      final List<Range> ranges, TabletInformation.Field... fields) throws TableNotFoundException {
+      final List<RowRange> ranges, TabletInformation.Field... fields)
+      throws TableNotFoundException {
     EXISTING_TABLE_NAME.validate(tableName);
     Objects.requireNonNull(ranges, "ranges is null");
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletInformationCollector.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletInformationCollector.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.clientImpl;
+
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.DIR;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.FILES;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LAST;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LOCATION;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LOGS;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.SUSPEND;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import org.apache.accumulo.core.client.admin.TabletInformation;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.PartialKey;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.metadata.TServerInstance;
+import org.apache.accumulo.core.metadata.TabletState;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
+import org.apache.hadoop.io.Text;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Suppliers;
+
+/**
+ * Utility to read tablet information for one or more ranges.
+ */
+public class TabletInformationCollector {
+
+  private static final Logger log = LoggerFactory.getLogger(TabletInformationCollector.class);
+
+  private TabletInformationCollector() {}
+
+  /**
+   * Fetch tablet information for the provided ranges. Ranges will be merged.
+   */
+  public static Stream<TabletInformation> getTabletInformation(ClientContext context,
+      TableId tableId, List<Range> ranges, EnumSet<TabletInformation.Field> fields) {
+    var mergedRanges = Range.mergeOverlapping(ranges);
+
+    EnumSet<ColumnType> columns = columnsForFields(fields);
+
+    Set<TServerInstance> liveTserverSet = TabletMetadata.getLiveTServers(context);
+
+    Supplier<Duration> currentTime = Suppliers.memoize(() -> {
+      try {
+        return context.instanceOperations().getManagerTime();
+      } catch (Exception e) {
+        throw new IllegalStateException(e);
+      }
+    });
+
+    List<Stream<TabletInformation>> tabletStreams = new ArrayList<>();
+    // TODO replace the per-range builds below with a single multirange (maybe new TabletsMetadata
+    // logic)
+    for (Range range : mergedRanges) {
+
+      Text startRow = range.getStartKey() == null ? null : range.getStartKey().getRow();
+      Text endRow = range.getEndKey() == null ? null : range.getEndKey().getRow();
+      boolean startInclusive = range.getStartKey() == null || range.isStartKeyInclusive();
+
+      var tm = context.getAmple().readTablets().forTable(tableId)
+          .overlapping(startRow, startInclusive, endRow).fetch(columns.toArray(ColumnType[]::new))
+          .checkConsistency().build();
+
+      // we need to stop the stream when we have passed the end bound
+      Predicate<TabletMetadata> tabletMetadataPredicate = tme -> tme.getPrevEndRow() == null
+          || !range.afterEndKey(new Key(tme.getPrevEndRow()).followingKey(PartialKey.ROW));
+
+      Stream<TabletInformation> stream = tm.stream().onClose(tm::close).peek(tme -> {
+        if (startRow != null && tme.getEndRow() != null
+            && tme.getEndRow().compareTo(startRow) < 0) {
+          log.debug("tablet {} is before scan start range: {}", tme.getExtent(), startRow);
+          throw new RuntimeException("Bug in ample or this code.");
+        }
+      }).takeWhile(tabletMetadataPredicate).map(tme -> new TabletInformationImpl(tme,
+          () -> TabletState.compute(tme, liveTserverSet).toString(), currentTime));
+      tabletStreams.add(stream);
+    }
+
+    return tabletStreams.stream().reduce(Stream::concat).orElseGet(Stream::empty);
+  }
+
+  /**
+   * @return the required {@link ColumnType}s that need to be fetched for the given set of
+   *         {@link TabletInformation.Field}
+   */
+  private static EnumSet<ColumnType> columnsForFields(EnumSet<TabletInformation.Field> fields) {
+    EnumSet<ColumnType> columns = EnumSet.noneOf(ColumnType.class);
+    columns.add(ColumnType.PREV_ROW);
+    if (fields.contains(TabletInformation.Field.FILES)) {
+      Collections.addAll(columns, DIR, FILES, LOGS);
+    }
+    if (fields.contains(TabletInformation.Field.LOCATION)) {
+      Collections.addAll(columns, LOCATION, LAST, SUSPEND);
+    }
+    if (fields.contains(TabletInformation.Field.AVAILABILITY)) {
+      columns.add(ColumnType.AVAILABILITY);
+    }
+    if (fields.contains(TabletInformation.Field.MERGEABILITY)) {
+      columns.add(ColumnType.MERGEABILITY);
+    }
+    return columns;
+  }
+}

--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/BalancerEnvironment.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/BalancerEnvironment.java
@@ -95,6 +95,9 @@ public interface BalancerEnvironment extends ServiceEnvironment {
   /**
    * Retrieve tablet information for the provided list of ranges.
    *
+   * <p>
+   * The returned stream has no defined ordering.
+   *
    * @since 4.0.0
    */
   Stream<TabletInformation> getTabletInformation(TableId tableId, List<Range> ranges,

--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/BalancerEnvironment.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/BalancerEnvironment.java
@@ -25,7 +25,7 @@ import java.util.stream.Stream;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.admin.TabletInformation;
-import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.RowRange;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.TabletId;
 import org.apache.accumulo.core.spi.balancer.data.TabletServerId;
@@ -65,7 +65,7 @@ public interface BalancerEnvironment extends ServiceEnvironment {
    * no location available for a given tablet, then the returned mapping will have a {@code null}
    * value stored for the tablet id. If you don't need all tablets in the table, use
    * {@link BalancerEnvironment#getTabletInformation(TableId, List, TabletInformation.Field...)}
-   * which is more efficient for the case when specific Ranges are needed.
+   * which is more efficient for the case when specific row ranges are needed.
    *
    * @param tableId The id of the table for which to retrieve tablets.
    * @return a mapping of {@link TabletId} to {@link TabletServerId} (or @null if no location is
@@ -93,13 +93,11 @@ public interface BalancerEnvironment extends ServiceEnvironment {
   String tableContext(TableId tableId);
 
   /**
-   * Retrieve tablet information for the provided list of ranges.
-   *
-   * <p>
-   * The returned stream has no defined ordering.
+   * Retrieve tablet information for the provided list of row ranges. The stream may be backed by a
+   * scanner, so it's best to close the stream. The stream has no defined ordering.
    *
    * @since 4.0.0
    */
-  Stream<TabletInformation> getTabletInformation(TableId tableId, List<Range> ranges,
+  Stream<TabletInformation> getTabletInformation(TableId tableId, List<RowRange> ranges,
       TabletInformation.Field... fields);
 }

--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/BalancerEnvironment.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/BalancerEnvironment.java
@@ -63,7 +63,9 @@ public interface BalancerEnvironment extends ServiceEnvironment {
   /**
    * Fetch the locations for each of {@code tableId}'s tablets from the metadata table. If there is
    * no location available for a given tablet, then the returned mapping will have a {@code null}
-   * value stored for the tablet id.
+   * value stored for the tablet id. If you don't need all tablets in the table, use
+   * {@link BalancerEnvironment#getTabletInformation(TableId, List, TabletInformation.Field...)}
+   * which is more efficient for the case when specific Ranges are needed.
    *
    * @param tableId The id of the table for which to retrieve tablets.
    * @return a mapping of {@link TabletId} to {@link TabletServerId} (or @null if no location is
@@ -92,6 +94,8 @@ public interface BalancerEnvironment extends ServiceEnvironment {
 
   /**
    * Retrieve tablet information for the provided list of ranges.
+   *
+   * @since 4.0.0
    */
   Stream<TabletInformation> getTabletInformation(TableId tableId, List<Range> ranges,
       TabletInformation.Field... fields);

--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/BalancerEnvironment.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/BalancerEnvironment.java
@@ -20,9 +20,12 @@ package org.apache.accumulo.core.spi.balancer;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.admin.TabletInformation;
+import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.TabletId;
 import org.apache.accumulo.core.spi.balancer.data.TabletServerId;
@@ -86,4 +89,10 @@ public interface BalancerEnvironment extends ServiceEnvironment {
    * none is configured.
    */
   String tableContext(TableId tableId);
+
+  /**
+   * Retrieve tablet information for the provided list of ranges.
+   */
+  Stream<TabletInformation> getTabletInformation(TableId tableId, List<Range> ranges,
+      TabletInformation.Field... fields);
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/balancer/BalancerEnvironmentImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/balancer/BalancerEnvironmentImpl.java
@@ -36,7 +36,7 @@ import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.admin.TabletInformation;
 import org.apache.accumulo.core.clientImpl.TabletInformationCollector;
 import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
-import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.RowRange;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.TabletId;
 import org.apache.accumulo.core.dataImpl.TabletIdImpl;
@@ -118,7 +118,7 @@ public class BalancerEnvironmentImpl extends ServiceEnvironmentImpl implements B
   }
 
   @Override
-  public Stream<TabletInformation> getTabletInformation(TableId tableId, List<Range> ranges,
+  public Stream<TabletInformation> getTabletInformation(TableId tableId, List<RowRange> ranges,
       TabletInformation.Field... fields) {
     EnumSet<TabletInformation.Field> fieldSet = fields.length == 0
         ? EnumSet.allOf(TabletInformation.Field.class) : EnumSet.copyOf(Arrays.asList(fields));

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/balancer/BalancerEnvironmentImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/balancer/BalancerEnvironmentImpl.java
@@ -21,16 +21,22 @@ package org.apache.accumulo.server.manager.balancer;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LOCATION;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.PREV_ROW;
 
+import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.accumulo.core.classloader.ClassLoaderUtil;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.admin.TabletInformation;
+import org.apache.accumulo.core.clientImpl.TabletInformationCollector;
 import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
+import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.TabletId;
 import org.apache.accumulo.core.dataImpl.TabletIdImpl;
@@ -109,6 +115,14 @@ public class BalancerEnvironmentImpl extends ServiceEnvironmentImpl implements B
       throw new AccumuloException(e);
     }
     return null;
+  }
+
+  @Override
+  public Stream<TabletInformation> getTabletInformation(TableId tableId, List<Range> ranges,
+      TabletInformation.Field... fields) {
+    EnumSet<TabletInformation.Field> fieldSet = fields.length == 0
+        ? EnumSet.allOf(TabletInformation.Field.class) : EnumSet.copyOf(Arrays.asList(fields));
+    return TabletInformationCollector.getTabletInformation(getContext(), tableId, ranges, fieldSet);
   }
 
   @Override

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/InformationFetcher.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/InformationFetcher.java
@@ -157,7 +157,7 @@ public class InformationFetcher implements RemovalListener<ServerId,MetricRespon
       try {
         final String tableName = ctx.getQualifiedTableName(tableId);
         try (Stream<TabletInformation> tablets =
-            this.ctx.tableOperations().getTabletInformation(tableName, new Range())) {
+            this.ctx.tableOperations().getTabletInformation(tableName, List.of(new Range()))) {
           tablets.forEach(t -> summary.processTabletInformation(tableId, tableName, t));
         }
       } catch (TableNotFoundException e) {

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/InformationFetcher.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/InformationFetcher.java
@@ -45,7 +45,7 @@ import org.apache.accumulo.core.client.admin.servers.ServerId.Type;
 import org.apache.accumulo.core.compaction.thrift.CompactionCoordinatorService;
 import org.apache.accumulo.core.compaction.thrift.TExternalCompactionList;
 import org.apache.accumulo.core.conf.Property;
-import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.RowRange;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.process.thrift.MetricResponse;
 import org.apache.accumulo.core.process.thrift.ServerProcessService.Client;
@@ -157,7 +157,7 @@ public class InformationFetcher implements RemovalListener<ServerId,MetricRespon
       try {
         final String tableName = ctx.getQualifiedTableName(tableId);
         try (Stream<TabletInformation> tablets =
-            this.ctx.tableOperations().getTabletInformation(tableName, List.of(new Range()))) {
+            this.ctx.tableOperations().getTabletInformation(tableName, List.of(RowRange.all()))) {
           tablets.forEach(t -> summary.processTabletInformation(tableId, tableName, t));
         }
       } catch (TableNotFoundException e) {

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/GetAvailabilityCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/GetAvailabilityCommand.java
@@ -20,7 +20,7 @@ package org.apache.accumulo.shell.commands;
 
 import java.util.List;
 
-import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.RowRange;
 import org.apache.accumulo.shell.Shell;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
@@ -32,7 +32,7 @@ public class GetAvailabilityCommand extends TableOperation {
   private Option optRow;
   private Option optStartRowExclusive;
   private Option optEndRowExclusive;
-  private Range range;
+  private RowRange range;
 
   @Override
   public String getName() {
@@ -67,13 +67,14 @@ public class GetAvailabilityCommand extends TableOperation {
     }
 
     if (cl.hasOption(optRow.getOpt())) {
-      this.range = new Range(new Text(cl.getOptionValue(optRow.getOpt()).getBytes(Shell.CHARSET)));
+      this.range =
+          RowRange.closed(new Text(cl.getOptionValue(optRow.getOpt()).getBytes(Shell.CHARSET)));
     } else {
       Text startRow = OptUtil.getStartRow(cl);
       Text endRow = OptUtil.getEndRow(cl);
       final boolean startInclusive = !cl.hasOption(optStartRowExclusive.getOpt());
       final boolean endInclusive = !cl.hasOption(optEndRowExclusive.getOpt());
-      this.range = new Range(startRow, startInclusive, endRow, endInclusive);
+      this.range = RowRange.range(startRow, startInclusive, endRow, endInclusive);
     }
     return super.execute(fullCommand, cl, shellState);
   }

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/GetAvailabilityCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/GetAvailabilityCommand.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.shell.commands;
 
+import java.util.List;
+
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.shell.Shell;
 import org.apache.commons.cli.CommandLine;
@@ -46,8 +48,8 @@ public class GetAvailabilityCommand extends TableOperation {
   protected void doTableOp(Shell shellState, String tableName) throws Exception {
     shellState.getWriter().println("TABLE: " + tableName);
     shellState.getWriter().println("TABLET ID    AVAILABILITY");
-    try (var tabletInformation =
-        shellState.getAccumuloClient().tableOperations().getTabletInformation(tableName, range)) {
+    try (var tabletInformation = shellState.getAccumuloClient().tableOperations()
+        .getTabletInformation(tableName, List.of(range))) {
       tabletInformation.forEach(p -> shellState.getWriter()
           .println(String.format("%-10s   %s", p.getTabletId(), p.getTabletAvailability())));
     }

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ListTabletsCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ListTabletsCommand.java
@@ -76,8 +76,8 @@ public class ListTabletsCommand extends Command {
       String name = tableInfo.name;
       lines.add("TABLE: " + name);
 
-      try (Stream<TabletInformation> tabletInfoStream =
-          shellState.getContext().tableOperations().getTabletInformation(name, new Range())) {
+      try (Stream<TabletInformation> tabletInfoStream = shellState.getContext().tableOperations()
+          .getTabletInformation(name, List.of(new Range()))) {
         final AtomicInteger counter = new AtomicInteger(1);
         tabletInfoStream.forEach(tabletInfo -> {
           int i = counter.getAndIncrement();

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ListTabletsCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ListTabletsCommand.java
@@ -33,7 +33,7 @@ import org.apache.accumulo.core.client.NamespaceNotFoundException;
 import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.core.client.admin.TabletInformation;
 import org.apache.accumulo.core.data.NamespaceId;
-import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.RowRange;
 import org.apache.accumulo.core.util.NumUtil;
 import org.apache.accumulo.shell.Shell;
 import org.apache.accumulo.shell.Shell.Command;
@@ -77,7 +77,7 @@ public class ListTabletsCommand extends Command {
       lines.add("TABLE: " + name);
 
       try (Stream<TabletInformation> tabletInfoStream = shellState.getContext().tableOperations()
-          .getTabletInformation(name, List.of(new Range()))) {
+          .getTabletInformation(name, List.of(RowRange.all()))) {
         final AtomicInteger counter = new AtomicInteger(1);
         tabletInfoStream.forEach(tabletInfo -> {
           int i = counter.getAndIncrement();

--- a/shell/src/test/java/org/apache/accumulo/shell/commands/ListTabletsCommandTest.java
+++ b/shell/src/test/java/org/apache/accumulo/shell/commands/ListTabletsCommandTest.java
@@ -193,7 +193,7 @@ public class ListTabletsCommandTest {
     EasyMock.expect(shellState.getContext()).andReturn(context).anyTimes();
     EasyMock.expect(client.tableOperations()).andReturn(tableOps).anyTimes();
     EasyMock.expect(context.tableOperations()).andReturn(tableOps).anyTimes();
-    EasyMock.expect(tableOps.getTabletInformation(tableName, new Range()))
+    EasyMock.expect(tableOps.getTabletInformation(tableName, List.of(new Range())))
         .andReturn(Stream.of(tabletInformation));
 
     Map<String,String> idMap = new TreeMap<>();

--- a/shell/src/test/java/org/apache/accumulo/shell/commands/ListTabletsCommandTest.java
+++ b/shell/src/test/java/org/apache/accumulo/shell/commands/ListTabletsCommandTest.java
@@ -39,7 +39,7 @@ import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.core.client.admin.TabletAvailability;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.clientImpl.TabletInformationImpl;
-import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.RowRange;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.ReferencedTabletFile;
@@ -193,7 +193,7 @@ public class ListTabletsCommandTest {
     EasyMock.expect(shellState.getContext()).andReturn(context).anyTimes();
     EasyMock.expect(client.tableOperations()).andReturn(tableOps).anyTimes();
     EasyMock.expect(context.tableOperations()).andReturn(tableOps).anyTimes();
-    EasyMock.expect(tableOps.getTabletInformation(tableName, List.of(new Range())))
+    EasyMock.expect(tableOps.getTabletInformation(tableName, List.of(RowRange.all())))
         .andReturn(Stream.of(tabletInformation));
 
     Map<String,String> idMap = new TreeMap<>();

--- a/test/src/main/java/org/apache/accumulo/test/ComprehensiveITBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/ComprehensiveITBase.java
@@ -1105,7 +1105,7 @@ public abstract class ComprehensiveITBase extends SharedMiniClusterBase {
         IteratorUtil.IteratorScope.scan));
 
     try (Stream<TabletInformation> tabletInfo =
-        client.tableOperations().getTabletInformation(table, List.of(new Range()))) {
+        client.tableOperations().getTabletInformation(table, List.of(RowRange.all()))) {
       tabletInfo.forEach(tabletInformation -> {
         if (tabletInformation.getTabletId().getEndRow() == null) {
           assertEquals(expectedAvailabilityForDefaultTable,

--- a/test/src/main/java/org/apache/accumulo/test/ComprehensiveITBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/ComprehensiveITBase.java
@@ -1105,7 +1105,7 @@ public abstract class ComprehensiveITBase extends SharedMiniClusterBase {
         IteratorUtil.IteratorScope.scan));
 
     try (Stream<TabletInformation> tabletInfo =
-        client.tableOperations().getTabletInformation(table, new Range())) {
+        client.tableOperations().getTabletInformation(table, List.of(new Range()))) {
       tabletInfo.forEach(tabletInformation -> {
         if (tabletInformation.getTabletId().getEndRow() == null) {
           assertEquals(expectedAvailabilityForDefaultTable,

--- a/test/src/main/java/org/apache/accumulo/test/ComprehensiveTableOperationsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ComprehensiveTableOperationsIT.java
@@ -802,8 +802,8 @@ public class ComprehensiveTableOperationsIT extends SharedMiniClusterBase {
       // should not be able to unhost any system table
       assertThrows(AccumuloException.class,
           () -> ops.setTabletAvailability(sysTable, new Range(), TabletAvailability.UNHOSTED));
-      assertTrue(ops.getTabletInformation(sysTable, new Range()).findAny().isPresent());
-      ops.getTabletInformation(sysTable, new Range())
+      assertTrue(ops.getTabletInformation(sysTable, List.of(new Range())).findAny().isPresent());
+      ops.getTabletInformation(sysTable, List.of(new Range()))
           .forEach(ti -> assertEquals(TabletAvailability.HOSTED, ti.getTabletAvailability()));
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/ComprehensiveTableOperationsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ComprehensiveTableOperationsIT.java
@@ -802,8 +802,8 @@ public class ComprehensiveTableOperationsIT extends SharedMiniClusterBase {
       // should not be able to unhost any system table
       assertThrows(AccumuloException.class,
           () -> ops.setTabletAvailability(sysTable, new Range(), TabletAvailability.UNHOSTED));
-      assertTrue(ops.getTabletInformation(sysTable, List.of(new Range())).findAny().isPresent());
-      ops.getTabletInformation(sysTable, List.of(new Range()))
+      assertTrue(ops.getTabletInformation(sysTable, List.of(RowRange.all())).findAny().isPresent());
+      ops.getTabletInformation(sysTable, List.of(RowRange.all()))
           .forEach(ti -> assertEquals(TabletAvailability.HOSTED, ti.getTabletAvailability()));
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
@@ -444,7 +444,7 @@ public class ImportExportIT extends AccumuloClusterHarness {
       // Get all `file` colfams from the metadata table for the new table
       log.info("Imported into table with ID: {}", destTableId);
 
-      client.tableOperations().getTabletInformation(destTable, new Range())
+      client.tableOperations().getTabletInformation(destTable, List.of(new Range()))
           .forEach(tabletInformation -> assertEquals(TabletAvailability.ONDEMAND,
               tabletInformation.getTabletAvailability(),
               "Expected all tablets in imported table to be ONDEMAND"));

--- a/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
@@ -55,6 +55,7 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.RowRange;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.TabletId;
 import org.apache.accumulo.core.data.Value;
@@ -377,7 +378,7 @@ public class ImportExportIT extends AccumuloClusterHarness {
           TabletAvailability.UNHOSTED);
       setExpectedTabletAvailability(expectedTabletAvailability, srcTableId, null, "q",
           TabletAvailability.HOSTED);
-      verifyTabletAvailabilities(client, srcTable, new Range(), expectedTabletAvailability);
+      verifyTabletAvailabilities(client, srcTable, RowRange.all(), expectedTabletAvailability);
 
       // Add a split within each of the existing tablets. Adding 'd', 'm', and 'v'
       splits = Sets.newTreeSet(Arrays.asList(new Text("d"), new Text("m"), new Text("v")));
@@ -397,7 +398,7 @@ public class ImportExportIT extends AccumuloClusterHarness {
           TabletAvailability.HOSTED);
       setExpectedTabletAvailability(expectedTabletAvailability, srcTableId, null, "v",
           TabletAvailability.HOSTED);
-      verifyTabletAvailabilities(client, srcTable, new Range(), expectedTabletAvailability);
+      verifyTabletAvailabilities(client, srcTable, RowRange.all(), expectedTabletAvailability);
 
       // Make a directory we can use to throw the export and import directories
       // Must exist on the filesystem the cluster is running.
@@ -444,7 +445,7 @@ public class ImportExportIT extends AccumuloClusterHarness {
       // Get all `file` colfams from the metadata table for the new table
       log.info("Imported into table with ID: {}", destTableId);
 
-      client.tableOperations().getTabletInformation(destTable, List.of(new Range()))
+      client.tableOperations().getTabletInformation(destTable, List.of(RowRange.all()))
           .forEach(tabletInformation -> assertEquals(TabletAvailability.ONDEMAND,
               tabletInformation.getTabletAvailability(),
               "Expected all tablets in imported table to be ONDEMAND"));

--- a/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
@@ -69,6 +69,7 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.RowRange;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.TabletId;
 import org.apache.accumulo.core.data.Value;
@@ -570,17 +571,17 @@ public class TableOperationsIT extends AccumuloClusterHarness {
       Map<TabletId,TabletAvailability> expectedTabletAvailability = new HashMap<>();
       setExpectedTabletAvailability(expectedTabletAvailability, idMap.get(tableOnDemand), null,
           null, TabletAvailability.ONDEMAND);
-      verifyTabletAvailabilities(tableOnDemand, new Range(), expectedTabletAvailability);
+      verifyTabletAvailabilities(tableOnDemand, RowRange.all(), expectedTabletAvailability);
 
       expectedTabletAvailability.clear();
       setExpectedTabletAvailability(expectedTabletAvailability, idMap.get(tableHosted), null, null,
           TabletAvailability.HOSTED);
-      verifyTabletAvailabilities(tableHosted, new Range(), expectedTabletAvailability);
+      verifyTabletAvailabilities(tableHosted, RowRange.all(), expectedTabletAvailability);
 
       expectedTabletAvailability.clear();
       setExpectedTabletAvailability(expectedTabletAvailability, idMap.get(tableUnhosted), null,
           null, TabletAvailability.UNHOSTED);
-      verifyTabletAvailabilities(tableUnhosted, new Range(), expectedTabletAvailability);
+      verifyTabletAvailabilities(tableUnhosted, RowRange.all(), expectedTabletAvailability);
 
       verifyTablesWithSplits(tableOnDemandWithSplits, idMap, splits, TabletAvailability.ONDEMAND);
       verifyTablesWithSplits(tableHostedWithSplits, idMap, splits, TabletAvailability.HOSTED);
@@ -637,7 +638,7 @@ public class TableOperationsIT extends AccumuloClusterHarness {
           TabletAvailability.HOSTED);
       setExpectedTabletAvailability(expectedTabletAvailability, tableId, null, "s",
           TabletAvailability.UNHOSTED);
-      verifyTabletAvailabilities(tableName, new Range(), expectedTabletAvailability);
+      verifyTabletAvailabilities(tableName, RowRange.all(), expectedTabletAvailability);
     } finally {
       accumuloClient.tableOperations().delete(tableName);
     }
@@ -676,10 +677,10 @@ public class TableOperationsIT extends AccumuloClusterHarness {
       setExpectedTabletAvailability(expectedTabletAvailability, tableId, "d", null,
           TabletAvailability.HOSTED);
       // test using row as range constructor
-      verifyTabletAvailabilities(tableName, new Range("a"), expectedTabletAvailability);
+      verifyTabletAvailabilities(tableName, RowRange.closed("a"), expectedTabletAvailability);
 
       // test using startRowInclusive set to true
-      Range range = new Range(new Text("c"), true, new Text("c"), true);
+      RowRange range = RowRange.closed(new Text("c"));
       verifyTabletAvailabilities(tableName, range, expectedTabletAvailability);
 
       expectedTabletAvailability.clear();
@@ -688,7 +689,7 @@ public class TableOperationsIT extends AccumuloClusterHarness {
       setExpectedTabletAvailability(expectedTabletAvailability, tableId, "s", "m",
           TabletAvailability.HOSTED);
 
-      range = new Range(new Text("m"), new Text("p"));
+      range = RowRange.closed(new Text("m"), new Text("p"));
       verifyTabletAvailabilities(tableName, range, expectedTabletAvailability);
 
       expectedTabletAvailability.clear();
@@ -701,7 +702,7 @@ public class TableOperationsIT extends AccumuloClusterHarness {
       setExpectedTabletAvailability(expectedTabletAvailability, tableId, null, "s",
           TabletAvailability.ONDEMAND);
 
-      range = new Range("b", false, "t", true);
+      range = RowRange.openClosed("b", "t");
       verifyTabletAvailabilities(tableName, range, expectedTabletAvailability);
 
     } finally {
@@ -729,7 +730,7 @@ public class TableOperationsIT extends AccumuloClusterHarness {
       String tableId = idMap.get(tableName);
       setExpectedTabletAvailability(expectedTabletAvailability, tableId, null, null,
           TabletAvailability.HOSTED);
-      verifyTabletAvailabilities(tableName, new Range(), expectedTabletAvailability);
+      verifyTabletAvailabilities(tableName, RowRange.all(), expectedTabletAvailability);
 
       // Add splits after the fact
       SortedSet<Text> splits =
@@ -745,7 +746,7 @@ public class TableOperationsIT extends AccumuloClusterHarness {
           TabletAvailability.HOSTED);
       setExpectedTabletAvailability(expectedTabletAvailability, tableId, null, "r",
           TabletAvailability.HOSTED);
-      verifyTabletAvailabilities(tableName, new Range(), expectedTabletAvailability);
+      verifyTabletAvailabilities(tableName, RowRange.all(), expectedTabletAvailability);
     } finally {
       accumuloClient.tableOperations().delete(tableName);
     }
@@ -788,7 +789,7 @@ public class TableOperationsIT extends AccumuloClusterHarness {
           TabletAvailability.UNHOSTED);
       setExpectedTabletAvailability(expectedTabletAvailability, tableId, null, "q",
           TabletAvailability.HOSTED);
-      verifyTabletAvailabilities(tableName, new Range(), expectedTabletAvailability);
+      verifyTabletAvailabilities(tableName, RowRange.all(), expectedTabletAvailability);
 
       // Add a split within each of the existing tablets. Adding 'd', 'm', and 'v'
       splits = Sets.newTreeSet(Arrays.asList(new Text("d"), new Text("m"), new Text("v")));
@@ -808,7 +809,7 @@ public class TableOperationsIT extends AccumuloClusterHarness {
           TabletAvailability.HOSTED);
       setExpectedTabletAvailability(expectedTabletAvailability, tableId, null, "v",
           TabletAvailability.HOSTED);
-      verifyTabletAvailabilities(tableName, new Range(), expectedTabletAvailability);
+      verifyTabletAvailabilities(tableName, RowRange.all(), expectedTabletAvailability);
     } finally {
       accumuloClient.tableOperations().delete(tableName);
     }
@@ -830,33 +831,33 @@ public class TableOperationsIT extends AccumuloClusterHarness {
         tabletAvailability);
     setExpectedTabletAvailability(expectedTabletAvailability, tableId, null, splitPts[2],
         tabletAvailability);
-    verifyTabletAvailabilities(tableName, new Range(), expectedTabletAvailability);
+    verifyTabletAvailabilities(tableName, RowRange.all(), expectedTabletAvailability);
 
     // verify individual tablets can be retrieved
     expectedTabletAvailability.clear();
     setExpectedTabletAvailability(expectedTabletAvailability, tableId, splitPts[0], null,
         tabletAvailability);
-    verifyTabletAvailabilities(tableName, new Range(null, new Text(splitPts[0])),
+    verifyTabletAvailabilities(tableName, RowRange.atMost(new Text(splitPts[0])),
         expectedTabletAvailability);
 
     expectedTabletAvailability.clear();
     setExpectedTabletAvailability(expectedTabletAvailability, tableId, splitPts[1], splitPts[0],
         tabletAvailability);
     verifyTabletAvailabilities(tableName,
-        new Range(new Text(splitPts[0]), false, new Text(splitPts[1]), true),
+        RowRange.openClosed(new Text(splitPts[0]), new Text(splitPts[1])),
         expectedTabletAvailability);
 
     expectedTabletAvailability.clear();
     setExpectedTabletAvailability(expectedTabletAvailability, tableId, splitPts[2], splitPts[1],
         tabletAvailability);
     verifyTabletAvailabilities(tableName,
-        new Range(new Text(splitPts[1]), false, new Text(splitPts[2]), true),
+        RowRange.openClosed(new Text(splitPts[1]), new Text(splitPts[2])),
         expectedTabletAvailability);
 
     expectedTabletAvailability.clear();
     setExpectedTabletAvailability(expectedTabletAvailability, tableId, null, splitPts[2],
         tabletAvailability);
-    verifyTabletAvailabilities(tableName, new Range(new Text(splitPts[2]), false, null, true),
+    verifyTabletAvailabilities(tableName, RowRange.greaterThan(new Text(splitPts[2])),
         expectedTabletAvailability);
 
     expectedTabletAvailability.clear();
@@ -865,17 +866,17 @@ public class TableOperationsIT extends AccumuloClusterHarness {
     setExpectedTabletAvailability(expectedTabletAvailability, tableId, splitPts[2], splitPts[1],
         tabletAvailability);
     verifyTabletAvailabilities(tableName,
-        new Range(new Text(splitPts[0]), false, new Text(splitPts[2]), true),
+        RowRange.openClosed(new Text(splitPts[0]), new Text(splitPts[2])),
         expectedTabletAvailability);
   }
 
-  public static void verifyTabletAvailabilities(String tableName, Range range,
+  public static void verifyTabletAvailabilities(String tableName, RowRange range,
       Map<TabletId,TabletAvailability> expectedAvailability) throws TableNotFoundException {
     verifyTabletAvailabilities(accumuloClient, tableName, range, expectedAvailability);
   }
 
   public static void verifyTabletAvailabilities(AccumuloClient client, String tableName,
-      Range range, Map<TabletId,TabletAvailability> expectedAvailability)
+      RowRange range, Map<TabletId,TabletAvailability> expectedAvailability)
       throws TableNotFoundException {
     Map<TabletId,TabletAvailability> seenAvailability =
         client.tableOperations().getTabletInformation(tableName, List.of(range)).collect(Collectors
@@ -945,7 +946,7 @@ public class TableOperationsIT extends AccumuloClusterHarness {
       var tableId = TableId.of(accumuloClient.tableOperations().tableIdMap().get(tableName));
 
       try (var tablets = accumuloClient.tableOperations().getTabletInformation(tableName,
-          List.of(new Range()), TabletInformation.Field.LOCATION)) {
+          List.of(RowRange.all()), TabletInformation.Field.LOCATION)) {
         var tabletList = tablets.collect(Collectors.toList());
         assertEquals(9, tabletList.size());
         tabletList.forEach(ti -> {
@@ -963,7 +964,7 @@ public class TableOperationsIT extends AccumuloClusterHarness {
       }
 
       try (var tablets = accumuloClient.tableOperations().getTabletInformation(tableName,
-          List.of(new Range()), TabletInformation.Field.FILES)) {
+          List.of(RowRange.all()), TabletInformation.Field.FILES)) {
         var tabletList = tablets.collect(Collectors.toList());
         assertEquals(9, tabletList.size());
         tabletList.forEach(ti -> {
@@ -980,8 +981,9 @@ public class TableOperationsIT extends AccumuloClusterHarness {
         });
       }
 
-      try (var tablets = accumuloClient.tableOperations().getTabletInformation(tableName,
-          List.of(new Range()), TabletInformation.Field.FILES, TabletInformation.Field.LOCATION)) {
+      try (var tablets =
+          accumuloClient.tableOperations().getTabletInformation(tableName, List.of(RowRange.all()),
+              TabletInformation.Field.FILES, TabletInformation.Field.LOCATION)) {
         var tabletList = tablets.collect(Collectors.toList());
         assertEquals(9, tabletList.size());
         tabletList.forEach(ti -> {
@@ -999,7 +1001,7 @@ public class TableOperationsIT extends AccumuloClusterHarness {
       }
 
       try (var tablets = accumuloClient.tableOperations().getTabletInformation(tableName,
-          List.of(new Range()), TabletInformation.Field.AVAILABILITY)) {
+          List.of(RowRange.all()), TabletInformation.Field.AVAILABILITY)) {
         var tabletList = tablets.collect(Collectors.toList());
         assertEquals(9, tabletList.size());
         tabletList.forEach(ti -> {
@@ -1017,7 +1019,7 @@ public class TableOperationsIT extends AccumuloClusterHarness {
       }
 
       try (var tablets = accumuloClient.tableOperations().getTabletInformation(tableName,
-          List.of(new Range()), TabletInformation.Field.MERGEABILITY)) {
+          List.of(RowRange.all()), TabletInformation.Field.MERGEABILITY)) {
         var tabletList = tablets.collect(Collectors.toList());
         assertEquals(9, tabletList.size());
         tabletList.forEach(ti -> {
@@ -1038,7 +1040,7 @@ public class TableOperationsIT extends AccumuloClusterHarness {
         });
       }
 
-      var unboundedStartRange = new Range(null, new Text("4"));
+      var unboundedStartRange = RowRange.atMost(new Text("4"));
       try (var tablets = accumuloClient.tableOperations().getTabletInformation(tableName,
           List.of(unboundedStartRange), TabletInformation.Field.LOCATION)) {
         var endRows = tablets.map(TabletInformation::getTabletId).map(TabletId::getEndRow)
@@ -1046,7 +1048,7 @@ public class TableOperationsIT extends AccumuloClusterHarness {
         assertEquals(List.of("1", "2", "3", "4"), endRows);
       }
 
-      var unboundedEndRange = new Range(new Text("6"), true, null, true);
+      var unboundedEndRange = RowRange.atLeast(new Text("6"));
       try (var tablets = accumuloClient.tableOperations().getTabletInformation(tableName,
           List.of(unboundedEndRange), TabletInformation.Field.LOCATION)) {
         var endRows = tablets.map(TabletInformation::getTabletId).map(TabletId::getEndRow)
@@ -1054,7 +1056,7 @@ public class TableOperationsIT extends AccumuloClusterHarness {
         assertEquals(List.of("6", "7", "8", "null"), endRows);
       }
 
-      var exclusiveStartRange = new Range(new Text("4"), false, new Text("6"), true);
+      var exclusiveStartRange = RowRange.openClosed(new Text("4"), new Text("6"));
       try (var tablets = accumuloClient.tableOperations().getTabletInformation(tableName,
           List.of(exclusiveStartRange), TabletInformation.Field.LOCATION)) {
         var endRows = tablets.map(TabletInformation::getTabletId).map(TabletId::getEndRow)
@@ -1062,7 +1064,7 @@ public class TableOperationsIT extends AccumuloClusterHarness {
         assertEquals(List.of("5", "6"), endRows);
       }
 
-      var inclusiveStartRange = new Range(new Text("4"), true, new Text("6"), true);
+      var inclusiveStartRange = RowRange.closed(new Text("4"), new Text("6"));
       try (var tablets = accumuloClient.tableOperations().getTabletInformation(tableName,
           List.of(inclusiveStartRange), TabletInformation.Field.LOCATION)) {
         var endRows = tablets.map(TabletInformation::getTabletId).map(TabletId::getEndRow)
@@ -1070,15 +1072,15 @@ public class TableOperationsIT extends AccumuloClusterHarness {
         assertEquals(List.of("4", "5", "6"), endRows);
       }
 
-      var fileFieldMissingRange = List.of(new Range(new Text("2"), new Text("4")));
+      var fileFieldMissingRange = List.of(RowRange.closed(new Text("2"), new Text("4")));
       try (var tablets = accumuloClient.tableOperations().getTabletInformation(tableName,
           fileFieldMissingRange, TabletInformation.Field.LOCATION)) {
         tablets.forEach(ti -> assertThrows(IllegalStateException.class, ti::getNumFiles));
       }
 
-      var overlappingRange = new Range(new Text("2"), new Text("4"));
-      var overlappingRange2 = new Range(new Text("3"), new Text("5"));
-      var disjointRange = new Range(new Text("7"), new Text("8"));
+      var overlappingRange = RowRange.closed(new Text("2"), new Text("4"));
+      var overlappingRange2 = RowRange.closed(new Text("3"), new Text("5"));
+      var disjointRange = RowRange.closed(new Text("7"), new Text("8"));
       try (var tablets = accumuloClient.tableOperations().getTabletInformation(tableName,
           List.of(overlappingRange, overlappingRange2, disjointRange),
           TabletInformation.Field.LOCATION)) {

--- a/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
@@ -884,7 +884,7 @@ public class TableOperationsIT extends AccumuloClusterHarness {
   }
 
   /**
-   * assert the given List<String> equals what's returned from
+   * assert the given {@code List<String>} equals what's returned from
    * {@link TableOperations#getTabletInformation(String, List, TabletInformation.Field...)} using
    * the given RowRange
    */

--- a/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
@@ -878,7 +878,7 @@ public class TableOperationsIT extends AccumuloClusterHarness {
       Range range, Map<TabletId,TabletAvailability> expectedAvailability)
       throws TableNotFoundException {
     Map<TabletId,TabletAvailability> seenAvailability =
-        client.tableOperations().getTabletInformation(tableName, range).collect(Collectors
+        client.tableOperations().getTabletInformation(tableName, List.of(range)).collect(Collectors
             .toMap(TabletInformation::getTabletId, TabletInformation::getTabletAvailability));
     assertEquals(expectedAvailability, seenAvailability);
   }
@@ -945,7 +945,7 @@ public class TableOperationsIT extends AccumuloClusterHarness {
       var tableId = TableId.of(accumuloClient.tableOperations().tableIdMap().get(tableName));
 
       try (var tablets = accumuloClient.tableOperations().getTabletInformation(tableName,
-          new Range(), TabletInformation.Field.LOCATION)) {
+          List.of(new Range()), TabletInformation.Field.LOCATION)) {
         var tabletList = tablets.collect(Collectors.toList());
         assertEquals(9, tabletList.size());
         tabletList.forEach(ti -> {
@@ -963,7 +963,7 @@ public class TableOperationsIT extends AccumuloClusterHarness {
       }
 
       try (var tablets = accumuloClient.tableOperations().getTabletInformation(tableName,
-          new Range(), TabletInformation.Field.FILES)) {
+          List.of(new Range()), TabletInformation.Field.FILES)) {
         var tabletList = tablets.collect(Collectors.toList());
         assertEquals(9, tabletList.size());
         tabletList.forEach(ti -> {
@@ -981,7 +981,7 @@ public class TableOperationsIT extends AccumuloClusterHarness {
       }
 
       try (var tablets = accumuloClient.tableOperations().getTabletInformation(tableName,
-          new Range(), TabletInformation.Field.FILES, TabletInformation.Field.LOCATION)) {
+          List.of(new Range()), TabletInformation.Field.FILES, TabletInformation.Field.LOCATION)) {
         var tabletList = tablets.collect(Collectors.toList());
         assertEquals(9, tabletList.size());
         tabletList.forEach(ti -> {
@@ -999,7 +999,7 @@ public class TableOperationsIT extends AccumuloClusterHarness {
       }
 
       try (var tablets = accumuloClient.tableOperations().getTabletInformation(tableName,
-          new Range(), TabletInformation.Field.AVAILABILITY)) {
+          List.of(new Range()), TabletInformation.Field.AVAILABILITY)) {
         var tabletList = tablets.collect(Collectors.toList());
         assertEquals(9, tabletList.size());
         tabletList.forEach(ti -> {
@@ -1017,7 +1017,7 @@ public class TableOperationsIT extends AccumuloClusterHarness {
       }
 
       try (var tablets = accumuloClient.tableOperations().getTabletInformation(tableName,
-          new Range(), TabletInformation.Field.MERGEABILITY)) {
+          List.of(new Range()), TabletInformation.Field.MERGEABILITY)) {
         var tabletList = tablets.collect(Collectors.toList());
         assertEquals(9, tabletList.size());
         tabletList.forEach(ti -> {
@@ -1040,7 +1040,7 @@ public class TableOperationsIT extends AccumuloClusterHarness {
 
       var unboundedStartRange = new Range(null, new Text("4"));
       try (var tablets = accumuloClient.tableOperations().getTabletInformation(tableName,
-          unboundedStartRange, TabletInformation.Field.LOCATION)) {
+          List.of(unboundedStartRange), TabletInformation.Field.LOCATION)) {
         var endRows = tablets.map(TabletInformation::getTabletId).map(TabletId::getEndRow)
             .map(er -> er == null ? "null" : er.toString()).toList();
         assertEquals(List.of("1", "2", "3", "4"), endRows);
@@ -1048,7 +1048,7 @@ public class TableOperationsIT extends AccumuloClusterHarness {
 
       var unboundedEndRange = new Range(new Text("6"), true, null, true);
       try (var tablets = accumuloClient.tableOperations().getTabletInformation(tableName,
-          unboundedEndRange, TabletInformation.Field.LOCATION)) {
+          List.of(unboundedEndRange), TabletInformation.Field.LOCATION)) {
         var endRows = tablets.map(TabletInformation::getTabletId).map(TabletId::getEndRow)
             .map(er -> er == null ? "null" : er.toString()).toList();
         assertEquals(List.of("6", "7", "8", "null"), endRows);
@@ -1056,7 +1056,7 @@ public class TableOperationsIT extends AccumuloClusterHarness {
 
       var exclusiveStartRange = new Range(new Text("4"), false, new Text("6"), true);
       try (var tablets = accumuloClient.tableOperations().getTabletInformation(tableName,
-          exclusiveStartRange, TabletInformation.Field.LOCATION)) {
+          List.of(exclusiveStartRange), TabletInformation.Field.LOCATION)) {
         var endRows = tablets.map(TabletInformation::getTabletId).map(TabletId::getEndRow)
             .map(Text::toString).toList();
         assertEquals(List.of("5", "6"), endRows);
@@ -1064,7 +1064,7 @@ public class TableOperationsIT extends AccumuloClusterHarness {
 
       var inclusiveStartRange = new Range(new Text("4"), true, new Text("6"), true);
       try (var tablets = accumuloClient.tableOperations().getTabletInformation(tableName,
-          inclusiveStartRange, TabletInformation.Field.LOCATION)) {
+          List.of(inclusiveStartRange), TabletInformation.Field.LOCATION)) {
         var endRows = tablets.map(TabletInformation::getTabletId).map(TabletId::getEndRow)
             .map(Text::toString).toList();
         assertEquals(List.of("4", "5", "6"), endRows);
@@ -1087,7 +1087,6 @@ public class TableOperationsIT extends AccumuloClusterHarness {
         assertEquals(6, tabletIds.size());
         assertEquals(tabletIds.size(), new HashSet<>(tabletIds).size());
         assertEquals(endRows, new ArrayList<>(new LinkedHashSet<>(endRows)));
-        assertEquals(Set.of("2", "3", "4", "5", "7", "8"), new HashSet<>(endRows));
         assertEquals(List.of("2", "3", "4", "5", "7", "8"), endRows);
       }
 

--- a/test/src/main/java/org/apache/accumulo/test/ample/metadata/TestAmple.java
+++ b/test/src/main/java/org/apache/accumulo/test/ample/metadata/TestAmple.java
@@ -42,7 +42,7 @@ import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
-import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.RowRange;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
@@ -301,7 +301,7 @@ public class TestAmple {
 
     TabletAvailability availability;
     try (var tabletStream = client.tableOperations()
-        .getTabletInformation(SystemTables.METADATA.tableName(), List.of(new Range()))) {
+        .getTabletInformation(SystemTables.METADATA.tableName(), List.of(RowRange.all()))) {
       availability = tabletStream.map(TabletInformation::getTabletAvailability).distinct()
           .collect(MoreCollectors.onlyElement());
     }

--- a/test/src/main/java/org/apache/accumulo/test/ample/metadata/TestAmple.java
+++ b/test/src/main/java/org/apache/accumulo/test/ample/metadata/TestAmple.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.test.ample.metadata;
 
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -300,7 +301,7 @@ public class TestAmple {
 
     TabletAvailability availability;
     try (var tabletStream = client.tableOperations()
-        .getTabletInformation(SystemTables.METADATA.tableName(), new Range())) {
+        .getTabletInformation(SystemTables.METADATA.tableName(), List.of(new Range()))) {
       availability = tabletStream.map(TabletInformation::getTabletAvailability).distinct()
           .collect(MoreCollectors.onlyElement());
     }

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_1_IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_1_IT.java
@@ -78,6 +78,7 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.ResourceGroupId;
+import org.apache.accumulo.core.data.RowRange;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.TabletId;
 import org.apache.accumulo.core.data.Value;
@@ -536,7 +537,7 @@ public class ExternalCompaction_1_IT extends SharedMiniClusterBase {
       List<TabletId> tabletIds;
       // start a compaction on each tablet
       try (var tablets =
-          client.tableOperations().getTabletInformation(table1, List.of(new Range()))) {
+          client.tableOperations().getTabletInformation(table1, List.of(RowRange.all()))) {
         tabletIds = tablets.map(TabletInformation::getTabletId).collect(Collectors.toList());
       }
       // compact the even tablet with a modulus filter of 2

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_1_IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_1_IT.java
@@ -535,7 +535,8 @@ public class ExternalCompaction_1_IT extends SharedMiniClusterBase {
 
       List<TabletId> tabletIds;
       // start a compaction on each tablet
-      try (var tablets = client.tableOperations().getTabletInformation(table1, new Range())) {
+      try (var tablets =
+          client.tableOperations().getTabletInformation(table1, List.of(new Range()))) {
         tabletIds = tablets.map(TabletInformation::getTabletId).collect(Collectors.toList());
       }
       // compact the even tablet with a modulus filter of 2

--- a/test/src/main/java/org/apache/accumulo/test/fate/FateTestUtil.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FateTestUtil.java
@@ -22,6 +22,7 @@ import static org.apache.accumulo.harness.AccumuloITBase.ZOOKEEPER_TESTING_SERVE
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -64,8 +65,8 @@ public class FateTestUtil {
         client.tableOperations().getTableProperties(SystemTables.FATE.tableName());
 
     TabletAvailability availability;
-    try (var tabletStream =
-        client.tableOperations().getTabletInformation(SystemTables.FATE.tableName(), new Range())) {
+    try (var tabletStream = client.tableOperations()
+        .getTabletInformation(SystemTables.FATE.tableName(), List.of(new Range()))) {
       availability = tabletStream.map(TabletInformation::getTabletAvailability).distinct()
           .collect(MoreCollectors.onlyElement());
     }

--- a/test/src/main/java/org/apache/accumulo/test/fate/FateTestUtil.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FateTestUtil.java
@@ -34,7 +34,7 @@ import org.apache.accumulo.core.client.admin.TabletInformation;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.Property;
-import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.RowRange;
 import org.apache.accumulo.core.fate.Fate;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.FateKey;
@@ -66,7 +66,7 @@ public class FateTestUtil {
 
     TabletAvailability availability;
     try (var tabletStream = client.tableOperations()
-        .getTabletInformation(SystemTables.FATE.tableName(), List.of(new Range()))) {
+        .getTabletInformation(SystemTables.FATE.tableName(), List.of(RowRange.all()))) {
       availability = tabletStream.map(TabletInformation::getTabletAvailability).distinct()
           .collect(MoreCollectors.onlyElement());
     }

--- a/test/src/main/java/org/apache/accumulo/test/functional/AddSplitIT_SimpleSuite.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/AddSplitIT_SimpleSuite.java
@@ -51,7 +51,7 @@ import org.apache.accumulo.core.client.admin.TabletMergeabilityInfo;
 import org.apache.accumulo.core.clientImpl.TabletMergeabilityUtil;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
-import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.RowRange;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
@@ -207,15 +207,15 @@ public class AddSplitIT_SimpleSuite extends SharedMiniClusterBase {
       splits.put(split, TabletMergeability.after(Duration.ofMinutes(5)));
 
       var originalTmi =
-          c.tableOperations().getTabletInformation(tableName, List.of(new Range(split))).findFirst()
-              .orElseThrow().getTabletMergeabilityInfo();
+          c.tableOperations().getTabletInformation(tableName, List.of(RowRange.closed(split)))
+              .findFirst().orElseThrow().getTabletMergeabilityInfo();
       assertTrue(originalTmi.getElapsed().orElseThrow().toNanos() > 0);
 
       // Update existing with same delay of 5 minutes
       c.tableOperations().putSplits(tableName, splits);
       var updatedTmi =
-          c.tableOperations().getTabletInformation(tableName, List.of(new Range(split))).findFirst()
-              .orElseThrow().getTabletMergeabilityInfo();
+          c.tableOperations().getTabletInformation(tableName, List.of(RowRange.closed(split)))
+              .findFirst().orElseThrow().getTabletMergeabilityInfo();
 
       // TabletMergeability setting should be the same but the new elapsed time should
       // be different (less time has passed as it was updated with a new insertion time)
@@ -247,7 +247,7 @@ public class AddSplitIT_SimpleSuite extends SharedMiniClusterBase {
       Thread.sleep(100);
       assertEquals(splits.keySet(), new TreeSet<>(c.tableOperations().listSplits(tableName)));
 
-      var tableInfo = c.tableOperations().getTabletInformation(tableName, List.of(new Range()))
+      var tableInfo = c.tableOperations().getTabletInformation(tableName, List.of(RowRange.all()))
           .collect(Collectors.toMap(ti -> ti.getTabletId().getEndRow(), Function.identity()));
 
       // Set to always
@@ -375,7 +375,7 @@ public class AddSplitIT_SimpleSuite extends SharedMiniClusterBase {
   private void verifySplitsWithApi(AccumuloClient c, String tableName,
       SortedMap<Text,TabletMergeability> splits) throws TableNotFoundException {
     final Set<Text> addedSplits = new HashSet<>(splits.keySet());
-    c.tableOperations().getTabletInformation(tableName, List.of(new Range())).forEach(ti -> {
+    c.tableOperations().getTabletInformation(tableName, List.of(RowRange.all())).forEach(ti -> {
       var tmInfo = ti.getTabletMergeabilityInfo();
       var split = ti.getTabletId().getEndRow();
       // default tablet should always be set to always

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
@@ -82,6 +82,7 @@ import org.apache.accumulo.core.data.LoadPlan;
 import org.apache.accumulo.core.data.LoadPlan.RangeType;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.RowRange;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.data.constraints.Constraint;
@@ -1273,7 +1274,7 @@ public class BulkNewIT extends SharedMiniClusterBase {
   private static Map<String,TabletAvailability> getTabletAvailabilities(AccumuloClient c,
       String tableName) throws TableNotFoundException {
     try (var tabletsInfo =
-        c.tableOperations().getTabletInformation(tableName, List.of(new Range()))) {
+        c.tableOperations().getTabletInformation(tableName, List.of(RowRange.all()))) {
       return tabletsInfo.collect(Collectors.toMap(ti -> {
         var er = ti.getTabletId().getEndRow();
         return er == null ? "NULL" : er.toString();

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
@@ -1272,7 +1272,8 @@ public class BulkNewIT extends SharedMiniClusterBase {
    */
   private static Map<String,TabletAvailability> getTabletAvailabilities(AccumuloClient c,
       String tableName) throws TableNotFoundException {
-    try (var tabletsInfo = c.tableOperations().getTabletInformation(tableName, new Range())) {
+    try (var tabletsInfo =
+        c.tableOperations().getTabletInformation(tableName, List.of(new Range()))) {
       return tabletsInfo.collect(Collectors.toMap(ti -> {
         var er = ti.getTabletId().getEndRow();
         return er == null ? "NULL" : er.toString();

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitMillionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitMillionIT.java
@@ -42,6 +42,7 @@ import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.RowRange;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.Filter;
@@ -153,7 +154,7 @@ public class SplitMillionIT extends ConfigurableMacBase {
       long count;
       t1 = System.currentTimeMillis();
       try (var tabletInformation =
-          c.tableOperations().getTabletInformation(tableName, List.of(new Range()))) {
+          c.tableOperations().getTabletInformation(tableName, List.of(RowRange.all()))) {
         count = tabletInformation.count();
       }
       t2 = System.currentTimeMillis();

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitMillionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitMillionIT.java
@@ -153,7 +153,7 @@ public class SplitMillionIT extends ConfigurableMacBase {
       long count;
       t1 = System.currentTimeMillis();
       try (var tabletInformation =
-          c.tableOperations().getTabletInformation(tableName, new Range())) {
+          c.tableOperations().getTabletInformation(tableName, List.of(new Range()))) {
         count = tabletInformation.count();
       }
       t2 = System.currentTimeMillis();

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletAvailabilityIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletAvailabilityIT.java
@@ -44,6 +44,7 @@ import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.client.admin.TabletAvailability;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.RowRange;
 import org.apache.accumulo.core.metadata.SystemTables;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.hadoop.io.Text;
@@ -104,7 +105,7 @@ public class TabletAvailabilityIT extends AccumuloClusterHarness {
 
       // ensure tablet availability is as expected
       SortedMap<String,TabletAvailability> availabilitesSeen = new TreeMap<>();
-      client.tableOperations().getTabletInformation(table, List.of(new Range())).forEach(ti -> {
+      client.tableOperations().getTabletInformation(table, List.of(RowRange.all())).forEach(ti -> {
         if (ti.getTabletId().getEndRow() != null) {
           availabilitesSeen.put(ti.getTabletId().getEndRow().toString(),
               ti.getTabletAvailability());

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletAvailabilityIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletAvailabilityIT.java
@@ -104,7 +104,7 @@ public class TabletAvailabilityIT extends AccumuloClusterHarness {
 
       // ensure tablet availability is as expected
       SortedMap<String,TabletAvailability> availabilitesSeen = new TreeMap<>();
-      client.tableOperations().getTabletInformation(table, new Range()).forEach(ti -> {
+      client.tableOperations().getTabletInformation(table, List.of(new Range())).forEach(ti -> {
         if (ti.getTabletId().getEndRow() != null) {
           availabilitesSeen.put(ti.getTabletId().getEndRow().toString(),
               ti.getTabletAvailability());


### PR DESCRIPTION
Fixes #5667

This PR adds the following:

multi-range tablet info API:
* added an overload of `TableOperations.getTabletInformation()` which now accepts a `List<Range>` and the single range overload now delegates to this new method
* added `BalancerEnvironment.getTabletInformation(TableId, List<Range>, TabletInformation.Field...)` so balancer plugins can request only the tablets they need
Created new `TabletInformationCollector` class to centralize logic
* overlapping ranges are merged, adds required `Feild`s and reads tablets via Ample

`TableOperationsImpl` and `BalancerEnvironmentImpl` now delegate to `TabletInformationCollector` for both single- and multi-range calls