### PR TITLE
Updated some logging levels, deprecated fate property value

### DIFF
--- a/assemble/conf/log4j2.properties
+++ b/assemble/conf/log4j2.properties
@@ -41,5 +41,8 @@ logger.shell.level = info
 logger.zookeeper.name = org.apache.zookeeper
 logger.zookeeper.level = error
 
+logger.hadoop.name = org.apache.hadoop
+logger.hadoop.level = warn
+
 rootLogger.level = info
 rootLogger.appenderRef.console.ref = STDERR

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -520,7 +520,7 @@ public enum Property {
           operations and whose value is a pool size for those operations.
           """, "4.0.0"),
   @Deprecated(since = "4.0.0")
-  MANAGER_FATE_THREADPOOL_SIZE("manager.fate.threadpool.size", "64",
+  MANAGER_FATE_THREADPOOL_SIZE("manager.fate.threadpool.size", "",
       PropertyType.FATE_THREADPOOL_SIZE, """
           Previously, the number of threads used to run fault-tolerant executions (FATE). \
           This is no longer used in 4.0+. %s and %s are the replacement and must be \

--- a/core/src/main/java/org/apache/accumulo/core/conf/PropertyType.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/PropertyType.java
@@ -569,10 +569,12 @@ public enum PropertyType {
 
     @Override
     public boolean test(String s) {
-      log.warn(
-          "The manager fate thread pool size property is no longer used. See the {} and {} for "
-              + "the replacements to this property.",
-          ValidUserFateConfig.NAME, ValidMetaFateConfig.NAME);
+      if (!s.isEmpty()) {
+        log.warn(
+            "The manager fate thread pool size property is no longer used. See the {} and {} for "
+                + "the replacements to this property.",
+            ValidUserFateConfig.NAME, ValidMetaFateConfig.NAME);
+      }
       return true;
     }
   }

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/bcfile/CompressionAlgorithm.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/bcfile/CompressionAlgorithm.java
@@ -284,7 +284,7 @@ public class CompressionAlgorithm extends Configured {
       clazz = System.getProperty(codecClazzProp, getConf().get(codecClazzProp, defaultClazz));
     }
     try {
-      LOG.info("Trying to load codec class {}", clazz);
+      LOG.debug("Trying to load codec class {}", clazz);
       Configuration config = new Configuration(getConf());
       updateBuffer(config, bufferSizeConfigOpt, bufferSize);
       return (CompressionCodec) ReflectionUtils.newInstance(Class.forName(clazz), config);

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
@@ -336,10 +336,10 @@ public class ServerContext extends ClientContext {
   }
 
   public void waitForZookeeperAndHdfs() {
-    log.info("Attempting to talk to zookeeper");
+    log.debug("Attempting to talk to zookeeper");
     // Next line blocks until connection is established
     getZooSession();
-    log.info("ZooKeeper connected and initialized, attempting to talk to HDFS");
+    log.debug("ZooKeeper connected and initialized, attempting to talk to HDFS");
     long sleep = 1000;
     int unknownHostTries = 3;
     while (true) {
@@ -370,12 +370,12 @@ public class ServerContext extends ClientContext {
           throw e;
         }
       }
-      log.info("Backing off due to failure; current sleep period is {} seconds", sleep / 1000.);
+      log.debug("Backing off due to failure; current sleep period is {} seconds", sleep / 1000.);
       sleepUninterruptibly(sleep, TimeUnit.MILLISECONDS);
       /* Back off to give transient failures more time to clear. */
       sleep = Math.min(MINUTES.toMillis(1), sleep * 2);
     }
-    log.info("Connected to HDFS");
+    log.debug("Connected to HDFS");
   }
 
   /**

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/store/impl/PropStoreWatcher.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/store/impl/PropStoreWatcher.java
@@ -139,7 +139,7 @@ public class PropStoreWatcher implements Watcher {
           // terminal - never coming back.
           case Expired:
           case Closed:
-            log.info("ZooKeeper connection closed event received");
+            log.debug("ZooKeeper connection closed event received");
             zkReadyMonitor.clearReady();
             zkReadyMonitor.setClosed(); // terminal condition
             executorService.execute(

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/util/ZooInfoViewer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/util/ZooInfoViewer.java
@@ -120,9 +120,9 @@ public class ZooInfoViewer extends ServerKeywordExecutable<ViewerOpts> {
   public void execute(JCommander cl, ViewerOpts opts) throws Exception {
     nullWatcher = new NullWatcher(new ReadyMonitor(ZooInfoViewer.class.getSimpleName(), 20_000L));
 
-    log.info("print ids map: {}", opts.printIdMap);
-    log.info("print properties: {}", opts.printProps);
-    log.info("print instances: {}", opts.printInstanceIds);
+    log.debug("print ids map: {}", opts.printIdMap);
+    log.debug("print properties: {}", opts.printProps);
+    log.debug("print instances: {}", opts.printInstanceIds);
 
     generateReport(getServerContext(), opts);
   }


### PR DESCRIPTION
This change updates some logging levels to remove the unnecessary logging output when starting and stopping services. This change also modifies the default value of the deprecated fate thread pool size property from "64" to "" and it's associated property type so that the deprecation warning is only logged when the value is included in the config instead of always being logged.