### PR TITLE
WIP - Refactor External Compactions monitor view to use snapshot-backed Top 50 data

### DIFF
--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -49,9 +49,6 @@ import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.cli.ServerOpts;
 import org.apache.accumulo.core.client.admin.servers.ServerId;
 import org.apache.accumulo.core.client.admin.servers.ServerId.Type;
-import org.apache.accumulo.core.compaction.thrift.CompactionCoordinatorService;
-import org.apache.accumulo.core.compaction.thrift.TExternalCompaction;
-import org.apache.accumulo.core.compaction.thrift.TExternalCompactionMap;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil.NodeExistsPolicy;
@@ -66,7 +63,6 @@ import org.apache.accumulo.core.manager.thrift.ManagerClientService;
 import org.apache.accumulo.core.manager.thrift.ManagerMonitorInfo;
 import org.apache.accumulo.core.manager.thrift.TableInfo;
 import org.apache.accumulo.core.manager.thrift.TabletServerStatus;
-import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
 import org.apache.accumulo.core.metrics.MetricsInfo;
 import org.apache.accumulo.core.rpc.ThriftUtil;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
@@ -81,7 +77,6 @@ import org.apache.accumulo.monitor.next.InformationFetcher;
 import org.apache.accumulo.server.AbstractServer;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.util.TableInfoUtil;
-import org.apache.thrift.transport.TTransportException;
 import org.apache.zookeeper.KeeperException;
 import org.eclipse.jetty.ee10.servlet.ResourceServlet;
 import org.eclipse.jetty.ee10.servlet.ServletHolder;
