### PR TITLE
fixes command variable passed to accumulo-env.sh

### DIFF
--- a/assemble/bin/accumulo
+++ b/assemble/bin/accumulo
@@ -34,6 +34,9 @@ function main() {
   export conf="${ACCUMULO_CONF_DIR:-${basedir}/conf}"
   export lib="${basedir}/lib"
   export cmd="$1"
+  if [[ $cmd == "proc" ]]; then
+    cmd="$2"
+  fi
 
   if [[ -z $conf || ! -d $conf ]]; then
     echo "$conf is not a valid directory.  Please make sure it exists"


### PR DESCRIPTION
Now that starting a manager looks like `accumulo proc manager` the correct thing is no longer being passed to the accumulo-env.sh for the `cmd` variable.  This was causing logging and other things to not work correctly.