### PR TITLE
Adds binary unit test for VisibilityEvaluator

### DIFF
--- a/core/src/test/java/org/apache/accumulo/core/security/VisibilityEvaluatorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/security/VisibilityEvaluatorTest.java
@@ -132,4 +132,39 @@ public class VisibilityEvaluatorTest {
         ct.evaluate(new ColumnVisibility(quote("五") + "&(" + quote("四") + "|" + quote("三") + ")")));
     assertFalse(ct.evaluate(new ColumnVisibility("\"五\"&(\"四\"|\"三\")")));
   }
+
+  @Test
+  public void testBinary() throws VisibilityParseException {
+    for (int i = 0; i < 256; i++) {
+      if (i == '\\' || i == '"') {
+        // these have to be escaped
+        continue;
+      }
+
+      byte b = (byte) i;
+
+      byte[] exp1 = new byte[] {'"', b, 2, '"', '&', '"', (byte) 250, 6, '"'};
+      byte[] exp2 = new byte[] {'"', b, 2, '"', '|', '"', (byte) 250, 6, '"'};
+
+      var auths1 = new Authorizations(List.of(new byte[] {b, 2}, new byte[] {(byte) 250, 6}));
+      VisibilityEvaluator ve1 = new VisibilityEvaluator(auths1);
+      assertTrue(ve1.evaluate(new ColumnVisibility(exp1)));
+      assertTrue(ve1.evaluate(new ColumnVisibility(exp2)));
+
+      var auths2 = new Authorizations(List.of(new byte[] {b, 2}));
+      VisibilityEvaluator ve2 = new VisibilityEvaluator(auths2);
+      assertFalse(ve2.evaluate(new ColumnVisibility(exp1)));
+      assertTrue(ve2.evaluate(new ColumnVisibility(exp2)));
+
+      var auths3 = new Authorizations(List.of(new byte[] {b, 2, 0}));
+      VisibilityEvaluator ve3 = new VisibilityEvaluator(auths3);
+      assertFalse(ve3.evaluate(new ColumnVisibility(exp1)));
+      assertFalse(ve3.evaluate(new ColumnVisibility(exp2)));
+
+      var bs = new ArrayByteSequence(new byte[] {b, 2});
+      VisibilityEvaluator ve4 = new VisibilityEvaluator(auth -> auth.equals(bs));
+      assertFalse(ve4.evaluate(new ColumnVisibility(exp1)));
+      assertTrue(ve4.evaluate(new ColumnVisibility(exp2)));
+    }
+  }
 }


### PR DESCRIPTION
Pulled this test from #6053 back to 2.1 to ensure this behavior is the same across two very different implementations of VisibilityEvaluator.