### PR TITLE
Added option to Initialize to remove resource group zk node

### DIFF
--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -333,7 +333,7 @@ function parse_config() {
   else
     for group in $COMPACTOR_GROUPS; do
       if ! arrayContains "$group" "${all_resource_groups[@]}"; then
-        echo "$(red ERROR): Resource group $(yellow "$group") does not exist. Use 'accumulo init --add-resource-groups' to create it"
+        echo "$(red ERROR): Resource group $(yellow "$group") does not exist. Use 'accumulo inst init --add-resource-groups' to create it"
         exit 1
       fi
       G="COMPACTOR_HOSTS_$group"
@@ -349,7 +349,7 @@ function parse_config() {
   else
     for group in $TSERVER_GROUPS; do
       if ! arrayContains "$group" "${all_resource_groups[@]}"; then
-        echo "$(red ERROR): Resource group $(yellow "$group") does not exist. Use 'accumulo init --add-resource-groups' to create it"
+        echo "$(red ERROR): Resource group $(yellow "$group") does not exist. Use 'accumulo inst init --add-resource-groups' to create it"
         exit 1
       fi
       G="TSERVER_HOSTS_$group"
@@ -369,7 +369,7 @@ function parse_config() {
   if [[ -n $SSERVER_GROUPS ]]; then
     for group in $SSERVER_GROUPS; do
       if ! arrayContains "$group" "${all_resource_groups[@]}"; then
-        echo "$(red ERROR): Resource group $(yellow "$group") does not exist. Use 'accumulo init --add-resource-groups' to create it"
+        echo "$(red ERROR): Resource group $(yellow "$group") does not exist. Use 'accumulo inst init --add-resource-groups' to create it"
         exit 1
       fi
       G="SSERVER_HOSTS_$group"

--- a/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
@@ -467,6 +467,33 @@ public class Initialize implements KeywordExecutable {
     }
   }
 
+  private static boolean removeResourceGroups(InitialConfiguration initConfig,
+      String resourceGroupsArg) {
+
+    try (ServerContext context = new ServerContext(initConfig.getSiteConf())) {
+      if (resourceGroupsArg == null) {
+        return true;
+      }
+      final ZooSession zs = context.getZooSession();
+      final String[] rgs = resourceGroupsArg.split(",");
+      for (String rg : rgs) {
+        String trimmed = rg.trim();
+        final var rgid = ResourceGroupId.of(trimmed);
+        if (rgid == ResourceGroupId.DEFAULT) {
+          continue;
+        }
+        try {
+          ResourceGroupPropKey.of(rgid).removeZNode(zs);
+          log.info("Removed resource group {}", trimmed);
+        } catch (IllegalStateException | KeeperException | InterruptedException e) {
+          log.error("Error removing resource group: " + trimmed, e);
+          return false;
+        }
+      }
+      return true;
+    }
+  }
+
   private static boolean addVolumes(VolumeManager fs, InitialConfiguration initConfig,
       ServerDirs serverDirs) {
     var hadoopConf = initConfig.getHadoopConf();
@@ -511,6 +538,9 @@ public class Initialize implements KeywordExecutable {
     @Parameter(names = "--add-resource-groups",
         description = "Add resource groups (comma separated list of names)")
     String resourceGroups = null;
+    @Parameter(names = "--remove-resource-groups",
+        description = "Remove resource groups (comma separated list of names)")
+    String removeResourceGroups = null;
     @Parameter(names = "--add-volumes",
         description = "Initialize any uninitialized volumes listed in instance.volumes")
     boolean addVolumes = false;
@@ -562,7 +592,7 @@ public class Initialize implements KeywordExecutable {
   public void execute(final String[] args) {
     boolean success = true;
     Opts opts = new Opts();
-    opts.parseArgs("accumulo init", args);
+    opts.parseArgs("init", args);
     var siteConfig = SiteConfiguration.auto();
     SecurityUtil.serverLogin(siteConfig);
     Configuration hadoopConfig = new Configuration();
@@ -579,7 +609,11 @@ public class Initialize implements KeywordExecutable {
       if (success && opts.resourceGroups != null) {
         success = addResourceGroups(initConfig, opts.resourceGroups);
       }
-      if (!opts.resetSecurity && !opts.addVolumes && opts.resourceGroups == null) {
+      if (success && opts.removeResourceGroups != null) {
+        success = removeResourceGroups(initConfig, opts.removeResourceGroups);
+      }
+      if (!opts.resetSecurity && !opts.addVolumes && opts.resourceGroups == null
+          && opts.removeResourceGroups == null) {
         try (var zk = new ZooSession(getClass().getSimpleName(), siteConfig)) {
           success = doInit(zk.asReaderWriter(), opts, fs, initConfig);
         }


### PR DESCRIPTION
Initialize only had an option to create the resource group node in ZK. ResourceGroupOperationsImpl has the ability to create and remove, so adding this feature provides a mechanism to create and remove the zk nodes in the shell and CLI. This change also includes some minor updates to account for the new command group in the CLI tools.

Closes #6357