### PR TITLE
Breaks Fate into Fate and FateClient

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
@@ -19,12 +19,6 @@
 package org.apache.accumulo.core.fate;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus.FAILED;
-import static org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus.FAILED_IN_PROGRESS;
-import static org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus.NEW;
-import static org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus.SUBMITTED;
-import static org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus.SUCCESSFUL;
-import static org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus.UNKNOWN;
 import static org.apache.accumulo.core.util.threads.ThreadPoolNames.META_DEAD_RESERVATION_CLEANER_POOL;
 import static org.apache.accumulo.core.util.threads.ThreadPoolNames.USER_DEAD_RESERVATION_CLEANER_POOL;
 
@@ -36,7 +30,6 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ExecutorService;
@@ -48,18 +41,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
-import org.apache.accumulo.core.fate.FateStore.FateTxStore;
-import org.apache.accumulo.core.fate.FateStore.Seeder;
-import org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus;
 import org.apache.accumulo.core.logging.FateLogger;
 import org.apache.accumulo.core.manager.thrift.TFateOperation;
-import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.core.util.threads.ThreadPools;
-import org.apache.thrift.TApplicationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -73,16 +60,15 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  */
 @SuppressFBWarnings(value = "CT_CONSTRUCTOR_THROW",
     justification = "Constructor validation is required for proper initialization")
