### PR TITLE
Fix failing 2.1 tests

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/admin/NewTableConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/NewTableConfiguration.java
@@ -206,7 +206,8 @@ public class NewTableConfiguration {
         try {
           TableOperationsHelper.checkIteratorConflicts(noDefaultsPropMap, setting, scopes);
         } catch (AccumuloException e) {
-          throw new IllegalStateException(e);
+          throw new IllegalStateException(String.format(
+              "conflict with default table iterator: scopes: %s setting: %s", scopes, setting), e);
         }
       });
 

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -1322,8 +1322,9 @@ public enum Property {
           + " constraints to a table. These properties start with the category"
           + " prefix, followed by a number, and their values correspond to a fully"
           + " qualified Java class that implements the Constraint interface.\nFor example:\n"
-          + "table.constraint.1 = org.apache.accumulo.core.constraints.MyCustomConstraint\n"
-          + "and:\n table.constraint.2 = my.package.constraints.MySecondConstraint.",
+          + "table.constraint.2 = org.apache.accumulo.core.constraints.MyCustomConstraint\n"
+          + "and:\n table.constraint.3 = my.package.constraints.MySecondConstraint.\n"
+          + "Note that table.constraint.1 is a reserved, default table constraint.",
       "1.3.5"),
   TABLE_INDEXCACHE_ENABLED("table.cache.index.enable", "true", PropertyType.BOOLEAN,
       "Determines whether index block cache is enabled for a table.", "1.3.5"),

--- a/test/src/main/java/org/apache/accumulo/test/BatchWriterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/BatchWriterIT.java
@@ -111,7 +111,7 @@ public class BatchWriterIT extends AccumuloClusterHarness {
     String table = getUniqueNames(1)[0];
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
       NewTableConfiguration ntc = new NewTableConfiguration();
-      ntc.setProperties(Map.of(Property.TABLE_CONSTRAINT_PREFIX.getKey() + "1",
+      ntc.setProperties(Map.of(Property.TABLE_CONSTRAINT_PREFIX.getKey() + "2",
           NumericValueConstraint.class.getName()));
       c.tableOperations().create(table, ntc);
 

--- a/test/src/main/java/org/apache/accumulo/test/WriteAfterCloseIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/WriteAfterCloseIT.java
@@ -127,7 +127,7 @@ public class WriteAfterCloseIT extends AccumuloClusterHarness {
 
     NewTableConfiguration ntc = new NewTableConfiguration().setTimeType(timeType);
     ntc.setProperties(
-        Map.of(Property.TABLE_CONSTRAINT_PREFIX.getKey() + "1", SleepyConstraint.class.getName()));
+        Map.of(Property.TABLE_CONSTRAINT_PREFIX.getKey() + "2", SleepyConstraint.class.getName()));
 
     // The short rpc timeout and the random sleep in the constraint can cause some of the writes
     // done by a batch writer to timeout. The batch writer will internally retry the write, but the

--- a/test/src/main/java/org/apache/accumulo/test/functional/FlushNoFileIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FlushNoFileIT.java
@@ -68,7 +68,7 @@ public class FlushNoFileIT extends AccumuloClusterHarness {
       String tableName = getUniqueNames(1)[0];
 
       NewTableConfiguration ntc = new NewTableConfiguration();
-      IteratorSetting iteratorSetting = new IteratorSetting(20, NullIterator.class);
+      IteratorSetting iteratorSetting = new IteratorSetting(30, NullIterator.class);
       ntc.attachIterator(iteratorSetting, EnumSet.of(IteratorUtil.IteratorScope.minc));
       ntc.withSplits(new TreeSet<>(Set.of(new Text("a"), new Text("s"))));
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/IteratorMincClassCastBugIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/IteratorMincClassCastBugIT.java
@@ -77,7 +77,7 @@ public class IteratorMincClassCastBugIT extends AccumuloClusterHarness {
       groups.put("g2", Set.of(new Text("odd")));
       ntc.setLocalityGroups(groups);
 
-      IteratorSetting iteratorSetting = new IteratorSetting(20, ClasCastIterator.class);
+      IteratorSetting iteratorSetting = new IteratorSetting(30, ClasCastIterator.class);
       ntc.attachIterator(iteratorSetting, EnumSet.of(IteratorUtil.IteratorScope.minc));
 
       c.tableOperations().create(tableName, ntc);


### PR DESCRIPTION
PR #5990 intruduced stricter checks to NewTableConfiguration to check that properties or iterators set on the NewTableConfiguration do not conflict with default table properties or iterators. These tests were setting properties which did conflict.