@@ -559,13 +554,6 @@ public class Monitor extends AbstractServer implements Connection.Listener {
   private final Supplier<Map<HostAndPort,CompactionStats>> compactionsSupplier =
       Suppliers.memoizeWithExpiration(this::fetchCompactions, expirationTimeMinutes, MINUTES);
 
-  private final Supplier<ExternalCompactorSnapshot> compactorInfoSupplier =
-      Suppliers.memoizeWithExpiration(this::fetchCompactorsInfo, expirationTimeMinutes, MINUTES);
-
-  private final Supplier<ExternalCompactionsSnapshot> externalCompactionsSupplier =
-      Suppliers.memoizeWithExpiration(this::computeExternalCompactionsSnapshot,
-          expirationTimeMinutes, MINUTES);
-
   /**
    * @return active tablet server scans. Values are cached and refresh after
    *         {@link #expirationTimeMinutes}.
@@ -587,41 +575,6 @@ public class Monitor extends AbstractServer implements Connection.Listener {
    */
   public Map<HostAndPort,CompactionStats> getCompactions() {
     return compactionsSupplier.get();
-  }
-
-  /**
-   * @return compaction coordinator host from the latest external compaction fetch.
-   */
-  public HostAndPort getCompactionCoordinatorHost() {
-    return compactorInfoSupplier.get().coordinatorHost;
-  }
-
-  /**
-   * @return compactors from the latest external compaction fetch.
-   */
-  public Set<ServerId> getCompactorServers() {
-    return compactorInfoSupplier.get().compactors;
-  }
-
-  /**
-   * @return timestamp in millis when external compactor info was last fetched.
-   */
-  public long getCompactorInfoFetchedTimeMillis() {
-    return compactorInfoSupplier.get().fetchedTimeMillis;
-  }
-
-  /**
-   * @return running external compactions keyed by ECID.
-   */
-  public Map<String,TExternalCompaction> getRunningCompactionsMap() {
-    return externalCompactionsSupplier.get().ecRunningMap;
-  }
-
-  /**
-   * @return running external compaction for the provided ECID, or null when not found.
-   */
-  public TExternalCompaction getRunningCompaction(ExternalCompactionId ecid) {
-    return getRunningCompactionsMap().get(ecid.canonical());
   }
 
   private Map<HostAndPort,ScanStats> fetchScans(Collection<ServerId> servers) {
@@ -668,58 +621,6 @@ public class Monitor extends AbstractServer implements Connection.Listener {
       }
     }
     return Collections.unmodifiableMap(allCompactions);
-  }
-
-  private ExternalCompactorSnapshot fetchCompactorsInfo() {
-    var compactionCoordinatorHost =
-        coordinatorHost.orElseThrow(() -> new IllegalStateException(coordinatorMissingMsg));
-    Set<ServerId> compactors =
-        getContext().instanceOperations().getServers(ServerId.Type.COMPACTOR);
-    log.debug("Found compactors: {}", compactors);
-    return new ExternalCompactorSnapshot(compactionCoordinatorHost, compactors,
-        System.currentTimeMillis());
-  }
-
-  private record ExternalCompactorSnapshot(HostAndPort coordinatorHost, Set<ServerId> compactors,
-      long fetchedTimeMillis) {
-    private ExternalCompactorSnapshot(HostAndPort coordinatorHost, Set<ServerId> compactors,
-        long fetchedTimeMillis) {
-      this.coordinatorHost = coordinatorHost;
-      this.compactors = Set.copyOf(compactors);
-      this.fetchedTimeMillis = fetchedTimeMillis;
-    }
-  }
-
-  private record ExternalCompactionsSnapshot(Map<String,TExternalCompaction> ecRunningMap) {
-    private ExternalCompactionsSnapshot(Optional<Map<String,TExternalCompaction>> ecRunningMap) {
-      this(ecRunningMap.map(Collections::unmodifiableMap).orElse(Collections.emptyMap()));
-    }
-  }
-
-  private ExternalCompactionsSnapshot computeExternalCompactionsSnapshot() {
-    if (coordinatorHost.isEmpty()) {
-      throw new IllegalStateException(coordinatorMissingMsg);
-    }
-    var ccHost = coordinatorHost.orElseThrow();
-    log.info("User initiated fetch of running External Compactions from {}", ccHost);
-    try {
-      CompactionCoordinatorService.Client client =
-          ThriftUtil.getClient(ThriftClientTypes.COORDINATOR, ccHost, getContext());
-      TExternalCompactionMap running;
-      try {
-        running = client.getRunningCompactions(TraceUtil.traceInfo(), getContext().rpcCreds());
-        return new ExternalCompactionsSnapshot(Optional.ofNullable(running.getCompactions()));
-      } catch (Exception e) {
-        throw new IllegalStateException("Unable to get running compactions from " + ccHost, e);
-      } finally {
-        if (client != null) {
-          ThriftUtil.returnClient(client, getContext());
-        }
-      }
-    } catch (TTransportException e) {
-      log.error("Unable to get Compaction coordinator at {}", ccHost);
-      throw new IllegalStateException(coordinatorMissingMsg, e);
-    }
   }
 
   /**

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/Endpoints.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/Endpoints.java
@@ -46,7 +46,6 @@ import jakarta.ws.rs.core.MediaType;
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.admin.TabletInformation;
 import org.apache.accumulo.core.client.admin.servers.ServerId;
-import org.apache.accumulo.core.compaction.thrift.TExternalCompaction;
 import org.apache.accumulo.core.data.ResourceGroupId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
@@ -331,40 +330,13 @@ public class Endpoints {
   }
 
   @GET
-  @Path("compactions/detail")
-  @Produces(MediaType.APPLICATION_JSON)
-  @Description("Returns a map of Compactor resource group to the 50 oldest running compactions")
-  public Map<String,List<TExternalCompaction>> getCompactions() {
-    Map<String,List<TExternalCompaction>> all =
-        monitor.getInformationFetcher().getSummaryForEndpoint().getCompactions();
-    if (all == null) {
-      return Map.of();
-    }
-    return all;
-  }
-
-  @GET
-  @Path("compactions/detail/{" + GROUP_PARAM_KEY + "}")
-  @Produces(MediaType.APPLICATION_JSON)
-  @Description("Returns a list of the 50 oldest running compactions in the supplied resource group")
-  public List<TExternalCompaction>
-      getCompactions(@PathParam(GROUP_PARAM_KEY) String resourceGroup) {
-    validateResourceGroup(resourceGroup);
-    List<TExternalCompaction> compactions =
-        monitor.getInformationFetcher().getSummaryForEndpoint().getCompactions(resourceGroup);
-    if (compactions == null) {
-      return List.of();
-    }
-    return compactions;
-  }
-
-  @GET
   @Path("ec")
   @Produces(MediaType.APPLICATION_JSON)
   @Description("Returns External Compaction coordinator summary")
   public CoordinatorSummary getExternalCompactionCoordinator() {
-    return new CoordinatorSummary(monitor.getCompactionCoordinatorHost(),
-        monitor.getCompactorServers(), monitor.getCompactorInfoFetchedTimeMillis());
+    var summary = monitor.getInformationFetcher().getSummaryForEndpoint();
+    return CoordinatorSummary.fromHost(summary.getCoordinatorHost(), summary.getCompactorServers(),
+        summary.getTimestamp());
   }
 
   @GET
@@ -372,16 +344,17 @@ public class Endpoints {
   @Produces(MediaType.APPLICATION_JSON)
   @Description("Returns External Compactor process details")
   public CompactorsSummary getExternalCompactors() {
-    return new CompactorsSummary(monitor.getCompactorServers(),
-        monitor.getCompactorInfoFetchedTimeMillis());
+    var summary = monitor.getInformationFetcher().getSummaryForEndpoint();
+    return new CompactorsSummary(summary.getCompactorServers(), summary.getTimestamp());
   }
 
   @GET
   @Path("ec/running")
   @Produces(MediaType.APPLICATION_JSON)
-  @Description("Returns running External Compactions")
+  @Description("Returns the 50 longest-running External Compactions for the UI")
   public RunningCompactionsSummary getExternalCompactions() {
-    return new RunningCompactionsSummary(monitor.getRunningCompactionsMap());
+    return new RunningCompactionsSummary(
+        monitor.getInformationFetcher().getSummaryForEndpoint().getTopRunningCompactions());
   }
 
   @GET
@@ -394,7 +367,8 @@ public class Endpoints {
       throw new BadRequestException("Missing required query parameter: ecid");
     }
     final var externalCompactionId = ExternalCompactionId.from(ecid);
-    var runningCompaction = monitor.getRunningCompaction(externalCompactionId);
+    var runningCompaction = monitor.getInformationFetcher().getSummaryForEndpoint()
+        .getRunningCompactions().get(externalCompactionId.canonical());
     if (runningCompaction == null) {
       throw new IllegalStateException("Failed to find details for ECID: " + externalCompactionId);
     }

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/InformationFetcher.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/InformationFetcher.java
@@ -43,7 +43,7 @@ import org.apache.accumulo.core.client.admin.TabletInformation;
 import org.apache.accumulo.core.client.admin.servers.ServerId;
 import org.apache.accumulo.core.client.admin.servers.ServerId.Type;
 import org.apache.accumulo.core.compaction.thrift.CompactionCoordinatorService;
-import org.apache.accumulo.core.compaction.thrift.TExternalCompactionList;
+import org.apache.accumulo.core.compaction.thrift.TExternalCompaction;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.RowRange;
 import org.apache.accumulo.core.data.TableId;
@@ -180,8 +180,7 @@ public class InformationFetcher implements RemovalListener<ServerId,MetricRespon
       this.summary = summary;
     }
 
-    // Copied from Monitor
-    private Map<String,TExternalCompactionList> getLongRunningCompactions() {
+    private Map<String,TExternalCompaction> getRunningCompactions() {
       Set<ServerId> managers = ctx.instanceOperations().getServers(ServerId.Type.MANAGER);
       if (managers.isEmpty()) {
         throw new IllegalStateException(coordinatorMissingMsg);
@@ -192,7 +191,11 @@ public class InformationFetcher implements RemovalListener<ServerId,MetricRespon
         CompactionCoordinatorService.Client client =
             ThriftUtil.getClient(ThriftClientTypes.COORDINATOR, hp, ctx);
         try {
-          return client.getLongRunningCompactions(TraceUtil.traceInfo(), ctx.rpcCreds());
+          var running = client.getRunningCompactions(TraceUtil.traceInfo(), ctx.rpcCreds());
+          if (running == null || running.getCompactions() == null) {
+            return Map.of();
+          }
+          return running.getCompactions();
         } catch (Exception e) {
           throw new IllegalStateException("Unable to get running compactions from " + hp, e);
         } finally {
@@ -209,7 +212,7 @@ public class InformationFetcher implements RemovalListener<ServerId,MetricRespon
     @Override
     public void run() {
       try {
-        summary.processExternalCompactionList(getLongRunningCompactions());
+        summary.processExternalCompactions(getRunningCompactions());
       } catch (Exception e) {
         LOG.warn("Error gathering running compaction information.", e);
       }
@@ -307,6 +310,14 @@ public class InformationFetcher implements RemovalListener<ServerId,MetricRespon
 
       final List<Future<?>> futures = new ArrayList<>();
       final SystemInformation summary = new SystemInformation(allMetrics, this.ctx);
+      Set<ServerId> managers = this.ctx.instanceOperations().getServers(ServerId.Type.MANAGER);
+      HostAndPort coordinatorHost = null;
+      if (!managers.isEmpty()) {
+        ServerId manager = managers.iterator().next();
+        coordinatorHost = HostAndPort.fromParts(manager.getHost(), manager.getPort());
+      }
+      Set<ServerId> compactors = this.ctx.instanceOperations().getServers(Type.COMPACTOR);
+      summary.processExternalCompactionInventory(compactors, coordinatorHost);
 
       for (ServerId.Type type : ServerId.Type.values()) {
         if (type == Type.MONITOR) {

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/SystemInformation.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/SystemInformation.java
@@ -22,11 +22,10 @@ import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -40,7 +39,6 @@ import org.apache.accumulo.core.client.admin.TabletInformation;
 import org.apache.accumulo.core.client.admin.TabletMergeabilityInfo;
 import org.apache.accumulo.core.client.admin.servers.ServerId;
 import org.apache.accumulo.core.compaction.thrift.TExternalCompaction;
-import org.apache.accumulo.core.compaction.thrift.TExternalCompactionList;
 import org.apache.accumulo.core.data.ResourceGroupId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.TabletId;
@@ -52,6 +50,7 @@ import org.apache.accumulo.core.metrics.flatbuffers.FMetric;
 import org.apache.accumulo.core.metrics.flatbuffers.FTag;
 import org.apache.accumulo.core.process.thrift.MetricResponse;
 import org.apache.accumulo.core.spi.balancer.TableLoadBalancer;
+import org.apache.accumulo.core.util.compaction.RunningCompactionInfo;
 import org.apache.accumulo.monitor.next.sservers.ScanServerView;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.conf.TableConfiguration;
@@ -60,6 +59,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.benmanes.caffeine.cache.Cache;
+import com.google.common.net.HostAndPort;
 
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Meter.Id;
@@ -336,9 +336,12 @@ public class SystemInformation {
       new ConcurrentHashMap<>();
 
   // Compaction Information
+  private static final int ACTIVE_COMPACTIONS_LIMIT = 50;
   private final Map<String,List<FMetric>> queueMetrics = new ConcurrentHashMap<>();
-  private final AtomicReference<Map<String,TExternalCompactionList>> oldestCompactions =
-      new AtomicReference<>();
+  private volatile Set<ServerId> registeredCompactors = Set.of();
+  private volatile HostAndPort coordinatorHost;
+  private volatile Map<String,TExternalCompaction> runningCompactions = Map.of();
+  private volatile List<RunningCompactionInfo> runningCompactionsTop = List.of();
 
   // Table Information
   private final Map<TableId,TableSummary> tables = new ConcurrentHashMap<>();
@@ -371,6 +374,10 @@ public class SystemInformation {
     rgSServerMetrics.clear();
     rgTServerMetrics.clear();
     queueMetrics.clear();
+    registeredCompactors = Set.of();
+    coordinatorHost = null;
+    runningCompactions = Map.of();
+    runningCompactionsTop = List.of();
     tables.clear();
     tablets.clear();
     deployment.clear();
@@ -476,8 +483,21 @@ public class SystemInformation {
 
   }
 
-  public void processExternalCompactionList(Map<String,TExternalCompactionList> running) {
-    oldestCompactions.set(running);
+  public void processExternalCompactions(Map<String,TExternalCompaction> running) {
+    if (running == null) {
+      runningCompactions = Map.of();
+    } else {
+      runningCompactions = Map.copyOf(running);
+    }
+  }
+
+  public void processExternalCompactionInventory(Set<ServerId> compactors, HostAndPort host) {
+    if (compactors == null) {
+      registeredCompactors = Set.of();
+    } else {
+      registeredCompactors = Set.copyOf(compactors);
+    }
+    coordinatorHost = host;
   }
 
   public void processTabletInformation(TableId tableId, String tableName, TabletInformation info) {
@@ -523,6 +543,8 @@ public class SystemInformation {
     timestamp = System.currentTimeMillis();
     scanServerView = ScanServerView.fromMetrics(responses, scanServers.size(),
         problemScanServerCount, timestamp);
+    runningCompactionsTop =
+        buildTopRunningCompactions(runningCompactions, ACTIVE_COMPACTIONS_LIMIT);
   }
 
   public Set<String> getResourceGroups() {
@@ -584,29 +606,20 @@ public class SystemInformation {
     return this.queueMetrics;
   }
 
-  public Map<String,List<TExternalCompaction>> getCompactions() {
-
-    Map<String,TExternalCompactionList> oldest = oldestCompactions.get();
-    if (oldest == null) {
-      return null;
-    }
-
-    Map<String,List<TExternalCompaction>> results = new HashMap<>();
-    for (Entry<String,TExternalCompactionList> e : oldest.entrySet()) {
-      List<TExternalCompaction> compactions = e.getValue().getCompactions();
-      if (compactions != null && compactions.size() > 0) {
-        results.put(e.getKey(), compactions);
-      }
-    }
-    return results;
+  public Set<ServerId> getCompactorServers() {
+    return registeredCompactors;
   }
 
-  public List<TExternalCompaction> getCompactions(String group) {
-    TExternalCompactionList list = oldestCompactions.get().get(group);
-    if (list == null) {
-      return null;
-    }
-    return list.getCompactions();
+  public HostAndPort getCoordinatorHost() {
+    return coordinatorHost;
+  }
+
+  public Map<String,TExternalCompaction> getRunningCompactions() {
+    return runningCompactions;
+  }
+
+  public List<RunningCompactionInfo> getTopRunningCompactions() {
+    return runningCompactionsTop;
   }
 
   public Map<TableId,TableSummary> getTables() {
@@ -631,6 +644,16 @@ public class SystemInformation {
 
   public ScanServerView getScanServerView() {
     return this.scanServerView;
+  }
+
+  private static List<RunningCompactionInfo>
+      buildTopRunningCompactions(Map<String,TExternalCompaction> allCompactions, int limit) {
+    if (allCompactions == null || allCompactions.isEmpty()) {
+      return List.of();
+    }
+    return allCompactions.values().stream().map(RunningCompactionInfo::new)
+        .sorted(Comparator.comparingLong((RunningCompactionInfo r) -> r.duration).reversed())
+        .limit(limit).toList();
   }
 
 }

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/ec/CoordinatorSummary.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/ec/CoordinatorSummary.java
@@ -28,9 +28,10 @@ import com.google.common.net.HostAndPort;
 public record CoordinatorSummary(long lastContact, String server, long numQueues,
     int numCompactors) {
 
-  public CoordinatorSummary(HostAndPort coordinatorHost, Set<ServerId> compactors,
-      long fetchedTimeMillis) {
-    this(System.currentTimeMillis() - fetchedTimeMillis, coordinatorHost.toString(),
+  public static CoordinatorSummary fromHost(HostAndPort coordinatorHost, Set<ServerId> compactors,
+      long snapshotTimeMillis) {
+    return new CoordinatorSummary(System.currentTimeMillis() - snapshotTimeMillis,
+        coordinatorHost == null ? null : coordinatorHost.toString(),
         compactors.stream().map(ServerId::getResourceGroup).distinct().count(), compactors.size());
   }
 }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
@@ -703,25 +703,6 @@ function getTable(name) {
 }
 
 /**
- * REST GET call for /compactions/detail/{num},
- * stores it on a sessionStorage variable
- * @param {number} num Detail number
- */
-function getCompactionsDetail(num) {
-  const url = `${REST_V2_PREFIX}/compactions/detail/${num}`;
-  const sessionDataVar = `compactionsDetail_${num}`;
-  return getJSONForTable(url, sessionDataVar);
-}
-
-/**
- * REST GET call for /compactions/detail,
- * stores it on a sessionStorage variable
- */
-function getCompactionsDetail() {
-  return getJSONForTable(REST_V2_PREFIX + '/compactions/detail', 'compactionsDetail');
-}
-
-/**
  * REST GET call for /compactions/summary,
  * stores it on a sessionStorage variable
  */


### PR DESCRIPTION
Fixes #6174 

This PR:
* moves EC monitor data gathering into `InformationFetcher`/`SystemInformation` snapshot flow
* serves the active compaction data from top 50 longest running compactions view
* removes the old/competing `rest-v2/compactions/detail` path
* makes no intended changes to the active compactions page and just refactors the data collection on the backend