### PR TITLE
Clears accumulo.properties system property after setting it.

### DIFF
--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterControl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterControl.java
@@ -323,6 +323,8 @@ public class MiniAccumuloClusterControl implements ClusterControl {
               new ZooZap().execute(new String[] {"-managers"});
             } catch (Exception e) {
               log.error("Error zapping Manager zookeeper lock", e);
+            } finally {
+              System.clearProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY);
             }
           } finally {
             managerProcesses.clear();

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
@@ -1038,6 +1038,8 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
       if (!e.getMessage().startsWith("Accumulo not initialized")) {
         log.error("Error zapping zookeeper locks", e);
       }
+    } finally {
+      System.clearProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY);
     }
 
     // Clear the location of the servers in ZooCache.

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
@@ -757,7 +757,7 @@ public class MiniAccumuloConfigImpl {
 
     this.existingInstance = Boolean.TRUE;
 
-    System.setProperty("accumulo.properties", "accumulo.properties");
+    System.setProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY, "accumulo.properties");
     this.hadoopConfDir = hadoopConfDir;
     var siteConfiguration = SiteConfiguration.fromFile(accumuloProps).build();
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
@@ -809,6 +809,7 @@ public class CompactionIT extends CompactionITBase {
       // The compression type used on the intermediate compaction file should be 'gz'
       assertEquals("gz", interCompressionType);
     } finally {
+      System.clearProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY);
       // Re-enable GC
       getCluster().getClusterControl().startAllServers(ServerType.GARBAGE_COLLECTOR);
     }

--- a/test/src/main/java/org/apache/accumulo/test/functional/FindCompactionTmpFilesIT_SimpleSuite.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FindCompactionTmpFilesIT_SimpleSuite.java
@@ -169,6 +169,8 @@ public class FindCompactionTmpFilesIT_SimpleSuite extends SharedMiniClusterBase 
       assertEquals(100, foundPaths.size());
       assertEquals(foundPaths, generatedPaths);
 
+    } finally {
+      System.clearProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY);
     }
   }
 
@@ -217,6 +219,8 @@ public class FindCompactionTmpFilesIT_SimpleSuite extends SharedMiniClusterBase 
       foundPaths = FindCompactionTmpFiles.findTempFiles(ctx, tid.canonical());
       assertEquals(0, foundPaths.size());
 
+    } finally {
+      System.clearProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY);
     }
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/functional/LocalityGroupIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/LocalityGroupIT.java
@@ -108,6 +108,8 @@ public class LocalityGroupIT extends AccumuloClusterHarness {
       createAndSetLocalityGroups(accumuloClient, tableName);
       verifyLocalityGroupSet(accumuloClient, tableName);
       verifyLocalityGroupsInRFile(accumuloClient, tableName);
+    } finally {
+      System.clearProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY);
     }
   }
 
@@ -141,6 +143,8 @@ public class LocalityGroupIT extends AccumuloClusterHarness {
       ntc.setLocalityGroups(groups);
       accumuloClient.tableOperations().create(tableName, ntc);
       verifyLocalityGroupsInRFile(accumuloClient, tableName);
+    } finally {
+      System.clearProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY);
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/PerTableCryptoIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/PerTableCryptoIT.java
@@ -211,6 +211,8 @@ public class PerTableCryptoIT extends AccumuloClusterHarness {
           }
         }
       }
+    } finally {
+      System.clearProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY);
     }
   }
 
@@ -258,6 +260,7 @@ public class PerTableCryptoIT extends AccumuloClusterHarness {
       assertTrue(stdout.contains(AESCryptoService.class.getName()));
     } finally {
       System.setOut(oldOut);
+      System.clearProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY);
     }
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/upgrade/UpgradeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/upgrade/UpgradeIT.java
@@ -140,11 +140,14 @@ public class UpgradeIT extends AccumuloClusterHarness {
     // Validate the exception from the servers
     System.setProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY,
         "file://" + getCluster().getAccumuloPropertiesPath());
