### PR TITLE
Properly account for iterator opt keys with muplitple dots

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/IteratorProperty.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/IteratorProperty.java
@@ -138,7 +138,8 @@ public class IteratorProperty {
       return null;
     }
 
-    String[] iterPropParts = property.split("\\.", -1);
+    // Iterator option keys may contain dots, so preserve everything after ".opt." as one token.
+    String[] iterPropParts = property.split("\\.", 6);
     check(iterPropParts.length == 4 || iterPropParts.length == 6, property, value);
     IteratorUtil.IteratorScope scope = IteratorUtil.IteratorScope.valueOf(iterPropParts[2]);
     String iterName = iterPropParts[3];

--- a/core/src/test/java/org/apache/accumulo/core/iteratorsImpl/IteratorConfigUtilTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iteratorsImpl/IteratorConfigUtilTest.java
@@ -284,6 +284,27 @@ public class IteratorConfigUtilTest {
 
   }
 
+  /**
+   * Test that options with keys that contain dots are properly parsed
+   */
+  @Test
+  public void testOptionKeyContainingDots() {
+    Map<String,Map<String,String>> options = new HashMap<>();
+    ConfigurationCopy conf = new ConfigurationCopy();
+    conf.set(Property.TABLE_ITERATOR_SCAN_PREFIX + "error",
+        "50," + SummingCombiner.class.getName());
+
+    // add an option with a key that contains dots
+    conf.set(Property.TABLE_ITERATOR_SCAN_PREFIX + "error.opt.error.throwing.iterator.times", "3");
+
+    List<IterInfo> iterators =
+        IteratorConfigUtil.parseIterConf(IteratorScope.scan, EMPTY_ITERS, options, conf);
+
+    assertEquals(1, iterators.size());
+    assertEquals(new IterInfo(50, SummingCombiner.class.getName(), "error"), iterators.get(0));
+    assertEquals(Map.of("error.throwing.iterator.times", "3"), options.get("error"));
+  }
+
   @Test
   public void test5() throws IOException, ReflectiveOperationException {
     ConfigurationCopy conf = new ConfigurationCopy();

--- a/test/src/main/java/org/apache/accumulo/test/NamespacesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/NamespacesIT.java
@@ -411,9 +411,8 @@ public class NamespacesIT extends SharedMiniClusterBase {
           EnumSet.allOf(IteratorScope.class));
       c.namespaceOperations().attachIterator(namespace, setting);
       sleepUninterruptibly(2, TimeUnit.SECONDS);
-      var e = assertThrows(AccumuloException.class, () -> c.namespaceOperations()
-          .checkIteratorConflicts(namespace, setting, EnumSet.allOf(IteratorScope.class)));
-      assertEquals(IllegalArgumentException.class, e.getCause().getClass());
+      c.namespaceOperations().checkIteratorConflicts(namespace, setting,
+          EnumSet.allOf(IteratorScope.class));
       IteratorSetting setting2 = c.namespaceOperations().getIteratorSetting(namespace,
           setting.getName(), IteratorScope.scan);
       assertEquals(setting, setting2);


### PR DESCRIPTION
#6111 added increased checks when parsing iterators. One of the checks disallowed iterator opt keys to have multiple dots in it. This PR fixes that.

A new test was added to cover this case and an existing test case that was failing was fixed here.