### PR TITLE
Improvements to the Server Type Summary Monitor table

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/overview.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/overview.js
@@ -20,6 +20,16 @@
 
 var deploymentSummaryTable;
 var deploymentBreakdownTable;
+const SERVER_TYPE_LINKS = new Map([
+  ['Manager', 'manager'],
+  ['Garbage Collector', 'gc'],
+  ['Compactor', 'compactors'],
+  ['Scan Server', 'sservers'],
+  ['Tablet Server', 'tservers']
+]);
+const SUMMARY_SERVER_TYPES = ['Manager', 'Garbage Collector', 'Compactor', 'Scan Server',
+  'Tablet Server'
+];
 
 /**
  * Creates overview initial table
@@ -46,7 +56,19 @@ $(function () {
       }
     ],
     "columns": [{
-        "data": "serverType"
+        "data": "serverType",
+        "render": function (data, type) {
+          if (type !== 'display') {
+            return data;
+          }
+
+          var link = SERVER_TYPE_LINKS.get(data);
+          if (link === undefined) {
+            return data;
+          }
+
+          return '<a href="' + sanitize(link) + '">' + sanitize(data) + '</a>';
+        }
       },
       {
         "data": null,
@@ -152,7 +174,19 @@ function refreshDeploymentTables() {
 }
 
 function buildDeploymentSummary(breakdown) {
+  if (breakdown.length === 0) {
+    return [];
+  }
+
   var totalsByType = new Map();
+
+  SUMMARY_SERVER_TYPES.forEach(function (serverType) {
+    totalsByType.set(serverType, {
+      serverType: serverType,
+      total: 0,
+      responding: 0
+    });
+  });
 
   breakdown.forEach(function (row) {
     var existing = totalsByType.get(row.serverType);


### PR DESCRIPTION
* Adds rows to the Server Type Summary table even if that server type has a count of 0. (this was suggested [here](https://github.com/apache/accumulo/pull/6240#pullrequestreview-4038713856))
* Makes the server type a hyperlink to the associated server page

Note the scan server row:
<img width="770" height="366" alt="image" src="https://github.com/user-attachments/assets/37403f9d-33f0-45f9-93b2-827716406445" />
