### PR TITLE
Update log4j version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@ under the License.
     <version.curator>5.8.0</version.curator>
     <version.errorprone>2.41.0</version.errorprone>
     <version.hadoop>3.3.6</version.hadoop>
-    <version.log4j>2.25.1</version.log4j>
+    <version.log4j>2.25.3</version.log4j>
     <version.opentelemetry>1.48.0</version.opentelemetry>
     <version.powermock>2.0.9</version.powermock>
     <version.slf4j>2.0.17</version.slf4j>


### PR DESCRIPTION
Updates the log4j version to fix CVE-2025-68161

Closes #6063 