### PR TITLE
fixes ManagerAssignmentIT

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/functional/ManagerAssignmentIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ManagerAssignmentIT.java
@@ -122,7 +122,7 @@ public class ManagerAssignmentIT extends AccumuloClusterHarness {
 
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
 
-      Wait.waitFor(() -> client.instanceOperations().getTabletServers().size() == 1);
+      Wait.waitFor(() -> client.instanceOperations().getTabletServers().size() == 1, 60_000);
 
       client.tableOperations().create(tableName);
 


### PR DESCRIPTION
The test was killing two tservers and then not waiting long enough for their ZK locks to timeout.  Increased the time to wait.  Not sure why this test was passing before.  Maybe something used to delete the ZK locks or the maybe the ZK timeout was changed elsewhere?