### PR TITLE
Add Add RowRange filters to listtablets command

### DIFF
--- a/shell/src/main/java/org/apache/accumulo/shell/commands/GetAvailabilityCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/GetAvailabilityCommand.java
@@ -82,7 +82,7 @@ public class GetAvailabilityCommand extends TableOperation {
     Option optStartRowInclusive =
         new Option(OptUtil.START_ROW_OPT, "begin-row", true, "begin row (inclusive)");
     optStartRowExclusive = new Option("be", "begin-exclusive", false,
-        "make start row exclusive (by default it's inclusive");
+        "make start row exclusive (by default it's inclusive)");
     optStartRowExclusive.setArgName("begin-exclusive");
     optRow = new Option("r", "row", true, "tablet row to read");
     optRow.setArgName("row");

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/GetAvailabilityCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/GetAvailabilityCommand.java
@@ -31,7 +31,6 @@ public class GetAvailabilityCommand extends TableOperation {
 
   private Option optRow;
   private Option optStartRowExclusive;
-  private Option optEndRowExclusive;
   private RowRange range;
 
   @Override
@@ -73,8 +72,7 @@ public class GetAvailabilityCommand extends TableOperation {
       Text startRow = OptUtil.getStartRow(cl);
       Text endRow = OptUtil.getEndRow(cl);
       final boolean startInclusive = !cl.hasOption(optStartRowExclusive.getOpt());
-      final boolean endInclusive = !cl.hasOption(optEndRowExclusive.getOpt());
-      this.range = RowRange.range(startRow, startInclusive, endRow, endInclusive);
+      this.range = RowRange.range(startRow, startInclusive, endRow, true);
     }
     return super.execute(fullCommand, cl, shellState);
   }
