### PR TITLE
fails on iterator configuration conflicts

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/NamespaceOperationsHelper.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/NamespaceOperationsHelper.java
@@ -148,8 +148,7 @@ public abstract class NamespaceOperationsHelper implements NamespaceOperations {
       throw new NamespaceNotFoundException(null, namespace, null);
     }
     var props = this.getNamespaceProperties(namespace);
-    IteratorConfigUtil.checkIteratorConflicts("namespace:" + namespace, props, setting, scopes,
-        true);
+    IteratorConfigUtil.checkIteratorConflicts("namespace:" + namespace, props, setting, scopes);
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsHelper.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsHelper.java
@@ -140,7 +140,7 @@ public abstract class TableOperationsHelper implements TableOperations {
       EnumSet<IteratorScope> scopes) throws AccumuloException {
     checkArgument(setting != null, "setting is null");
     checkArgument(scopes != null, "scopes is null");
-    IteratorConfigUtil.checkIteratorConflicts("", props, setting, scopes, true);
+    IteratorConfigUtil.checkIteratorConflicts("", props, setting, scopes);
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/IteratorConfigUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/IteratorConfigUtil.java
@@ -288,8 +288,9 @@ public class IteratorConfigUtil {
           // properties.
           if (iterProps.stream()
               .anyMatch(iterProp -> newProperties.containsKey(iterProp.getProperty()))) {
-            log.warn("For {}, newly set property introduced an iterator priority conflict : {}",
-                errorContext, iterProps);
+            throw new IllegalArgumentException(String.format(
+                "For %s, newly set property introduced an iterator priority conflict : %s",
+                errorContext, iterProps));
           }
         }
       });
