### PR TITLE
Add overview matrix to monitor home page

### DIFF
--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/SystemInformation.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/SystemInformation.java
@@ -853,8 +853,16 @@ public class SystemInformation {
     int missingMetricCount = (int) servers.stream()
         .filter(serverId -> !TableDataFactory.hasMetricData(allMetrics.getIfPresent(serverId)))
         .count();
-    return Status.buildStatus(servers.size(), problemHostCount, missingMetricCount,
-        type == ServerId.Type.TABLET_SERVER);
+    return Status.buildStatus(servers.size(), problemHostCount, missingMetricCount, switch (type) {
+      case MANAGER:
+      case GARBAGE_COLLECTOR:
+      case COMPACTOR:
+      case SCAN_SERVER:
+      case TABLET_SERVER:
+        yield true;
+      case MONITOR:
+        yield false;
+    });
   }
 
   private String computeManagerGoalState() {

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/css/screen.css
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/css/screen.css
@@ -252,6 +252,84 @@ pre.logevent {
   color: #5cb85c;
 }
 
+.server-count {
+  color: #6c757d;
+  font-size: 0.875em;
+  font-variant-numeric: tabular-nums;
+}
+
+.deployment-overview-content {
+  width: fit-content;
+  max-width: 100%;
+  margin: 0 auto;
+}
+
+.deployment-overview-content .form-control {
+  min-width: 28rem;
+}
+
+.deployment-matrix-table {
+  margin: 0 auto;
+  table-layout: auto;
+  width: auto;
+}
+
+.deployment-matrix-table th,
+.deployment-matrix-table td {
+  text-align: center;
+  vertical-align: middle;
+}
+
+.deployment-matrix-group {
+  min-width: 10rem;
+  text-align: left !important;
+  white-space: nowrap;
+  font-weight: 400;
+}
+
+.deployment-matrix-cell {
+  min-width: 5.25rem;
+}
+
+.deployment-matrix-total {
+  font-weight: 600;
+}
+
+.deployment-matrix-header {
+  font-weight: 600;
+  white-space: normal;
+  line-height: 1.15;
+  background-color: #f8f9fa;
+}
+
+.deployment-matrix-table tfoot th,
+.deployment-matrix-table tfoot td {
+  font-weight: 600;
+}
+
+.deployment-count-badge {
+  min-width: 2.35rem;
+  padding: 0.3em 0.55em;
+  color: #333333;
+  font-variant-numeric: tabular-nums;
+}
+
+.deployment-count-ok {
+  background-color: #5cb85c;
+}
+
+.deployment-count-warn {
+  background-color: #f0ad4e;
+}
+
+.deployment-count-error {
+  background-color: #d9534f;
+}
+
+.deployment-count-empty {
+  background-color: #f5f5f5;
+}
+
 .highlight {
   background-color: #cef4b5;
 }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/css/screen.css
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/css/screen.css
@@ -264,10 +264,6 @@ pre.logevent {
   margin: 0 auto;
 }
 
-.deployment-overview-content .form-control {
-  min-width: 28rem;
-}
-
 .deployment-matrix-table {
   margin: 0 auto;
   table-layout: auto;

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/css/screen.css
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/css/screen.css
@@ -314,6 +314,11 @@ pre.logevent {
   font-variant-numeric: tabular-nums;
 }
 
+.deployment-count-total {
+  background-color: #f5f5f5;
+  border: 1px solid #d9d9d9;
+}
+
 .deployment-count-ok {
   background-color: #5cb85c;
 }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
@@ -36,6 +36,28 @@ const CLASS = {
   ERROR: 'error'
 };
 
+const NAVBAR_COMPONENTS = [{
+  statusKey: 'MANAGER',
+  indicatorId: 'managerStatusNotification',
+  countId: 'managerStatusCount'
+}, {
+  statusKey: 'TABLET_SERVER',
+  indicatorId: 'serverStatusNotification',
+  countId: 'serverStatusCount'
+}, {
+  statusKey: 'GARBAGE_COLLECTOR',
+  indicatorId: 'gcStatusNotification',
+  countId: 'gcStatusCount'
+}, {
+  statusKey: 'SCAN_SERVER',
+  indicatorId: 'sserverStatusNotification',
+  countId: 'sserverStatusCount'
+}, {
+  statusKey: 'COMPACTOR',
+  indicatorId: 'compactorStatusNotification',
+  countId: 'compactorStatusCount'
+}];
+
 /**
  * Remove other bootstrap color classes and add the given class to the given element
  * @param {string} elementId the element id to update
@@ -59,6 +81,21 @@ function updateElementStatus(elementId, status) {
   }
 }
 
+function updateServerCount(elementId, status) {
+  const $element = $(`#${elementId}`);
+
+  if (!status || Number(status.serverCount) <= 0) {
+    $element.text('0/0');
+    return;
+  }
+
+  const total = Number(status.serverCount);
+  const problem = Number(status.problemServerCount || 0);
+  const responding = Math.max(0, total - problem);
+
+  $element.text(`${responding}/${total}`);
+}
+
 /**
  * Updates the notifications of the servers dropdown notification as well as the individual server notifications.
  * @param {JSON} statusData object containing the status info for the servers
@@ -67,14 +104,13 @@ function updateServerNotifications(statusData) {
   const managerGoalState = statusData.managerGoalState;
   const isSafeMode = managerGoalState === 'SAFE_MODE';
   const isCleanStop = managerGoalState === 'CLEAN_STOP';
-  const componentStatuses = [
-    getComponentStatus(statusData, 'MANAGER'),
-    getComponentStatus(statusData, 'TABLET_SERVER'),
-    getComponentStatus(statusData, 'GARBAGE_COLLECTOR'),
-    getComponentStatus(statusData, 'SCAN_SERVER'),
-    getComponentStatus(statusData, 'COMPACTOR')
-  ];
+  const componentStatuses = NAVBAR_COMPONENTS.map(function (component) {
+    return getComponentStatus(statusData, component.statusKey);
+  });
   const managerStatus = componentStatuses[0];
+  const componentData = NAVBAR_COMPONENTS.map(function (component) {
+    return statusData.componentStatuses?.[component.statusKey] || null;
+  });
 
   // setting manager status notification
   if (managerStatus === STATUS.ERROR || isCleanStop) {
@@ -88,10 +124,13 @@ function updateServerNotifications(statusData) {
       '. Could not properly set manager status notification.');
   }
 
-  updateElementStatus('serverStatusNotification', componentStatuses[1]);
-  updateElementStatus('gcStatusNotification', componentStatuses[2]);
-  updateElementStatus('sserverStatusNotification', componentStatuses[3]);
-  updateElementStatus('compactorStatusNotification', componentStatuses[4]);
+  NAVBAR_COMPONENTS.forEach(function (component, index) {
+    updateServerCount(component.countId, componentData[index]);
+    if (index === 0) {
+      return;
+    }
+    updateElementStatus(component.indicatorId, componentStatuses[index]);
+  });
 
   // Setting overall servers status notification
   if (!isSafeMode && !isCleanStop && componentStatuses.every(status => status === STATUS.OK)) {

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/overview.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/overview.js
@@ -18,18 +18,7 @@
  */
 "use strict";
 
-var deploymentSummaryTable;
-var deploymentBreakdownTable;
-const SERVER_TYPE_LINKS = new Map([
-  ['Manager', 'manager'],
-  ['Garbage Collector', 'gc'],
-  ['Compactor', 'compactors'],
-  ['Scan Server', 'sservers'],
-  ['Tablet Server', 'tservers']
-]);
-const SUMMARY_SERVER_TYPES = ['Manager', 'Garbage Collector', 'Compactor', 'Scan Server',
-  'Tablet Server'
-];
+var deploymentBreakdown = [];
 
 /**
  * Creates overview initial table
@@ -37,98 +26,12 @@ const SUMMARY_SERVER_TYPES = ['Manager', 'Garbage Collector', 'Compactor', 'Scan
 $(function () {
   // display datatables errors in the console instead of in alerts
   $.fn.dataTable.ext.errMode = 'throw';
-
-  deploymentSummaryTable = $('#deploymentSummaryTable').DataTable({
-    "autoWidth": false,
-    "paging": false,
-    "searching": false,
-    "info": false,
-    "ordering": false,
-    "dom": 't',
-    "data": [],
-    "columnDefs": [{
-        "targets": 0,
-        "width": "60%"
-      },
-      {
-        "targets": 1,
-        "width": "40%"
-      }
-    ],
-    "columns": [{
-        "data": "serverType",
-        "render": function (data, type) {
-          if (type !== 'display') {
-            return data;
-          }
-
-          var link = SERVER_TYPE_LINKS.get(data);
-          if (link === undefined) {
-            return data;
-          }
-
-          return '<a class="link-body-emphasis" href="' + sanitize(link) + '">' + sanitize(data) + '</a>';
-        }
-      },
-      {
-        "data": null,
-        "render": function (data, type, row) {
-          return row.responding + ' / ' + row.total;
-        }
-      }
-    ]
-  });
-
-  deploymentBreakdownTable = $('#deploymentBreakdownTable').DataTable({
-    "autoWidth": false,
-    "paging": true,
-    "pageLength": 10,
-    "searching": true,
-    "info": true,
-    "order": [
-      [0, 'asc'],
-      [1, 'asc']
-    ],
-    "dom": 't<"row"<"col-sm-3"l><"col-sm-5 text-center"i><"col-sm-4 text-right"p>>',
-    "data": [],
-    "columnDefs": [{
-        "targets": 0,
-        "width": "30%"
-      },
-      {
-        "targets": 1,
-        "width": "40%"
-      },
-      {
-        "targets": 2,
-        "width": "30%"
-      }
-    ],
-    "columns": [{
-        "data": "resourceGroup",
-        "name": "resourceGroup"
-      },
-      {
-        "data": "serverType"
-      },
-      {
-        "data": null,
-        "render": function (data, type, row) {
-          return row.responding + ' / ' + row.total;
-        }
-      }
-    ]
-  });
-
   $('#deployment-rg-filter').on('keyup', function () {
     var input = this.value;
     if (isValidRegex(input) || input === '') {
       $('#deployment-rg-feedback').hide();
       $(this).removeClass('is-invalid');
-      deploymentBreakdownTable
-        .column('resourceGroup:name')
-        .search(input, true, false)
-        .draw();
+      renderDeploymentMatrix(deploymentBreakdown, input);
     } else {
       $('#deployment-rg-feedback').show();
       $(this).addClass('is-invalid');
@@ -159,7 +62,8 @@ function refreshDeploymentTables() {
   getDeployment().then(function () {
     var data = JSON.parse(sessionStorage.deployment);
     var breakdown = Array.isArray(data.breakdown) ? data.breakdown : [];
-    var summary = buildDeploymentSummary(breakdown);
+    var filterValue = $('#deployment-rg-filter').val() || '';
+    deploymentBreakdown = breakdown;
 
     if (breakdown.length === 0) {
       $('#deploymentWarning').html('<div class="alert alert-warning" role="alert">' +
@@ -168,39 +72,172 @@ function refreshDeploymentTables() {
       $('#deploymentWarning').empty();
     }
 
-    deploymentSummaryTable.clear().rows.add(summary).draw();
-    deploymentBreakdownTable.clear().rows.add(breakdown).draw();
+    renderDeploymentMatrix(breakdown, filterValue);
   });
 }
 
-function buildDeploymentSummary(breakdown) {
+function renderDeploymentMatrix(breakdown, resourceGroupFilter) {
+  var matrixData = buildDeploymentMatrix(breakdown, resourceGroupFilter);
+  var $container = $('#deploymentBreakdownMatrix');
+
   if (breakdown.length === 0) {
-    return [];
+    $container.empty();
+    return;
   }
 
-  var totalsByType = new Map();
+  if (matrixData.filteredResourceGroups.length === 0) {
+    $container.html(buildDeploymentEmptyState(resourceGroupFilter));
+    return;
+  }
 
-  SUMMARY_SERVER_TYPES.forEach(function (serverType) {
-    totalsByType.set(serverType, {
-      serverType: serverType,
-      total: 0,
-      responding: 0
+  $container.html(buildDeploymentMatrixTable(matrixData));
+}
+
+function buildDeploymentMatrix(breakdown, resourceGroupFilter) {
+  var serverTypes = [];
+  var serverTypeSet = new Set();
+  var resourceGroups = new Map();
+  var filterRegex = createRegex(resourceGroupFilter);
+
+  breakdown.forEach(function (row) {
+    if (serverTypeSet.has(row.serverType) === false) {
+      serverTypeSet.add(row.serverType);
+      serverTypes.push(row.serverType);
+    }
+
+    if (resourceGroups.has(row.resourceGroup) === false) {
+      resourceGroups.set(row.resourceGroup, new Map());
+    }
+
+    resourceGroups.get(row.resourceGroup).set(row.serverType, {
+      responding: Number(row.responding),
+      total: Number(row.total)
     });
   });
 
-  breakdown.forEach(function (row) {
-    var existing = totalsByType.get(row.serverType);
-    if (existing === undefined) {
-      totalsByType.set(row.serverType, {
-        serverType: row.serverType,
-        total: row.total,
-        responding: row.responding
-      });
-    } else {
-      existing.total += row.total;
-      existing.responding += row.responding;
+  var sortedResourceGroups = Array.from(resourceGroups.keys()).sort();
+  var filteredResourceGroups = sortedResourceGroups.filter(function (resourceGroup) {
+    if (filterRegex === null) {
+      return true;
     }
+    return filterRegex.test(resourceGroup);
   });
 
-  return Array.from(totalsByType.values());
+  return {
+    serverTypes: serverTypes,
+    resourceGroups: resourceGroups,
+    filteredResourceGroups: filteredResourceGroups
+  };
+}
+
+function buildDeploymentMatrixTable(matrixData) {
+  var headerCells = ['<th class="deployment-matrix-group deployment-matrix-header">Resource Group</th>'];
+  var totalByServerType = new Map();
+  var grandTotals = {
+    responding: 0,
+    total: 0
+  };
+
+  matrixData.serverTypes.forEach(function (serverType) {
+    headerCells.push('<th class="deployment-matrix-cell deployment-matrix-header">' +
+      sanitize(serverType) + '</th>');
+    totalByServerType.set(serverType, {
+      responding: 0,
+      total: 0
+    });
+  });
+  headerCells.push('<th class="deployment-matrix-cell deployment-matrix-header">Total</th>');
+
+  var rowsHtml = matrixData.filteredResourceGroups.map(function (resourceGroup) {
+    var cells = ['<th scope="row" class="deployment-matrix-group">' + sanitize(resourceGroup) + '</th>'];
+    var rowTotals = {
+      responding: 0,
+      total: 0
+    };
+    var rowData = matrixData.resourceGroups.get(resourceGroup);
+
+    matrixData.serverTypes.forEach(function (serverType) {
+      var counts = rowData.get(serverType) || {
+        responding: 0,
+        total: 0
+      };
+      var totals = totalByServerType.get(serverType);
+
+      totals.responding += counts.responding;
+      totals.total += counts.total;
+      rowTotals.responding += counts.responding;
+      rowTotals.total += counts.total;
+
+      cells.push('<td class="deployment-matrix-cell">' + buildDeploymentCell(counts) + '</td>');
+    });
+
+    grandTotals.responding += rowTotals.responding;
+    grandTotals.total += rowTotals.total;
+    cells.push('<td class="deployment-matrix-cell deployment-matrix-total">' +
+      buildDeploymentCell(rowTotals) + '</td>');
+
+    return '<tr>' + cells.join('') + '</tr>';
+  }).join('');
+
+  var footerCells = ['<th scope="row" class="deployment-matrix-group deployment-matrix-total">Total</th>'];
+
+  matrixData.serverTypes.forEach(function (serverType) {
+    footerCells.push('<td class="deployment-matrix-cell deployment-matrix-total">' +
+      buildDeploymentCell(totalByServerType.get(serverType)) + '</td>');
+  });
+  footerCells.push('<td class="deployment-matrix-cell deployment-matrix-total">' +
+    buildDeploymentCell(grandTotals) + '</td>');
+
+  return '<div class="table-responsive">' +
+    '<table class="table table-bordered table-sm align-middle deployment-matrix-table mb-0">' +
+    '<thead><tr><th colspan="' + sanitize(String(matrixData.serverTypes.length + 2)) +
+    '" class="center">Deployment Breakdown</th></tr><tr>' + headerCells.join('') +
+    '</tr></thead><tbody>' + rowsHtml + '</tbody><tfoot><tr>' + footerCells.join('') +
+    '</tr></tfoot></table></div>';
+}
+
+function buildDeploymentCell(counts) {
+  var badgeClass = getDeploymentBadgeClass(counts.responding, counts.total);
+  var label = counts.responding + '/' + counts.total;
+
+  return '<span class="badge rounded-pill deployment-count-badge ' + badgeClass + '">' +
+    sanitize(label) + '</span>';
+}
+
+function getDeploymentBadgeClass(responding, total) {
+  if (total === 0) {
+    return 'deployment-count-empty';
+  }
+
+  if (responding === 0) {
+    return 'deployment-count-error';
+  }
+
+  if (responding === total) {
+    return 'deployment-count-ok';
+  }
+
+  return 'deployment-count-warn';
+}
+
+function buildDeploymentEmptyState(resourceGroupFilter) {
+  if (resourceGroupFilter && resourceGroupFilter !== '') {
+    return '<div class="alert alert-secondary mb-0" role="alert">' +
+      'No resource groups match the current filter.</div>';
+  }
+
+  return '<div class="alert alert-secondary mb-0" role="alert">' +
+    'No deployment breakdown data is currently available.</div>';
+}
+
+function createRegex(pattern) {
+  if (!pattern) {
+    return null;
+  }
+
+  try {
+    return new RegExp(pattern, 'i');
+  } catch (error) {
+    return null;
+  }
 }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/overview.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/overview.js
@@ -26,18 +26,6 @@ var deploymentBreakdown = [];
 $(function () {
   // display datatables errors in the console instead of in alerts
   $.fn.dataTable.ext.errMode = 'throw';
-  $('#deployment-rg-filter').on('keyup', function () {
-    var input = this.value;
-    if (isValidRegex(input) || input === '') {
-      $('#deployment-rg-feedback').hide();
-      $(this).removeClass('is-invalid');
-      renderDeploymentMatrix(deploymentBreakdown, input);
-    } else {
-      $('#deployment-rg-feedback').show();
-      $(this).addClass('is-invalid');
-    }
-  });
-
   refreshOverview();
 });
 
@@ -62,7 +50,6 @@ function refreshDeploymentTables() {
   getDeployment().then(function () {
     var data = JSON.parse(sessionStorage.deployment);
     var breakdown = Array.isArray(data.breakdown) ? data.breakdown : [];
-    var filterValue = $('#deployment-rg-filter').val() || '';
     deploymentBreakdown = breakdown;
 
     if (breakdown.length === 0) {
@@ -72,12 +59,12 @@ function refreshDeploymentTables() {
       $('#deploymentWarning').empty();
     }
 
-    renderDeploymentMatrix(breakdown, filterValue);
+    renderDeploymentMatrix(breakdown);
   });
 }
 
-function renderDeploymentMatrix(breakdown, resourceGroupFilter) {
-  var matrixData = buildDeploymentMatrix(breakdown, resourceGroupFilter);
+function renderDeploymentMatrix(breakdown) {
+  var matrixData = buildDeploymentMatrix(breakdown);
   var $container = $('#deploymentBreakdownMatrix');
 
   if (breakdown.length === 0) {
@@ -93,11 +80,10 @@ function renderDeploymentMatrix(breakdown, resourceGroupFilter) {
   $container.html(buildDeploymentMatrixTable(matrixData));
 }
 
-function buildDeploymentMatrix(breakdown, resourceGroupFilter) {
+function buildDeploymentMatrix(breakdown) {
   var serverTypes = [];
   var serverTypeSet = new Set();
   var resourceGroups = new Map();
-  var filterRegex = createRegex(resourceGroupFilter);
 
   breakdown.forEach(function (row) {
     if (serverTypeSet.has(row.serverType) === false) {
@@ -116,17 +102,11 @@ function buildDeploymentMatrix(breakdown, resourceGroupFilter) {
   });
 
   var sortedResourceGroups = Array.from(resourceGroups.keys()).sort();
-  var filteredResourceGroups = sortedResourceGroups.filter(function (resourceGroup) {
-    if (filterRegex === null) {
-      return true;
-    }
-    return filterRegex.test(resourceGroup);
-  });
 
   return {
     serverTypes: serverTypes,
     resourceGroups: resourceGroups,
-    filteredResourceGroups: filteredResourceGroups
+    filteredResourceGroups: sortedResourceGroups
   };
 }
 
@@ -231,24 +211,7 @@ function getDeploymentBadgeClass(responding, total) {
   return 'deployment-count-warn';
 }
 
-function buildDeploymentEmptyState(resourceGroupFilter) {
-  if (resourceGroupFilter && resourceGroupFilter !== '') {
-    return '<div class="alert alert-secondary mb-0" role="alert">' +
-      'No resource groups match the current filter.</div>';
-  }
-
+function buildDeploymentEmptyState() {
   return '<div class="alert alert-secondary mb-0" role="alert">' +
     'No deployment breakdown data is currently available.</div>';
-}
-
-function createRegex(pattern) {
-  if (!pattern) {
-    return null;
-  }
-
-  try {
-    return new RegExp(pattern, 'i');
-  } catch (error) {
-    return null;
-  }
 }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/overview.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/overview.js
@@ -174,7 +174,7 @@ function buildDeploymentMatrixTable(matrixData) {
     grandTotals.responding += rowTotals.responding;
     grandTotals.total += rowTotals.total;
     cells.push('<td class="deployment-matrix-cell deployment-matrix-total">' +
-      buildDeploymentCell(rowTotals) + '</td>');
+      buildDeploymentTotalCell(rowTotals) + '</td>');
 
     return '<tr>' + cells.join('') + '</tr>';
   }).join('');
@@ -183,10 +183,10 @@ function buildDeploymentMatrixTable(matrixData) {
 
   matrixData.serverTypes.forEach(function (serverType) {
     footerCells.push('<td class="deployment-matrix-cell deployment-matrix-total">' +
-      buildDeploymentCell(totalByServerType.get(serverType)) + '</td>');
+      buildDeploymentTotalCell(totalByServerType.get(serverType)) + '</td>');
   });
   footerCells.push('<td class="deployment-matrix-cell deployment-matrix-total">' +
-    buildDeploymentCell(grandTotals) + '</td>');
+    buildDeploymentTotalCell(grandTotals) + '</td>');
 
   return '<div class="table-responsive">' +
     '<table class="table table-bordered table-sm align-middle deployment-matrix-table mb-0">' +
@@ -196,11 +196,23 @@ function buildDeploymentMatrixTable(matrixData) {
     '</tr></tfoot></table></div>';
 }
 
-function buildDeploymentCell(counts) {
+/**
+ * Builds the HTML for a badge containing the counts of responding vs total servers
+ */
+function buildDeploymentCell(counts, neutral) {
   var badgeClass = getDeploymentBadgeClass(counts.responding, counts.total);
   var label = counts.responding + '/' + counts.total;
 
   return '<span class="badge rounded-pill deployment-count-badge ' + badgeClass + '">' +
+    sanitize(label) + '</span>';
+}
+/**
+ * Builds the HTML for a badge containing the total counts of responding vs total servers
+ */
+function buildDeploymentTotalCell(counts) {
+  var label = counts.responding + '/' + counts.total;
+
+  return '<span class="badge rounded-pill deployment-count-badge deployment-count-total">' +
     sanitize(label) + '</span>';
 }
 

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/overview.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/overview.js
@@ -190,8 +190,7 @@ function buildDeploymentMatrixTable(matrixData) {
 
   return '<div class="table-responsive">' +
     '<table class="table table-bordered table-sm align-middle deployment-matrix-table mb-0">' +
-    '<thead><tr><th colspan="' + sanitize(String(matrixData.serverTypes.length + 2)) +
-    '" class="center">Deployment Breakdown</th></tr><tr>' + headerCells.join('') +
+    '<thead><tr>' + headerCells.join('') +
     '</tr></thead><tbody>' + rowsHtml + '</tbody><tfoot><tr>' + footerCells.join('') +
     '</tr></tfoot></table></div>';
 }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/navbar.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/navbar.ftl
@@ -39,11 +39,11 @@
                 <span id="statusNotification" class="icon-dot normal"></span>&nbsp;Servers
               </a>
               <ul class="dropdown-menu">
-                <li><a class="link-body-emphasis dropdown-item" href="manager"><span id="managerStatusNotification" class="icon-dot normal"></span>&nbsp;Manager&nbsp;Server&nbsp;</a></li>
-                <li><a class="link-body-emphasis dropdown-item" href="tservers"><span id="serverStatusNotification" class="icon-dot normal"></span>&nbsp;Tablet&nbsp;Servers&nbsp;</a></li>
-                <li><a class="link-body-emphasis dropdown-item" href="sservers"><span id="sserverStatusNotification" class="icon-dot normal"></span>&nbsp;Scan&nbsp;Servers&nbsp;</a></li>
-                <li><a class="link-body-emphasis dropdown-item" href="compactors"><span id="compactorStatusNotification" class="icon-dot normal"></span>&nbsp;Compactors</a></li>
-                <li><a class="link-body-emphasis dropdown-item" href="gc"><span id="gcStatusNotification" class="icon-dot normal"></span>&nbsp;Garbage&nbsp;collector&nbsp;</a></li>
+                <li><a class="link-body-emphasis dropdown-item d-flex justify-content-between align-items-center gap-3" href="manager"><span><span id="managerStatusNotification" class="icon-dot normal"></span>&nbsp;Manager&nbsp;Server</span><span id="managerStatusCount" class="server-count"></span></a></li>
+                <li><a class="link-body-emphasis dropdown-item d-flex justify-content-between align-items-center gap-3" href="tservers"><span><span id="serverStatusNotification" class="icon-dot normal"></span>&nbsp;Tablet&nbsp;Servers</span><span id="serverStatusCount" class="server-count"></span></a></li>
+                <li><a class="link-body-emphasis dropdown-item d-flex justify-content-between align-items-center gap-3" href="sservers"><span><span id="sserverStatusNotification" class="icon-dot normal"></span>&nbsp;Scan&nbsp;Servers</span><span id="sserverStatusCount" class="server-count"></span></a></li>
+                <li><a class="link-body-emphasis dropdown-item d-flex justify-content-between align-items-center gap-3" href="compactors"><span><span id="compactorStatusNotification" class="icon-dot normal"></span>&nbsp;Compactors</span><span id="compactorStatusCount" class="server-count"></span></a></li>
+                <li><a class="link-body-emphasis dropdown-item d-flex justify-content-between align-items-center gap-3" href="gc"><span><span id="gcStatusNotification" class="icon-dot normal"></span>&nbsp;Garbage&nbsp;collector</span><span id="gcStatusCount" class="server-count"></span></a></li>
               </ul>
             </li>
             <li>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/overview.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/overview.ftl
@@ -26,23 +26,7 @@
       <div class="row d-flex justify-content-center">
         <div class="col-xs-12" id="deploymentOverview">
           <div id="deploymentWarning"></div>
-          <div class="mb-4" style="max-width: 560px; margin: 0 auto;">
-            <table id="deploymentSummaryTable"
-              class="table table-bordered table-striped table-condensed" style="width: 100%;">
-              <thead>
-                <tr>
-                  <th colspan="2" class="center">Server Type Summary</th>
-                </tr>
-                <tr>
-                  <th>Server Type</th>
-                  <th>Responding / Total</th>
-                </tr>
-              </thead>
-              <tbody></tbody>
-            </table>
-          </div>
-
-          <div style="max-width: 760px; margin: 0 auto;">
+          <div class="deployment-overview-content">
             <div class="mb-3">
               <label for="deployment-rg-filter" class="form-label">Resource Group Filter</label>
               <input type="text" id="deployment-rg-filter" class="form-control"
@@ -50,20 +34,7 @@
               <small id="deployment-rg-feedback" class="form-text text-danger"
                 style="display:none;">Invalid regex pattern</small>
             </div>
-            <table id="deploymentBreakdownTable"
-              class="table table-bordered table-striped table-condensed" style="width: 100%;">
-              <thead>
-                <tr>
-                  <th colspan="3" class="center">Deployment Breakdown</th>
-                </tr>
-                <tr>
-                  <th>Resource Group</th>
-                  <th>Server Type</th>
-                  <th>Responding / Total</th>
-                </tr>
-              </thead>
-              <tbody></tbody>
-            </table>
+            <div id="deploymentBreakdownMatrix"></div>
           </div>
         </div>
       </div>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/overview.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/overview.ftl
@@ -27,13 +27,6 @@
         <div class="col-xs-12" id="deploymentOverview">
           <div id="deploymentWarning"></div>
           <div class="deployment-overview-content">
-            <div class="mb-3">
-              <label for="deployment-rg-filter" class="form-label">Resource Group Filter</label>
-              <input type="text" id="deployment-rg-filter" class="form-control"
-                placeholder="Enter resource group regex">
-              <small id="deployment-rg-feedback" class="form-text text-danger"
-                style="display:none;">Invalid regex pattern</small>
-            </div>
             <div id="deploymentBreakdownMatrix"></div>
           </div>
         </div>


### PR DESCRIPTION
This PR replaces the two tables on the monitor home/overview page with a single matrix showing the counts of servers on each resource group with color highlighting problems. This PR also adds counts to the Servers navbar dropdown menu list.