### PR TITLE
Backport Bulk Import test to 2.1

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
@@ -731,7 +731,7 @@ public class BulkNewIT extends SharedMiniClusterBase {
 
       final int numTasks = 16;
       var executor = Executors.newFixedThreadPool(numTasks);
-      var futures = new ArrayList<Future<?>>(numTasks);
+      var futures = new ArrayList<Future<?>>();
       // wait for a portion of the tasks to be ready
       CountDownLatch startLatch = new CountDownLatch(numTasks);
       assertTrue(numTasks >= startLatch.getCount(),


### PR DESCRIPTION
Closes [Issue #5046 ](https://github.com/apache/accumulo/issues/5046)
I added the `testManyTabletAndFiles()` test from main to the 2.1 branch. The test provides coverage for bulk import with many files. 