### PR TITLE
reduces flaking in ClassLoaderContextCompactionIT

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
@@ -680,7 +680,7 @@ public class CompactionCoordinator
       throw new AccumuloSecurityException(credentials.getPrincipal(),
           SecurityErrorCode.PERMISSION_DENIED).asThriftException();
     }
-    if (failureState != TCompactionState.CANCELLED || failureState != TCompactionState.FAILED) {
+    if (failureState != TCompactionState.CANCELLED && failureState != TCompactionState.FAILED) {
       LOG.error("Unexpected failure state sent to compactionFailed: {}. This is likely a bug.",
           failureState);
     }

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ClassLoaderContextCompactionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ClassLoaderContextCompactionIT.java
@@ -42,6 +42,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.admin.CloneConfiguration;
 import org.apache.accumulo.core.client.admin.CompactionConfig;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.conf.Property;
@@ -172,7 +173,9 @@ public class ClassLoaderContextCompactionIT extends AccumuloClusterHarness {
     });
     thread.start();
 
-    final String table1 = this.getUniqueNames(1)[0];
+    var uniqNames = getUniqueNames(2);
+    final String table1 = uniqNames[0];
+    final String clone = uniqNames[1];
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
       Wait.waitFor(() -> ExternalCompactionUtil.countCompactors(ResourceGroupId.of(GROUP1),
           (ClientContext) client) == 1);
@@ -219,6 +222,10 @@ public class ClassLoaderContextCompactionIT extends AccumuloClusterHarness {
           new IteratorSetting(101, "FooFilter", "org.apache.accumulo.test.FooFilter");
       client.tableOperations().attachIterator(table1, cfg, EnumSet.of(IteratorScope.majc));
 
+      // Clone the table to avoid problems w/ table properties not yet propagating to compactors
+      client.tableOperations().clone(table1, clone,
+          CloneConfiguration.builder().setFlush(true).build());
+
       // delete Test.jar, so that the classloader will fail
       assertTrue(fs.delete(dst, false));
 
@@ -228,28 +235,9 @@ public class ClassLoaderContextCompactionIT extends AccumuloClusterHarness {
       assertEquals(0, terminations.get());
       assertEquals(0, consecutive.get());
 
-      // Start a compaction. The missing jar should cause a failure
-      client.tableOperations().compact(table1, new CompactionConfig().setWait(false));
-      Wait.waitFor(
-          () -> ExternalCompactionUtil.getRunningCompaction(compactorAddr, (ClientContext) client)
-              == null);
-      assertEquals(1, ExternalCompactionUtil.countCompactors(ResourceGroupId.of(GROUP1),
-          (ClientContext) client));
-      Wait.waitFor(() -> failures.get() == 1);
-      Wait.waitFor(() -> consecutive.get() == 1);
-
-      Wait.waitFor(() -> failures.get() == 0);
-      client.tableOperations().compact(table1, new CompactionConfig().setWait(false));
-      Wait.waitFor(
-          () -> ExternalCompactionUtil.getRunningCompaction(compactorAddr, (ClientContext) client)
-              == null);
-      assertEquals(1, ExternalCompactionUtil.countCompactors(ResourceGroupId.of(GROUP1),
-          (ClientContext) client));
-      Wait.waitFor(() -> failures.get() == 1);
-      Wait.waitFor(() -> consecutive.get() == 2);
-
-      Wait.waitFor(() -> failures.get() == 0);
-      client.tableOperations().compact(table1, new CompactionConfig().setWait(false));
+      // Start a compaction. The missing jar should cause a failure. As compaction jobs fail this
+      // table operation will keep causing new ones to run.
+      client.tableOperations().compact(clone, new CompactionConfig().setWait(false));
       Wait.waitFor(
           () -> ExternalCompactionUtil.getRunningCompaction(compactorAddr, (ClientContext) client)
               == null);


### PR DESCRIPTION
There were two sources of flakiness in this test.  One was that table properties would not always propagate to compactors before compactions ran.  Another was that the first table compaction initiated could spawn multiple compactions, like after one failed it would spawn another. This caused metrics to jump ahead of what the test was looking for.  The test sill flakes sometimes because it may not always see the metrics its looking for, but it flakes less frequently w/ these changes.