### PR TITLE
docs: fix 'occured' -> 'occurred' in Compactor comment

### DIFF
--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -959,7 +959,7 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
           watcher.run();
 
           if (err.get() != null) {
-            // maybe the error occured because the table was deleted or something like that, so
+            // maybe the error occurred because the table was deleted or something like that, so
             // force a cancel check to possibly reduce noise in the logs
             checkIfCanceled();
           }


### PR DESCRIPTION
Trivial spelling fix in a code comment inside `server/compactor/.../Compactor.java`.

No functional changes.