### PR TITLE
Support building with java 21

### DIFF
--- a/.github/workflows/maven-full-its.yaml
+++ b/.github/workflows/maven-full-its.yaml
@@ -19,7 +19,6 @@
 
 # This workflow will build a Java project with Maven
 # See also:
-#   https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 #   https://docs.github.com/en/actions/reference/events-that-trigger-workflows#manual-events
 #   https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#fromjson
 
@@ -45,14 +44,14 @@ jobs:
   fastbuild:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: ${{ github.event.inputs.buildRef }}
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4
+    - name: Set up JDK 21
+      uses: actions/setup-java@v5
       with:
         distribution: temurin
-        java-version: 17
+        java-version: 21
         cache: 'maven'
     - name: Show the first log message
       run: git log -n1
@@ -68,7 +67,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.CUSTOM_MATRIX }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: ${{ github.event.inputs.buildRef }}
     - id: set-matrix
@@ -82,14 +81,14 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: ${{ github.event.inputs.buildRef }}
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4
+    - name: Set up JDK 21
+      uses: actions/setup-java@v5
       with:
         distribution: temurin
-        java-version: 17
+        java-version: 21
         cache: 'maven'
     - name: Override DNS to fix IP address for hostname
       run: |
@@ -113,21 +112,21 @@ jobs:
         MAVEN_OPTS: -Djansi.force=true
     - name: Upload unit test results
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: surefire-reports-${{ matrix.profile.name }}
         path: ./**/target/surefire-reports/
         if-no-files-found: ignore
     - name: Upload integration test results
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: failsafe-reports-${{ matrix.profile.name }}
         path: ./**/target/failsafe-reports/
         if-no-files-found: ignore
     - name: Upload mini test logs
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: mini-tests-logs-${{ matrix.profile.name }}
         path: ./**/target/**/mini-tests/**/logs/

--- a/.github/workflows/maven-on-demand.yaml
+++ b/.github/workflows/maven-on-demand.yaml
@@ -18,9 +18,6 @@
 #
 
 # This workflow will build a Java project with Maven
-# See also:
-#   https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
-#   https://docs.github.com/en/actions/reference/events-that-trigger-workflows#manual-events
 
 name: Manual Build
 
@@ -62,14 +59,14 @@ jobs:
     name: mvn (triggered by ${{ github.event.sender.login }})
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: ${{ github.event.inputs.buildRef }}
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4
+    - name: Set up JDK 21
+      uses: actions/setup-java@v5
       with:
         distribution: temurin
-        java-version: 17
+        java-version: 21
         cache: 'maven'
     - name: Show the first log message
       run: git log -n1
@@ -95,21 +92,21 @@ jobs:
         MAVEN_OPTS: -Djansi.force=true
     - name: Upload unit test results
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: surefire-reports
         path: ./**/target/surefire-reports/
         if-no-files-found: ignore
     - name: Upload integration test results
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: failsafe-reports
         path: ./**/target/failsafe-reports/
         if-no-files-found: ignore
     - name: Upload mini test logs
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: mini-tests-logs
         path: ./**/target/**/mini-tests/**/logs/

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -18,8 +18,6 @@
 #
 
 # This workflow will build a Java project with Maven
-# See also:
-#   https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
 name: QA
 
@@ -37,12 +35,12 @@ jobs:
   fastbuild:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4
+    - uses: actions/checkout@v6
+    - name: Set up JDK 21
+      uses: actions/setup-java@v5
       with:
         distribution: temurin
-        java-version: 17
+        java-version: 21
         cache: 'maven'
     - name: Show the first log message
       run: git log -n1
@@ -65,16 +63,16 @@ jobs:
     strategy:
       matrix:
         profile:
