### PR TITLE
Implement workaround in accumulo-env.sh for OpenTelemetry CVE

### DIFF
--- a/assemble/conf/accumulo-env.sh
+++ b/assemble/conf/accumulo-env.sh
@@ -117,7 +117,7 @@ JAVA_OPTS=("-Daccumulo.log.dir=${ACCUMULO_LOG_DIR}"
   "-Dlog4j2.statusLoggerLevel=ERROR"
   "-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector"
   "-Dotel.service.name=${ACCUMULO_SERVICE_INSTANCE}"
-# Mitigation for CVE-2026-33701
+  # Mitigation for CVE-2026-33701
   "-Dotel.instrumentation.rmi.enabled=false"
   "${JAVA_OPTS[@]}"
 )


### PR DESCRIPTION
Added a system property in accumulo-env.sh to disable the RMI instrumentation of the OpenTelemetry Java Agent. See https://github.com/apache/accumulo/security/dependabot/25 for more information.