@@ -298,8 +299,7 @@ public class IteratorConfigUtil {
 
   public static void checkIteratorConflicts(String logContext, IteratorSetting iterToCheck,
       EnumSet<IteratorScope> iterScopesToCheck,
-      Map<IteratorScope,List<IteratorSetting>> existingIters, boolean shouldThrow)
-      throws AccumuloException {
+      Map<IteratorScope,List<IteratorSetting>> existingIters) throws AccumuloException {
     // The reason for the 'shouldThrow' var is to prevent newly added 2.x checks from breaking
     // existing user code. Just log the problem and proceed. Major version > 2 will always throw
     for (var scope : iterScopesToCheck) {
@@ -316,28 +316,20 @@ public class IteratorConfigUtil {
           String msg =
               String.format("%s iterator name conflict at %s scope. %s conflicts with existing %s",
                   logContext, scope, iterToCheck, existingIter);
-          if (shouldThrow) {
-            throw new AccumuloException(new IllegalArgumentException(msg));
-          } else {
-            log.warn(msg + WARNING_MSG);
-          }
+          throw new AccumuloException(new IllegalArgumentException(msg));
         }
         if (iterToCheck.getPriority() == existingIter.getPriority()) {
           String msg = String.format(
               "%s iterator priority conflict at %s scope. %s conflicts with existing %s",
               logContext, scope, iterToCheck, existingIter);
-          if (shouldThrow) {
-            throw new AccumuloException(new IllegalArgumentException(msg));
-          } else {
-            log.warn(msg + WARNING_MSG);
-          }
+          throw new AccumuloException(new IllegalArgumentException(msg));
         }
       }
     }
   }
 
   public static void checkIteratorConflicts(String logContext, Map<String,String> props,
-      IteratorSetting iterToCheck, EnumSet<IteratorScope> iterScopesToCheck, boolean shouldThrow)
+      IteratorSetting iterToCheck, EnumSet<IteratorScope> iterScopesToCheck)
       throws AccumuloException {
     // parse the props map
     Map<IteratorScope,Map<String,IteratorSetting>> iteratorSettings = new HashMap<>();
@@ -368,11 +360,7 @@ public class IteratorConfigUtil {
             String msg = String.format(
                 "%s iterator name conflict at %s scope. %s conflicts with existing %s", logContext,
                 iterProp.getScope(), iterToCheck, iterProp);
-            if (shouldThrow) {
-              throw new AccumuloException(new IllegalArgumentException(msg));
-            } else {
-              log.warn(msg + WARNING_MSG);
-            }
+            throw new AccumuloException(new IllegalArgumentException(msg));
           }
         } else {
           iterSetting.addOption(iterProp.getOptionKey(), iterProp.getOptionValue());
@@ -381,6 +369,6 @@ public class IteratorConfigUtil {
     }
 
     // check if the given iterator conflicts with any existing iterators
-    checkIteratorConflicts(logContext, iterToCheck, iterScopesToCheck, existingIters, shouldThrow);
+    checkIteratorConflicts(logContext, iterToCheck, iterScopesToCheck, existingIters);
   }
 }

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/ManagerClientService.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/ManagerClientService.java
@@ -41,7 +41,7 @@ public class ManagerClientService {
 
     public void setNamespaceProperty(org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String ns, java.lang.String property, java.lang.String value) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException, ThriftPropertyException, org.apache.thrift.TException;
 
-    public void modifyNamespaceProperties(org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String ns, org.apache.accumulo.core.clientImpl.thrift.TVersionedProperties vProperties) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException, org.apache.accumulo.core.clientImpl.thrift.ThriftConcurrentModificationException, org.apache.thrift.TException;
+    public void modifyNamespaceProperties(org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String ns, org.apache.accumulo.core.clientImpl.thrift.TVersionedProperties vProperties) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException, org.apache.accumulo.core.clientImpl.thrift.ThriftConcurrentModificationException, ThriftPropertyException, org.apache.thrift.TException;
 
     public void removeNamespaceProperty(org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String ns, java.lang.String property) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException, org.apache.thrift.TException;
 
@@ -387,7 +387,7 @@ public class ManagerClientService {
     }
 
     @Override
-    public void modifyNamespaceProperties(org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String ns, org.apache.accumulo.core.clientImpl.thrift.TVersionedProperties vProperties) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException, org.apache.accumulo.core.clientImpl.thrift.ThriftConcurrentModificationException, org.apache.thrift.TException
+    public void modifyNamespaceProperties(org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String ns, org.apache.accumulo.core.clientImpl.thrift.TVersionedProperties vProperties) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException, org.apache.accumulo.core.clientImpl.thrift.ThriftConcurrentModificationException, ThriftPropertyException, org.apache.thrift.TException
     {
       send_modifyNamespaceProperties(tinfo, credentials, ns, vProperties);
       recv_modifyNamespaceProperties();
@@ -403,7 +403,7 @@ public class ManagerClientService {
       sendBase("modifyNamespaceProperties", args);
     }
 
-    public void recv_modifyNamespaceProperties() throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException, org.apache.accumulo.core.clientImpl.thrift.ThriftConcurrentModificationException, org.apache.thrift.TException
+    public void recv_modifyNamespaceProperties() throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException, org.apache.accumulo.core.clientImpl.thrift.ThriftConcurrentModificationException, ThriftPropertyException, org.apache.thrift.TException
     {
       modifyNamespaceProperties_result result = new modifyNamespaceProperties_result();
       receiveBase(result, "modifyNamespaceProperties");
@@ -418,6 +418,9 @@ public class ManagerClientService {
       }
       if (result.tcme != null) {
         throw result.tcme;
+      }
+      if (result.tpe != null) {
+        throw result.tpe;
       }
       return;
     }
@@ -1400,7 +1403,7 @@ public class ManagerClientService {
       }
 
       @Override
-      public Void getResult() throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException, org.apache.accumulo.core.clientImpl.thrift.ThriftConcurrentModificationException, org.apache.thrift.TException {
+      public Void getResult() throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException, org.apache.accumulo.core.clientImpl.thrift.ThriftConcurrentModificationException, ThriftPropertyException, org.apache.thrift.TException {
         if (getState() != org.apache.thrift.async.TAsyncMethodCall.State.RESPONSE_READ) {
           throw new java.lang.IllegalStateException("Method call not finished!");
         }
@@ -2610,6 +2613,8 @@ public class ManagerClientService {
           result.tnase = tnase;
         } catch (org.apache.accumulo.core.clientImpl.thrift.ThriftConcurrentModificationException tcme) {
           result.tcme = tcme;
+        } catch (ThriftPropertyException tpe) {
+          result.tpe = tpe;
         }
         return result;
       }
@@ -3918,6 +3923,10 @@ public class ManagerClientService {
             } else if (e instanceof org.apache.accumulo.core.clientImpl.thrift.ThriftConcurrentModificationException) {
               result.tcme = (org.apache.accumulo.core.clientImpl.thrift.ThriftConcurrentModificationException) e;
               result.setTcmeIsSet(true);
+              msg = result;
+            } else if (e instanceof ThriftPropertyException) {
+              result.tpe = (ThriftPropertyException) e;
+              result.setTpeIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
               _LOGGER.error("TTransportException inside handler", e);
@@ -14989,6 +14998,7 @@ public class ManagerClientService {
     private static final org.apache.thrift.protocol.TField TOPE_FIELD_DESC = new org.apache.thrift.protocol.TField("tope", org.apache.thrift.protocol.TType.STRUCT, (short)2);
     private static final org.apache.thrift.protocol.TField TNASE_FIELD_DESC = new org.apache.thrift.protocol.TField("tnase", org.apache.thrift.protocol.TType.STRUCT, (short)3);
     private static final org.apache.thrift.protocol.TField TCME_FIELD_DESC = new org.apache.thrift.protocol.TField("tcme", org.apache.thrift.protocol.TType.STRUCT, (short)4);
+    private static final org.apache.thrift.protocol.TField TPE_FIELD_DESC = new org.apache.thrift.protocol.TField("tpe", org.apache.thrift.protocol.TType.STRUCT, (short)5);
 
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new modifyNamespaceProperties_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new modifyNamespaceProperties_resultTupleSchemeFactory();
@@ -14997,13 +15007,15 @@ public class ManagerClientService {
     public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException tope; // required
     public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
     public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftConcurrentModificationException tcme; // required
+    public @org.apache.thrift.annotation.Nullable ThriftPropertyException tpe; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
       SEC((short)1, "sec"),
       TOPE((short)2, "tope"),
       TNASE((short)3, "tnase"),
-      TCME((short)4, "tcme");
+      TCME((short)4, "tcme"),
+      TPE((short)5, "tpe");
 
       private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -15027,6 +15039,8 @@ public class ManagerClientService {
             return TNASE;
           case 4: // TCME
             return TCME;
+          case 5: // TPE
+            return TPE;
           default:
             return null;
         }
@@ -15081,6 +15095,8 @@ public class ManagerClientService {
           new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException.class)));
       tmpMap.put(_Fields.TCME, new org.apache.thrift.meta_data.FieldMetaData("tcme", org.apache.thrift.TFieldRequirementType.DEFAULT, 
           new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, org.apache.accumulo.core.clientImpl.thrift.ThriftConcurrentModificationException.class)));
+      tmpMap.put(_Fields.TPE, new org.apache.thrift.meta_data.FieldMetaData("tpe", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, ThriftPropertyException.class)));
       metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(modifyNamespaceProperties_result.class, metaDataMap);
     }
@@ -15092,13 +15108,15 @@ public class ManagerClientService {
       org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec,
       org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException tope,
       org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase,
-      org.apache.accumulo.core.clientImpl.thrift.ThriftConcurrentModificationException tcme)
+      org.apache.accumulo.core.clientImpl.thrift.ThriftConcurrentModificationException tcme,
+      ThriftPropertyException tpe)
     {
       this();
       this.sec = sec;
       this.tope = tope;
       this.tnase = tnase;
       this.tcme = tcme;
+      this.tpe = tpe;
     }
 
     /**
@@ -15117,6 +15135,9 @@ public class ManagerClientService {
       if (other.isSetTcme()) {
         this.tcme = new org.apache.accumulo.core.clientImpl.thrift.ThriftConcurrentModificationException(other.tcme);
       }
+      if (other.isSetTpe()) {
+        this.tpe = new ThriftPropertyException(other.tpe);
+      }
     }
 
     @Override
@@ -15130,6 +15151,7 @@ public class ManagerClientService {
       this.tope = null;
       this.tnase = null;
       this.tcme = null;
+      this.tpe = null;
     }
 
     @org.apache.thrift.annotation.Nullable
@@ -15232,6 +15254,31 @@ public class ManagerClientService {
       }
     }
 
+    @org.apache.thrift.annotation.Nullable
+    public ThriftPropertyException getTpe() {
+      return this.tpe;
+    }
+
+    public modifyNamespaceProperties_result setTpe(@org.apache.thrift.annotation.Nullable ThriftPropertyException tpe) {
+      this.tpe = tpe;
+      return this;
+    }
+
+    public void unsetTpe() {
+      this.tpe = null;
+    }
+
+    /** Returns true if field tpe is set (has been assigned a value) and false otherwise */
+    public boolean isSetTpe() {
+      return this.tpe != null;
+    }
+
+    public void setTpeIsSet(boolean value) {
+      if (!value) {
+        this.tpe = null;
+      }
+    }
+
     @Override
     public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
       switch (field) {
@@ -15267,6 +15314,14 @@ public class ManagerClientService {
         }
         break;
 
+      case TPE:
+        if (value == null) {
+          unsetTpe();
+        } else {
+          setTpe((ThriftPropertyException)value);
+        }
+        break;
+
       }
     }
 
