### PR TITLE
Fixed a case where exceptions was not thrown when Tablet closing

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -1213,6 +1213,7 @@ public class Tablet extends TabletBase {
         String msg = "Data files in " + extent + " differ from in-memory data "
             + tabletMeta.getFilesMap() + " " + getDatafileManager().getDatafileSizes();
         log.error(msg);
+        throw new RuntimeException(msg);
       }
     } catch (Exception e) {
       String msg = "Failed to do close consistency check for tablet " + extent;


### PR DESCRIPTION
All of the other checks in closeConsistencyCheck throw a RuntimeException, but this check was missing it.