-public class Fate<T> {
+public class Fate<T> extends FateClient<T> {
 
-  private static final Logger log = LoggerFactory.getLogger(Fate.class);
+  static final Logger log = LoggerFactory.getLogger(Fate.class);
 
   private final FateStore<T> store;
   private final ScheduledFuture<?> fatePoolsWatcherFuture;
   private final AtomicInteger needMoreThreadsWarnCount = new AtomicInteger(0);
   private final ExecutorService deadResCleanerExecutor;
 
-  private static final EnumSet<TStatus> FINISHED_STATES = EnumSet.of(FAILED, SUCCESSFUL, UNKNOWN);
   public static final Duration INITIAL_DELAY = Duration.ofSeconds(3);
   private static final Duration DEAD_RES_CLEANUP_DELAY = Duration.ofMinutes(3);
   public static final Duration POOL_WATCHER_DELAY = Duration.ofSeconds(30);
@@ -262,6 +248,7 @@ public class Fate<T> {
   public Fate(T environment, FateStore<T> store, boolean runDeadResCleaner,
       Function<Repo<T>,String> toLogStrFunc, AccumuloConfiguration conf,
       ScheduledThreadPoolExecutor genSchedExecutor) {
+    super(store, toLogStrFunc);
     this.store = FateLogger.wrap(store, toLogStrFunc, false);
 
     fatePoolsWatcherFuture =
@@ -380,133 +367,6 @@ public class Fate<T> {
   @VisibleForTesting
   public AtomicInteger getNeedMoreThreadsWarnCount() {
     return needMoreThreadsWarnCount;
-  }
-
-  // get a transaction id back to the requester before doing any work
-  public FateId startTransaction() {
-    return store.create();
-  }
-
-  public Seeder<T> beginSeeding() {
-    return store.beginSeeding();
-  }
-
-  public void seedTransaction(FateOperation fateOp, FateKey fateKey, Repo<T> repo,
-      boolean autoCleanUp) {
-    try (var seeder = store.beginSeeding()) {
-      @SuppressWarnings("unused")
-      var unused = seeder.attemptToSeedTransaction(fateOp, fateKey, repo, autoCleanUp);
-    }
-  }
-
-  // start work in the transaction.. it is safe to call this
-  // multiple times for a transaction... but it will only seed once
-  public void seedTransaction(FateOperation fateOp, FateId fateId, Repo<T> repo,
-      boolean autoCleanUp, String goalMessage) {
-    log.info("[{}] Seeding {} {} {}", store.type(), fateOp, fateId, goalMessage);
-    store.seedTransaction(fateOp, fateId, repo, autoCleanUp);
-  }
-
-  // check on the transaction
-  public TStatus waitForCompletion(FateId fateId) {
-    return store.read(fateId).waitForStatusChange(FINISHED_STATES);
-  }
-
-  /**
-   * Attempts to cancel a running Fate transaction
-   *
-   * @param fateId fate transaction id
-   * @return true if transaction transitioned to a failed state or already in a completed state,
-   *         false otherwise
-   */
-  public boolean cancel(FateId fateId) {
-    for (int retries = 0; retries < 5; retries++) {
-      Optional<FateTxStore<T>> optionalTxStore = store.tryReserve(fateId);
-      if (optionalTxStore.isPresent()) {
-        var txStore = optionalTxStore.orElseThrow();
-        try {
-          TStatus status = txStore.getStatus();
-          log.info("[{}] status is: {}", store.type(), status);
-          if (status == NEW || status == SUBMITTED) {
-            txStore.setTransactionInfo(TxInfo.EXCEPTION, new TApplicationException(
-                TApplicationException.INTERNAL_ERROR, "Fate transaction cancelled by user"));
-            txStore.setStatus(FAILED_IN_PROGRESS);
-            log.info(
-                "[{}] Updated status for {} to FAILED_IN_PROGRESS because it was cancelled by user",
-                store.type(), fateId);
-            return true;
-          } else {
-            log.info("[{}] {} cancelled by user but already in progress or finished state",
-                store.type(), fateId);
-            return false;
-          }
-        } finally {
-          txStore.unreserve(Duration.ZERO);
-        }
-      } else {
-        // reserved, lets retry.
-        UtilWaitThread.sleep(500);
-      }
-    }
-    log.info("[{}] Unable to reserve transaction {} to cancel it", store.type(), fateId);
-    return false;
-  }
-
-  // resource cleanup
-  public void delete(FateId fateId) {
-    FateTxStore<T> txStore = store.reserve(fateId);
-    try {
-      switch (txStore.getStatus()) {
-        case NEW:
-        case SUBMITTED:
-        case FAILED:
-        case SUCCESSFUL:
-          txStore.delete();
-          break;
-        case FAILED_IN_PROGRESS:
-        case IN_PROGRESS:
-          throw new IllegalStateException("Can not delete in progress transaction " + fateId);
-        case UNKNOWN:
-          // nothing to do, it does not exist
-          break;
-      }
-    } finally {
-      txStore.unreserve(Duration.ZERO);
-    }
-  }
-
-  public String getReturn(FateId fateId) {
-    FateTxStore<T> txStore = store.reserve(fateId);
-    try {
-      if (txStore.getStatus() != SUCCESSFUL) {
-        throw new IllegalStateException(
-            "Tried to get exception when transaction " + fateId + " not in successful state");
-      }
-      return (String) txStore.getTransactionInfo(TxInfo.RETURN_VALUE);
-    } finally {
-      txStore.unreserve(Duration.ZERO);
-    }
-  }
-
-  // get reportable failures
-  public Exception getException(FateId fateId) {
-    FateTxStore<T> txStore = store.reserve(fateId);
-    try {
-      if (txStore.getStatus() != FAILED) {
-        throw new IllegalStateException(
-            "Tried to get exception when transaction " + fateId + " not in failed state");
-      }
-      return (Exception) txStore.getTransactionInfo(TxInfo.EXCEPTION);
-    } finally {
-      txStore.unreserve(Duration.ZERO);
-    }
-  }
-
-  /**
-   * Lists transctions for a given fate key type.
-   */
-  public Stream<FateKey> list(FateKey.FateKeyType type) {
-    return store.list(type);
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/fate/FateClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/FateClient.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.fate;
+
+import static org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus.FAILED;
+import static org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus.FAILED_IN_PROGRESS;
+import static org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus.NEW;
+import static org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus.SUBMITTED;
+import static org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus.SUCCESSFUL;
+import static org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus.UNKNOWN;
+
+import java.time.Duration;
+import java.util.EnumSet;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.apache.accumulo.core.logging.FateLogger;
+import org.apache.accumulo.core.util.UtilWaitThread;
+import org.apache.thrift.TApplicationException;
+
+/**
+ * Supports initiating and checking status of fate operations.
+ *
+ */
+public class FateClient<T> {
+
+  private final FateStore<T> store;
+
+  private static final EnumSet<ReadOnlyFateStore.TStatus> FINISHED_STATES =
+      EnumSet.of(FAILED, SUCCESSFUL, UNKNOWN);
+
+  public FateClient(FateStore<T> store, Function<Repo<T>,String> toLogStrFunc) {
+    this.store = FateLogger.wrap(store, toLogStrFunc, false);
+  }
+
+  // get a transaction id back to the requester before doing any work
+  public FateId startTransaction() {
+    return store.create();
+  }
+
+  public FateStore.Seeder<T> beginSeeding() {
+    return store.beginSeeding();
+  }
+
+  public void seedTransaction(Fate.FateOperation fateOp, FateKey fateKey, Repo<T> repo,
+      boolean autoCleanUp) {
+    try (var seeder = store.beginSeeding()) {
+      @SuppressWarnings("unused")
+      var unused = seeder.attemptToSeedTransaction(fateOp, fateKey, repo, autoCleanUp);
+    }
+  }
+
+  // start work in the transaction.. it is safe to call this
+  // multiple times for a transaction... but it will only seed once
+  public void seedTransaction(Fate.FateOperation fateOp, FateId fateId, Repo<T> repo,
+      boolean autoCleanUp, String goalMessage) {
+    Fate.log.info("[{}] Seeding {} {} {}", store.type(), fateOp, fateId, goalMessage);
+    store.seedTransaction(fateOp, fateId, repo, autoCleanUp);
+  }
+
+  // check on the transaction
+  public ReadOnlyFateStore.TStatus waitForCompletion(FateId fateId) {
+    return store.read(fateId).waitForStatusChange(FINISHED_STATES);
+  }
+
+  /**
+   * Attempts to cancel a running Fate transaction
+   *
+   * @param fateId fate transaction id
+   * @return true if transaction transitioned to a failed state or already in a completed state,
+   *         false otherwise
+   */
+  public boolean cancel(FateId fateId) {
+    for (int retries = 0; retries < 5; retries++) {
+      Optional<FateStore.FateTxStore<T>> optionalTxStore = store.tryReserve(fateId);
+      if (optionalTxStore.isPresent()) {
+        var txStore = optionalTxStore.orElseThrow();
+        try {
+          ReadOnlyFateStore.TStatus status = txStore.getStatus();
+          Fate.log.info("[{}] status is: {}", store.type(), status);
+          if (status == NEW || status == SUBMITTED) {
+            txStore.setTransactionInfo(Fate.TxInfo.EXCEPTION, new TApplicationException(
+                TApplicationException.INTERNAL_ERROR, "Fate transaction cancelled by user"));
+            txStore.setStatus(FAILED_IN_PROGRESS);
+            Fate.log.info(
+                "[{}] Updated status for {} to FAILED_IN_PROGRESS because it was cancelled by user",
+                store.type(), fateId);
+            return true;
+          } else {
+            Fate.log.info("[{}] {} cancelled by user but already in progress or finished state",
+                store.type(), fateId);
+            return false;
+          }
+        } finally {
+          txStore.unreserve(Duration.ZERO);
+        }
+      } else {
+        // reserved, lets retry.
+        UtilWaitThread.sleep(500);
+      }
+    }
+    Fate.log.info("[{}] Unable to reserve transaction {} to cancel it", store.type(), fateId);
+    return false;
+  }
+
+  // resource cleanup
+  public void delete(FateId fateId) {
+    FateStore.FateTxStore<T> txStore = store.reserve(fateId);
+    try {
+      switch (txStore.getStatus()) {
+        case NEW:
+        case SUBMITTED:
+        case FAILED:
+        case SUCCESSFUL:
+          txStore.delete();
+          break;
+        case FAILED_IN_PROGRESS:
+        case IN_PROGRESS:
+          throw new IllegalStateException("Can not delete in progress transaction " + fateId);
+        case UNKNOWN:
+          // nothing to do, it does not exist
+          break;
+      }
+    } finally {
+      txStore.unreserve(Duration.ZERO);
+    }
+  }
+
+  public String getReturn(FateId fateId) {
+    FateStore.FateTxStore<T> txStore = store.reserve(fateId);
+    try {
+      if (txStore.getStatus() != SUCCESSFUL) {
+        throw new IllegalStateException(
+            "Tried to get exception when transaction " + fateId + " not in successful state");
+      }
+      return (String) txStore.getTransactionInfo(Fate.TxInfo.RETURN_VALUE);
+    } finally {
+      txStore.unreserve(Duration.ZERO);
+    }
+  }
+
+  // get reportable failures
+  public Exception getException(FateId fateId) {
+    FateStore.FateTxStore<T> txStore = store.reserve(fateId);
+    try {
+      if (txStore.getStatus() != FAILED) {
+        throw new IllegalStateException(
+            "Tried to get exception when transaction " + fateId + " not in failed state");
+      }
+      return (Exception) txStore.getTransactionInfo(Fate.TxInfo.EXCEPTION);
+    } finally {
+      txStore.unreserve(Duration.ZERO);
+    }
+  }
+
+  /**
+   * Lists transctions for a given fate key type.
+   */
+  public Stream<FateKey> list(FateKey.FateKeyType type) {
+    return store.list(type);
+  }
+}

--- a/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
@@ -132,7 +132,7 @@ class FateServiceHandler implements FateService.Iface {
       throws ThriftSecurityException {
     authenticate(credentials);
     return new TFateId(type,
-        manager.fate(FateInstanceType.fromThrift(type)).startTransaction().getTxUUIDStr());
+        manager.fateClient(FateInstanceType.fromThrift(type)).startTransaction().getTxUUIDStr());
   }
 
   @Override
@@ -157,7 +157,7 @@ class FateServiceHandler implements FateService.Iface {
         }
 
         goalMessage += "Create " + namespace + " namespace.";
-        manager.fate(type).seedTransaction(op, fateId,
+        manager.fateClient(type).seedTransaction(op, fateId,
             new TraceRepo<>(new CreateNamespace(c.getPrincipal(), namespace, options)), autoCleanup,
             goalMessage);
         break;
@@ -176,7 +176,7 @@ class FateServiceHandler implements FateService.Iface {
         }
 
         goalMessage += "Rename " + oldName + " namespace to " + newName;
-        manager.fate(type).seedTransaction(op, fateId,
+        manager.fateClient(type).seedTransaction(op, fateId,
             new TraceRepo<>(new RenameNamespace(namespaceId, oldName, newName)), autoCleanup,
             goalMessage);
         break;
@@ -194,7 +194,7 @@ class FateServiceHandler implements FateService.Iface {
         }
 
         goalMessage += "Delete namespace Id: " + namespaceId;
-        manager.fate(type).seedTransaction(op, fateId,
+        manager.fateClient(type).seedTransaction(op, fateId,
             new TraceRepo<>(new DeleteNamespace(namespaceId)), autoCleanup, goalMessage);
         break;
       }
@@ -252,7 +252,7 @@ class FateServiceHandler implements FateService.Iface {
         goalMessage += "Create table " + tableName + " " + initialTableState + " with " + splitCount
             + " splits and initial tabletAvailability of " + initialTabletAvailability;
 
-        manager.fate(type).seedTransaction(op, fateId,
+        manager.fateClient(type).seedTransaction(op, fateId,
             new TraceRepo<>(new CreateTable(c.getPrincipal(), tableName, timeType, options,
                 splitsPath, splitCount, splitsDirsPath, initialTableState,
                 // Set the default tablet to be auto-mergeable with other tablets if it is split
@@ -288,7 +288,7 @@ class FateServiceHandler implements FateService.Iface {
         goalMessage += "Rename table " + oldTableName + "(" + tableId + ") to " + oldTableName;
 
         try {
-          manager.fate(type).seedTransaction(op, fateId,
+          manager.fateClient(type).seedTransaction(op, fateId,
               new TraceRepo<>(new RenameTable(namespaceId, tableId, oldTableName, newTableName)),
               autoCleanup, goalMessage);
         } catch (NamespaceNotFoundException e) {
@@ -370,7 +370,7 @@ class FateServiceHandler implements FateService.Iface {
           goalMessage += " and keep offline.";
         }
 
-        manager.fate(type).seedTransaction(op, fateId,
+        manager.fateClient(type).seedTransaction(op, fateId,
             new TraceRepo<>(new CloneTable(c.getPrincipal(), srcNamespaceId, srcTableId,
                 namespaceId, tableName, propertiesToSet, propertiesToExclude, keepOffline)),
             autoCleanup, goalMessage);
@@ -400,7 +400,7 @@ class FateServiceHandler implements FateService.Iface {
         }
 
         goalMessage += "Delete table " + tableName + "(" + tableId + ")";
-        manager.fate(type).seedTransaction(op, fateId,
+        manager.fateClient(type).seedTransaction(op, fateId,
             new TraceRepo<>(new PreDeleteTable(namespaceId, tableId)), autoCleanup, goalMessage);
         break;
       }
@@ -427,7 +427,7 @@ class FateServiceHandler implements FateService.Iface {
         goalMessage += "Online table " + tableId;
         final EnumSet<TableState> expectedCurrStates =
             EnumSet.of(TableState.ONLINE, TableState.OFFLINE);
-        manager.fate(type).seedTransaction(op, fateId,
+        manager.fateClient(type).seedTransaction(op, fateId,
             new TraceRepo<>(
                 new ChangeTableState(namespaceId, tableId, tableOp, expectedCurrStates)),
             autoCleanup, goalMessage);
@@ -456,7 +456,7 @@ class FateServiceHandler implements FateService.Iface {
         goalMessage += "Offline table " + tableId;
         final EnumSet<TableState> expectedCurrStates =
             EnumSet.of(TableState.ONLINE, TableState.OFFLINE);
-        manager.fate(type).seedTransaction(op, fateId,
+        manager.fateClient(type).seedTransaction(op, fateId,
             new TraceRepo<>(
                 new ChangeTableState(namespaceId, tableId, tableOp, expectedCurrStates)),
             autoCleanup, goalMessage);
@@ -492,7 +492,7 @@ class FateServiceHandler implements FateService.Iface {
             startRowStr, endRowStr);
         goalMessage += "Merge table " + tableName + "(" + tableId + ") splits from " + startRowStr
             + " to " + endRowStr;
-        manager.fate(type).seedTransaction(op, fateId, new TraceRepo<>(
+        manager.fateClient(type).seedTransaction(op, fateId, new TraceRepo<>(
             new TableRangeOp(MergeInfo.Operation.MERGE, namespaceId, tableId, startRow, endRow)),
             autoCleanup, goalMessage);
         break;
@@ -524,7 +524,7 @@ class FateServiceHandler implements FateService.Iface {
 
         goalMessage +=
             "Delete table " + tableName + "(" + tableId + ") range " + startRow + " to " + endRow;
-        manager.fate(type).seedTransaction(op, fateId, new TraceRepo<>(
+        manager.fateClient(type).seedTransaction(op, fateId, new TraceRepo<>(
             new TableRangeOp(MergeInfo.Operation.DELETE, namespaceId, tableId, startRow, endRow)),
             autoCleanup, goalMessage);
         break;
@@ -550,7 +550,7 @@ class FateServiceHandler implements FateService.Iface {
         }
 
         goalMessage += "Compact table (" + tableId + ") with config " + compactionConfig;
-        manager.fate(type).seedTransaction(op, fateId,
+        manager.fateClient(type).seedTransaction(op, fateId,
             new TraceRepo<>(new CompactRange(namespaceId, tableId, compactionConfig)), autoCleanup,
             goalMessage);
         break;
@@ -574,7 +574,7 @@ class FateServiceHandler implements FateService.Iface {
         }
 
         goalMessage += "Cancel compaction of table (" + tableId + ")";
-        manager.fate(type).seedTransaction(op, fateId,
+        manager.fateClient(type).seedTransaction(op, fateId,
             new TraceRepo<>(new CancelCompactions(namespaceId, tableId)), autoCleanup, goalMessage);
         break;
       }
@@ -609,7 +609,7 @@ class FateServiceHandler implements FateService.Iface {
         }
 
         goalMessage += "Import table with new name: " + tableName + " from " + exportDirs;
-        manager.fate(type)
+        manager.fateClient(type)
             .seedTransaction(op, fateId, new TraceRepo<>(new ImportTable(c.getPrincipal(),
                 tableName, exportDirs, namespaceId, keepMappings, keepOffline)), autoCleanup,
                 goalMessage);
@@ -639,7 +639,7 @@ class FateServiceHandler implements FateService.Iface {
         }
 
         goalMessage += "Export table " + tableName + "(" + tableId + ") to " + exportDir;
-        manager.fate(type).seedTransaction(op, fateId,
+        manager.fateClient(type).seedTransaction(op, fateId,
             new TraceRepo<>(new ExportTable(namespaceId, tableName, tableId, exportDir)),
             autoCleanup, goalMessage);
         break;
@@ -676,7 +676,7 @@ class FateServiceHandler implements FateService.Iface {
         manager.updateBulkImportStatus(dir, BulkImportState.INITIAL);
 
         goalMessage += "Bulk import (v2)  " + dir + " to " + tableName + "(" + tableId + ")";
-        manager.fate(type).seedTransaction(op, fateId,
+        manager.fateClient(type).seedTransaction(op, fateId,
             new TraceRepo<>(new ComputeBulkRange(tableId, dir, setTime)), autoCleanup, goalMessage);
         break;
       }
@@ -720,7 +720,7 @@ class FateServiceHandler implements FateService.Iface {
 
         goalMessage += "Set availability for table: " + tableName + "(" + tableId + ") range: "
             + tRange + " to: " + tabletAvailability.name();
-        manager.fate(type).seedTransaction(op, fateId,
+        manager.fateClient(type).seedTransaction(op, fateId,
             new TraceRepo<>(new LockTable(tableId, namespaceId, tRange, tabletAvailability)),
             autoCleanup, goalMessage);
         break;
@@ -794,8 +794,8 @@ class FateServiceHandler implements FateService.Iface {
         }
 
         goalMessage = "Splitting " + extent + " for user into " + (splits.size() + 1) + " tablets";
-        manager.fate(type).seedTransaction(op, fateId, new PreSplit(extent, splits), autoCleanup,
-            goalMessage);
+        manager.fateClient(type).seedTransaction(op, fateId, new PreSplit(extent, splits),
+            autoCleanup, goalMessage);
         break;
       }
       default:
@@ -847,9 +847,9 @@ class FateServiceHandler implements FateService.Iface {
 
     FateId fateId = FateId.fromThrift(opid);
     FateInstanceType type = fateId.getType();
-    TStatus status = manager.fate(type).waitForCompletion(fateId);
+    TStatus status = manager.fateClient(type).waitForCompletion(fateId);
     if (status == TStatus.FAILED) {
-      Exception e = manager.fate(type).getException(fateId);
+      Exception e = manager.fateClient(type).getException(fateId);
       if (e instanceof ThriftTableOperationException) {
         throw (ThriftTableOperationException) e;
       } else if (e instanceof ThriftSecurityException) {
@@ -861,7 +861,7 @@ class FateServiceHandler implements FateService.Iface {
       }
     }
 
-    String ret = manager.fate(type).getReturn(fateId);
+    String ret = manager.fateClient(type).getReturn(fateId);
     if (ret == null) {
       ret = ""; // thrift does not like returning null
     }
@@ -873,7 +873,7 @@ class FateServiceHandler implements FateService.Iface {
       throws ThriftSecurityException {
     authenticate(credentials);
     FateId fateId = FateId.fromThrift(opid);
-    manager.fate(fateId.getType()).delete(fateId);
+    manager.fateClient(fateId.getType()).delete(fateId);
   }
 
   protected void authenticate(TCredentials credentials) throws ThriftSecurityException {
@@ -987,6 +987,6 @@ class FateServiceHandler implements FateService.Iface {
           SecurityErrorCode.PERMISSION_DENIED);
     }
 
-    return manager.fate(fateId.getType()).cancel(fateId);
+    return manager.fateClient(fateId.getType()).cancel(fateId);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/merge/FindMergeableRangeTask.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/merge/FindMergeableRangeTask.java
@@ -158,7 +158,7 @@ public class FindMergeableRangeTask implements Runnable {
         tableId, startRowStr, endRowStr);
     var fateKey = FateKey.forMerge(new KeyExtent(tableId, range.endRow, range.startRow));
 
-    manager.fate(type).seedTransaction(FateOperation.SYSTEM_MERGE, fateKey,
+    manager.fateClient(type).seedTransaction(FateOperation.SYSTEM_MERGE, fateKey,
         new TraceRepo<>(
             new TableRangeOp(Operation.SYSTEM_MERGE, namespaceId, tableId, startRow, endRow)),
         true);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/split/Splitter.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/split/Splitter.java
@@ -89,7 +89,7 @@ public class Splitter {
 
   private void seedSplits(FateInstanceType instanceType, Map<Text,KeyExtent> splits) {
     if (!splits.isEmpty()) {
-      try (var seeder = manager.fate(instanceType).beginSeeding()) {
+      try (var seeder = manager.fateClient(instanceType).beginSeeding()) {
         for (KeyExtent extent : splits.values()) {
           @SuppressWarnings("unused")
           var unused = seeder.attemptToSeedTransaction(Fate.FateOperation.SYSTEM_SPLIT,

--- a/server/manager/src/test/java/org/apache/accumulo/manager/compaction/CompactionCoordinatorTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/compaction/CompactionCoordinatorTest.java
@@ -39,7 +39,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.admin.CompactionConfig;
@@ -55,7 +54,6 @@ import org.apache.accumulo.core.data.ResourceGroupId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.dataImpl.thrift.TKeyExtent;
-import org.apache.accumulo.core.fate.Fate;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.FateInstanceType;
 import org.apache.accumulo.core.iteratorsImpl.system.SystemIteratorUtil;
@@ -79,7 +77,6 @@ import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.compaction.coordinator.CompactionCoordinator;
 import org.apache.accumulo.manager.compaction.queue.CompactionJobPriorityQueue;
 import org.apache.accumulo.manager.compaction.queue.ResolvedCompactionJob;
-import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.conf.TableConfiguration;
 import org.apache.accumulo.server.security.AuditedSecurityOperation;
@@ -93,10 +90,6 @@ import org.junit.jupiter.api.TestInfo;
 import com.google.common.net.HostAndPort;
 
 public class CompactionCoordinatorTest {
-
-  // Need a non-null fateInstances reference for CompactionCoordinator.compactionCompleted
-  private static final AtomicReference<Map<FateInstanceType,Fate<FateEnv>>> fateInstances =
-      new AtomicReference<>(Map.of());
 
   private static final ResourceGroupId GROUP_ID = ResourceGroupId.of("R2DQ");
 
@@ -118,7 +111,7 @@ public class CompactionCoordinatorTest {
     private Set<ExternalCompactionId> metadataCompactionIds = null;
 
     public TestCoordinator(Manager manager, List<RunningCompaction> runningCompactions) {
-      super(manager, fateInstances);
+      super(manager, t -> null);
       this.runningCompactions = runningCompactions;
     }
 


### PR DESCRIPTION
Most code that interacts with fate only needs to start,check, or stop fate operations.  This change pulls that limited functionality into its own class.  This change is needed in #6139. 