### PR TITLE
Fixes ScanTracingIT flaking

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/tracing/ScanTraceClient.java
+++ b/test/src/main/java/org/apache/accumulo/test/tracing/ScanTraceClient.java
@@ -45,6 +45,7 @@ public class ScanTraceClient {
     String endRow;
     String family;
     String qualifier;
+    String untracedIntermediateScans;
 
     Options() {}
 
@@ -75,6 +76,12 @@ public class ScanTraceClient {
       }
     }
 
+    int getUntracedIntermediateScans() {
+      if (untracedIntermediateScans == null) {
+        return 0;
+      }
+      return Integer.parseInt(untracedIntermediateScans);
+    }
   }
 
   public static class Results {
@@ -104,8 +111,7 @@ public class ScanTraceClient {
 
     Tracer tracer = GlobalOpenTelemetry.get().getTracer(ScanTraceClient.class.getName());
     try (var client = Accumulo.newClient().from(clientPropsPath).build()) {
-      long scanCount = 0;
-      long scanSize = 0;
+
       long batchScancount = 0;
       long batchScanSize = 0;
 
@@ -120,6 +126,19 @@ public class ScanTraceClient {
         span.end();
       }
       var traceId1 = span.getSpanContext().getTraceId();
+
+      // These scans are done to ensure cacne is populated. Caffeine can evict things that were only
+      // used once.
+      for (int i = 0; i < opts.getUntracedIntermediateScans(); i++) {
+        try (var scanner = client.createScanner(table)) {
+          opts.conigureScanner(scanner);
+          scanner.setBatchSize(10_000);
+          var ignored = scanner.stream().count();
+        }
+      }
+
+      long scanCount = 0;
+      long scanSize = 0;
 
       // start a second trace
       span = tracer.spanBuilder("seq-scan").startSpan();

--- a/test/src/main/java/org/apache/accumulo/test/tracing/ScanTracingIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/tracing/ScanTracingIT.java
@@ -157,6 +157,12 @@ class ScanTracingIT extends ConfigurableMacBase {
       expectedColumns = 1;
     }
 
+    if (secondScanFitsInCache) {
+      // Do a bunch of scans before the second traced scan to make Caffeine keep the data. It can
+      // evict recently added data that is only used a few times.
+      options.untracedIntermediateScans = "" + 30;
+    }
+
     var results = run(options);
     System.out.println(results);
 


### PR DESCRIPTION
ScanTracingIT creates a table, does a first scan, and then a second scan. In some cases, the test was looking for second scan to all be in cache.  However as we learned in #6156 Caffeine may not always keep recently added data in cache.  This was causing the stats to sometime report cache misses which would fail the test.  The test is not trying to test the cache itself, only the stats.  To work around this added some intermediate scans between the first traced scan and second traced scan.  These intermediate scans ensure the cache is populated for validating trace data.