### PR TITLE
Backported Configuration method from accumulo 4

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/PluginEnvironment.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/PluginEnvironment.java
@@ -24,7 +24,10 @@ import java.util.Map.Entry;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import org.apache.accumulo.core.conf.ConfigurationCopy;
+import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.util.ConfigurationImpl;
 
 /**
  * This interface exposes Accumulo system level information to plugins in a stable manner. The
@@ -131,6 +134,20 @@ public interface PluginEnvironment {
      * reflected in the returned value.
      */
     <T> Supplier<T> getDerived(Function<Configuration,T> computeDerivedValue);
+
+    /**
+     * Creates a configuration object from a map of properties, this is useful for testing.
+     *
+     * @param includeDefaults If true will include accumulo's default properties and layer the
+     *        passed in map on top of these.
+     * @since 2.1.5
+     */
+    static Configuration from(Map<String,String> properties, boolean includeDefaults) {
+      ConfigurationCopy config = includeDefaults
+          ? new ConfigurationCopy(DefaultConfiguration.getInstance()) : new ConfigurationCopy();
+      properties.forEach(config::set);
+      return new ConfigurationImpl(config);
+    }
   }
 
   /**

--- a/core/src/test/java/org/apache/accumulo/core/client/PluginEnvironmentTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/PluginEnvironmentTest.java
@@ -1,0 +1,79 @@
+package org.apache.accumulo.core.client;
+
+import static org.apache.accumulo.core.client.PluginEnvironment.Configuration;
+import static org.apache.accumulo.core.conf.Property.TABLE_MAJC_RATIO;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.Test;
+
+public class PluginEnvironmentTest {
+
+  @Test
+  public void testFromWithoutDefaultsContainsOnlySuppliedProps() {
+    Map<String,String> props = new HashMap<>();
+    props.put("table.custom.foo", "true");
+    props.put("table.custom.bar", "false");
+
+    Configuration config = Configuration.from(props, false);
+
+    assertEquals("true", config.get("table.custom.foo"));
+    assertEquals("false", config.get("table.custom.bar"));
+
+    assertNull(config.get(TABLE_MAJC_RATIO.getKey()));
+    assertNull(config.get("table.custom.test.missing"));
+  }
+
+  @Test
+  public void testFromWithDefaults() {
+    Map<String,String> props = new HashMap<>();
+    props.put("table.custom.foo", "bar");
+
+    Configuration config = Configuration.from(props, true);
+    assertEquals("bar", config.get("table.custom.foo"));
+    assertEquals(TABLE_MAJC_RATIO.getDefaultValue(), config.get(TABLE_MAJC_RATIO.getKey()));
+  }
+
+  /**
+   * The supplied map must override the defaults values on collision.
+   */
+  @Test
+  public void testSuppliedPropertiesOverrideDefaults() {
+    String key = TABLE_MAJC_RATIO.getKey();
+    String defaultValue = TABLE_MAJC_RATIO.getDefaultValue();
+    String overrideValue = "10";
+    assertEquals(overrideValue, defaultValue, "default value cannot match override value");
+    Configuration config = Configuration.from(Map.of(key, overrideValue), true);
+    assertEquals(overrideValue, config.get(key));
+  }
+
+  @Test
+  public void testFromEmptyMapWithoutDefaultsIsEmpty() {
+    Configuration config = Configuration.from(Map.of(), false);
+
+    assertNull(config.get("table.custom.test"));
+    assertNull(config.get(TABLE_MAJC_RATIO.getKey()));
+    assertFalse(config.iterator().hasNext(),
+        "iterator should be empty when no props and no defaults");
+  }
+
+  /**
+   * getDerived should produce a Supplier that computes its value from the underlying configuration.
+   */
+  @Test
+  public void testGetDerived() {
+    Configuration config = Configuration.from(Map.of("table.custom.test", "5"), false);
+
+    Supplier<Integer> derived =
+        config.getDerived(cfg -> Integer.parseInt(cfg.get("table.custom.test")));
+
+    assertNotNull(derived);
+    assertEquals(5, derived.get());
+  }
+}

--- a/core/src/test/java/org/apache/accumulo/core/client/PluginEnvironmentTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/PluginEnvironmentTest.java
@@ -22,6 +22,7 @@ import static org.apache.accumulo.core.client.PluginEnvironment.Configuration;
 import static org.apache.accumulo.core.conf.Property.TABLE_MAJC_RATIO;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -66,7 +67,7 @@ public class PluginEnvironmentTest {
     String key = TABLE_MAJC_RATIO.getKey();
     String defaultValue = TABLE_MAJC_RATIO.getDefaultValue();
     String overrideValue = "10";
-    assertEquals(overrideValue, defaultValue, "default value cannot match override value");
+    assertNotEquals(overrideValue, defaultValue, "default value cannot match override value");
     Configuration config = Configuration.from(Map.of(key, overrideValue), true);
     assertEquals(overrideValue, config.get(key));
   }

--- a/core/src/test/java/org/apache/accumulo/core/client/PluginEnvironmentTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/PluginEnvironmentTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.accumulo.core.client;
 
 import static org.apache.accumulo.core.client.PluginEnvironment.Configuration;


### PR DESCRIPTION
Backported the  `Configuration.from` method from accumulo 4 to allow clients the ability to generate a Configuration without needing to fully create a separate Configuration wrapper implementation.

Added some test cases as well.