### PR TITLE
Use Properties.store for MAC config props

### DIFF
--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
@@ -502,12 +502,15 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
 
   private void writeConfigProperties(java.nio.file.Path file, Map<String,String> settings)
       throws IOException {
-    BufferedWriter fileWriter = Files.newBufferedWriter(file);
+    Properties props = new Properties();
 
     for (Entry<String,String> entry : settings.entrySet()) {
-      fileWriter.append(entry.getKey() + "=" + entry.getValue() + "\n");
+      props.setProperty(entry.getKey(), entry.getValue());
     }
-    fileWriter.close();
+
+    try (BufferedWriter fileWriter = Files.newBufferedWriter(file)) {
+      props.store(fileWriter, null);
+    }
   }
 
   private Configuration loadExistingHadoopConfiguration() {

--- a/test/src/main/java/org/apache/accumulo/test/ScanServerGroupConfigurationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ScanServerGroupConfigurationIT.java
@@ -45,58 +45,59 @@ import org.junit.jupiter.api.Test;
 
 public class ScanServerGroupConfigurationIT extends SharedMiniClusterBase {
 
-  // @formatter:off
-  public static final String clientConfiguration =
-     "["+
-     " {"+
-     "   \"isDefault\": true,"+
-     "   \"maxBusyTimeout\": \"5m\","+
-     "   \"busyTimeoutMultiplier\": 8,"+
-     "   \"scanTypeActivations\": [],"+
-     "   \"timeToWaitForScanServers\":\"0s\","+
-     "   \"attemptPlans\": ["+
-     "     {"+
-     "       \"servers\": \"3\","+
-     "       \"busyTimeout\": \"33ms\","+
-     "       \"salt\": \"one\""+
-     "     },"+
-     "     {"+
-     "       \"servers\": \"13\","+
-     "       \"busyTimeout\": \"33ms\","+
-     "       \"salt\": \"two\""+
-     "     },"+
-     "     {"+
-     "       \"servers\": \"100%\","+
-     "       \"busyTimeout\": \"33ms\""+
-     "     }"+
-     "   ]"+
-     "  },"+
-     " {"+
-     "   \"isDefault\": false,"+
-     "   \"maxBusyTimeout\": \"5m\","+
-     "   \"busyTimeoutMultiplier\": 8,"+
-     "   \"group\": \"GROUP1\","+
-     "   \"scanTypeActivations\": [\"use_group1\"],"+
-     "   \"timeToWaitForScanServers\":\"0s\","+
-     "   \"attemptPlans\": ["+
-     "     {"+
-     "       \"servers\": \"3\","+
-     "       \"busyTimeout\": \"33ms\","+
-     "       \"salt\": \"one\""+
-     "     },"+
-     "     {"+
-     "       \"servers\": \"13\","+
-     "       \"busyTimeout\": \"33ms\","+
-     "       \"salt\": \"two\""+
-     "     },"+
-     "     {"+
-     "       \"servers\": \"100%\","+
-     "       \"busyTimeout\": \"33ms\""+
-     "     }"+
-     "   ]"+
-     "  }"+
-     "]";
-  // @formatter:on
+  public static final String clientConfiguration = """
+      [
+          {
+              "isDefault": true,
+              "maxBusyTimeout": "5m",
+              "busyTimeoutMultiplier": 8,
+              "scanTypeActivations": [],
+              "timeToWaitForScanServers": "0s",
+              "attemptPlans": [
+                  {
+                      "servers": "3",
+                      "busyTimeout": "33ms",
+                      "salt": "one"
+                  },
+                  {
+                      "servers": "13",
+                      "busyTimeout": "33ms",
+                      "salt": "two"
+                  },
+                  {
+                      "servers": "100%",
+                      "busyTimeout": "33ms"
+                  }
+              ]
+          },
+          {
+              "isDefault": false,
+              "maxBusyTimeout": "5m",
+              "busyTimeoutMultiplier": 8,
+              "group": "GROUP1",
+              "scanTypeActivations": [
+                  "use_group1"
+              ],
+              "timeToWaitForScanServers": "0s",
+              "attemptPlans": [
+                  {
+                      "servers": "3",
+                      "busyTimeout": "33ms",
+                      "salt": "one"
+                  },
+                  {
+                      "servers": "13",
+                      "busyTimeout": "33ms",
+                      "salt": "two"
+                  },
+                  {
+                      "servers": "100%",
+                      "busyTimeout": "33ms"
+                  }
+              ]
+          }
+      ]
+      """;
 
   private static class Config implements MiniClusterConfigurationCallback {
     @Override


### PR DESCRIPTION
MAC writes to a `.properties` file in a way that breaks newline JSON values. This happened because `MiniAccumuloClusterImpl.writeConfigProperties()` manually wrote the `key=value` to the file without proper newline escaping. This PR uses Properties.store() for for .properties serialization so we can remove the manual code and properly handle newlines. 

I did not add any new tests for this but with the newline escaping removed from ScanServerGroupConfigurationIT, the test passes with these changes to `writeConfigProperties()` and throws a json parse exception without them.

Note:
This PR is against main since I wasn't sure if this was something we wanted to change in 2.1 or not.