### PR TITLE
Add unique table names for ParameterizedTest methods

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/WriteAfterCloseIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/WriteAfterCloseIT.java
@@ -120,7 +120,8 @@ public class WriteAfterCloseIT extends AccumuloClusterHarness {
   public void testWriteAfterClose(TimeType timeType, boolean killTservers, long timeout,
       boolean useConditionalWriter) throws Exception {
     // re #3721 test that tries to cause a write event to happen after a batch writer is closed
-    String table = getUniqueNames(1)[0];
+    String table = getUniqueNames(1)[0] + "_t" + timeType + "_k" + killTservers + "_to" + timeout
+        + "_c" + useConditionalWriter;
     var props = new Properties();
     props.putAll(getClientProps());
     props.setProperty(Property.GENERAL_RPC_TIMEOUT.getKey(), "1s");

--- a/test/src/main/java/org/apache/accumulo/test/ZombieScanIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ZombieScanIT.java
@@ -257,7 +257,7 @@ public class ZombieScanIT extends ConfigurableMacBase {
       return zsmc == -1 || zsmc == 0;
     }, 60_000);
 
-    String table = getUniqueNames(1)[0];
+    String table = getUniqueNames(1)[0] + "_" + consistency;
 
     final ServerType serverType = consistency == IMMEDIATE ? TABLET_SERVER : SCAN_SERVER;
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/ScannerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ScannerIT.java
@@ -133,7 +133,7 @@ public class ScannerIT extends ConfigurableMacBase {
   @ParameterizedTest
   @EnumSource
   public void testSessionCleanup(ConsistencyLevel consistency) throws Exception {
-    final String tableName = getUniqueNames(1)[0];
+    final String tableName = getUniqueNames(1)[0] + "_" + consistency;
     final ServerType serverType = consistency == IMMEDIATE ? TABLET_SERVER : SCAN_SERVER;
     try (AccumuloClient accumuloClient = Accumulo.newClient().from(getClientProperties()).build()) {
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletStateChangeIteratorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletStateChangeIteratorIT.java
@@ -116,12 +116,12 @@ public class TabletStateChangeIteratorIT extends AccumuloClusterHarness {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
 
       String[] tables = getUniqueNames(6);
-      final String t1 = tables[0];
-      final String t2 = tables[1];
-      final String t3 = tables[2];
-      final String metaCopy1 = tables[3];
-      final String metaCopy2 = tables[4];
-      final String metaCopy3 = tables[5];
+      final String t1 = tables[0] + "_" + compressionType;
+      final String t2 = tables[1] + "_" + compressionType;
+      final String t3 = tables[2] + "_" + compressionType;
+      final String metaCopy1 = tables[3] + "_" + compressionType;
+      final String metaCopy2 = tables[4] + "_" + compressionType;
+      final String metaCopy3 = tables[5] + "_" + compressionType;
 
       // create some metadata
       createTable(client, t1, true);


### PR DESCRIPTION
Looked through all the `@ParameterizedTest`s we have. `getUniqueNames()` uses the method name so to get a unique table name per ParameterizedTest, we need to add something else to ID each run. In this case some or all parameters.

This is not fixing any current bugs that I know of. More of a precaution.