### PR TITLE
Fixed iterator test in ComprehensiveTableOperationsIT

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/ComprehensiveTableOperationsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ComprehensiveTableOperationsIT.java
@@ -679,8 +679,7 @@ public class ComprehensiveTableOperationsIT extends SharedMiniClusterBase {
         assertNull(ops.getIteratorSetting(table, iterName, IteratorUtil.IteratorScope.scan));
         assertEquals(iterSetting,
             ops.getIteratorSetting(table, iterName, IteratorUtil.IteratorScope.majc));
-        assertThrows(AccumuloException.class,
-            () -> ops.checkIteratorConflicts(table, iterSetting, scope));
+        ops.checkIteratorConflicts(table, iterSetting, scope);
         ops.checkIteratorConflicts(table, iterSetting, EnumSet.of(IteratorUtil.IteratorScope.scan));
       } finally {
         ops.removeIterator(table, iterName, scope);


### PR DESCRIPTION
The test was failing because it was expecting an
exception be thrown if the same iterator settings
were added to the table again. The code in
IteratorConfigUtil.checkIteratorConflicts just
ignores additions that equivalent to the settings
on the table and does not throw an exception.