### PR TITLE
fixes ScanServerGroupConfigurationIT

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/ScanServerGroupConfigurationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ScanServerGroupConfigurationIT.java
@@ -80,6 +80,7 @@ public class ScanServerGroupConfigurationIT extends SharedMiniClusterBase {
      "   \"busyTimeoutMultiplier\": 8,"+
      "   \"group\": \"GROUP1\","+
      "   \"scanTypeActivations\": [\"use_group1\"],"+
+     "   \"timeToWaitForScanServers\": \"120s\","+
      "   \"attemptPlans\": ["+
      "     {"+
      "       \"servers\": \"3\","+


### PR DESCRIPTION
After the changes in #5937 the client side scan server plugin does not rebuild the list of scan servers as frequently.  The test was not seeing a scan server, falling back to a tserver, and failing.  Modified the scan server config in the test to wait for scan servers.