### PR TITLE
Support ClassLoader context in Grep and DeleteMany

### DIFF
--- a/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteManyCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteManyCommand.java
@@ -45,10 +45,19 @@ public class DeleteManyCommand extends ScanCommand {
     final org.apache.accumulo.core.util.interpret.ScanInterpreter interpreter =
         getInterpreter(cl, tableName, shellState);
 
+    String classLoaderContext = null;
+    if (cl.hasOption(contextOpt.getOpt())) {
+      classLoaderContext = cl.getOptionValue(contextOpt.getOpt());
+    }
+
     // handle first argument, if present, the authorizations list to
     // scan with
     final Authorizations auths = getAuths(cl, shellState);
     final Scanner scanner = shellState.getAccumuloClient().createScanner(tableName, auths);
+
+    if (classLoaderContext != null) {
+      scanner.setClassLoaderContext(classLoaderContext);
+    }
 
     scanner.addScanIterator(
         new IteratorSetting(Integer.MAX_VALUE, "NOVALUE", SortedKeyIterator.class));

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/GrepCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/GrepCommand.java
@@ -80,6 +80,11 @@ public class GrepCommand extends ScanCommand {
         negate = true;
       }
 
+      String classLoaderContext = null;
+      if (cl.hasOption(contextOpt.getOpt())) {
+        classLoaderContext = cl.getOptionValue(contextOpt.getOpt());
+      }
+
       final Authorizations auths = getAuths(cl, shellState);
       final BatchScanner scanner =
           shellState.getAccumuloClient().createBatchScanner(tableName, auths, numThreads);
@@ -88,6 +93,10 @@ public class GrepCommand extends ScanCommand {
       scanner.setTimeout(getTimeout(cl), TimeUnit.MILLISECONDS);
 
       scanner.setConsistencyLevel(getConsistency(cl));
+
+      if (classLoaderContext != null) {
+        scanner.setClassLoaderContext(classLoaderContext);
+      }
 
       setupSampling(tableName, cl, shellState, scanner);
       addScanIterators(shellState, cl, scanner, "");

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ScanCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ScanCommand.java
@@ -68,7 +68,7 @@ public class ScanCommand extends Command {
   private Option optEndRowExclusive;
   private Option timeoutOption;
   private Option sampleOpt;
-  private Option contextOpt;
+  protected Option contextOpt;
   private Option executionHintsOpt;
   private Option scanServerOpt;
 


### PR DESCRIPTION
Modified shell commands that extend ScanCommand
to support setting the classloader context.

Closes #6141