@@ -86,9 +84,6 @@ public class GetAvailabilityCommand extends TableOperation {
     optStartRowExclusive = new Option("be", "begin-exclusive", false,
         "make start row exclusive (by default it's inclusive");
     optStartRowExclusive.setArgName("begin-exclusive");
-    optEndRowExclusive = new Option("ee", "end-exclusive", false,
-        "make end row exclusive (by default it's inclusive)");
-    optEndRowExclusive.setArgName("end-exclusive");
     optRow = new Option("r", "row", true, "tablet row to read");
     optRow.setArgName("row");
 
@@ -96,7 +91,6 @@ public class GetAvailabilityCommand extends TableOperation {
     opts.addOption(optStartRowInclusive);
     opts.addOption(optStartRowExclusive);
     opts.addOption(OptUtil.endRowOpt());
-    opts.addOption(optEndRowExclusive);
     opts.addOption(optRow);
 
     return opts;

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ListTabletsCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ListTabletsCommand.java
@@ -273,7 +273,7 @@ public class ListTabletsCommand extends Command {
     Option optStartRowInclusive =
         new Option(OptUtil.START_ROW_OPT, "begin-row", true, "begin row (inclusive)");
     optStartRowExclusive = new Option("be", "begin-exclusive", false,
-        "make start row exclusive (by default it's inclusive");
+        "make start row exclusive (by default it's inclusive)");
     optStartRowExclusive.setArgName("begin-exclusive");
     opts.addOption(optStartRowInclusive);
     opts.addOption(optStartRowExclusive);

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ListTabletsCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ListTabletsCommand.java
@@ -56,7 +56,7 @@ public class ListTabletsCommand extends Command {
   private Option optHumanReadable;
   private Option optNamespace;
   private Option disablePaginationOpt;
-  private Option optStartRowExclusive;
+  private Option startRowExclusiveOpt;
 
   static final String header =
       String.format("%-4s %-15s %-5s %-5s %-9s %-9s %-10s %-30s %-5s %-20s %-20s %-10s", "NUM",
@@ -80,7 +80,7 @@ public class ListTabletsCommand extends Command {
 
       Text startRow = OptUtil.getStartRow(cl);
       Text endRow = OptUtil.getEndRow(cl);
-      final boolean startInclusive = !cl.hasOption(optStartRowExclusive.getOpt());
+      final boolean startInclusive = !cl.hasOption(startRowExclusiveOpt.getOpt());
       final RowRange range = (startRow == null && endRow == null) ? RowRange.all()
           : RowRange.range(startRow, startInclusive, endRow, true);
 
@@ -270,13 +270,13 @@ public class ListTabletsCommand extends Command {
     outputFileOpt.setArgName("file");
     opts.addOption(outputFileOpt);
 
-    Option optStartRowInclusive =
+    Option startRowOpt =
         new Option(OptUtil.START_ROW_OPT, "begin-row", true, "begin row (inclusive)");
-    optStartRowExclusive = new Option("be", "begin-exclusive", false,
+    startRowExclusiveOpt = new Option("be", "begin-exclusive", false,
         "make start row exclusive (by default it's inclusive)");
-    optStartRowExclusive.setArgName("begin-exclusive");
-    opts.addOption(optStartRowInclusive);
-    opts.addOption(optStartRowExclusive);
+    startRowExclusiveOpt.setArgName("begin-exclusive");
+    opts.addOption(startRowOpt);
+    opts.addOption(startRowExclusiveOpt);
     opts.addOption(OptUtil.endRowOpt());
 
     return opts;

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
@@ -1300,6 +1300,12 @@ public class ShellServerIT extends SharedMiniClusterBase {
       assertTrue(result.matches("(?s).*" + tableId + ";s;m\\s+HOSTED.*"));
       assertFalse(result.matches("(?s).*" + tableId + "<;s\\s+ONDEMAND.*"));
 
+      result = ts.exec("getavailability -e m");
+      assertTrue(result.matches("(?s).*" + tableId + ";d<\\s+ONDEMAND.*"));
+      assertTrue(result.matches("(?s).*" + tableId + ";m;d\\s+ONDEMAND.*"));
+      assertFalse(result.matches("(?s).*" + tableId + ";s;m\\s+HOSTED.*"));
+      assertFalse(result.matches("(?s).*" + tableId + "<;s\\s+ONDEMAND.*"));
+
     } finally {
       if (splitsFilePath != null) {
         Files.delete(splitsFilePath);
@@ -2384,6 +2390,38 @@ public class ShellServerIT extends SharedMiniClusterBase {
         results.contains(tableId2 + "     m                    t                    HOSTED"));
     assertTrue(
         results.contains(tableId2 + "     t                    +INF                 ONDEMAND"));
+
+    String filtered = ts.exec("listtablets -np -t " + table1 + " -b h -e t", true);
+    assertTrue(
+        filtered.contains(tableId1 + "     g                    n                    ONDEMAND"));
+    assertTrue(
+        filtered.contains(tableId1 + "     n                    u                    HOSTED"));
+    assertFalse(filtered.contains(tableId1 + "     -INF                 g"));
+    assertFalse(filtered.contains(tableId1 + "     u                    +INF"));
+
+    filtered = ts.exec("listtablets -np -t " + table1 + " -b n", true);
+    assertFalse(filtered.contains(tableId1 + "     -INF                 g"));
+    assertTrue(
+        filtered.contains(tableId1 + "     g                    n                    ONDEMAND"));
+    assertTrue(
+        filtered.contains(tableId1 + "     n                    u                    HOSTED"));
+    assertTrue(
+        filtered.contains(tableId1 + "     u                    +INF                 ONDEMAND"));
+
+    filtered = ts.exec("listtablets -np -t " + table1 + " -e n", true);
+    assertTrue(
+        filtered.contains(tableId1 + "     -INF                 g                    HOSTED"));
+    assertTrue(
+        filtered.contains(tableId1 + "     g                    n                    ONDEMAND"));
+    assertFalse(
+        filtered.contains(tableId1 + "     n                    u                    HOSTED"));
+    assertFalse(filtered.contains(tableId1 + "     u                    +INF"));
+
+    filtered = ts.exec("listtablets -np -t " + table1 + " -b n -be", true);
+    assertFalse(filtered.contains(tableId1 + "     -INF                 g"));
+    assertFalse(filtered.contains(tableId1 + "     g                    n"));
+    assertTrue(filtered.contains(tableId1 + "     n                    u"));
+    assertTrue(filtered.contains(tableId1 + "     u                    +INF"));
 
     // verify the sum of the tablets sizes, number of entries, and dir name match the data in a
     // metadata scan


### PR DESCRIPTION
Fixes #6035 
This PR adds new options to the `listtablets` command and also removed one from the `getavailability` command.

Added row range filtering to `listtablets` matching what `getavailability` already supports:
```
  -b,--begin-row <arg>            begin row (inclusive)
  -be,--begin-exclusive           make start row exclusive (by default it's inclusive)
  -e,--end-row <end-row>          end row (inclusive)
```

The `-ee`/`--end-exclusive` option was removed from `getavailability` since it was not being used anyways. Ultimately both `listtablets` and `getavailability` call this portion of the code which just sets end exclusive to true:
https://github.com/apache/accumulo/blob/3dfe28e8e1774a143c86edbeb645ea3ac301cdd5/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java#L415-L425