### PR TITLE
Fixes lock check for prune exclude actions

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ServiceLock.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ServiceLock.java
@@ -785,7 +785,7 @@ public class ServiceLock implements Watcher {
 
   }
 
-  public static void removeLock(ZooReaderWriter zoo, String path,
+  public static void deleteLock(ZooReaderWriter zoo, String path,
       ServerServices.Service serviceType, Predicate<HostAndPort> hostPortPredicate,
       Consumer<String> messageOutput, Boolean dryRun) throws KeeperException, InterruptedException {
     var lockData = ServiceLock.getLockData(zoo.getZooKeeper(), ServiceLock.path(path));

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
@@ -179,7 +179,7 @@ public class ZooZap implements KeywordExecutable {
     if (opts.zapGc) {
       String gcLockPath = Constants.ZROOT + "/" + iid + Constants.ZGC_LOCK;
       try {
-        ServiceLock.removeLock(zoo, gcLockPath, ServerServices.Service.GC_CLIENT, hostPortPredicate,
+        ServiceLock.deleteLock(zoo, gcLockPath, ServerServices.Service.GC_CLIENT, hostPortPredicate,
             m -> message(m, opts), opts.dryRun);
       } catch (KeeperException | InterruptedException e) {
         log.error("Error deleting gc lock", e);


### PR DESCRIPTION
Correctly checks the lock format so that exclude options for the prune command work correctly.

Closes #6076 