### PR TITLE
fixes more ShellIT tests

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellIT.java
@@ -171,8 +171,7 @@ public class ShellIT extends SharedMiniClusterBase {
     reader = LineReaderBuilder.builder().terminal(terminal).build();
     shell = new TestShell(reader);
     shell.setLogErrorsToConsole();
-    shell.execute(
-        new String[] {"--config-file", config.toString(), "-u", "root", "-p", getRootPassword()});
+    shell.execute(new String[] {"--config-file", config.toString()});
   }
 
   @AfterEach


### PR DESCRIPTION
Removed unsupported shell startup options in common test code. These options were causing lots of tests in ShellIT to fail.