### PR TITLE
avoids creating lots of site config on startup

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/util/ServerKeywordExecutable.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ServerKeywordExecutable.java
@@ -38,7 +38,7 @@ public abstract class ServerKeywordExecutable<OPTS extends ServerOpts>
   }
 
   public synchronized ServerContext getServerContext() {
-    if(context == null){
+    if (context == null) {
       context = new ServerContext(SiteConfiguration.auto());
     }
 


### PR DESCRIPTION
When running ITs noticed a lot of log message about creating site configuration objects.  Tracked it down to key word executables being autoloaded and in their constructor creating a site config.  Moved the the site config creation out of the constructor.