### PR TITLE
fixes resource group IT

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/conf/ResourceGroupConfigIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/conf/ResourceGroupConfigIT.java
@@ -100,7 +100,7 @@ public class ResourceGroupConfigIT extends SharedMiniClusterBase {
   @BeforeEach
   public void beforeTest() throws Exception {
     var rgops = getCluster().getServerContext().resourceGroupOperations();
-    for(var rgid : rgops.list()){
+    for (var rgid : rgops.list()) {
       if (!rgid.equals(ResourceGroupId.DEFAULT)) {
         rgops.remove(rgid);
       }


### PR DESCRIPTION
Resource group IT had two test that used the same resource group names and could see each others property changes.  One of the test was recently and changed and this caused the other test to break.  Modified the test to use unique names.