### PR TITLE
Adds logging message when removing watchers

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ServiceLock.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ServiceLock.java
@@ -483,6 +483,8 @@ public class ServiceLock implements Watcher {
                   // if stat is null from the zookeeper.exists(path, Watcher) call, then we just
                   // created a Watcher on a node that does not exist. Delete the watcher we just
                   // created.
+                  LOG.debug("Removing watcher for path {} since stat return was null",
+                      pathForWatcher);
                   zooKeeper.removeWatches(pathForWatcher, this, WatcherType.Any, true);
 
                   if (lockNodeName != null) {


### PR DESCRIPTION
When seeing tservers that have connection issues, they will eventually get a `SyncConnected` event. 
Noticed this code would be fired if the tserver reconnected to ZK.

This PR adds a log message if watchers were removed after the reconnect event.

Relates to #6044 