@@ -15285,6 +15340,9 @@ public class ManagerClientService {
 
       case TCME:
         return getTcme();
+
+      case TPE:
+        return getTpe();
 
       }
       throw new java.lang.IllegalStateException();
@@ -15306,6 +15364,8 @@ public class ManagerClientService {
         return isSetTnase();
       case TCME:
         return isSetTcme();
+      case TPE:
+        return isSetTpe();
       }
       throw new java.lang.IllegalStateException();
     }
@@ -15359,6 +15419,15 @@ public class ManagerClientService {
           return false;
       }
 
+      boolean this_present_tpe = true && this.isSetTpe();
+      boolean that_present_tpe = true && that.isSetTpe();
+      if (this_present_tpe || that_present_tpe) {
+        if (!(this_present_tpe && that_present_tpe))
+          return false;
+        if (!this.tpe.equals(that.tpe))
+          return false;
+      }
+
       return true;
     }
 
@@ -15381,6 +15450,10 @@ public class ManagerClientService {
       hashCode = hashCode * 8191 + ((isSetTcme()) ? 131071 : 524287);
       if (isSetTcme())
         hashCode = hashCode * 8191 + tcme.hashCode();
+
+      hashCode = hashCode * 8191 + ((isSetTpe()) ? 131071 : 524287);
+      if (isSetTpe())
+        hashCode = hashCode * 8191 + tpe.hashCode();
 
       return hashCode;
     }
