### PR TITLE
Fix refresh button on running compactions table in Monitor

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/ec.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/ec.ftl
@@ -31,7 +31,7 @@
                 <div class="d-flex justify-content-between align-items-center mb-3">
                   <div>
                     <span class="table-caption">Running Compactions</span>&nbsp;&nbsp;
-                    <a href="javascript:refreshRunning();">
+                    <a href="javascript:refreshRunningCompactions();">
                       <span style="font-size: 1.5em; color: black;" class="bi bi-arrow-repeat"></span>
                     </a>
                   </div>


### PR DESCRIPTION
#6200 renamed this called method from `refreshRunning()` -> `refreshRunningCompactions()`

There was an error in the browser console when clicking the refresh button since `refreshRunning()` no longer exists.