### PR TITLE
Fixes LocatorIT when locating tablets for offline table

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -1930,6 +1930,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
     requireNonNull(ranges, "ranges must be non null");
 
     TableId tableId = context.getTableId(tableName);
+    context.requireNotOffline(tableId, tableName);
     TabletLocator locator = TabletLocator.getLocator(context, tableId);
 
     List<Range> rangeList = null;

--- a/test/src/main/java/org/apache/accumulo/test/LocatorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/LocatorIT.java
@@ -36,6 +36,7 @@ import java.util.TreeSet;
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.TableOfflineException;
 import org.apache.accumulo.core.client.admin.Locations;
 import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.core.data.Range;
@@ -123,6 +124,8 @@ public class LocatorIT extends AccumuloClusterHarness {
           Map.of(t2, Set.of(r1, r2), t3, Set.of(r2)));
 
       tableOps.offline(tableName, true);
+
+      assertThrows(TableOfflineException.class, () -> tableOps.locate(tableName, ranges));
 
       tableOps.delete(tableName);
 


### PR DESCRIPTION
The TabletLocator no longer throws an exception when trying to locate tablets for an offline table due to the changes in PR #6156 that allows Scan Servers to scan an offline table.