### PR TITLE
Fix TableDiskUsage Options

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/util/TableDiskUsage.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/TableDiskUsage.java
@@ -320,8 +320,8 @@ public class TableDiskUsage {
   }
 
   static class Opts extends ServerUtilOpts {
-    @Parameter(description = " <table> { <table> ... } ")
-    final List<String> tables = new ArrayList<>();
+    @Parameter(required = true, description = " <table> { <table> ... } ")
+    List<String> tables = new ArrayList<>();
   }
 
   public static void main(String[] args) throws Exception {


### PR DESCRIPTION
Set the required annotation parameter so that
it shows up in the help/usage output. Remove
the final modifier from the variable that
makes the variable unusable.

Closes #6100