### PR TITLE
Fix typos: 'seperated', 'occured' in comments/annotation descriptions

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
@@ -94,7 +94,7 @@ public class ZooZap extends ServerKeywordExecutable<ZapOpts> {
     @Parameter(names = "-verbose", description = "print out messages about progress")
     boolean verbose = false;
     @Parameter(names = "--include-groups",
-        description = "Comma seperated list of resource groups to include")
+        description = "Comma separated list of resource groups to include")
     String includeGroups;
     @Parameter(names = "--exclude-host-ports",
         description = "File with lines of <host>:<port> to exclude from removal")

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -959,7 +959,7 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
           watcher.run();
 
           if (err.get() != null) {
-            // maybe the error occured because the table was deleted or something like that, so
+            // maybe the error occurred because the table was deleted or something like that, so
             // force a cancel check to possibly reduce noise in the logs
             checkIfCanceled();
           }


### PR DESCRIPTION
- `ZooZap.java`: annotation description `Comma seperated list` -> `Comma separated list`
- `Compactor.java`: comment `error occured` -> `error occurred`

No behavior changes.