### PR TITLE
Override apache-rat-plugin dependency to remove transitive log4j reference

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -969,6 +969,13 @@ under the License.
               <exclude>**/*.rf</exclude>
             </excludes>
           </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>org.apache.maven.doxia</groupId>
+              <artifactId>doxia-site-renderer</artifactId>
+              <version>2.0.0</version>
+            </dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <groupId>net.revelc.code</groupId>


### PR DESCRIPTION
Override the top level dependency for apache-rat-plugin so the transitive reference to log4j:1.12.12 is removed.
This change can be removed once apache-rat-plugin releases their 0.18 version.

We can update the rat version by setting the property `version.apache-rat-plugin` to `0.18` in our project pom.
