### PR TITLE
logs uncaught errors in AbstractServer

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/AbstractServer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/AbstractServer.java
@@ -228,6 +228,9 @@ public abstract class AbstractServer
     log.info(getClass().getSimpleName() + " process shut down.");
     Throwable thrown = err.get();
     if (thrown != null) {
+      System.err.println("Uncaught execption in AbstractServer.runServer");
+      thrown.printStackTrace();
+      System.err.flush();
       log.error("Uncaught exception ", thrown);
       if (thrown instanceof Error) {
         throw (Error) thrown;


### PR DESCRIPTION
While working #6139 caused an exception in the servers main threads that also initiated a halt.  The halt seemed to preempt java from printing exceptions from the main thread, so the exception was never seen.  This made tracking the bug down more difficult.