### PR TITLE
fixes spurious exception in tests

### DIFF
--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterControl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterControl.java
@@ -37,6 +37,7 @@ import java.util.concurrent.TimeoutException;
 import org.apache.accumulo.cluster.ClusterControl;
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.data.ResourceGroupId;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl.ProcessInfo;
@@ -312,6 +313,8 @@ public class MiniAccumuloClusterControl implements ClusterControl {
           try {
             cluster.stopProcessWithTimeout(managerProcess, 30, TimeUnit.SECONDS);
             try {
+              System.setProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY,
+                  "file://" + this.cluster.getAccumuloPropertiesPath());
               new ZooZap().execute(new String[] {"-manager"});
             } catch (Exception e) {
               log.error("Error zapping Manager zookeeper lock", e);


### PR DESCRIPTION
Seeing exceptions like the following when running ITs.  This exception does not cause the test to fail,  it is just printed after the test runs.  The reason it happens is the code ServerKeywordExecutable.getConfiguration() is run w/o the java system property for accumulo.properties set.   So it searches and finds `test/src/main/resources/accumulo.properties` on the classpath which does not contain `instance.volumes`.    This fix sets the java system property so that accumulo.properties created by mini is found.  Opening this as draft for the moment because I am not sure if this is the best way to fix this (feels a bit hacky). 

```
java.lang.IllegalArgumentException: Missing required property instance.volumes
	at org.apache.accumulo.core.volume.VolumeConfiguration.getVolumeUris(VolumeConfiguration.java:41)
	at org.apache.accumulo.server.fs.VolumeManagerImpl.get(VolumeManagerImpl.java:435)
	at org.apache.accumulo.server.ServerInfo.lambda$new$10(ServerInfo.java:132)
	at com.google.common.base.Suppliers$NonSerializableMemoizingSupplier.get(Suppliers.java:198)
	at org.apache.accumulo.server.ServerInfo.getVolumeManager(ServerInfo.java:156)
	at org.apache.accumulo.server.ServerInfo.lambda$fromServerConfig$3(ServerInfo.java:66)
	at org.apache.accumulo.server.ServerInfo.lambda$new$16(ServerInfo.java:147)
	at com.google.common.base.Suppliers$NonSerializableMemoizingSupplier.get(Suppliers.java:198)
	at org.apache.accumulo.server.ServerInfo.getInstanceId(ServerInfo.java:161)
	at org.apache.accumulo.server.ServerInfo.lambda$new$12(ServerInfo.java:139)
	at com.google.common.base.Suppliers$NonSerializableMemoizingSupplier.get(Suppliers.java:198)
	at org.apache.accumulo.server.ServerInfo.getCredentials(ServerInfo.java:212)
	at org.apache.accumulo.server.ServerInfo.getPrincipal(ServerInfo.java:181)
	at org.apache.accumulo.core.clientImpl.ClientContext.lambda$new$1(ClientContext.java:263)
	at com.google.common.base.Suppliers$NonSerializableMemoizingSupplier.get(Suppliers.java:198)
	at org.apache.accumulo.core.clientImpl.ClientContext.getZooSession(ClientContext.java:1160)
	at org.apache.accumulo.server.ServerContext.lambda$new$0(ServerContext.java:138)
	at com.google.common.base.Suppliers$NonSerializableMemoizingSupplier.get(Suppliers.java:198)
	at org.apache.accumulo.server.ServerContext.getPropStore(ServerContext.java:463)
	at org.apache.accumulo.server.conf.ZooBasedConfiguration.<init>(ZooBasedConfiguration.java:63)
	at org.apache.accumulo.server.conf.SystemConfiguration.<init>(SystemConfiguration.java:36)
	at org.apache.accumulo.server.conf.ServerConfigurationFactory.lambda$new$0(ServerConfigurationFactory.java:87)
	at com.google.common.base.Suppliers$NonSerializableMemoizingSupplier.get(Suppliers.java:198)
	at org.apache.accumulo.server.conf.ServerConfigurationFactory.getSystemConfiguration(ServerConfigurationFactory.java:126)
	at org.apache.accumulo.server.conf.ServerConfigurationFactory.lambda$new$1(ServerConfigurationFactory.java:93)
	at com.google.common.base.Suppliers$NonSerializableMemoizingSupplier.get(Suppliers.java:198)
	at org.apache.accumulo.server.conf.ServerConfigurationFactory.getResourceGroupConfiguration(ServerConfigurationFactory.java:121)
	at org.apache.accumulo.server.ServerContext.getConfiguration(ServerContext.java:194)
	at org.apache.accumulo.server.util.ServerKeywordExecutable.doExecute(ServerKeywordExecutable.java:56)
	at org.apache.accumulo.server.util.ServerKeywordExecutable.doExecute(ServerKeywordExecutable.java:31)
	at org.apache.accumulo.core.cli.BaseKeywordExecutable.execute(BaseKeywordExecutable.java:50)
	at org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterControl.stop(MiniAccumuloClusterControl.java:318)
	at org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl.stop(MiniAccumuloClusterImpl.java:1021)
	at org.apache.accumulo.harness.AccumuloClusterHarness.teardownCluster(AccumuloClusterHarness.java:207)
```


