### PR TITLE
Removed manager primary lock in ZooZap, fix calls to ZooZap

### DIFF
--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterControl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterControl.java
@@ -37,6 +37,7 @@ import java.util.concurrent.TimeoutException;
 import org.apache.accumulo.cluster.ClusterControl;
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.data.ResourceGroupId;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl.ProcessInfo;
@@ -317,6 +318,8 @@ public class MiniAccumuloClusterControl implements ClusterControl {
             cluster.stopProcessesWithTimeout(ServerType.MANAGER, managerProcesses, 30,
                 TimeUnit.SECONDS);
             try {
+              System.setProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY,
+                  "file://" + cluster.getAccumuloPropertiesPath());
               new ZooZap().execute(new String[] {"-managers"});
             } catch (Exception e) {
               log.error("Error zapping Manager zookeeper lock", e);

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
@@ -1030,6 +1030,8 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
     // is restarted, then the processes will start right away
     // and not wait for the old locks to be cleaned up.
     try {
+      System.setProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY,
+          "file://" + getAccumuloPropertiesPath());
       new ZooZap()
           .execute(new String[] {"-managers", "-tservers", "-compactors", "-sservers", "--gc"});
     } catch (Exception e) {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
@@ -149,6 +149,9 @@ public class ZooZap extends ServerKeywordExecutable<ZapOpts> {
             zrw.recursiveDelete(serverLockPath.toString(), NodeMissingPolicy.SKIP);
           }
         }
+        ServiceLockPath primaryMgrPath = context.getServerPaths().createManagerPath();
+        filterSingleton(context, primaryMgrPath, addressSelector)
+            .ifPresent(slp -> removeSingletonLock(zrw, slp, opts));
       } catch (RuntimeException e) {
         log.error("Error deleting manager lock", e);
       }

--- a/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
@@ -796,7 +796,7 @@ public class CompactionIT extends CompactionITBase {
       });
       assertNotNull(interCompactionFile[0]);
       System.setProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY,
-          getCluster().getAccumuloPropertiesPath());
+          "file://" + getCluster().getAccumuloPropertiesPath());
       String[] args = new String[1];
       args[0] = finalCompactionFile;
       PrintBCInfo bcInfo = new PrintBCInfo(args);


### PR DESCRIPTION
Calls to ZooZap were failing in some ITs because it could not create the ServerContext. This was an issue from a prior change to reorganize the commands and the
ServerKeywordExecutable class was created that creates the ServerContext. In the ITs the system property for the accumulo.properties file location needs to be set before calling one of the ServerKeywordExecutable
classes. In this case the issue manifested as an
exception in the test output when MiniAccumuloCluster was stopped with a message saying that it could not find the instance.volumes property.

This commit also fixes ZooZap to remove the primary manager lock in addition to the assistant manager
locks. The prior address was still in place in the primary lock causing the AdvertiseAndBindIT to fail.