### PR TITLE
Add back manager goal state to monitor

### DIFF
--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/serializers/FMetricSerializer.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/serializers/FMetricSerializer.java
@@ -47,12 +47,12 @@ public class FMetricSerializer extends JsonSerializer<FMetric> {
       gen.writeEndObject();
     }
     gen.writeEndArray();
-    // Write the non-zero number as the value
-    if (fm.lvalue() > 0) {
-      gen.writeNumberField("value", fm.lvalue());
-    } else if (fm.ivalue() > 0) {
+    // Write the number as the value (preserve negatives)
+    if (fm.ivalue() != 0) {
       gen.writeNumberField("value", fm.ivalue());
-    } else if (fm.dvalue() > 0.0d) {
+    } else if (fm.lvalue() != 0L) {
+      gen.writeNumberField("value", fm.lvalue());
+    } else if (fm.dvalue() != 0.0d) {
       gen.writeNumberField("value", fm.dvalue());
     } else {
       gen.writeNumberField("value", 0);

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/serializers/MetricResponseSerializer.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/serializers/MetricResponseSerializer.java
@@ -54,12 +54,12 @@ public class MetricResponseSerializer extends JsonSerializer<MetricResponse> {
           gen.writeEndObject();
         }
         gen.writeEndArray();
-        // Write the non-zero number as the value
-        if (fm.lvalue() > 0) {
-          gen.writeNumberField("value", fm.lvalue());
-        } else if (fm.ivalue() > 0) {
+        // Write the number as the value (preserve negatives)
+        if (fm.ivalue() != 0) {
           gen.writeNumberField("value", fm.ivalue());
-        } else if (fm.dvalue() > 0.0d) {
+        } else if (fm.lvalue() != 0L) {
+          gen.writeNumberField("value", fm.lvalue());
+        } else if (fm.dvalue() != 0.0d) {
           gen.writeNumberField("value", fm.dvalue());
         } else {
           gen.writeNumberField("value", 0);

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/manager.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/manager.js
@@ -19,7 +19,7 @@
 /* JSLint global definitions */
 /*global
     $, document, sessionStorage, getManager, bigNumberForQuantity,
-    timeDuration, dateFormat, getStatus, ajaxReloadTable
+    timeDuration, dateFormat, getStatus, ajaxReloadTable, getManagerGoalStateFromSession
 */
 "use strict";
 
@@ -88,11 +88,25 @@ function refreshManagerBanners() {
     // show the manager error banner and hide manager table
     $('#managerRunningBanner').show();
     $('#managerStatusTable').hide();
+    $('#managerStateBanner').hide();
   } else {
     // otherwise, hide the error banner and show manager table
     $('#managerRunningBanner').hide();
     $('#managerStatusTable').show();
+    updateManagerGoalStateBanner();
   }
+}
+
+function updateManagerGoalStateBanner() {
+  getManager().always(function () {
+    const goalState = getManagerGoalStateFromSession();
+    if (goalState === 'SAFE_MODE' || goalState === 'CLEAN_STOP') {
+      $('#manager-banner-message').text('Manager goal state: ' + goalState);
+      $('#managerStateBanner').show();
+    } else {
+      $('#managerStateBanner').hide();
+    }
+  });
 }
 
 /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/manager.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/manager.ftl
@@ -26,6 +26,9 @@
     <div id="managerRunningBanner" style="display: none;">
         <div class="alert alert-danger" role="alert">Manager Server Not Running</div>
     </div>
+    <div id="managerStateBanner" style="display: none;">
+        <div id="manager-banner-message" class="alert alert-warning" role="alert"></div>
+    </div>
     <table id="managerStatusTable" class="table caption-top table-bordered table-striped table-condensed">
         <caption><span class="table-caption">${title}</span><br /></caption>
         <thead>


### PR DESCRIPTION
fixes #6105 
Use the manager goal state to affect the status LED in the navbar and show it on the manager page when the goal state is not `NORMAL`:

<img width="1583" height="306" alt="Screenshot from 2026-02-05 15-22-55" src="https://github.com/user-attachments/assets/6b853d44-8af1-4841-af62-917652cfda63" />
<img width="1583" height="306" alt="Screenshot from 2026-02-05 15-22-41" src="https://github.com/user-attachments/assets/853a8545-52be-468c-b7f3-97c039e21897" />
<img width="1583" height="306" alt="Screenshot from 2026-02-05 15-22-09" src="https://github.com/user-attachments/assets/bd8113c2-d81c-49dd-b85c-e75bad87a4e0" />
