### PR TITLE
fixes ExistingMacIT

### DIFF
--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
@@ -804,7 +804,6 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
             result.put(type, references(control.gcProcess));
           }
           break;
-        case MASTER:
         case MANAGER:
           if (control.managerProcess != null) {
             result.put(type, references(control.managerProcess));
@@ -827,6 +826,7 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
           }
           break;
         case TRACER:
+        case MASTER:
           break;
         default:
           throw new IllegalArgumentException("Unhandled server type : " + type);


### PR DESCRIPTION
This test was failing because it tried to kill the manager and master process, but they were the same process.  Changed the get processes function in mini to not return both.  It used to only return the manager until #6072 so it seems ok to keep doing that.