### PR TITLE
Fix sorting on bulk import tables in monitor

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/bulkImport.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/bulkImport.js
@@ -50,6 +50,7 @@ $(document).ready(function () {
       "dataSrc": "bulkImport"
     },
     "stateSave": true,
+    "autoWidth": false,
     "columns": [{
         "data": "filename",
         "width": "40%"
@@ -58,12 +59,11 @@ $(document).ready(function () {
         "data": "age",
         "width": "45%",
         "render": function (data, type) {
-          if (type === 'display' && Number(data) > 0) {
-            data = new Date(Number(data));
-          } else {
-            data = "-";
+          var age = Number(data);
+          if (type === 'display') {
+            return age > 0 ? new Date(age) : "-";
           }
-          return data;
+          return age > 0 ? age : 0;
         }
       },
       {
@@ -96,12 +96,11 @@ $(document).ready(function () {
       {
         "data": "oldestAge",
         "render": function (data, type) {
-          if (type === 'display' && Number(data) > 0) {
-            data = new Date(Number(data));
-          } else {
-            data = "-";
+          var age = Number(data);
+          if (type === 'display') {
+            return age > 0 ? new Date(age) : "-";
           }
-          return data;
+          return age > 0 ? age : 0;
         }
       }
     ]


### PR DESCRIPTION
Fixes #6058 

### Main changes here:
* properly interprets the incoming age data so we can correctly sort it in the bulk import tables

When a value was not present for the age, the renderers returned "-" which DataTables could not compare to other values so the order was essentially undefined. Now, we map to a value of 0 for sorting those rows.

I took a quick look through other pages and I don't think this bug exists elsewhere.

### Unrelated to the bug but still fixed:
* made a small change to add `autoWidth=false` which allows the Bulk Import table to properly resize its width while still respecting the defined percentages. Without this, the table would not dynamically resize if the page width changed. Now it aligns with how the other tables in the monitor behave.