@@ -15429,6 +15502,16 @@ public class ManagerClientService {
       }
       if (isSetTcme()) {
         lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.tcme, other.tcme);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
+      lastComparison = java.lang.Boolean.compare(isSetTpe(), other.isSetTpe());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (isSetTpe()) {
+        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.tpe, other.tpe);
         if (lastComparison != 0) {
           return lastComparison;
         }
@@ -15485,6 +15568,14 @@ public class ManagerClientService {
         sb.append("null");
       } else {
         sb.append(this.tcme);
+      }
+      first = false;
+      if (!first) sb.append(", ");
+      sb.append("tpe:");
+      if (this.tpe == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.tpe);
       }
       first = false;
       sb.append(")");
@@ -15568,6 +15659,15 @@ public class ManagerClientService {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
+            case 5: // TPE
+              if (schemeField.type == org.apache.thrift.protocol.TType.STRUCT) {
+                struct.tpe = new ThriftPropertyException();
+                struct.tpe.read(iprot);
+                struct.setTpeIsSet(true);
+              } else { 
+                org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+              }
+              break;
             default:
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
           }
@@ -15604,6 +15704,11 @@ public class ManagerClientService {
           struct.tcme.write(oprot);
           oprot.writeFieldEnd();
         }
+        if (struct.tpe != null) {
+          oprot.writeFieldBegin(TPE_FIELD_DESC);
+          struct.tpe.write(oprot);
+          oprot.writeFieldEnd();
+        }
         oprot.writeFieldStop();
         oprot.writeStructEnd();
       }