-          - {name: 'unit-tests',    javaver: 17, args: 'verify -PskipQA -DskipTests=false'}
-          - {name: 'qa-checks',     javaver: 17, args: 'verify javadoc:jar -Psec-bugs -DskipTests -Dspotbugs.timeout=3600000'}
-          - {name: 'compat',        javaver: 17, args: 'package -DskipTests -Dversion.hadoop=3.0.3 -Dversion.zookeeper=3.5.10'}
-          - {name: 'errorprone',    javaver: 17, args: 'verify -Derrorprone -PskipQA'}
+          - {name: 'unit-tests',    javaver: 21, args: 'verify -PskipQA -DskipTests=false'}
+          - {name: 'qa-checks',     javaver: 21, args: 'verify javadoc:jar -Psec-bugs -DskipTests -Dspotbugs.timeout=3600000'}
+          - {name: 'compat',        javaver: 21, args: 'package -DskipTests -Dversion.hadoop=3.0.3 -Dversion.zookeeper=3.5.10'}
+          - {name: 'errorprone',    javaver: 21, args: 'verify -Derrorprone -PskipQA'}
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up JDK ${{ matrix.profile.javaver }}
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: temurin
         java-version: ${{ matrix.profile.javaver }}
@@ -101,21 +99,21 @@ jobs:
         MAVEN_OPTS: -Djansi.force=true
     - name: Upload unit test results
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: surefire-reports-${{ matrix.profile.name }}
         path: ./**/target/surefire-reports/
         if-no-files-found: ignore
     - name: Upload integration test results
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: failsafe-reports-${{ matrix.profile.name }}
         path: ./**/target/failsafe-reports/
         if-no-files-found: ignore
     - name: Upload mini test logs
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: mini-tests-logs-${{ matrix.profile.name }}
         path: ./**/target/**/mini-tests/**/logs/

--- a/.github/workflows/scripts.yaml
+++ b/.github/workflows/scripts.yaml
@@ -18,8 +18,6 @@
 #
 
 # This workflow will build a Java project with Maven
-# See also:
-#   https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
 name: ScriptQA
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -43,11 +43,6 @@
       <artifactId>caffeine</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.auto.service</groupId>
