### PR TITLE
fixes multiple shell ITs

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/shell/MockShell.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/MockShell.java
@@ -62,8 +62,7 @@ public class MockShell {
   public LineReader reader;
   public Terminal terminal;
 
-  MockShell(String user, String rootPass, String instanceName, String zookeepers, File configFile)
-      throws Exception {
+  MockShell(File configFile) throws Exception {
     ClientInfo info = ClientInfo.from(configFile.toPath());
     // start the shell
     output = new TestOutputStream();
@@ -72,14 +71,7 @@ public class MockShell {
     reader = LineReaderBuilder.builder().terminal(terminal).build();
     shell = new TestShell(reader);
     shell.setLogErrorsToConsole();
-    if (info.saslEnabled()) {
-      // Pull the kerberos principal out when we're using SASL
-      shell.execute(new String[] {"-u", user, "-z", instanceName, zookeepers, "--config-file",
-          configFile.getAbsolutePath()});
-    } else {
-      shell.execute(new String[] {"-u", user, "-p", rootPass, "-z", instanceName, zookeepers,
-          "--config-file", configFile.getAbsolutePath()});
-    }
+    shell.execute(new String[] {"--config-file", configFile.getAbsolutePath()});
     exec("quit", true);
     shell.start();
     shell.setExit(false);

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellConfigIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellConfigIT.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.test.shell;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.test.VolumeChooserIT.PERTABLE_CHOOSER_PROP;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -30,8 +29,6 @@ import java.time.Duration;
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
-import org.apache.accumulo.core.client.security.tokens.KerberosToken;
-import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.clientImpl.Namespace;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
@@ -97,17 +94,7 @@ public class ShellConfigIT extends AccumuloClusterHarness {
 
     assertNotNull(clientPropsFile);
 
-    MockShell ts = null;
-    if (token instanceof PasswordToken) {
-      String passwd = new String(((PasswordToken) token).getPassword(), UTF_8);
-      ts = new MockShell(getAdminPrincipal(), passwd, getCluster().getInstanceName(),
-          getCluster().getZooKeepers(), clientPropsFile);
-    } else if (token instanceof KerberosToken) {
-      ts = new MockShell(getAdminPrincipal(), null, getCluster().getInstanceName(),
-          getCluster().getZooKeepers(), clientPropsFile);
-    } else {
-      fail("Unknown token type");
-    }
+    MockShell ts = new MockShell(clientPropsFile);
 
     assertTrue(Property.TABLE_CRYPTO_PREFIX.isExperimental());
     assertTrue(Property.TABLE_CRYPTO_SENSITIVE_PREFIX.isExperimental());

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellCreateNamespaceIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellCreateNamespaceIT.java
@@ -60,9 +60,7 @@ public class ShellCreateNamespaceIT extends SharedMiniClusterBase {
 
   @BeforeEach
   public void setupShell() throws Exception {
-    ts = new MockShell(getPrincipal(), getRootPassword(),
-        getCluster().getConfig().getInstanceName(), getCluster().getConfig().getZooKeepers(),
-        getCluster().getConfig().getClientPropsFile());
+    ts = new MockShell(getCluster().getConfig().getClientPropsFile());
   }
 
   @AfterAll

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellCreateTableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellCreateTableIT.java
@@ -92,9 +92,7 @@ public class ShellCreateTableIT extends SharedMiniClusterBase {
 
   @BeforeEach
   public void setupShell() throws Exception {
-    ts = new MockShell(getPrincipal(), getRootPassword(),
-        getCluster().getConfig().getInstanceName(), getCluster().getConfig().getZooKeepers(),
-        getCluster().getConfig().getClientPropsFile());
+    ts = new MockShell(getCluster().getConfig().getClientPropsFile());
   }
 
   @AfterAll

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
@@ -157,9 +157,7 @@ public class ShellServerIT extends SharedMiniClusterBase {
 
   @BeforeEach
   public void setupShell() throws Exception {
-    ts = new MockShell(getPrincipal(), getRootPassword(),
-        getCluster().getConfig().getInstanceName(), getCluster().getConfig().getZooKeepers(),
-        getCluster().getConfig().getClientPropsFile());
+    ts = new MockShell(getCluster().getConfig().getClientPropsFile());
   }
 
   @AfterAll


### PR DESCRIPTION
All shell ITs were failing because they were using removed command line options.  Fixed the command line options and now most of the test pass.