### PR TITLE
Adds a new transform method to RecoveryPath

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/manager/recovery/RecoveryPath.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/recovery/RecoveryPath.java
@@ -100,6 +100,7 @@ public class RecoveryPath {
     return recoveryPath.toString();
   }
 
+  @Deprecated(since = "2.1.5")
   // given a wal path, transform it to a recovery path
   public static Path getRecoveryPath(Path walPath) {
     if (walPath.depth() >= 3 && walPath.toUri().getScheme() != null) {

--- a/server/base/src/test/java/org/apache/accumulo/server/manager/recovery/RecoveryPathTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/manager/recovery/RecoveryPathTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.apache.hadoop.fs.Path;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("deprecation")
 public class RecoveryPathTest {
 
   private static final String UUID = "2d961760-db4f-47eb-97fe-d283331ec254";

--- a/server/manager/src/main/java/org/apache/accumulo/manager/recovery/RecoveryManager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/recovery/RecoveryManager.java
@@ -192,7 +192,7 @@ public class RecoveryManager {
     String[] parts = walog.split("/");
     String sortId = parts[parts.length - 1];
     String filename = new Path(walog).toString();
-    String dest = RecoveryPath.getRecoveryPath(new Path(filename)).toString();
+    String dest = RecoveryPath.transformToRecoveryPath(filename);
 
     boolean sortQueued;
     synchronized (this) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -1248,9 +1248,9 @@ public class TabletServer extends AbstractServer
     sorted.sort((e1, e2) -> (int) (e1.timestamp - e2.timestamp));
     for (LogEntry entry : sorted) {
       Path recovery = null;
-      Path finished = RecoveryPath.getRecoveryPath(new Path(entry.filename));
+      Path finished = new Path(RecoveryPath.transformToRecoveryPath(entry.filename));
       finished = SortedLogState.getFinishedMarkerPath(finished);
-      TabletServer.log.debug("Looking for " + finished);
+      TabletServer.log.debug("Looking for {}", finished);
       if (fs.exists(finished)) {
         recovery = finished.getParent();
       }


### PR DESCRIPTION
Adds a new method that does not use Hadoop.fs.path to transform the wal path into a recoveryPath. 

Also adds test cases to validate existing behavior and then switches over to using the new method. 
This new method reduces the number of Path objects that are created and then immediately discarded.

This work was originally done against main but  since other recovery related work could be performed in 2.1 with minimal changes I've reworked the changes.

The only change when merging this to main is to drop the support for 1.4 WAL recoveries (enforce the inclusion of the server component).