### PR TITLE
Improve Monitor status LED notifications

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/compactors.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/compactors.js
@@ -20,15 +20,50 @@
 
 var compactorsTable;
 
+/**
+ * Shows a red banner with the given message
+ */
+function showCompactorsBanner(message) {
+  $('#compactors-banner-message')
+    .removeClass('alert-warning')
+    .addClass('alert-danger')
+    .text(message);
+  $('#compactorsStatusBanner').show();
+}
+
+/**
+ * Show the error banner when there are no compactors
+ */
+function updateCompactorsBanner(compactors) {
+  if (!Array.isArray(compactors) || compactors.length === 0) {
+    showCompactorsBanner('No compactors are currently registered.');
+  } else {
+    $('#compactorsStatusBanner').hide();
+  }
+}
+
 $(function () {
   // display datatables errors in the console instead of in alerts
   $.fn.dataTable.ext.errMode = 'throw';
 
   compactorsTable = $('#compactorsTable').DataTable({
     "autoWidth": false,
-    "ajax": {
-      "url": contextPath + 'rest-v2/ec/compactors',
-      "dataSrc": "compactors"
+    "ajax": function (data, callback) {
+      $.ajax({
+        "url": contextPath + 'rest-v2/ec/compactors',
+        "method": 'GET'
+      }).done(function (response) {
+        var compactors = Array.isArray(response.compactors) ? response.compactors : [];
+        updateCompactorsBanner(compactors);
+        callback({
+          "data": compactors
+        });
+      }).fail(function () {
+        showCompactorsBanner('Unable to retrieve compactor status.');
+        callback({
+          "data": []
+        });
+      });
     },
     "stateSave": true,
     "dom": 't<"align-left"l>p',

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
@@ -144,7 +144,7 @@ function updateServerNotifications(statusData) {
 }
 
 /**
- * Updates the scan server notification based on REST v2 metrics status.
+ * Updates the scan server notification based on REST v2 status.
  */
 function refreshSserverStatus() {
   return getSserversView().done(function () {
@@ -156,7 +156,7 @@ function refreshSserverStatus() {
       return;
     }
 
-    if (status.level === STATUS.WARN) {
+    if (status.hasProblemScanServers === true) {
       sessionStorage.sServerStatus = STATUS.WARN;
       updateElementStatus('sserverStatusNotification', STATUS.WARN);
     } else {

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/tservers.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/tservers.js
@@ -18,7 +18,7 @@
  */
 /* JSLint global definitions */
 /*global
-    $, sessionStorage, getTServers, getRecoveryList, bigNumberForQuantity, timeDuration,
+    $, sessionStorage, getTServers, getRecoveryList, getStatus, bigNumberForQuantity, timeDuration,
     ajaxReloadTable
 */
 "use strict";
@@ -70,11 +70,34 @@ function refreshTServersTable() {
 }
 
 /**
+ * If manager is down, tserver status will be ERROR. Add a banner to indicate
+ */
+function refreshTServersBanner(managerStatus) {
+  if (managerStatus === 'ERROR') {
+    $('#tserversManagerBanner').show();
+    $('#tservers_wrapper').hide();
+    $('#recovery-caption').hide();
+  } else {
+    $('#tserversManagerBanner').hide();
+    $('#tservers_wrapper').show();
+  }
+}
+
+/**
  * Makes the REST calls, generates the tables with the new information
  */
 function refreshTServers() {
-  getTServers().then(function () {
-    refreshTServersTable();
+  getStatus().then(function () {
+    var managerStatus = JSON.parse(sessionStorage.status).managerStatus;
+    refreshTServersBanner(managerStatus);
+
+    if (managerStatus === 'ERROR') {
+      return;
+    }
+
+    getTServers().then(function () {
+      refreshTServersTable();
+    });
   });
 }
 

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/compactors.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/compactors.ftl
@@ -23,6 +23,9 @@
           <h3>${title}</h3>
         </div>
       </div>
+      <div id="compactorsStatusBanner" style="display: none;">
+        <div id="compactors-banner-message" class="alert" role="alert"></div>
+      </div>
       <div class="row">
         <div class="col-xs-12">
           <table id="compactorsTable" class="table caption-top table-bordered table-striped table-condensed">

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/tservers.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/tservers.ftl
@@ -23,6 +23,9 @@
         <h3>${title}</h3>
       </div>
     </div>
+    <div id="tserversManagerBanner" style="display: none;">
+      <div class="alert alert-danger" role="alert">Manager Not Running</div>
+    </div>
     <div class="row">
       <div class="col-xs-12">
         <span id="recovery-caption" style="background-color: gold; display: none;">Highlighted rows correspond to tservers in recovery mode.</span>


### PR DESCRIPTION
* Scan Server menu status LED no longer set to WARN just because metrics are missing. Instead, only indicate server problems if present (banner on the page asks if metrics are enabled if they are not being received by the front end)
* Tablet Servers page now shows a banner when the manager is not running since the tserver status LED will be ERROR in that case too. This helps indicate why the status LED is ERROR
* Added banner to compactors page to show on error states:
  * no compactors
  * unable to fetch status