### PR TITLE
fix threadpool name

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/InternalCompactionExecutor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/InternalCompactionExecutor.java
@@ -208,7 +208,7 @@ public class InternalCompactionExecutor implements CompactionExecutor {
 
   public void setThreads(int numThreads) {
     ThreadPools.resizePool(threadPool, () -> numThreads,
-        ACCUMULO_POOL_PREFIX.poolName + ".accumulo.pool.compaction." + ceid);
+        ACCUMULO_POOL_PREFIX.poolName + ".compaction." + ceid);
   }
 
   @Override


### PR DESCRIPTION
Removes the duplicate accumulo pool prefix
old: `accumulo.pool.accumulo.pool.compaction.<ceid>` 
new: `accumulo.pool.compaction.<ceid>`