@@ -15635,7 +15740,10 @@ public class ManagerClientService {
         if (struct.isSetTcme()) {
           optionals.set(3);
         }
-        oprot.writeBitSet(optionals, 4);
+        if (struct.isSetTpe()) {
+          optionals.set(4);
+        }
+        oprot.writeBitSet(optionals, 5);
         if (struct.isSetSec()) {
           struct.sec.write(oprot);
         }
@@ -15648,12 +15756,15 @@ public class ManagerClientService {
         if (struct.isSetTcme()) {
           struct.tcme.write(oprot);
         }
+        if (struct.isSetTpe()) {
+          struct.tpe.write(oprot);
+        }
       }
 
       @Override
       public void read(org.apache.thrift.protocol.TProtocol prot, modifyNamespaceProperties_result struct) throws org.apache.thrift.TException {
         org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
-        java.util.BitSet incoming = iprot.readBitSet(4);
+        java.util.BitSet incoming = iprot.readBitSet(5);
         if (incoming.get(0)) {
           struct.sec = new org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException();
           struct.sec.read(iprot);
@@ -15673,6 +15784,11 @@ public class ManagerClientService {
           struct.tcme = new org.apache.accumulo.core.clientImpl.thrift.ThriftConcurrentModificationException();
           struct.tcme.read(iprot);
           struct.setTcmeIsSet(true);
+        }
+        if (incoming.get(4)) {
+          struct.tpe = new ThriftPropertyException();
+          struct.tpe.read(iprot);
+          struct.setTpeIsSet(true);
         }
       }
     }

--- a/core/src/main/thrift/manager.thrift
+++ b/core/src/main/thrift/manager.thrift
@@ -329,6 +329,7 @@ service ManagerClientService {
     2:client.ThriftTableOperationException tope
     3:client.ThriftNotActiveServiceException tnase
     4:client.ThriftConcurrentModificationException tcme
+    5:ThriftPropertyException tpe
   )
 
   void removeNamespaceProperty(

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfiguration.java
@@ -80,8 +80,8 @@ public class TableConfiguration extends ZooBasedConfiguration {
             // This code assumes the list of iterators is sorted on priority
             Preconditions.checkState(last.getPriority() <= curr.getPriority());
             if (last.getPriority() == curr.getPriority()) {
-              // duplicate priority
-              log.warn("iterator priority conflict seen for tableId:{} {} {}", tableId, last, curr);
+              throw new IllegalStateException(String.format(
+                  "iterator priority conflict seen for tableId:%s %s %s", tableId, last, curr));
             }
           }
         }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
@@ -238,8 +238,13 @@ class FateServiceHandler implements FateService.Iface {
 
         var namespaceIterProps = manager.getContext().getNamespaceConfiguration(namespaceId)
             .getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_PREFIX);
-        IteratorConfigUtil.checkIteratorPriorityConflicts("create table:" + tableName, options,
-            namespaceIterProps);
+        try {
+          IteratorConfigUtil.checkIteratorPriorityConflicts("create table:" + tableName, options,
+              namespaceIterProps);
+        } catch (IllegalArgumentException iae) {
+          throw new ThriftTableOperationException(null, tableName, tableOp,
+              TableOperationExceptionType.OTHER, iae.getMessage());
+        }
         for (Map.Entry<String,String> entry : options.entrySet()) {
           validateTableProperty(entry.getKey(), entry.getValue(), tableName, tableOp);
         }
@@ -351,9 +356,14 @@ class FateServiceHandler implements FateService.Iface {
         srcTableProps.keySet().removeAll(propertiesToExclude);
         var namespaceProps = manager.getContext().getNamespaceConfiguration(namespaceId)
             .getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_PREFIX);
-        IteratorConfigUtil.checkIteratorPriorityConflicts(
-            "clone table source tableId:" + srcTableId + " tablename:" + tableName, srcTableProps,
-            namespaceProps);
+        try {
+          IteratorConfigUtil.checkIteratorPriorityConflicts(
+              "clone table source tableId:" + srcTableId + " tablename:" + tableName, srcTableProps,
+              namespaceProps);
+        } catch (IllegalArgumentException iae) {
+          throw new ThriftTableOperationException(null, tableName, tableOp,
+              TableOperationExceptionType.OTHER, iae.getMessage());
+        }
 
         goalMessage += "Clone table " + srcTableId + " to " + tableName;
         if (keepOffline) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
@@ -265,8 +265,7 @@ class ScanDataSource implements DataSource {
               IteratorConfigUtil.checkIteratorConflicts(tablet.getExtent().toString(),
                   getIteratorSetting(scanParamIterInfo,
                       scanParams.getSsio().get(scanParamIterInfo.getIterName())),
-                  EnumSet.of(IteratorScope.scan), Map.of(IteratorScope.scan, picIteratorSettings),
-                  false);
+                  EnumSet.of(IteratorScope.scan), Map.of(IteratorScope.scan, picIteratorSettings));
             } catch (AccumuloException e) {
               throw new IllegalArgumentException(e);
             }

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -172,14 +172,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.thrift</groupId>
       <artifactId>libthrift</artifactId>
     </dependency>


### PR DESCRIPTION
This is a follow on issue to #6040 that makes all code fail when detecting iterator conflicts instead of logging at warn.