### PR TITLE
fixes displaying multiple managers on monitor

### DIFF
--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/Endpoints.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/Endpoints.java
@@ -151,30 +151,6 @@ public class Endpoints {
   }
 
   @GET
-  @Path("manager")
-  @Produces(MediaType.APPLICATION_JSON)
-  @Description("Returns the metric response for the Manager")
-  public MetricResponse getManager() {
-    final ServerId s = monitor.getInformationFetcher().getSummaryForEndpoint().getManager();
-    if (s == null) {
-      throw new NotFoundException("Manager not found");
-    }
-    return monitor.getInformationFetcher().getAllMetrics().asMap().get(s);
-  }
-
-  @GET
-  @Path("manager/metrics")
-  @Produces(MediaType.APPLICATION_JSON)
-  @Description("Returns the metrics for the Manager")
-  public List<FMetric> getManagerMetrics() {
-    var managerMetrics = getManager().getMetrics();
-    if (managerMetrics != null) {
-      return managerMetrics.stream().map(FMetric::getRootAsFMetric).collect(Collectors.toList());
-    }
-    return List.of();
-  }
-
-  @GET
   @Path("gc")
   @Produces(MediaType.APPLICATION_JSON)
   @Description("Returns the metric response for the Garbage Collector")

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/InformationFetcher.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/InformationFetcher.java
@@ -358,8 +358,8 @@ public class InformationFetcher implements RemovalListener<ServerId,MetricRespon
 
         LOG.info("Finished fetching metrics from servers");
         LOG.info(
-            "All: {}, Manager: {}, Garbage Collector: {}, Compactors: {}, Scan Servers: {}, Tablet Servers: {}",
-            allMetrics.estimatedSize(), summary.getManager() != null,
+            "All: {}, Managers: {}, Garbage Collector: {}, Compactors: {}, Scan Servers: {}, Tablet Servers: {}",
+            allMetrics.estimatedSize(), summary.getManagers().size(),
             summary.getGarbageCollector() != null,
             summary.getCompactorAllMetricSummary().isEmpty() ? 0
                 : summary.getCompactorAllMetricSummary().entrySet().iterator().next().getValue()

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/SystemInformation.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/SystemInformation.java
@@ -365,7 +365,7 @@ public class SystemInformation {
   private final Set<String> resourceGroups = ConcurrentHashMap.newKeySet();
   private final Set<ServerId> problemHosts = ConcurrentHashMap.newKeySet();
   private final Set<ServerId> metricProblemHosts = ConcurrentHashMap.newKeySet();
-  private final AtomicReference<ServerId> manager = new AtomicReference<>();
+  private final Set<ServerId> managers = ConcurrentHashMap.newKeySet();
   private final AtomicReference<ServerId> gc = new AtomicReference<>();
 
   // index of resource group name to set of servers
@@ -431,6 +431,7 @@ public class SystemInformation {
     resourceGroups.clear();
     problemHosts.clear();
     metricProblemHosts.clear();
+    managers.clear();
     compactors.clear();
     sservers.clear();
     tservers.clear();
@@ -527,9 +528,7 @@ public class SystemInformation {
         }
         break;
       case MANAGER:
-        if (manager.get() == null || !manager.get().equals(server)) {
-          manager.set(server);
-        }
+        managers.add(server);
         createCompactionSummary(response);
         break;
       case SCAN_SERVER:
@@ -672,7 +671,7 @@ public class SystemInformation {
               () -> new ServersView(servers, problemHostCount, allMetrics, timestamp.get())));
           break;
         case MANAGER:
-          servers.add(manager.get());
+          servers.addAll(managers);
           serverMetricsView.put(type, memoize(
               () -> new ServersView(servers, problemHostCount, allMetrics, timestamp.get())));
           break;
@@ -702,8 +701,8 @@ public class SystemInformation {
     return this.problemHosts;
   }
 
-  public ServerId getManager() {
-    return this.manager.get();
+  public Set<ServerId> getManagers() {
+    return this.managers;
   }
 
   public ServerId getGarbageCollector() {

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
@@ -373,7 +373,7 @@ function getJSONForTable(call, sessionDataVar) {
  * Performs POST call and builds console logging message if successful
  * @param {string} call REST url called
  * @param {string} callback POST callback to execute, if available
- * @param {boolean} shouldSanitize Whether to sanitize the call 
+ * @param {boolean} shouldSanitize Whether to sanitize the call
  */
 function doLoggedPostCall(call, callback, shouldSanitize) {
 
@@ -395,14 +395,6 @@ function doLoggedPostCall(call, callback, shouldSanitize) {
 }
 
 ///// REST Calls /////////////
-
-/**
- * REST GET call for the manager information,
- * stores it on a sessionStorage variable
- */
-function getManager() {
-  return getJSONForTable(REST_V2_PREFIX + '/manager', 'manager');
-}
 
 /**
  * Gets the manager goal state from the cached manager response, if available.

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
@@ -136,9 +136,8 @@ function updateServerNotifications(statusData) {
     }
   };
 
-  applyStatuses(getManagerGoalStateFromSession());
 
-  getManager().always(function () {
+  getManagersView().always(function () {
     applyStatuses(getManagerGoalStateFromSession());
   });
 }


### PR DESCRIPTION
The monitor manager page was displaying a single manager when there were multiple managers running.  Found a point in the code that only tracked a single manager and made it track multiple.  Also removed two unused rest endpoints.