-
-    IllegalStateException ise =
-        assertThrows(IllegalStateException.class, () -> new ServerThatWontStart(new String[0]));
-    assertTrue(ise.getMessage()
-        .startsWith("Instance has been prepared for upgrade to a minor or major version"));
+    try {
+      IllegalStateException ise =
+          assertThrows(IllegalStateException.class, () -> new ServerThatWontStart(new String[0]));
+      assertTrue(ise.getMessage()
+          .startsWith("Instance has been prepared for upgrade to a minor or major version"));
+    } finally {
+      System.clearProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY);
+    }
 
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/upgrade/UpgradeUtilIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/upgrade/UpgradeUtilIT.java
@@ -100,10 +100,14 @@ public class UpgradeUtilIT extends AccumuloClusterHarness {
 
     System.setProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY,
         "file://" + getCluster().getAccumuloPropertiesPath());
-    IllegalStateException ise = assertThrows(IllegalStateException.class,
-        () -> new UpgradeUtil().execute(new String[] {"--prepare"}));
-    assertEquals("Manager is running, shut it down and retry this operation", ise.getMessage());
-    assertFalse(zr.exists(Constants.ZPREPARE_FOR_UPGRADE));
+    try {
+      IllegalStateException ise = assertThrows(IllegalStateException.class,
+          () -> new UpgradeUtil().execute(new String[] {"--prepare"}));
+      assertEquals("Manager is running, shut it down and retry this operation", ise.getMessage());
+      assertFalse(zr.exists(Constants.ZPREPARE_FOR_UPGRADE));
+    } finally {
+      System.clearProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY);
+    }
   }
 
   @Test
@@ -124,11 +128,15 @@ public class UpgradeUtilIT extends AccumuloClusterHarness {
 
     System.setProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY,
         "file://" + getCluster().getAccumuloPropertiesPath());
-    IllegalStateException ise = assertThrows(IllegalStateException.class,
-        () -> new UpgradeUtil().execute(new String[] {"--prepare"}));
-    assertTrue(ise.getMessage()
-        .startsWith("Cannot complete upgrade preparation because FATE transactions exist."));
-    assertFalse(zr.exists(Constants.ZPREPARE_FOR_UPGRADE));
+    try {
+      IllegalStateException ise = assertThrows(IllegalStateException.class,
+          () -> new UpgradeUtil().execute(new String[] {"--prepare"}));
+      assertTrue(ise.getMessage()
+          .startsWith("Cannot complete upgrade preparation because FATE transactions exist."));
+      assertFalse(zr.exists(Constants.ZPREPARE_FOR_UPGRADE));
+    } finally {
+      System.clearProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY);
+    }
   }
 
   @Test
@@ -145,26 +153,38 @@ public class UpgradeUtilIT extends AccumuloClusterHarness {
 
     System.setProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY,
         "file://" + getCluster().getAccumuloPropertiesPath());
-    new UpgradeUtil().execute(new String[] {"--prepare"});
-    assertTrue(zr.exists(Constants.ZPREPARE_FOR_UPGRADE));
+    try {
+      new UpgradeUtil().execute(new String[] {"--prepare"});
+      assertTrue(zr.exists(Constants.ZPREPARE_FOR_UPGRADE));
+    } finally {
+      System.clearProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY);
+    }
   }
 
   @Test
   public void testExclusiveOptionsFail() {
     System.setProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY,
         "file://" + getCluster().getAccumuloPropertiesPath());
