### PR TITLE
Add ECID to running external compactions table in the Monitor

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/ec.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/ec.js
@@ -36,6 +36,7 @@ $(function () {
   $.fn.dataTable.ext.errMode = 'throw';
 
   compactorsTable = $('#compactorsTable').DataTable({
+    "autoWidth": false,
     "ajax": {
       "url": contextPath + 'rest/ec/compactors',
       "dataSrc": "compactors"
@@ -72,10 +73,12 @@ $(function () {
   const hostnameColumnName = 'hostname';
   const queueNameColumnName = 'queueName';
   const tableIdColumnName = 'tableId';
+  const ecidColumnName = 'ecid';
   const durationColumnName = 'duration';
 
   // Create a table for running compactors
   runningTable = $('#runningTable').DataTable({
+    "autoWidth": false,
     "ajax": {
       "url": contextPath + 'rest/ec/running',
       "dataSrc": "running"
@@ -114,6 +117,10 @@ $(function () {
       {
         "data": "tableId",
         "name": tableIdColumnName
+      },
+      {
+        "data": "ecid",
+        "name": ecidColumnName
       },
       {
         "data": "numFiles"
@@ -179,6 +186,10 @@ $(function () {
     handleFilterKeyup.call(this, this.value, $('#tableid-feedback'), tableIdColumnName);
   });
 
+  $('#ecid-filter').on('keyup', function () {
+    handleFilterKeyup.call(this, this.value, $('#ecid-feedback'), ecidColumnName);
+  });
+
   $('#duration-filter').on('keyup', function () {
     runningTable.draw();
   });
@@ -191,6 +202,7 @@ $(function () {
     $('#hostname-filter').val('').trigger('keyup');
     $('#queue-filter').val('').trigger('keyup');
     $('#tableid-filter').val('').trigger('keyup');
+    $('#ecid-filter').val('').trigger('keyup');
     $('#duration-filter').val('').trigger('keyup');
 
     $(this).prop('disabled', false); // re-enable the clear
@@ -274,6 +286,7 @@ $(function () {
 
   // Create a table for compaction coordinator
   coordinatorTable = $('#coordinatorTable').DataTable({
+    "autoWidth": false,
     "ajax": {
       "url": contextPath + 'rest/ec',
       "dataSrc": function (data) {

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/ec.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/ec.ftl
@@ -96,6 +96,12 @@
                           <input type="text" id="tableid-filter" class="form-control" placeholder="Enter table ID regex">
                           <small id="tableid-feedback" class="form-text text-danger" style="display:none;">Invalid regex pattern</small>
                         </div>
+                        <!-- ECID Filter -->
+                        <div class="mb-3">
+                          <label for="ecid-filter" class="form-label">ECID Filter</label>
+                          <input type="text" id="ecid-filter" class="form-control" placeholder="Enter ECID regex">
+                          <small id="ecid-feedback" class="form-text text-danger" style="display:none;">Invalid regex pattern</small>
+                        </div>
                         <!-- Duration Filter -->
                         <div class="mb-3">
                           <label for="duration-filter" class="form-label">Duration Filter</label>
@@ -119,6 +125,7 @@
                   <th title="The status returned by the last update.">Status</th>
                   <th title="The name of the queue this compactor is assigned.">Queue</th>
                   <th title="The ID of the table being compacted.">Table ID</th>
+                  <th title="The ID of the running external compaction.">ECID</th>
                   <th title="The number of files being compacted."># of Files</th>
                   <th title="The progress of the compaction." class="progBar">Progress</th>
                   <th class="duration" title="The time of the last update for the compaction">Last Update</th>


### PR DESCRIPTION
Fixes #6096 

Adds ECID column to the running compactions table on the external compactions page in the monitor.

An accompanying regex filter was added to filter the table based on this new ECID value.

Here is a screenshot with a regex that returns a row in the table
<img width="2053" height="764" alt="image" src="https://github.com/user-attachments/assets/b517443d-bbe1-41d5-a0e8-29bb6dc6bd3d" />

And another screenshot with a regex that does not match any ECID
<img width="2053" height="707" alt="image" src="https://github.com/user-attachments/assets/4575b8fb-86d5-43b8-ac4e-99aa58cc0ee9" />
