### PR TITLE
removed Log 

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/NamespacesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/NamespacesIT.java
@@ -411,12 +411,8 @@ public class NamespacesIT extends SharedMiniClusterBase {
           EnumSet.allOf(IteratorScope.class));
       c.namespaceOperations().attachIterator(namespace, setting);
       sleepUninterruptibly(2, TimeUnit.SECONDS);
-      // conflicting iterator with same name and different priority
-      IteratorSetting conflictingSetting = new IteratorSetting(setting.getPriority() + 1,
-          setting.getName(), setting.getIteratorClass());
-      var e = assertThrows(AccumuloException.class,
-          () -> c.namespaceOperations().checkIteratorConflicts(namespace, conflictingSetting,
-              EnumSet.allOf(IteratorScope.class)));
+      var e = assertThrows(AccumuloException.class, () -> c.namespaceOperations()
+          .checkIteratorConflicts(namespace, setting, EnumSet.allOf(IteratorScope.class)));
       assertEquals(IllegalArgumentException.class, e.getCause().getClass());
       IteratorSetting setting2 = c.namespaceOperations().getIteratorSetting(namespace,
           setting.getName(), IteratorScope.scan);


### PR DESCRIPTION
Closes [issue #6045 ](https://github.com/apache/accumulo/issues/6045)

I removed the log from `lookupNamespaceId`, the DEBUG log was misleading since its  a "fail quietly" wrapper around `getNamespaceId` and was intended to "fail" there.  It looks like its called during namespace creation specifically to check that the namespace does not yet exist and should fail quietly and the null return is handled by the methods that call it. 

~~Additionally I fixed the error thrown in `namspacesIT`. The test was expecting for an error thrown but was being passed the same iterator. `IteratorConfigUtil` intentionally skips conflict detection when the iterator being checked is the same as an existing one, reattaching the same iterator is not an error.~~