### PR TITLE
Fix Monitor deployment calculation

### DIFF
--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/SystemInformation.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/SystemInformation.java
@@ -448,6 +448,8 @@ public class SystemInformation {
     problemHosts.remove(server);
     allMetrics.put(server, response);
     resourceGroups.add(response.getResourceGroup());
+    deployment.computeIfAbsent(server.getResourceGroup(), g -> new ConcurrentHashMap<>())
+        .computeIfAbsent(server.getType().name(), t -> new ProcessSummary()).addResponded();
     switch (response.serverType) {
       case COMPACTOR:
         compactors
@@ -480,7 +482,6 @@ public class SystemInformation {
         LOG.error("Unhandled server type in fetch metric response: {}", response.serverType);
         break;
     }
-
   }
 
   public void processExternalCompactions(Map<String,TExternalCompaction> running) {
@@ -516,11 +517,8 @@ public class SystemInformation {
   }
 
   public void finish() {
-    // Compute the deployment overview
-    allMetrics.asMap().keySet().forEach(serverId -> {
-      deployment.computeIfAbsent(serverId.getResourceGroup(), g -> new ConcurrentHashMap<>())
-          .computeIfAbsent(serverId.getType().name(), t -> new ProcessSummary()).addResponded();
-    });
+    // Update the deployment not-responded numbers based
+    // on the problem hosts.
     problemHosts.forEach(serverId -> {
       deployment.computeIfAbsent(serverId.getResourceGroup(), g -> new ConcurrentHashMap<>())
           .computeIfAbsent(serverId.getType().name(), t -> new ProcessSummary())


### PR DESCRIPTION
The deployment calculation was off because it was being computed off the metrics cache, which keeps metrics for 10 minutes before expiring them. This change updates the deployment when the responses are received from the server instead, so it should represent only servers that are still alive.