-    IllegalArgumentException ise = assertThrows(IllegalArgumentException.class,
-        () -> new UpgradeUtil().execute(new String[] {"--prepare", "--start"}));
-    assertTrue(ise.getMessage().equals("prepare and start options are mutually exclusive"));
+    try {
+      IllegalArgumentException ise = assertThrows(IllegalArgumentException.class,
+          () -> new UpgradeUtil().execute(new String[] {"--prepare", "--start"}));
+      assertTrue(ise.getMessage().equals("prepare and start options are mutually exclusive"));
+    } finally {
+      System.clearProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY);
+    }
   }
 
   @Test
   public void testStartFailsNotNeeded() throws Exception {
     System.setProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY,
         "file://" + getCluster().getAccumuloPropertiesPath());
-    IllegalStateException ise = assertThrows(IllegalStateException.class,
-        () -> new UpgradeUtil().execute(new String[] {"--start"}));
-    assertTrue(ise.getMessage().startsWith("Running this utility is unnecessary"));
+    try {
+      IllegalStateException ise = assertThrows(IllegalStateException.class,
+          () -> new UpgradeUtil().execute(new String[] {"--start"}));
+      assertTrue(ise.getMessage().startsWith("Running this utility is unnecessary"));
+    } finally {
+      System.clearProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY);
+    }
   }
 
   @Test
@@ -173,9 +193,13 @@ public class UpgradeUtilIT extends AccumuloClusterHarness {
 
     System.setProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY,
         "file://" + getCluster().getAccumuloPropertiesPath());
-    IllegalStateException ise = assertThrows(IllegalStateException.class,
-        () -> new UpgradeUtil().execute(new String[] {"--start"}));
-    assertTrue(ise.getMessage().equals("Cannot run this command with the Manager running."));
+    try {
+      IllegalStateException ise = assertThrows(IllegalStateException.class,
+          () -> new UpgradeUtil().execute(new String[] {"--start"}));
+      assertTrue(ise.getMessage().equals("Cannot run this command with the Manager running."));
+    } finally {
+      System.clearProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY);
+    }
   }
 
   @Test
@@ -191,10 +215,14 @@ public class UpgradeUtilIT extends AccumuloClusterHarness {
 
     System.setProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY,
         "file://" + getCluster().getAccumuloPropertiesPath());
-    IllegalStateException ise = assertThrows(IllegalStateException.class,
-        () -> new UpgradeUtil().execute(new String[] {"--start"}));
-    assertTrue(ise.getMessage()
-        .startsWith(Constants.ZPREPARE_FOR_UPGRADE + " node not found in ZooKeeper"));
+    try {
+      IllegalStateException ise = assertThrows(IllegalStateException.class,
+          () -> new UpgradeUtil().execute(new String[] {"--start"}));
+      assertTrue(ise.getMessage()
+          .startsWith(Constants.ZPREPARE_FOR_UPGRADE + " node not found in ZooKeeper"));
+    } finally {
+      System.clearProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY);
+    }
   }
 
   @Test
@@ -218,11 +246,15 @@ public class UpgradeUtilIT extends AccumuloClusterHarness {
 
     System.setProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY,
         "file://" + getCluster().getAccumuloPropertiesPath());
-    IllegalStateException ise = assertThrows(IllegalStateException.class,
-        () -> new UpgradeUtil().execute(new String[] {"--start", "--force"}));
-    assertTrue(ise.getMessage()
-        .startsWith("Cannot continue pre-upgrade checks because FATE transactions exist."));
-    assertFalse(zr.exists(Constants.ZPREPARE_FOR_UPGRADE));
+    try {
+      IllegalStateException ise = assertThrows(IllegalStateException.class,
+          () -> new UpgradeUtil().execute(new String[] {"--start", "--force"}));
+      assertTrue(ise.getMessage()
+          .startsWith("Cannot continue pre-upgrade checks because FATE transactions exist."));
+      assertFalse(zr.exists(Constants.ZPREPARE_FOR_UPGRADE));
+    } finally {
+      System.clearProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY);
+    }
   }
 
   @Test
@@ -245,9 +277,13 @@ public class UpgradeUtilIT extends AccumuloClusterHarness {
 
     System.setProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY,
         "file://" + getCluster().getAccumuloPropertiesPath());
