### PR TITLE
Add unique table names for ParameterizedTest methods

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
@@ -210,7 +210,9 @@ public class ImportExportIT extends AccumuloClusterHarness {
   public void testExportImportThenScan(boolean fenced) throws Exception {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
       String[] tableNames = getUniqueNames(2);
-      doExportImportThenScan(fenced, client, tableNames[0], tableNames[1]);
+      String tableName1 = tableNames[0] + "_" + fenced;
+      String tableName2 = tableNames[1] + "_" + fenced;
+      doExportImportThenScan(fenced, client, tableName1, tableName2);
     }
   }
 
@@ -222,7 +224,7 @@ public class ImportExportIT extends AccumuloClusterHarness {
       client.namespaceOperations().create(ns1);
       String ns2 = "namespace2";
       client.namespaceOperations().create(ns2);
-      String tableName = getUniqueNames(1)[0];
+      String tableName = getUniqueNames(1)[0] + "_" + fenced;
       doExportImportThenScan(fenced, client, ns1 + "." + tableName, ns2 + "." + tableName);
     }
   }
@@ -233,8 +235,8 @@ public class ImportExportIT extends AccumuloClusterHarness {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
 
       String[] tableNames = getUniqueNames(2);
-      String srcTable = tableNames[0];
-      String destTable = tableNames[1];
+      String srcTable = tableNames[0] + "_" + fenced;
+      String destTable = tableNames[1] + "_" + fenced;
       client.tableOperations().create(srcTable);
 
       try (BatchWriter bw = client.createBatchWriter(srcTable)) {

--- a/test/src/main/java/org/apache/accumulo/test/RecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/RecoveryIT.java
@@ -114,7 +114,7 @@ public class RecoveryIT extends AccumuloClusterHarness {
     super.setupCluster();
 
     // create a table
-    String tableName = getUniqueNames(1)[0];
+    String tableName = getUniqueNames(1)[0] + "_" + serverForSorting;
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
 
       SortedSet<Text> splits = new TreeSet<>();

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletManagementIteratorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletManagementIteratorIT.java
@@ -150,16 +150,16 @@ public class TabletManagementIteratorIT extends AccumuloClusterHarness {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
 
       String[] tables = getUniqueNames(10);
-      final String t1 = tables[0];
-      final String t2 = tables[1];
-      final String t3 = tables[2];
-      final String t4 = tables[3];
-      final String metaCopy1 = tables[4];
-      final String metaCopy2 = tables[5];
-      final String metaCopy3 = tables[6];
-      final String metaCopy4 = tables[7];
-      final String metaCopy5 = tables[8];
-      final String metaCopy6 = tables[9];
+      final String t1 = tables[0] + "_" + compressionType;
+      final String t2 = tables[1] + "_" + compressionType;
+      final String t3 = tables[2] + "_" + compressionType;
+      final String t4 = tables[3] + "_" + compressionType;
+      final String metaCopy1 = tables[4] + "_" + compressionType;
+      final String metaCopy2 = tables[5] + "_" + compressionType;
+      final String metaCopy3 = tables[6] + "_" + compressionType;
+      final String metaCopy4 = tables[7] + "_" + compressionType;
+      final String metaCopy5 = tables[8] + "_" + compressionType;
+      final String metaCopy6 = tables[9] + "_" + compressionType;
 
       // create some metadata
       createTable(client, t1, true);


### PR DESCRIPTION
Use the input param for ParameterizedTest that would otherwise not have a unique table name between runs. This is a continuation of #6031 which was merged into 2.1. This PR contains changes that didn't exist in 2.1