### PR TITLE
Split External Compactions Monitor page into Active Compactions and Compactors pages

### DIFF
--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/view/WebViews.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/view/WebViews.java
@@ -242,22 +242,35 @@ public class WebViews {
   }
 
   /**
-   * Returns the compactions template
+   * Returns the active compactions template.
    *
-   * @return Scans model
+   * @return Active compactions model
    */
   @GET
   @Path("ec")
   @Template(name = "/default.ftl")
-  public Map<String,Object> getExternalCompactions() {
-    var ccHost = monitor.getCoordinatorHost();
-
+  public Map<String,Object> getActiveCompactions() {
     Map<String,Object> model = getModel();
-    model.put("title", "External Compactions");
+    model.put("title", "Active Compactions");
     model.put("template", "ec.ftl");
-
-    model.put("coordinatorRunning", ccHost.isPresent());
     model.put("js", "ec.js");
+
+    return model;
+  }
+
+  /**
+   * Returns the compactors template
+   *
+   * @return Compactors model
+   */
+  @GET
+  @Path("compactors")
+  @Template(name = "/default.ftl")
+  public Map<String,Object> getCompactors() {
+    Map<String,Object> model = getModel();
+    model.put("title", "Compactors");
+    model.put("template", "compactors.ftl");
+    model.put("js", "compactors.js");
 
     return model;
   }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/compactors.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/compactors.js
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+"use strict";
+
+var compactorsTable;
+
+$(function () {
+  // display datatables errors in the console instead of in alerts
+  $.fn.dataTable.ext.errMode = 'throw';
+
+  compactorsTable = $('#compactorsTable').DataTable({
+    "autoWidth": false,
+    "ajax": {
+      "url": contextPath + 'rest-v2/ec/compactors',
+      "dataSrc": "compactors"
+    },
+    "stateSave": true,
+    "dom": 't<"align-left"l>p',
+    "columnDefs": [{
+        "targets": "duration",
+        "render": function (data, type, row) {
+          if (type === 'display') data = timeDuration(data);
+          return data;
+        }
+      },
+      {
+        "targets": "date",
+        "render": function (data, type, row) {
+          if (type === 'display') data = dateFormat(data);
+          return data;
+        }
+      }
+    ],
+    "columns": [{
+        "data": "server"
+      },
+      {
+        "data": "groupName"
+      },
+      {
+        "data": "lastContact"
+      }
+    ]
+  });
+});
+
+function refreshCompactors() {
+  if (compactorsTable) {
+    ajaxReloadTable(compactorsTable);
+  }
+}
+
+function refresh() {
+  refreshCompactors();
+}

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/ec.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/ec.js
@@ -18,11 +18,7 @@
  */
 "use strict";
 
-var coordinatorTable;
-var compactorsTable;
-var compactorsTableData;
 var runningTable;
-var runningTableData;
 
 /**
  * Creates active compactions table
@@ -34,41 +30,6 @@ $(function () {
 
   // display datatables errors in the console instead of in alerts
   $.fn.dataTable.ext.errMode = 'throw';
-
-  compactorsTable = $('#compactorsTable').DataTable({
-    "autoWidth": false,
-    "ajax": {
-      "url": contextPath + 'rest-v2/ec/compactors',
-      "dataSrc": "compactors"
-    },
-    "stateSave": true,
-    "dom": 't<"align-left"l>p',
-    "columnDefs": [{
-        "targets": "duration",
-        "render": function (data, type, row) {
-          if (type === 'display') data = timeDuration(data);
-          return data;
-        }
-      },
-      {
-        "targets": "date",
-        "render": function (data, type, row) {
-          if (type === 'display') data = dateFormat(data);
-          return data;
-        }
-      }
-    ],
-    "columns": [{
-        "data": "server"
-      },
-      {
-        "data": "groupName"
-      },
-      {
-        "data": "lastContact"
-      }
-    ]
-  });
 
   const hostnameColumnName = 'hostname';
   const queueNameColumnName = 'queueName';
@@ -284,49 +245,6 @@ $(function () {
     return seconds;
   }
 
-  // Create a table for compaction coordinator
-  coordinatorTable = $('#coordinatorTable').DataTable({
-    "autoWidth": false,
-    "ajax": {
-      "url": contextPath + 'rest-v2/ec',
-      "dataSrc": function (data) {
-        // the data needs to be in an array to work with DataTables
-        var arr = [];
-        if (data === undefined) {
-          console.warn('the value of "data" is undefined');
-        } else {
-          arr = [data];
-        }
-
-        return arr;
-      }
-    },
-    "stateSave": true,
-    "searching": false,
-    "paging": false,
-    "info": false,
-    "columnDefs": [{
-      "targets": "duration",
-      "render": function (data, type, row) {
-        if (type === 'display') data = timeDuration(data);
-        return data;
-      }
-    }],
-    "columns": [{
-        "data": "server"
-      },
-      {
-        "data": "numQueues"
-      },
-      {
-        "data": "numCompactors"
-      },
-      {
-        "data": "lastContact"
-      }
-    ]
-  });
-
   // Array to track the ids of the details displayed rows
   var detailRows = [];
   $("#runningTable tbody").on('click', 'tr td.details-control', function () {
@@ -337,7 +255,6 @@ $(function () {
     if (row.child.isShown()) {
       tr.removeClass('details');
       row.child.hide();
-
       // Remove from the 'open' array
       detailRows.splice(idx, 1);
     } else {
@@ -346,12 +263,13 @@ $(function () {
       var idSuffix = ecid.substring(ecid.length - 5, ecid.length);
       tr.addClass('details');
       // put all the information into html for a single row
-      var htmlRow = "<table class='table table-bordered table-striped table-condensed' id='table" + idSuffix + "'>"
+      var htmlRow = "<table class='table table-bordered table-striped table-condensed' id='table" + idSuffix + "'>";
       htmlRow += "<thead><tr><th>#</th><th>Input Files</th><th>Size</th><th>Entries</th></tr></thead>";
       htmlRow += "<tbody></tbody></table>";
       htmlRow += "Output File: <span id='outputFile" + idSuffix + "'></span><br>";
       htmlRow += ecid;
       row.child(htmlRow).show();
+
       // show the row then populate the table
       var ecDetails = getDetailsFromStorage(idSuffix);
       if (ecDetails.length === 0) {
@@ -367,53 +285,49 @@ $(function () {
       }
     }
   });
-  refreshECTables();
+
+  refreshRunningCompactions();
 });
 
 /**
  * Used to redraw the page
  */
 function refresh() {
-  refreshECTables();
+  refreshRunningCompactions();
 }
 
 /**
- * Refreshes the compaction tables
+ * Refreshes the running compactions
  */
-function refreshECTables() {
-  refreshCoordinatorStatus().then(function (coordinatorStatus) {
-
+function refreshRunningCompactions() {
+  refreshManagerStatus().then(function (managerStatus) {
     // tables will not be shown, avoid reloading
-    if (coordinatorStatus === 'ERROR') {
+    if (managerStatus === 'ERROR') {
       return;
     }
 
     // user paging is not reset on reload
-    refreshCompactors();
-    refreshRunning();
-    ajaxReloadTable(coordinatorTable);
+    ajaxReloadTable(runningTable);
   });
 }
 
 /**
- * Updates session storage then checks if the coordinator is running. If it is,
- * show the tables and hide the 'coordinator not running' banner. Else, vise-versa.
- *
- * returns the coordinator status
+ * Updates session storage then checks if the manager is running. If it is,
+ * show the tables and hide the 'manager not running' banner. Else, vice-versa.
  */
-async function refreshCoordinatorStatus() {
+async function refreshManagerStatus() {
   return getStatus().then(function () {
-    var coordinatorStatus = JSON.parse(sessionStorage.status).coordinatorStatus;
-    if (coordinatorStatus === 'ERROR') {
+    var managerStatus = JSON.parse(sessionStorage.status).managerStatus;
+    if (managerStatus === 'ERROR') {
       // show banner and hide tables
-      $('#ccBanner').show();
-      $('#ecDiv').hide();
+      $('#managerBanner').show();
+      $('#runningDiv').hide();
     } else {
       // otherwise, hide banner and show tables
-      $('#ccBanner').hide();
-      $('#ecDiv').show();
+      $('#managerBanner').hide();
+      $('#runningDiv').show();
     }
-    return coordinatorStatus;
+    return managerStatus;
   });
 }
 
@@ -473,18 +387,6 @@ function populateDetails(data, idSuffix) {
     }).appendTo('#' + tableId + ' tbody');
   });
   $('#outputFile' + idSuffix).text(data.outputFile);
-}
-
-function refreshCompactors() {
-  console.log("Refresh compactors table.");
-  // user paging is not reset on reload
-  ajaxReloadTable(compactorsTable);
-}
-
-function refreshRunning() {
-  console.log("Refresh running compactions table.");
-  // user paging is not reset on reload
-  ajaxReloadTable(runningTable);
 }
 
 // Helper function to validate regex

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
@@ -108,16 +108,25 @@ function updateServerNotifications(statusData) {
         '. Could not properly set scan server status notification.');
     }
 
+    // setting compactor status notification
+    if (statusData.compactorStatus === STATUS.OK) {
+      updateElementStatus('compactorStatusNotification', STATUS.OK);
+    } else {
+      updateElementStatus('compactorStatusNotification', STATUS.ERROR);
+    }
+
     // Setting overall servers status notification
     if ((statusData.managerStatus === STATUS.OK && !isSafeMode && !isCleanStop) &&
       statusData.tServerStatus === STATUS.OK &&
       statusData.gcStatus === STATUS.OK &&
-      statusData.sServerStatus === STATUS.OK) {
+      statusData.sServerStatus === STATUS.OK &&
+      statusData.compactorStatus === STATUS.OK) {
       updateElementStatus('statusNotification', STATUS.OK);
     } else if (statusData.managerStatus === STATUS.ERROR || isCleanStop ||
       statusData.tServerStatus === STATUS.ERROR ||
       statusData.gcStatus === STATUS.ERROR ||
-      statusData.sServerStatus === STATUS.ERROR) {
+      statusData.sServerStatus === STATUS.ERROR ||
+      statusData.compactorStatus === STATUS.ERROR) {
       updateElementStatus('statusNotification', STATUS.ERROR);
     } else if (statusData.managerStatus === STATUS.WARN || isSafeMode ||
       statusData.tServerStatus === STATUS.WARN ||
@@ -162,6 +171,24 @@ function refreshSserverStatus() {
 }
 
 /**
+ * Sets compactor menu status LED notification to OK if any compactors exist, else ERROR
+ */
+function refreshCompactorStatus() {
+  return $.getJSON(REST_V2_PREFIX + '/ec/compactors').done(function (data) {
+    if (Number(data?.numCompactors) > 0) {
+      sessionStorage.compactorStatus = STATUS.OK;
+      updateElementStatus('compactorStatusNotification', STATUS.OK);
+    } else {
+      sessionStorage.compactorStatus = STATUS.ERROR;
+      updateElementStatus('compactorStatusNotification', STATUS.ERROR);
+    }
+  }).fail(function () {
+    sessionStorage.compactorStatus = STATUS.ERROR;
+    updateElementStatus('compactorStatusNotification', STATUS.ERROR);
+  });
+}
+
+/**
  * Creates the initial sidebar
  */
 $(function () {
@@ -172,7 +199,7 @@ $(function () {
  * Makes the REST call for the server status, generates the sidebar with the new information
  */
 function refreshSidebar() {
-  $.when(getStatus(), refreshSserverStatus()).always(function () {
+  $.when(getStatus(), refreshSserverStatus(), refreshCompactorStatus()).always(function () {
     refreshSideBarNotifications();
   });
 }
@@ -194,6 +221,7 @@ function refreshSideBarNotifications() {
     return;
   }
   statusData.sServerStatus = sessionStorage.sServerStatus || STATUS.OK;
+  statusData.compactorStatus = sessionStorage.compactorStatus || STATUS.OK;
 
   updateServerNotifications(statusData);
 }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/compactors.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/compactors.ftl
@@ -1,0 +1,41 @@
+<#--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+      <div class="row">
+        <div class="col-xs-12">
+          <h3>${title}</h3>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-xs-12">
+          <table id="compactorsTable" class="table caption-top table-bordered table-striped table-condensed">
+            <caption><span class="table-caption">Compactors</span>&nbsp;&nbsp;
+              <a href="javascript:refreshCompactors();"><span style="font-size: 1.5em; color: black;" class="bi bi-arrow-repeat"></span></a>
+            </caption>
+            <thead>
+              <tr>
+                <th class="firstcell" title="The hostname the compactor is running on.">Server</th>
+                <th title="The name of the group this compactor is assigned.">Group</th>
+                <th class="duration" title="Last time data was fetched. Server fetches on refresh, at most every minute.">Last Contact</th>
+              </tr>
+            </thead>
+          </table>
+        </div>
+      </div>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/ec.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/ec.ftl
@@ -23,40 +23,7 @@
           <h3>${title}</h3>
         </div>
       </div>
-      <div id="ecDiv" style="display: none;">
-        <div class="row">
-          <div class="col-xs-12">
-            <table id="coordinatorTable" class="table caption-top table-bordered table-striped table-condensed">
-              <caption><span class="table-caption">Compaction&nbsp;Coordinator</span></caption>
-              <thead>
-                <tr>
-                  <th class="firstcell" title="The hostname the compactor coordinator is running on.">Server&nbsp;</th>
-                  <th title="Number of queues configured">Queues</th>
-                  <th title="Number of compactors running">Compactors</th>
-                  <th class="duration">Last&nbsp;Contact</th>
-                </tr>
-              </thead>
-            </table>
-          </div>
-        </div>
-        <br />
-        <div class="row">
-          <div class="col-xs-12">
-            <table id="compactorsTable" class="table caption-top table-bordered table-striped table-condensed">
-              <caption><span class="table-caption">Compactors</span>&nbsp;&nbsp;
-                <a href="javascript:refreshCompactors();"><span style="font-size: 1.5em; color: black;" class="bi bi-arrow-repeat"></span></a>
-              </caption>
-              <thead>
-                <tr>
-                  <th class="firstcell" title="The hostname the compactor is running on.">Server</th>
-                  <th title="The name of the group this compactor is assigned.">Group</th>
-                  <th class="duration" title="Last time data was fetched. Server fetches on refresh, at most every minute.">Last Contact</th>
-                </tr>
-              </thead>
-            </table>
-          </div>
-        </div>
-        <br />
+      <div id="runningDiv" style="display: none;">
         <div class="row">
           <div class="col-xs-12">
             <table id="runningTable" class="table caption-top table-bordered table-striped table-condensed">
@@ -138,6 +105,6 @@
           </div>
         </div>
       </div>
-    <div id="ccBanner" style="display: none;">
-      <div class="alert alert-danger" role="alert">Compaction Coordinator Not Running</div>
+    <div id="managerBanner" style="display: none;">
+      <div class="alert alert-danger" role="alert">Manager Not Running</div>
     </div>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/navbar.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/navbar.ftl
@@ -42,6 +42,7 @@
                 <li><a class="dropdown-item" href="manager"><span id="managerStatusNotification" class="icon-dot normal"></span>&nbsp;Manager&nbsp;Server&nbsp;</a></li>
                 <li><a class="dropdown-item" href="tservers"><span id="serverStatusNotification" class="icon-dot normal"></span>&nbsp;Tablet&nbsp;Servers&nbsp;</a></li>
                 <li><a class="dropdown-item" href="sservers"><span id="sserverStatusNotification" class="icon-dot normal"></span>&nbsp;Scan&nbsp;Servers&nbsp;</a></li>
+                <li><a class="dropdown-item" href="compactors"><span id="compactorStatusNotification" class="icon-dot normal"></span>&nbsp;Compactors</a></li>
                 <li><a class="dropdown-item" href="gc"><span id="gcStatusNotification" class="icon-dot normal"></span>&nbsp;Garbage&nbsp;collector&nbsp;</a></li>
               </ul>
             </li>
@@ -53,10 +54,9 @@
                 Activity
               </a>
               <ul class="dropdown-menu col-xs-12" aria-labelledby="navbarDropdown">
-                <li><a class="dropdown-item" href="compactions">Active&nbsp;Compactions</a></li>
+                <li><a class="dropdown-item" href="ec">Active&nbsp;Compactions</a></li>
                 <li><a class="dropdown-item" href="scans">Active&nbsp;Scans</a></li>
                 <li><a class="dropdown-item" href="bulkImports">Bulk&nbsp;Imports</a></li>
-                <li><a class="dropdown-item" href="ec">External&nbsp;Compactions</a></li>
               </ul>
             </li>
             <li class="dropdown">


### PR DESCRIPTION
fixes #6090 

This PR:
* moves Compactors into its own page under Servers menu
* rename "external compactions" -> "active compactions" under activity menu
* remove "external compaction" menu item
* adds status LED notification for new Compactors page (OK when any compactor present, else ERROR)