### PR TITLE
Fix PermissionsIT, broken by #6253

### DIFF
--- a/test/src/main/java/org/apache/accumulo/harness/AccumuloClusterHarness.java
+++ b/test/src/main/java/org/apache/accumulo/harness/AccumuloClusterHarness.java
@@ -33,6 +33,8 @@ import org.apache.accumulo.cluster.ClusterUsers;
 import org.apache.accumulo.cluster.standalone.StandaloneAccumuloCluster;
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.admin.SecurityOperations;
 import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
@@ -166,8 +168,7 @@ public abstract class AccumuloClusterHarness extends AccumuloITBase
     if (type.isDynamic()) {
       cluster.start();
       try (AccumuloClient ac = Accumulo.newClient().from(getClientProps()).build()) {
-        AccumuloITBase.setSystemTablePermsForITs(ac,
-            cluster.getServerContext().securityOperations());
+        setSystemTablePerms(ac, cluster.getServerContext().securityOperations());
       }
     } else {
       log.info("Removing tables which appear to be from a previous test run");
@@ -176,6 +177,12 @@ public abstract class AccumuloClusterHarness extends AccumuloITBase
       cleanupUsers();
     }
 
+  }
+
+  protected void setSystemTablePerms(AccumuloClient client, SecurityOperations sops)
+      throws AccumuloException, AccumuloSecurityException {
+    AccumuloITBase.setSystemTablePermsForITs(client,
+        cluster.getServerContext().securityOperations());
   }
 
   public void cleanupTables() throws Exception {

--- a/test/src/main/java/org/apache/accumulo/test/functional/PermissionsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/PermissionsIT.java
@@ -44,6 +44,7 @@ import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.admin.SecurityOperations;
 import org.apache.accumulo.core.client.security.SecurityErrorCode;
 import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
@@ -75,6 +76,13 @@ public class PermissionsIT extends AccumuloClusterHarness {
   @Override
   protected Duration defaultTimeout() {
     return Duration.ofSeconds(90);
+  }
+
+  @Override
+  protected void setSystemTablePerms(AccumuloClient client, SecurityOperations sops)
+      throws AccumuloException, AccumuloSecurityException {
+    // overridden to do nothing. The parent class gives read permissions to the
+    // system tables for the ITs. We want to test the default behavior
   }
 
   @BeforeEach


### PR DESCRIPTION
PR #6253 fixed an issue where the fate and scanref tables could not be scanned by the ITs. The fix in in PermissionsIT which tests that non-system users don't have the ability to scan the fate and scanref tables. This commit overrides the behavior added in