-      <artifactId>auto-service</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
     </dependency>

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooSession.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooSession.java
@@ -110,7 +110,7 @@ public class ZooSession {
    */
   static ZooKeeper connect(String host, int timeout, String scheme, byte[] auth, Watcher watcher) {
     final int TIME_BETWEEN_CONNECT_CHECKS_MS = 100;
-    int connectTimeWait = Math.min(10_000, timeout);
+    long connectTimeWait = Math.min(10_000, timeout);
     boolean tryAgain = true;
     long sleepTime = 100;
     ZooKeeper zooKeeper = null;

--- a/core/src/main/java/org/apache/accumulo/core/security/Authorizations.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/Authorizations.java
@@ -43,11 +43,9 @@ import org.apache.accumulo.core.util.ByteBufferUtil;
 public class Authorizations implements Iterable<byte[]>, Serializable, AuthorizationContainer {
 
   private static final long serialVersionUID = 1L;
-  private static final Set<ByteSequence> EMPTY_AUTH_SET = Collections.emptySet();
-  private static final List<byte[]> EMPTY_AUTH_LIST = Collections.emptyList();
 
-  private final Set<ByteSequence> auths;
-  private final List<byte[]> authsList; // sorted order
+  private final HashSet<ByteSequence> auths; // type must be serializable
+  private final ArrayList<byte[]> authsList; // sorted order; type must be serializable
 
   /**
    * An empty set of authorizations.
@@ -103,21 +101,12 @@ public class Authorizations implements Iterable<byte[]>, Serializable, Authoriza
     }
   }
 
-  private static Set<ByteSequence> createInternalSet(int size) {
-    if (size < 1) {
-      return EMPTY_AUTH_SET;
-    } else {
-      return new HashSet<>(size);
-    }
+  private static HashSet<ByteSequence> createInternalSet(int size) {
+    return new HashSet<>(size);
   }
 
-  private static List<byte[]> createInternalList(int size) {
-    if (size < 1) {
-      return EMPTY_AUTH_LIST;
-    } else {
-      return new ArrayList<>(size);
-    }
-
+  private static ArrayList<byte[]> createInternalList(int size) {
+    return new ArrayList<>(size);
   }
 
   /**
@@ -195,8 +184,8 @@ public class Authorizations implements Iterable<byte[]>, Serializable, Authoriza
         this.authsList = createInternalList(parts.length);
         setAuthorizations(parts);
       } else {
-        this.auths = EMPTY_AUTH_SET;
-        this.authsList = EMPTY_AUTH_LIST;
+        this.auths = createInternalSet(0);
+        this.authsList = createInternalList(0);
       }
     }
   }
@@ -207,8 +196,8 @@ public class Authorizations implements Iterable<byte[]>, Serializable, Authoriza
    * @see #Authorizations(String...)
    */
   public Authorizations() {
-    this.auths = EMPTY_AUTH_SET;
-    this.authsList = EMPTY_AUTH_LIST;
+    this.auths = createInternalSet(0);
+    this.authsList = createInternalList(0);
   }
 
   /**

--- a/core/src/test/java/org/apache/accumulo/core/spi/balancer/GroupBalancerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/balancer/GroupBalancerTest.java
@@ -166,7 +166,7 @@ public class GroupBalancerTest {
 
       Map<String,Integer> expectedCounts = new HashMap<>();
 
-      int totalExtra = 0;
+      long totalExtra = 0;
       for (String group : groupCounts.keySet()) {
         long groupCount = groupCounts.get(group);
         totalExtra += groupCount % tservers.size();
@@ -174,12 +174,12 @@ public class GroupBalancerTest {
       }
 
       // The number of extra tablets from all groups that each tserver must have.
-      int expectedExtra = totalExtra / tservers.size();
-      int maxExtraGroups = expectedExtra + ((totalExtra % tservers.size() > 0) ? 1 : 0);
+      long expectedExtra = totalExtra / tservers.size();
+      long maxExtraGroups = expectedExtra + ((totalExtra % tservers.size() > 0) ? 1 : 0);
 
       for (Entry<TabletServerId,MapCounter<String>> entry : tserverGroupCounts.entrySet()) {
         MapCounter<String> tgc = entry.getValue();
-        int tserverExtra = 0;
+        long tserverExtra = 0;
         for (String group : groupCounts.keySet()) {
           assertTrue(tgc.get(group) >= expectedCounts.get(group));
           assertTrue(tgc.get(group) <= expectedCounts.get(group) + 1,

--- a/minicluster/pom.xml
+++ b/minicluster/pom.xml
@@ -35,11 +35,6 @@
       <artifactId>jcommander</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.auto.service</groupId>
-      <artifactId>auto-service</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>35</version>
+    <version>37</version>
   </parent>
   <groupId>org.apache.accumulo</groupId>
   <artifactId>accumulo-project</artifactId>
@@ -143,9 +143,9 @@ under the License.
     <failsafe.forkCount>1</failsafe.forkCount>
     <failsafe.groups />
     <failsafe.reuseForks>false</failsafe.reuseForks>
+    <javaVersion>11</javaVersion>
     <!-- prevent introduction of new compiler warnings -->
     <maven.compiler.failOnWarning>true</maven.compiler.failOnWarning>
-    <maven.compiler.target>11</maven.compiler.target>
     <maven.javadoc.failOnWarnings>true</maven.javadoc.failOnWarnings>
     <maven.site.deploy.skip>true</maven.site.deploy.skip>
     <maven.site.skip>true</maven.site.skip>
@@ -153,8 +153,9 @@ under the License.
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <!-- versions-maven-plugin ignore patterns for snapshots, alpha, beta, milestones, and release candidates -->
     <maven.version.ignore>.+-SNAPSHOT,(?i).*(alpha|beta)[0-9.-]*,(?i).*[.-](m|rc)[0-9]+</maven.version.ignore>
-    <minimalJavaBuildVersion>17</minimalJavaBuildVersion>
+    <minimalJavaBuildVersion>21</minimalJavaBuildVersion>
     <minimalMavenBuildVersion>3.9</minimalMavenBuildVersion>
+    <modernizer.javaVersion>${javaVersion}</modernizer.javaVersion>
     <!-- timestamp for reproducible outputs, updated on release by the release plugin -->
     <project.build.outputTimestamp>2025-08-13T01:30:03Z</project.build.outputTimestamp>
     <rat.consoleOutput>true</rat.consoleOutput>
@@ -280,7 +281,7 @@ under the License.
       </dependency>
       <dependency>
         <groupId>com.google.auto.service</groupId>
-        <artifactId>auto-service</artifactId>
+        <artifactId>auto-service-annotations</artifactId>
         <version>${version.auto-service}</version>
       </dependency>
       <dependency>
@@ -721,6 +722,12 @@ under the License.
       <artifactId>spotbugs-annotations</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <!-- needed for compile-time annotations only -->
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service-annotations</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
   <build>
     <pluginManagement>
@@ -729,7 +736,7 @@ under the License.
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
-          <version>2.19.0</version>
+          <version>2.21.0</version>
         </plugin>
         <plugin>
           <groupId>com.mycila</groupId>
@@ -774,14 +781,11 @@ under the License.
           <artifactId>modernizer-maven-plugin</artifactId>
           <!-- newer versions suggest changes not worth the effort in 2.1 -->
           <version>2.9.0</version>
-          <configuration>
-            <javaVersion>${maven.compiler.target}</javaVersion>
-          </configuration>
         </plugin>
         <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>4.9.5.0</version>
+          <version>4.9.8.2</version>
           <configuration>
             <xmlOutput>true</xmlOutput>
             <effort>Max</effort>
@@ -820,7 +824,7 @@ under the License.
         <plugin>
           <groupId>com.github.koraktor</groupId>
           <artifactId>mavanagaiata</artifactId>
-          <version>1.1.1</version>
+          <version>1.1.2</version>
           <configuration>
             <skipNoGit>true</skipNoGit>
           </configuration>
@@ -836,6 +840,8 @@ under the License.
               <arg>-Xlint:-processing</arg>
               <!-- suppress try to ignore unused variable in try-with-resources -->
               <arg>-Xlint:-try</arg>
+              <!-- suppress too many false positives, including generated thrift code -->
+              <arg>-Xlint:-this-escape</arg>
               <arg>-Xmaxwarns</arg>
               <arg>5</arg>
             </compilerArgs>
@@ -882,11 +888,11 @@ under the License.
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
           <configuration>
-            <arguments>-P !autoformat,verifyformat,thrift -DskipTests</arguments>
             <goals>clean deploy</goals>
             <preparationGoals>clean package</preparationGoals>
             <tagNameFormat>rel/@{project.version}</tagNameFormat>
-            <releaseProfiles>apache-release,accumulo-release</releaseProfiles>
+            <preparationProfiles>apache-release,accumulo-release,!autoformat,verifyformat,thrift</preparationProfiles>
+            <releaseProfiles>apache-release,accumulo-release,!autoformat,verifyformat,thrift</releaseProfiles>
             <useReleaseProfile>false</useReleaseProfile>
             <pushChanges>false</pushChanges>
             <localCheckout>true</localCheckout>
@@ -929,7 +935,7 @@ under the License.
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
-          <version>3.5.1</version>
+          <version>3.6.3</version>
         </plugin>
         <plugin>
           <groupId>net.revelc.code</groupId>
@@ -941,6 +947,9 @@ under the License.
           <artifactId>formatter-maven-plugin</artifactId>
           <version>2.29.0</version>
           <configuration>
+            <compilerCompliance>${javaVersion}</compilerCompliance>
+            <compilerSource>${javaVersion}</compilerSource>
+            <compilerTargetPlatform>${javaVersion}</compilerTargetPlatform>
             <configFile>${rootlocation}/src/build/eclipse-codestyle.xml</configFile>
             <excludes>
               <exclude>**/thrift/*.java</exclude>
@@ -985,7 +994,7 @@ under the License.
         <plugin>
           <groupId>net.revelc.code</groupId>
           <artifactId>impsort-maven-plugin</artifactId>
-          <version>1.12.0</version>
+          <version>1.13.0</version>
           <configuration>
             <removeUnused>true</removeUnused>
             <groups>java.,javax.,jakarta.,org.,com.</groups>
@@ -1008,9 +1017,7 @@ under the License.
             </goals>
             <configuration>
               <failOnWarning>true</failOnWarning>
-              <ignoredUsedUndeclaredDependencies>
-                <!-- auto-service-annotations is transitive via auto-service -->
-                <undeclared>com.google.auto.service:auto-service-annotations:jar:*</undeclared>
+              <ignoredUsedUndeclaredDependencies combine.children="append">
                 <!-- used/undeclared child jars brought in by parents below -->
                 <undeclared>org.apache.curator:curator-client:jar:*</undeclared>
                 <undeclared>org.apache.hadoop:hadoop-common:jar:*</undeclared>
@@ -1023,9 +1030,9 @@ under the License.
                 <!-- This should be removed upon completion of migrating junit 4 to 5 -->
                 <undeclared>junit:junit:jar:*</undeclared>
               </ignoredUsedUndeclaredDependencies>
-              <ignoredUnusedDeclaredDependencies>
-                <!-- auto-service isn't used in every module -->
-                <unused>com.google.auto.service:auto-service:jar:*</unused>
+              <ignoredUnusedDeclaredDependencies combine.children="append">
+                <!-- auto-service annotations may or may not be used in each module -->
+                <unused>com.google.auto.service:auto-service-annotations:jar:*</unused>
                 <!-- unused/declared implementation jars or parent jars that bring in children -->
                 <unused>org.apache.hadoop:hadoop-client:jar:*</unused>
                 <unused>org.apache.hadoop:hadoop-client-runtime:jar:*</unused>
@@ -1050,6 +1057,15 @@ under the License.
                 <!-- This is only used at runtime only by test, not at compile time  -->
                 <unused>io.opentelemetry.javaagent:opentelemetry-javaagent:jar:*</unused>
               </ignoredUnusedDeclaredDependencies>
+            </configuration>
+          </execution>
+          <execution>
+            <id>analyze-exclusions</id>
+            <goals>
+              <goal>analyze-exclusions</goal>
+            </goals>
+            <configuration>
+              <exclusionFail>true</exclusionFail>
             </configuration>
           </execution>
         </executions>
@@ -1785,6 +1801,7 @@ under the License.
             <configuration>
               <compilerArgs>
                 <arg>-XDcompilePolicy=simple</arg>
+                <arg>-XDaddTypeAnnotationsToSymbol=true</arg>
                 <arg>--should-stop=ifError=FLOW</arg>
                 <arg>
                   -Xplugin:ErrorProne \

--- a/server/base/pom.xml
+++ b/server/base/pom.xml
@@ -40,11 +40,6 @@
       <artifactId>caffeine</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.auto.service</groupId>
-      <artifactId>auto-service</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
     </dependency>

--- a/server/base/src/main/java/org/apache/accumulo/server/zookeeper/DistributedWorkQueue.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/zookeeper/DistributedWorkQueue.java
@@ -45,6 +45,8 @@ import org.apache.zookeeper.Watcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Provides a way to push work out to tablet servers via zookeeper and wait for that work to be
  * done. Any tablet server can pick up a work item and process it.
@@ -278,6 +280,8 @@ public class DistributedWorkQueue {
     final Object condVar = new Object();
 
     Watcher watcher = new Watcher() {
+      @SuppressFBWarnings(value = "NN_NAKED_NOTIFY",
+          justification = "Monitored object was updated in a ZK thread.")
       @Override
       public void process(WatchedEvent event) {
         switch (event.getType()) {

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/GroupBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/GroupBalancerTest.java
@@ -56,6 +56,7 @@ public class GroupBalancerTest {
     }
   };
 
+  @Deprecated
   public static class TabletServers {
     private final Set<TServerInstance> tservers = new HashSet<>();
     private final Map<KeyExtent,TServerInstance> tabletLocs = new HashMap<>();
@@ -159,7 +160,7 @@ public class GroupBalancerTest {
 
       Map<String,Integer> expectedCounts = new HashMap<>();
 
-      int totalExtra = 0;
+      long totalExtra = 0;
       for (String group : groupCounts.keySet()) {
         long groupCount = groupCounts.get(group);
         totalExtra += groupCount % tservers.size();
@@ -167,12 +168,12 @@ public class GroupBalancerTest {
       }
 
       // The number of extra tablets from all groups that each tserver must have.
-      int expectedExtra = totalExtra / tservers.size();
-      int maxExtraGroups = expectedExtra + ((totalExtra % tservers.size() > 0) ? 1 : 0);
+      long expectedExtra = totalExtra / tservers.size();
+      long maxExtraGroups = expectedExtra + ((totalExtra % tservers.size() > 0) ? 1 : 0);
 
       for (Entry<TServerInstance,MapCounter<String>> entry : tserverGroupCounts.entrySet()) {
         MapCounter<String> tgc = entry.getValue();
-        int tserverExtra = 0;
+        long tserverExtra = 0;
         for (String group : groupCounts.keySet()) {
           assertTrue(tgc.get(group) >= expectedCounts.get(group));
           assertTrue(tgc.get(group) <= expectedCounts.get(group) + 1,
@@ -187,6 +188,7 @@ public class GroupBalancerTest {
     }
   }
 
+  @Deprecated
   @Test
   public void testSingleGroup() {
 
@@ -211,6 +213,7 @@ public class GroupBalancerTest {
     }
   }
 
+  @Deprecated
   @Test
   public void testTwoGroups() {
     String[][] tests = {new String[] {"a", "b", "c", "d"}, new String[] {"a", "b", "c"},
@@ -240,6 +243,7 @@ public class GroupBalancerTest {
     }
   }
 
+  @Deprecated
   @Test
   public void testThreeGroups() {
     String[][] tests = {new String[] {"a", "b", "c", "d"}, new String[] {"a", "b", "c"},
@@ -275,6 +279,7 @@ public class GroupBalancerTest {
     }
   }
 
+  @Deprecated
   @Test
   public void testManySingleTabletGroups() {
 
@@ -297,6 +302,7 @@ public class GroupBalancerTest {
     }
   }
 
+  @Deprecated
   @Test
   public void testMaxMigrations() {
 
@@ -321,6 +327,7 @@ public class GroupBalancerTest {
     }
   }
 
+  @Deprecated
   @Test
   public void bigTest() {
     TabletServers tservers = new TabletServers();
@@ -339,6 +346,7 @@ public class GroupBalancerTest {
     tservers.balance(1000);
   }
 
+  @Deprecated
   @Test
   public void bigTest2() {
     TabletServers tservers = new TabletServers();

--- a/server/compaction-coordinator/pom.xml
+++ b/server/compaction-coordinator/pom.xml
@@ -35,11 +35,6 @@
       <artifactId>caffeine</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.auto.service</groupId>
-      <artifactId>auto-service</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/server/compactor/pom.xml
+++ b/server/compactor/pom.xml
@@ -35,11 +35,6 @@
       <artifactId>jcommander</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.auto.service</groupId>
-      <artifactId>auto-service</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/server/gc/pom.xml
+++ b/server/gc/pom.xml
@@ -32,11 +32,6 @@
   <description>The garbage collecting server for Apache Accumulo to clean up unused files.</description>
   <dependencies>
     <dependency>
-      <groupId>com.google.auto.service</groupId>
-      <artifactId>auto-service</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/server/manager/pom.xml
+++ b/server/manager/pom.xml
@@ -32,11 +32,6 @@
   <description>The manager server for Apache Accumulo for load balancing and other system-wide operations.</description>
   <dependencies>
     <dependency>
-      <groupId>com.google.auto.service</groupId>
-      <artifactId>auto-service</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
     </dependency>

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -899,7 +899,7 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener, 
                   break;
               }
           }
-        } catch (Exception t) {
+        } catch (RuntimeException t) {
           log.error("Error occurred reading / switching manager goal state. Will"
               + " continue with attempt to update status", t);
         }
@@ -908,7 +908,7 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener, 
         try (Scope scope = span.makeCurrent()) {
           wait = updateStatus();
           eventListener.waitForEvents(wait);
-        } catch (Exception t) {
+        } catch (RuntimeException t) {
           TraceUtil.setException(span, t, false);
           log.error("Error balancing tablets, will wait for {} (seconds) and then retry ",
               WAIT_BETWEEN_ERRORS / ONE_SECOND, t);
@@ -1030,6 +1030,8 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener, 
       }
     }
 
+    @SuppressFBWarnings(value = "NN_NAKED_NOTIFY",
+        justification = "balance state checked before notification")
     private long balanceTablets() {
 
       // Check for balancer property change
@@ -1844,7 +1846,8 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener, 
     }
   }
 
-  @SuppressFBWarnings(value = "UW_UNCOND_WAIT", justification = "TODO needs triage")
+  @SuppressFBWarnings(value = "UW_UNCOND_WAIT",
+      justification = "balance condition is modified in another thread")
   public void waitForBalance() {
     synchronized (balancedNotifier) {
       long eventCounter;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/TableInfo.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/TableInfo.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.manager.tableOps;
 
 import java.io.Serializable;
-import java.util.Map;
+import java.util.HashMap;
 
 import org.apache.accumulo.core.client.admin.InitialTableState;
 import org.apache.accumulo.core.client.admin.TimeType;
@@ -46,7 +46,7 @@ public class TableInfo implements Serializable {
   private String splitFile;
   private String splitDirsFile;
 
-  public Map<String,String> props;
+  public HashMap<String,String> props; // type must be serializable
 
   public String getTableName() {
     return tableName;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneInfo.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneInfo.java
@@ -18,7 +18,11 @@
  */
 package org.apache.accumulo.manager.tableOps.clone;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -35,8 +39,8 @@ class CloneInfo implements Serializable {
   // TODO: Make final in 3.1
   private NamespaceId namespaceId;
   private final NamespaceId srcNamespaceId;
-  private final Map<String,String> propertiesToSet;
-  private final Set<String> propertiesToExclude;
+  private final HashMap<String,String> propertiesToSet; // type must be serializable
+  private final HashSet<String> propertiesToExclude; // type must be serializable
   private final boolean keepOffline;
   private final String user;
 
@@ -48,8 +52,8 @@ class CloneInfo implements Serializable {
     this.srcTableId = srcTableId;
     this.tableName = dstTableName;
     this.namespaceId = dstNamespaceId;
-    this.propertiesToSet = propertiesToSet;
-    this.propertiesToExclude = propertiesToExclude;
+    this.propertiesToSet = new HashMap<>(requireNonNull(propertiesToSet));
+    this.propertiesToExclude = new HashSet<>(requireNonNull(propertiesToExclude));
     this.keepOffline = keepOffline;
     this.user = user;
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/CreateTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/CreateTable.java
@@ -18,7 +18,10 @@
  */
 package org.apache.accumulo.manager.tableOps.create;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.accumulo.core.client.admin.InitialTableState;
@@ -49,7 +52,7 @@ public class CreateTable extends ManagerRepo {
     tableInfo.setTableName(tableName);
     tableInfo.setTimeType(timeType);
     tableInfo.setUser(user);
-    tableInfo.props = props;
+    tableInfo.props = new HashMap<>(requireNonNull(props));
     tableInfo.setNamespaceId(namespaceId);
     tableInfo.setSplitPath(splitPath);
     tableInfo.setInitialSplitSize(splitCount);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/CreateNamespace.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/CreateNamespace.java
@@ -18,6 +18,9 @@
  */
 package org.apache.accumulo.manager.tableOps.namespace.create;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.accumulo.core.data.NamespaceId;
@@ -35,7 +38,7 @@ public class CreateNamespace extends ManagerRepo {
     namespaceInfo = new NamespaceInfo();
     namespaceInfo.namespaceName = namespaceName;
     namespaceInfo.user = user;
-    namespaceInfo.props = props;
+    namespaceInfo.props = new HashMap<>(requireNonNull(props));
   }
 
   @Override

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/NamespaceInfo.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/NamespaceInfo.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.manager.tableOps.namespace.create;
 
 import java.io.Serializable;
-import java.util.Map;
+import java.util.HashMap;
 
 import org.apache.accumulo.core.data.NamespaceId;
 
@@ -31,5 +31,5 @@ class NamespaceInfo implements Serializable {
   NamespaceId namespaceId;
   String user;
 
-  public Map<String,String> props;
+  public HashMap<String,String> props; // type must be serializable
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportTable.java
@@ -24,8 +24,7 @@ import static java.util.function.Predicate.not;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.util.Collections;
-import java.util.List;
+import java.util.ArrayList;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
@@ -164,12 +163,13 @@ public class ImportTable extends ManagerRepo {
     Utils.unreserveNamespace(env, tableInfo.namespaceId, tid, false);
   }
 
-  static List<ImportedTableInfo.DirectoryMapping> parseExportDir(Set<String> exportDirs) {
+  static ArrayList<ImportedTableInfo.DirectoryMapping> parseExportDir(Set<String> exportDirs) {
     if (exportDirs == null || exportDirs.isEmpty()) {
-      return Collections.emptyList();
+      return new ArrayList<>();
     }
 
     return exportDirs.stream().filter(not(String::isEmpty))
-        .map(ImportedTableInfo.DirectoryMapping::new).collect(Collectors.toList());
+        .map(ImportedTableInfo.DirectoryMapping::new)
+        .collect(Collectors.toCollection(ArrayList::new));
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportedTableInfo.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportedTableInfo.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.manager.tableOps.tableImport;
 
 import java.io.Serializable;
-import java.util.List;
+import java.util.ArrayList;
 
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
@@ -32,7 +32,7 @@ class ImportedTableInfo implements Serializable {
   public String tableName;
   public TableId tableId;
   public NamespaceId namespaceId;
-  public List<DirectoryMapping> directories;
+  public ArrayList<DirectoryMapping> directories; // type must be serializable
   public String exportFile;
   public boolean keepMappings;
   public boolean keepOffline;

--- a/server/monitor/pom.xml
+++ b/server/monitor/pom.xml
@@ -40,11 +40,6 @@
       <artifactId>caffeine</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.auto.service</groupId>
-      <artifactId>auto-service</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
     </dependency>

--- a/server/tserver/pom.xml
+++ b/server/tserver/pom.xml
@@ -40,11 +40,6 @@
       <artifactId>caffeine</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.auto.service</groupId>
-      <artifactId>auto-service</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -35,11 +35,6 @@
       <artifactId>jcommander</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.auto.service</groupId>
-      <artifactId>auto-service</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
     </dependency>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -42,11 +42,6 @@
       <artifactId>caffeine</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.auto.service</groupId>
-      <artifactId>auto-service</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
     </dependency>


### PR DESCRIPTION
* Require Java 21 for build (does not change runtime requirements)
* Update GitHub Actions workflows
* Update ASF Parent POM to latest and update some plugins
* Fix some issues caught by the new compiler and/or spotbugs
* Suppress 'this-escape' category of compiler checks, because of too
  many false-positive issues, including with generated thrift code that
  is hard to suppress on a case-by-case basis
* Add dependency exclusion analysis (checks for unnecessary exclusions)
* Update errorprone to work with Java 21