### PR TITLE
Remove warnings from unused code

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientInfo.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientInfo.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.core.clientImpl;
 
-import java.nio.file.Path;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Supplier;
@@ -100,10 +99,4 @@ public interface ClientInfo {
     return new ClientInfoImpl(properties, Optional.of(token));
   }
 
-  /**
-   * @return ClientInfo given path to client config file
-   */
-  static ClientInfo from(Path propertiesFile) {
-    return new ClientInfoImpl(ClientInfoImpl.toProperties(propertiesFile), Optional.empty());
-  }
 }

--- a/core/src/main/java/org/apache/accumulo/core/fate/FateKey.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/FateKey.java
@@ -42,14 +42,12 @@ public class FateKey {
   private final FateKeyType type;
   private final Optional<KeyExtent> keyExtent;
   private final Optional<ExternalCompactionId> compactionId;
-  private final Optional<TServerInstance> tServerInstance;
   private final byte[] serialized;
 
   private FateKey(FateKeyType type, KeyExtent keyExtent) {
     this.type = Objects.requireNonNull(type);
     this.keyExtent = Optional.of(keyExtent);
     this.compactionId = Optional.empty();
-    this.tServerInstance = Optional.empty();
     this.serialized = serialize(type, keyExtent);
   }
 
@@ -57,7 +55,6 @@ public class FateKey {
     this.type = Objects.requireNonNull(type);
     this.keyExtent = Optional.empty();
     this.compactionId = Optional.of(compactionId);
-    this.tServerInstance = Optional.empty();
     this.serialized = serialize(type, compactionId);
   }
 
@@ -65,7 +62,6 @@ public class FateKey {
     this.type = Objects.requireNonNull(type);
     this.keyExtent = Optional.empty();
     this.compactionId = Optional.empty();
-    this.tServerInstance = Optional.of(tServerInstance);
     this.serialized = serialize(type, tServerInstance);
   }
 
@@ -75,7 +71,6 @@ public class FateKey {
       this.type = FateKeyType.valueOf(buffer.readUTF());
       this.keyExtent = deserializeKeyExtent(type, buffer);
       this.compactionId = deserializeCompactionId(type, buffer);
-      this.tServerInstance = deserializeTserverId(type, buffer);
       this.serialized = serialized;
     } catch (IOException e) {
       throw new UncheckedIOException(e);
@@ -197,14 +192,6 @@ public class FateKey {
     return switch (type) {
       case SPLIT, MERGE, TSERVER_SHUTDOWN -> Optional.empty();
       case COMPACTION_COMMIT -> Optional.of(ExternalCompactionId.of(buffer.readUTF()));
-    };
-  }
-
-  private static Optional<TServerInstance> deserializeTserverId(FateKeyType type,
-      DataInputBuffer buffer) throws IOException {
-    return switch (type) {
-      case SPLIT, MERGE, COMPACTION_COMMIT -> Optional.empty();
-      case TSERVER_SHUTDOWN -> Optional.of(new TServerInstance(buffer.readUTF()));
     };
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -27,7 +27,6 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.accumulo.core.metrics.Metric.MANAGER_GOAL_STATE;
-import static org.apache.accumulo.core.util.threads.ThreadPoolNames.FILE_RENAME_POOL;
 
 import java.io.IOException;
 import java.net.UnknownHostException;
@@ -281,7 +280,6 @@ public class Manager extends AbstractServer
   private final TabletStateStore rootTabletStore;
   private final TabletStateStore metadataTabletStore;
   private final TabletStateStore userTabletStore;
-  private final ExecutorService renamePool;
 
   public synchronized ManagerState getManagerState() {
     return state;
@@ -488,9 +486,6 @@ public class Manager extends AbstractServer
       BiFunction<SiteConfiguration,ResourceGroupId,ServerContext> serverContextFactory,
       String[] args) throws IOException {
     super(ServerId.Type.MANAGER, opts, serverContextFactory, args);
-    int poolSize = this.getConfiguration().getCount(Property.MANAGER_RENAME_THREADS);
-    renamePool = ThreadPools.getServerThreadPools().getPoolBuilder(FILE_RENAME_POOL.poolName)
-        .numCoreThreads(poolSize).build();
     ServerContext context = super.getContext();
     upgradeCoordinator = new UpgradeCoordinator(context);
     balanceManager = new BalanceManager();

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
@@ -192,8 +192,6 @@ public class CompactionCoordinator
 
   private final LoadingCache<ResourceGroupId,Integer> compactorCounts;
 
-  private volatile long coordinatorStartTime;
-
   private final Map<DataLevel,ThreadPoolExecutor> reservationPools;
   private final Set<String> activeCompactorReservationRequest = ConcurrentHashMap.newKeySet();
 
@@ -301,8 +299,6 @@ public class CompactionCoordinator
 
   @Override
   public void run() {
-
-    this.coordinatorStartTime = System.currentTimeMillis();
     startConfigMonitor(ctx.getScheduledExecutor());
     startCompactorZKCleaner(ctx.getScheduledExecutor());
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/PutGcCandidates.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/PutGcCandidates.java
@@ -45,6 +45,6 @@ public class PutGcCandidates extends AbstractFateOperation {
 
     // For user initiated table compactions, the fate operation will refresh tablets. Can also
     // refresh as part of this compaction commit as it may run sooner.
-    return new RefreshTablet(commitData.ecid, commitData.textent, refreshLocation);
+    return new RefreshTablet(commitData.textent, refreshLocation);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/RefreshTablet.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/RefreshTablet.java
@@ -38,10 +38,8 @@ public class RefreshTablet extends AbstractFateOperation {
   private static final long serialVersionUID = 1L;
   private final TKeyExtent extent;
   private final String tserverInstance;
-  private final String compactionId;
 
-  public RefreshTablet(String ecid, TKeyExtent extent, String tserverInstance) {
-    this.compactionId = ecid;
+  public RefreshTablet(TKeyExtent extent, String tserverInstance) {
     this.extent = extent;
     this.tserverInstance = tserverInstance;
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/fate/FateManager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/fate/FateManager.java
@@ -215,7 +215,7 @@ public class FateManager {
     }
 
     if (!timer.isExpired()) {
-      FateStore<FateEnv> store = switch (fateType) {
+      try (FateStore<FateEnv> store = switch (fateType) {
         case USER -> new UserFateStore<FateEnv>(context, SystemTables.FATE.tableName(), null, null);
         case META -> {
           try {
@@ -224,18 +224,20 @@ public class FateManager {
             throw new IllegalStateException(e);
           }
         }
-      };
-      var reserved = store.getActiveReservations(Set.of(FatePartition.all(FateInstanceType.USER)));
-      while (!reserved.isEmpty() && !timer.isExpired()) {
-        if (log.isTraceEnabled()) {
-          reserved.forEach((fateId, reservation) -> {
-            log.trace("In stop(), waiting on {} {} ", fateId, reservation);
-          });
-        }
-        try {
-          Thread.sleep(Math.min(100, timer.timeLeft(TimeUnit.MILLISECONDS)));
-        } catch (InterruptedException e) {
-          throw new IllegalStateException(e);
+      }) {
+        var reserved =
+            store.getActiveReservations(Set.of(FatePartition.all(FateInstanceType.USER)));
+        while (!reserved.isEmpty() && !timer.isExpired()) {
+          if (log.isTraceEnabled()) {
+            reserved.forEach((fateId, reservation) -> {
+              log.trace("In stop(), waiting on {} {} ", fateId, reservation);
+            });
+          }
+          try {
+            Thread.sleep(Math.min(100, timer.timeLeft(TimeUnit.MILLISECONDS)));
+          } catch (InterruptedException e) {
+            throw new IllegalStateException(e);
+          }
         }
       }
     }

--- a/server/manager/src/test/java/org/apache/accumulo/manager/compaction/CompactionCoordinatorTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/compaction/CompactionCoordinatorTest.java
@@ -32,7 +32,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -96,13 +95,8 @@ public class CompactionCoordinatorTest {
 
   public class TestCoordinator extends CompactionCoordinator {
 
-    private final List<TExternalCompaction> runningCompactions;
-
-    private Set<ExternalCompactionId> metadataCompactionIds = null;
-
     public TestCoordinator(Manager manager, List<TExternalCompaction> runningCompactions) {
       super(manager, t -> null);
-      this.runningCompactions = runningCompactions;
     }
 
     @Override
@@ -138,14 +132,6 @@ public class CompactionCoordinatorTest {
     public void compactionFailed(TInfo tinfo, TCredentials credentials, String externalCompactionId,
         TKeyExtent extent, String exceptionClassName, TCompactionState failureState,
         String groupName, String compactorAddress) throws ThriftSecurityException {}
-
-    void setMetadataCompactionIds(Set<ExternalCompactionId> mci) {
-      metadataCompactionIds = mci;
-    }
-
-    public void resetInternals() {
-      metadataCompactionIds = null;
-    }
 
     @Override
     protected CompactionMetadata reserveCompaction(ResolvedCompactionJob rcJob,

--- a/test/src/main/java/org/apache/accumulo/test/LocatorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/LocatorIT.java
@@ -45,7 +45,6 @@ import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.core.client.admin.TabletAvailability;
 import org.apache.accumulo.core.client.admin.servers.ServerId;
-import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.RowRange;
 import org.apache.accumulo.core.data.TableId;
@@ -194,7 +193,7 @@ public class LocatorIT extends AccumuloClusterHarness {
       tableOps.create(table3, new NewTableConfiguration().createOffline());
       tableOps.create(table4, new NewTableConfiguration().createOffline());
 
-      ClientContext ctx = (ClientContext) client;
+      var ctx = getCluster().getServerContext();
 
       ctx.setClearFrequency(Duration.ofMillis(100));
 

--- a/test/src/main/java/org/apache/accumulo/test/shell/MockShell.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/MockShell.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import org.apache.accumulo.core.clientImpl.ClientInfo;
 import org.apache.accumulo.shell.Shell;
 import org.apache.accumulo.shell.ShellOptionsJC;
 import org.jline.reader.LineReader;
@@ -63,7 +62,6 @@ public class MockShell {
   public Terminal terminal;
 
   MockShell(File configFile) throws Exception {
-    ClientInfo info = ClientInfo.from(configFile.toPath());
     // start the shell
     output = new TestOutputStream();
     input = new StringInputStream();

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellConfigIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellConfigIT.java
@@ -28,7 +28,6 @@ import java.time.Duration;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
-import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
 import org.apache.accumulo.core.clientImpl.Namespace;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
@@ -76,20 +75,18 @@ public class ShellConfigIT extends AccumuloClusterHarness {
   public void experimentalPropTest() throws Exception {
     // ensure experimental props do not show up in config output unless set
 
-    AuthenticationToken token = getAdminToken();
     File clientPropsFile = null;
     switch (getClusterType()) {
-      case MINI:
+      case MINI -> {
         MiniAccumuloClusterImpl mac = (MiniAccumuloClusterImpl) getCluster();
         clientPropsFile = mac.getConfig().getClientPropsFile();
-        break;
-      case STANDALONE:
+      }
+      case STANDALONE -> {
         StandaloneAccumuloClusterConfiguration standaloneConf =
             (StandaloneAccumuloClusterConfiguration) getClusterConfiguration();
         clientPropsFile = standaloneConf.getClientPropsFile();
-        break;
-      default:
-        fail("Unknown cluster type");
+      }
+      default -> fail("Unknown cluster type");
     }
 
     assertNotNull(clientPropsFile);

--- a/test/src/main/java/org/apache/accumulo/test/tracing/ScanTraceClient.java
+++ b/test/src/main/java/org/apache/accumulo/test/tracing/ScanTraceClient.java
@@ -127,13 +127,15 @@ public class ScanTraceClient {
       }
       var traceId1 = span.getSpanContext().getTraceId();
 
-      // These scans are done to ensure cacne is populated. Caffeine can evict things that were only
+      // These scans are done to ensure cache is populated. Caffeine can evict things that were only
       // used once.
       for (int i = 0; i < opts.getUntracedIntermediateScans(); i++) {
         try (var scanner = client.createScanner(table)) {
           opts.conigureScanner(scanner);
           scanner.setBatchSize(10_000);
-          var ignored = scanner.stream().count();
+          scanner.forEach((k, v) -> {
+            // do nothing with the result, just ensure the cache is populated
+          });
         }
       }
 


### PR DESCRIPTION
* Remove unused variables, methods, and parameters, causing IDE compiler warnings
* Also remove warning from unclosed FateStore by placing the new store in a try-with-resources block
* Also removed one false positive potentially unclosed resource warning in LocatorIT by using the ServerContext for altering the system state for the test instead of using the AccumuloClient as a ClientContext