### PR TITLE
Update TableDeleteException to use TableId type

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/TableDeletedException.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/TableDeletedException.java
@@ -31,6 +31,12 @@ public class TableDeletedException extends RuntimeException {
   private static final long serialVersionUID = 1L;
   private final TableId tableId;
 
+  @Deprecated(since = "4.0.0")
+  public TableDeletedException(String tableId) {
+    super("Table ID " + tableId + " was deleted");
+    this.tableId = TableId.of(tableId);
+  }
+
   public TableDeletedException(TableId tableId) {
     super("Table ID " + tableId + " was deleted");
     this.tableId = tableId;

--- a/core/src/main/java/org/apache/accumulo/core/client/TableDeletedException.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/TableDeletedException.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.core.client;
 
+import org.apache.accumulo.core.data.TableId;
+
 /**
  * This exception is thrown if a table is deleted after an operation starts.
  *
@@ -27,22 +29,22 @@ package org.apache.accumulo.core.client;
 public class TableDeletedException extends RuntimeException {
 
   private static final long serialVersionUID = 1L;
-  private final String tableId;
+  private final TableId tableId;
 
-  public TableDeletedException(String tableId) {
+  public TableDeletedException(TableId tableId) {
     super("Table ID " + tableId + " was deleted");
     this.tableId = tableId;
   }
 
   /**
-   * @since 2.0.0
+   * @since 4.0.0
    */
-  public TableDeletedException(String tableId, Exception cause) {
+  public TableDeletedException(TableId tableId, Exception cause) {
     super("Table ID " + tableId + " was deleted", cause);
     this.tableId = tableId;
   }
 
-  public String getTableId() {
+  public TableId getTableId() {
     return tableId;
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
@@ -748,7 +748,7 @@ public class ClientContext implements AccumuloClient {
   // use cases overlap with requireTableExists, but this throws a runtime exception
   public TableId requireNotDeleted(TableId tableId) {
     if (!tableNodeExists(tableId)) {
-      throw new TableDeletedException(tableId.canonical());
+      throw new TableDeletedException(tableId);
     }
     return tableId;
   }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java
@@ -463,7 +463,7 @@ public final class TabletServerBatchReaderIterator implements Iterator<Entry<Key
         if (context.tableNodeExists(tableId)) {
           fatalException = e;
         } else {
-          fatalException = new TableDeletedException(tableId.canonical());
+          fatalException = new TableDeletedException(tableId);
         }
       } catch (SampleNotPresentException e) {
         fatalException = e;


### PR DESCRIPTION
The TableDeleteException was only used in places where a tableId was being passed into the Exception.

Updates the Exception constructor to accept a TableId object.

NOTE: this changes the public API and will require a deprecation in 2.1.x or a 3.x deprecation release.

I could also pull this change back to the 2.1 branch and just add a new constructor method and change the string constructor to use a `TableId.of()` call. 