### PR TITLE
Remove JSLint comment blocks from the JavaScript code

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/compactors.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/compactors.js
@@ -16,10 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-/* JSLint global definitions */
-/*global
-    $, COMPACTOR_SERVER_PROCESS_VIEW, getCompactorsView, refreshServerInformation
-*/
 "use strict";
 
 const htmlBanner = '#compactorsStatusBanner'

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
@@ -16,10 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-/* JSLint global definitions */
-/*global
-    $, sessionStorage, TIMER:true, NAMESPACES:true, refreshNavBar
-*/
 "use strict";
 
 // Suffixes for quantity

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/gc.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/gc.js
@@ -16,11 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-/* JSLint global definitions */
-/*global
-    $, GC_SERVER_PROCESS_VIEW, GC_FILE_SERVER_PROCESS_VIEW, GC_WAL_SERVER_PROCESS_VIEW,
-    getGcView, getGcFileView, getGcWalView, refreshServerInformation
-*/
 "use strict";
 
 const htmlBanner = '#gcStatusBanner'

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/manager.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/manager.js
@@ -16,13 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-/* JSLint global definitions */
-/*global
-    $, sessionStorage, MANAGER_SERVER_PROCESS_VIEW, getManagersView, getStoredRows, getStoredStatus,
-    MANAGER_FATE_SERVER_PROCESS_VIEW, MANAGER_COMPACTION_SERVER_PROCESS_VIEW, getManagersFateView,
-    getManagersCompactionView, refreshTable, refreshBanner, showBannerError,
-    getManagerGoalStateFromSession
-*/
 "use strict";
 
 const runningBanner = '#managerRunningBanner'
@@ -126,11 +119,6 @@ $(function () {
 
 // TODO: 6106 - left code commented for the recovery list table to be re-added
 
-/* JSLint global definitions */
-/*global
-    $, document, sessionStorage, getManager, bigNumberForQuantity,
-    timeDuration, dateFormat, getStatus, ajaxReloadTable, getManagerGoalStateFromSession
-*/
 /*
 "use strict";
 

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-/*global getSserversView */
 "use strict";
 
 /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/server_process_common.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/server_process_common.js
@@ -16,11 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-/* JSLint global definitions */
-/*global
-    $, sessionStorage, timeDuration, bigNumberForQuantity, bigNumberForSize, ajaxReloadTable,
-    renderActivityState, renderMemoryState, dateFormat
-*/
 "use strict";
 
 /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/sservers.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/sservers.js
@@ -16,10 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-/* JSLint global definitions */
-/*global
-    $, SCAN_SERVER_PROCESS_VIEW, getSserversView, refreshServerInformation
-*/
 "use strict";
 
 const htmlBanner = '#sserversStatusBanner'

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/tservers.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/tservers.js
@@ -16,11 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-/* JSLint global definitions */
-/*global
-    $, sessionStorage, getTServers, getRecoveryList, getStatus, bigNumberForQuantity, timeDuration,
-    ajaxReloadTable
-*/
 "use strict";
 
 const htmlBanner = '#tserversStatusBanner'


### PR DESCRIPTION
We do not have JSList in our build and I'm not sure any developers use it anymore. At this point these comments are just a maintenance burden that are not adding any value.