-    new UpgradeUtil().execute(new String[] {"--start"});
-    assertFalse(zr.exists(Constants.ZPREPARE_FOR_UPGRADE));
-    assertTrue(zr.exists(Constants.ZUPGRADE_PROGRESS));
+    try {
+      new UpgradeUtil().execute(new String[] {"--start"});
+      assertFalse(zr.exists(Constants.ZPREPARE_FOR_UPGRADE));
+      assertTrue(zr.exists(Constants.ZUPGRADE_PROGRESS));
+    } finally {
+      System.clearProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY);
+    }
   }
 
   @Test
@@ -267,9 +303,13 @@ public class UpgradeUtilIT extends AccumuloClusterHarness {
 
     System.setProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY,
         "file://" + getCluster().getAccumuloPropertiesPath());
-    new UpgradeUtil().execute(new String[] {"--start", "--force"});
-    assertFalse(zr.exists(Constants.ZPREPARE_FOR_UPGRADE));
-    assertTrue(zr.exists(Constants.ZUPGRADE_PROGRESS));
+    try {
+      new UpgradeUtil().execute(new String[] {"--start", "--force"});
+      assertFalse(zr.exists(Constants.ZPREPARE_FOR_UPGRADE));
+      assertTrue(zr.exists(Constants.ZUPGRADE_PROGRESS));
+    } finally {
+      System.clearProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY);
+    }
   }
 
   @Test
@@ -298,9 +338,13 @@ public class UpgradeUtilIT extends AccumuloClusterHarness {
 
     System.setProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY,
         "file://" + getCluster().getAccumuloPropertiesPath());
-    new UpgradeUtil().execute(new String[] {"--start"});
-    assertFalse(zr.exists(Constants.ZPREPARE_FOR_UPGRADE));
-    assertTrue(zr.exists(Constants.ZUPGRADE_PROGRESS));
+    try {
+      new UpgradeUtil().execute(new String[] {"--start"});
+      assertFalse(zr.exists(Constants.ZPREPARE_FOR_UPGRADE));
+      assertTrue(zr.exists(Constants.ZUPGRADE_PROGRESS));
+    } finally {
+      System.clearProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY);
+    }
   }
 
   @Test
@@ -331,11 +375,15 @@ public class UpgradeUtilIT extends AccumuloClusterHarness {
 
     System.setProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY,
         "file://" + getCluster().getAccumuloPropertiesPath());
-    IllegalStateException ise = assertThrows(IllegalStateException.class,
-        () -> new UpgradeUtil().execute(new String[] {"--start"}));
-    assertTrue(ise.getMessage().startsWith("It appears that an upgrade is in progress."));
-    assertTrue(zr.exists(Constants.ZPREPARE_FOR_UPGRADE));
-    assertTrue(zr.exists(Constants.ZUPGRADE_PROGRESS));
+    try {
+      IllegalStateException ise = assertThrows(IllegalStateException.class,
+          () -> new UpgradeUtil().execute(new String[] {"--start"}));
+      assertTrue(ise.getMessage().startsWith("It appears that an upgrade is in progress."));
+      assertTrue(zr.exists(Constants.ZPREPARE_FOR_UPGRADE));
+      assertTrue(zr.exists(Constants.ZUPGRADE_PROGRESS));
+    } finally {
+      System.clearProperty(SiteConfiguration.ACCUMULO_PROPERTIES_PROPERTY);
+    }
 
   }
 


### PR DESCRIPTION
Recently ZooPropEditorIT_SimpleSuite added a check to ensure the system property "accumulo.properties" is null.  This test fails when run with all other accumulo test, but not when run by itself.  This change clears the system property in all test code that sets it.  Not sure if this will fix ZooPropEditorIT_SimpleSuite but its a good general change as leaving this system property set can impact unrelated tests.