### PR TITLE
Adds missing opentelem library to tarball

### DIFF
--- a/assemble/pom.xml
+++ b/assemble/pom.xml
@@ -159,6 +159,11 @@
     </dependency>
     <dependency>
       <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-common</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-context</artifactId>
       <optional>true</optional>
     </dependency>


### PR DESCRIPTION
Was seeing these stack traces when trying to setup accumulo 4 from a tarball.  Found a library that needed to be added and that fixed it.

```
Exception in thread "init" java.lang.NoClassDefFoundError: io/opentelemetry/common/ComponentLoader
        at io.opentelemetry.context.LazyStorage.createStorage(LazyStorage.java:107)
        at io.opentelemetry.context.LazyStorage.<clinit>(LazyStorage.java:80)
        at io.opentelemetry.context.ContextStorage.get(ContextStorage.java:72)
        at io.opentelemetry.context.Context.current(Context.java:92)
        at org.apache.accumulo.core.trace.TraceWrappedRunnable.<init>(TraceWrappedRunnable.java:45)
        at org.apache.accumulo.core.trace.TraceUtil.wrap(TraceUtil.java:179)
        at org.apache.accumulo.core.util.threads.ThreadPools$1.execute(ThreadPools.java:590)
        at org.apache.accumulo.core.util.threads.ThreadPools.<clinit>(ThreadPools.java:192)
        at org.apache.accumulo.server.conf.ServerConfigurationFactory$ConfigRefreshRunner.<init>(ServerConfigurationFactory.java:213)
        at org.apache.accumulo.server.conf.ServerConfigurationFactory.<init>(ServerConfigurationFactory.java:103)
        at org.apache.accumulo.server.ServerContext.lambda$new$3(ServerContext.java:148)
        at com.google.common.base.Suppliers$NonSerializableMemoizingSupplier.get(Suppliers.java:198)
        at org.apache.accumulo.server.ServerContext.getConfiguration(ServerContext.java:198)
        at org.apache.accumulo.server.ServiceEnvironmentImpl.<init>(ServiceEnvironmentImpl.java:46)
        at org.apache.accumulo.server.fs.VolumeChooserEnvironmentImpl.<init>(VolumeChooserEnvironmentImpl.java:63)
        at org.apache.accumulo.server.init.Initialize.doInit(Initialize.java:169)
        at org.apache.accumulo.server.init.Initialize.execute(Initialize.java:584)
        at org.apache.accumulo.start.Main.lambda$execKeyword$1(Main.java:115)
        at java.base/java.lang.Thread.run(Thread.java:1583)
```