### PR TITLE
Upgrade OpenTelemetry dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@ under the License.
     <version.errorprone>2.41.0</version.errorprone>
     <version.hadoop>3.3.6</version.hadoop>
     <version.log4j>2.25.3</version.log4j>
-    <version.opentelemetry>1.48.0</version.opentelemetry>
+    <version.opentelemetry>1.60.1</version.opentelemetry>
     <version.powermock>2.0.9</version.powermock>
     <version.slf4j>2.0.17</version.slf4j>
     <version.thrift>0.17.0</version.thrift>
@@ -351,13 +351,13 @@ under the License.
         <groupId>io.opentelemetry.javaagent</groupId>
         <artifactId>opentelemetry-javaagent</artifactId>
         <!-- This version was selected because it aligns with the version of open telemetry that Accumulo 2.1 is using. -->
-        <version>2.14.0</version>
+        <version>2.26.1</version>
       </dependency>
       <dependency>
         <groupId>io.opentelemetry.proto</groupId>
         <artifactId>opentelemetry-proto</artifactId>
         <!-- This version was selected because it aligns with the version of protocol buffers that Accumulo 2.1 is using. -->
-        <version>1.3.2-alpha</version>
+        <version>1.10.0-alpha</version>
       </dependency>
       <dependency>
         <!-- legacy junit version specified here for dependency convergence -->


### PR DESCRIPTION
Upgrade OpenTelemetry dependencies. This should resolve https://github.com/apache/accumulo/security/dependabot/25, but
tracing will need to be tested before release.