### PR TITLE
Give ITs read permissions on Fate and ScanRef tables

### DIFF
--- a/test/src/main/java/org/apache/accumulo/harness/AccumuloClusterHarness.java
+++ b/test/src/main/java/org/apache/accumulo/harness/AccumuloClusterHarness.java
@@ -165,6 +165,10 @@ public abstract class AccumuloClusterHarness extends AccumuloITBase
 
     if (type.isDynamic()) {
       cluster.start();
+      try (AccumuloClient ac = Accumulo.newClient().from(getClientProps()).build()) {
+        AccumuloITBase.setSystemTablePermsForITs(ac,
+            cluster.getServerContext().securityOperations());
+      }
     } else {
       log.info("Removing tables which appear to be from a previous test run");
       cleanupTables();

--- a/test/src/main/java/org/apache/accumulo/harness/AccumuloITBase.java
+++ b/test/src/main/java/org/apache/accumulo/harness/AccumuloITBase.java
@@ -30,9 +30,15 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.Map.Entry;
 
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.admin.SecurityOperations;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.metadata.SystemTables;
+import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.test.util.Wait;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -159,5 +165,15 @@ public class AccumuloITBase extends WithTestNames {
     jar.deleteOnExit();
 
     return jar;
+  }
+
+  // ITs may use the client properties to create an AccumuloClient
+  // and then interact with the Fate and ScanRef tables. By default
+  // only the system user can interact with these tables.
+  public static void setSystemTablePermsForITs(AccumuloClient client, SecurityOperations ops)
+      throws AccumuloException, AccumuloSecurityException {
+    ops.grantTablePermission(client.whoami(), SystemTables.FATE.tableName(), TablePermission.READ);
+    ops.grantTablePermission(client.whoami(), SystemTables.SCAN_REF.tableName(),
+        TablePermission.READ);
   }
 }

--- a/test/src/main/java/org/apache/accumulo/harness/SharedMiniClusterBase.java
+++ b/test/src/main/java/org/apache/accumulo/harness/SharedMiniClusterBase.java
@@ -136,7 +136,9 @@ public abstract class SharedMiniClusterBase extends AccumuloITBase implements Cl
     cluster = harness.create(getTestClassName(), SharedMiniClusterBase.class.getSimpleName(), token,
         miniClusterCallback, krb);
     cluster.start();
-
+    try (AccumuloClient ac = Accumulo.newClient().from(getClientProps()).build()) {
+      AccumuloITBase.setSystemTablePermsForITs(ac, cluster.getServerContext().securityOperations());
+    }
   }
 
   private static String getTestClassName() {

--- a/test/src/main/java/org/apache/accumulo/test/functional/ConfigurableMacBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ConfigurableMacBase.java
@@ -30,6 +30,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import org.apache.accumulo.core.client.Accumulo;
+import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.conf.ClientProperty;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
@@ -136,6 +138,10 @@ public class ConfigurableMacBase extends AccumuloITBase {
     for (int i = 0; i < 3; i++) {
       try {
         cluster.start();
+        try (AccumuloClient ac = Accumulo.newClient().from(getClientProperties()).build()) {
+          AccumuloITBase.setSystemTablePermsForITs(ac,
+              cluster.getServerContext().securityOperations());
+        }
         return;
       } catch (ZooKeeperBindException e) {
         lastException = e;


### PR DESCRIPTION
This change gives the majority of ITs read permissions on the Fate and ScanRef tables. It's still possible that additional work may need to be done in specific ITs that need write or other permission, are for classes that are not subclasses of the classes modified in this commit.