### PR TITLE
Use ServerContext for internal table checks in ITs

### DIFF
--- a/test/src/main/java/org/apache/accumulo/harness/AccumuloClusterHarness.java
+++ b/test/src/main/java/org/apache/accumulo/harness/AccumuloClusterHarness.java
@@ -33,8 +33,6 @@ import org.apache.accumulo.cluster.ClusterUsers;
 import org.apache.accumulo.cluster.standalone.StandaloneAccumuloCluster;
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
-import org.apache.accumulo.core.client.AccumuloException;
-import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.admin.SecurityOperations;
 import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
@@ -168,7 +166,8 @@ public abstract class AccumuloClusterHarness extends AccumuloITBase
     if (type.isDynamic()) {
       cluster.start();
       try (AccumuloClient ac = Accumulo.newClient().from(getClientProps()).build()) {
-        setSystemTablePerms(ac, cluster.getServerContext().securityOperations());
+        AccumuloITBase.setSystemTablePermsForITs(ac,
+            cluster.getServerContext().securityOperations());
       }
     } else {
       log.info("Removing tables which appear to be from a previous test run");
@@ -177,12 +176,6 @@ public abstract class AccumuloClusterHarness extends AccumuloITBase
       cleanupUsers();
     }
 
-  }
-
-  protected void setSystemTablePerms(AccumuloClient client, SecurityOperations sops)
-      throws AccumuloException, AccumuloSecurityException {
-    AccumuloITBase.setSystemTablePermsForITs(client,
-        cluster.getServerContext().securityOperations());
   }
 
   public void cleanupTables() throws Exception {

--- a/test/src/main/java/org/apache/accumulo/harness/AccumuloClusterHarness.java
+++ b/test/src/main/java/org/apache/accumulo/harness/AccumuloClusterHarness.java
@@ -165,10 +165,6 @@ public abstract class AccumuloClusterHarness extends AccumuloITBase
 
     if (type.isDynamic()) {
       cluster.start();
-      try (AccumuloClient ac = Accumulo.newClient().from(getClientProps()).build()) {
-        AccumuloITBase.setSystemTablePermsForITs(ac,
-            cluster.getServerContext().securityOperations());
-      }
     } else {
       log.info("Removing tables which appear to be from a previous test run");
       cleanupTables();

--- a/test/src/main/java/org/apache/accumulo/harness/AccumuloITBase.java
+++ b/test/src/main/java/org/apache/accumulo/harness/AccumuloITBase.java
@@ -30,15 +30,9 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.Map.Entry;
 
-import org.apache.accumulo.core.client.AccumuloClient;
-import org.apache.accumulo.core.client.AccumuloException;
-import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.Scanner;
-import org.apache.accumulo.core.client.admin.SecurityOperations;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.metadata.SystemTables;
-import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.test.util.Wait;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -165,15 +159,5 @@ public class AccumuloITBase extends WithTestNames {
     jar.deleteOnExit();
 
     return jar;
-  }
-
-  // ITs may use the client properties to create an AccumuloClient
-  // and then interact with the Fate and ScanRef tables. By default
-  // only the system user can interact with these tables.
-  public static void setSystemTablePermsForITs(AccumuloClient client, SecurityOperations ops)
-      throws AccumuloException, AccumuloSecurityException {
-    ops.grantTablePermission(client.whoami(), SystemTables.FATE.tableName(), TablePermission.READ);
-    ops.grantTablePermission(client.whoami(), SystemTables.SCAN_REF.tableName(),
-        TablePermission.READ);
   }
 }

--- a/test/src/main/java/org/apache/accumulo/harness/SharedMiniClusterBase.java
+++ b/test/src/main/java/org/apache/accumulo/harness/SharedMiniClusterBase.java
@@ -136,9 +136,7 @@ public abstract class SharedMiniClusterBase extends AccumuloITBase implements Cl
     cluster = harness.create(getTestClassName(), SharedMiniClusterBase.class.getSimpleName(), token,
         miniClusterCallback, krb);
     cluster.start();
-    try (AccumuloClient ac = Accumulo.newClient().from(getClientProps()).build()) {
-      AccumuloITBase.setSystemTablePermsForITs(ac, cluster.getServerContext().securityOperations());
-    }
+
   }
 
   private static String getTestClassName() {

--- a/test/src/main/java/org/apache/accumulo/test/ComprehensiveTableOperationsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ComprehensiveTableOperationsIT.java
@@ -327,7 +327,8 @@ public class ComprehensiveTableOperationsIT extends SharedMiniClusterBase {
     createFateTableRow(userTable);
     createScanRefTableRow();
     for (var sysTable : SystemTables.tableNames()) {
-      var maxRow = ops.getMaxRow(sysTable, Authorizations.EMPTY, RowRange.all());
+      var maxRow = getCluster().getServerContext().tableOperations().getMaxRow(sysTable,
+          Authorizations.EMPTY, RowRange.all());
       log.info("Max row of {} : {}", sysTable, maxRow);
       assertNotNull(maxRow);
     }
@@ -724,7 +725,8 @@ public class ComprehensiveTableOperationsIT extends SharedMiniClusterBase {
     createScanRefTableRow();
     for (var sysTable : SystemTables.tableNames()) {
       ops.flush(sysTable, null, null, true);
-      var diskUsageList = ops.getDiskUsage(Set.of(sysTable));
+      var diskUsageList =
+          getCluster().getServerContext().tableOperations().getDiskUsage(Set.of(sysTable));
       assertEquals(1, diskUsageList.size());
       var diskUsage = diskUsageList.get(0);
       log.info("table : {}, disk usage : {}", sysTable, diskUsage.getUsage());
@@ -837,7 +839,8 @@ public class ComprehensiveTableOperationsIT extends SharedMiniClusterBase {
     ReadWriteIT.ingest(client, 5, 5, 5, 0, table);
 
     Set<Text> rowsSeenBeforeNewOp = new HashSet<>();
-    try (var scanner = client.createScanner(SystemTables.FATE.tableName())) {
+    try (var scanner = getCluster().getServerContext().createScanner(SystemTables.FATE.tableName(),
+        Authorizations.EMPTY)) {
       for (var entry : scanner) {
         rowsSeenBeforeNewOp.add(entry.getKey().getRow());
       }
@@ -848,7 +851,8 @@ public class ComprehensiveTableOperationsIT extends SharedMiniClusterBase {
     ops.compact(table, null, null, true, false);
 
     Set<Text> rowsSeenAfterNewOp = new HashSet<>();
-    try (var scanner = client.createScanner(SystemTables.FATE.tableName())) {
+    try (var scanner = getCluster().getServerContext().createScanner(SystemTables.FATE.tableName(),
+        Authorizations.EMPTY)) {
       for (var entry : scanner) {
         rowsSeenAfterNewOp.add(entry.getKey().getRow());
       }
@@ -897,7 +901,8 @@ public class ComprehensiveTableOperationsIT extends SharedMiniClusterBase {
     ops.cancelCompaction(userTable);
     // Wait for FATE table to be clear
     Wait.waitFor(() -> {
-      try (var scanner = client.createScanner(SystemTables.FATE.tableName())) {
+      try (var scanner = getCluster().getServerContext()
+          .createScanner(SystemTables.FATE.tableName(), Authorizations.EMPTY)) {
         return !scanner.iterator().hasNext();
       }
     });
@@ -910,8 +915,10 @@ public class ComprehensiveTableOperationsIT extends SharedMiniClusterBase {
   private void cleanupScanRefTable() throws Exception {
     var scanServerRefs = getCluster().getServerContext().getAmple().scanServerRefs();
     scanServerRefs.delete(scanServerRefs.list().collect(Collectors.toSet()));
-    assertTrue(
-        client.createScanner(SystemTables.SCAN_REF.tableName()).stream().findAny().isEmpty());
+    try (var scanner = getCluster().getServerContext()
+        .createScanner(SystemTables.SCAN_REF.tableName(), Authorizations.EMPTY)) {
+      assertTrue(scanner.stream().findAny().isEmpty());
+    }
   }
 
   private boolean propFound(String tableName, String key, String val) throws Exception {

--- a/test/src/main/java/org/apache/accumulo/test/ScanServerMetadataEntriesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ScanServerMetadataEntriesIT.java
@@ -232,7 +232,7 @@ public class ScanServerMetadataEntriesIT extends SharedMiniClusterBase {
 
       List<Entry<Key,Value>> metadataEntries = null;
       try (Scanner scanner2 =
-          client.createScanner(SystemTables.SCAN_REF.tableName(), Authorizations.EMPTY)) {
+          ctx.createScanner(SystemTables.SCAN_REF.tableName(), Authorizations.EMPTY)) {
         metadataEntries = scanner2.stream().distinct().collect(Collectors.toList());
       }
       assertEquals(fileCount, metadataEntries.size());

--- a/test/src/main/java/org/apache/accumulo/test/fate/FateTestUtil.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FateTestUtil.java
@@ -63,6 +63,7 @@ public class FateTestUtil {
    */
   public static void createFateTable(ClientContext client, ServerContext serverContext,
       String table) throws Exception {
+    // Read the real FATE table as the server, but create the test table as the test client.
     final var fateTableProps =
         serverContext.tableOperations().getTableProperties(SystemTables.FATE.tableName());
 

--- a/test/src/main/java/org/apache/accumulo/test/fate/FateTestUtil.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FateTestUtil.java
@@ -42,6 +42,7 @@ import org.apache.accumulo.core.fate.FateStore;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.metadata.SystemTables;
 import org.apache.accumulo.core.zookeeper.ZooSession;
+import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.test.zookeeper.ZooKeeperTestingServer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.io.TempDir;
@@ -60,12 +61,13 @@ public class FateTestUtil {
    * Create the fate table with the exact configuration as the real Fate user instance table
    * including table properties and TabletAvailability. For use in testing UserFateStore
    */
-  public static void createFateTable(ClientContext client, String table) throws Exception {
+  public static void createFateTable(ClientContext client, ServerContext serverContext,
+      String table) throws Exception {
     final var fateTableProps =
-        client.tableOperations().getTableProperties(SystemTables.FATE.tableName());
+        serverContext.tableOperations().getTableProperties(SystemTables.FATE.tableName());
 
     TabletAvailability availability;
-    try (var tabletStream = client.tableOperations()
+    try (var tabletStream = serverContext.tableOperations()
         .getTabletInformation(SystemTables.FATE.tableName(), List.of(RowRange.all()))) {
       availability = tabletStream.map(TabletInformation::getTabletAvailability).distinct()
           .collect(MoreCollectors.onlyElement());

--- a/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateExecutionOrderIT_SimpleSuite.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateExecutionOrderIT_SimpleSuite.java
@@ -35,7 +35,7 @@ public class UserFateExecutionOrderIT_SimpleSuite extends FateExecutionOrderITBa
     var table = getUniqueNames(1)[0];
     try (ClientContext client =
         (ClientContext) Accumulo.newClient().from(getClientProps()).build()) {
-      createFateTable(client, table);
+      createFateTable(client, getCluster().getServerContext(), table);
       try (FateStore<FeoTestEnv> fs = new UserFateStore<>(client, table, createDummyLockID(), null,
           maxDeferred, fateIdGenerator)) {
         testMethod.execute(fs, getCluster().getServerContext());

--- a/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateIT_SimpleSuite.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateIT_SimpleSuite.java
@@ -68,7 +68,7 @@ public class UserFateIT_SimpleSuite extends FateITBase {
     table = getUniqueNames(1)[0];
     try (ClientContext client =
         (ClientContext) Accumulo.newClient().from(getClientProps()).build()) {
-      createFateTable(client, table);
+      createFateTable(client, getCluster().getServerContext(), table);
       try (FateStore<TestEnv> fs = new UserFateStore<>(client, table, createDummyLockID(), null,
           maxDeferred, fateIdGenerator)) {
         testMethod.execute(fs, getCluster().getServerContext());
@@ -81,45 +81,42 @@ public class UserFateIT_SimpleSuite extends FateITBase {
   // are initialized correctly
   @Test
   public void testFateInitialConfigCorrectness() throws Exception {
-    try (ClientContext client =
-        (ClientContext) Accumulo.newClient().from(getClientProps()).build()) {
 
-      // It is important here to use getTableProperties() and not getConfiguration()
-      // because we want only the table properties and not a merged view
-      var fateTableProps =
-          client.tableOperations().getTableProperties(SystemTables.FATE.tableName());
+    // It is important here to use getTableProperties() and not getConfiguration()
+    // because we want only the table properties and not a merged view
+    var fateTableProps = getCluster().getServerContext().tableOperations()
+        .getTableProperties(SystemTables.FATE.tableName());
 
-      // Verify properties all have a table. prefix
-      assertTrue(fateTableProps.keySet().stream().allMatch(key -> key.startsWith("table.")));
+    // Verify properties all have a table. prefix
+    assertTrue(fateTableProps.keySet().stream().allMatch(key -> key.startsWith("table.")));
 
-      // Verify properties are correctly set
-      assertEquals("5", fateTableProps.get(Property.TABLE_FILE_REPLICATION.getKey()));
-      assertEquals("sync", fateTableProps.get(Property.TABLE_DURABILITY.getKey()));
-      assertEquals("false", fateTableProps.get(Property.TABLE_FAILURES_IGNORE.getKey()));
-      assertEquals("", fateTableProps.get(Property.TABLE_DEFAULT_SCANTIME_VISIBILITY.getKey()));
+    // Verify properties are correctly set
+    assertEquals("5", fateTableProps.get(Property.TABLE_FILE_REPLICATION.getKey()));
+    assertEquals("sync", fateTableProps.get(Property.TABLE_DURABILITY.getKey()));
+    assertEquals("false", fateTableProps.get(Property.TABLE_FAILURES_IGNORE.getKey()));
+    assertEquals("", fateTableProps.get(Property.TABLE_DEFAULT_SCANTIME_VISIBILITY.getKey()));
 
-      // Verify VersioningIterator related properties are correct
-      var iterClass = "10," + VersioningIterator.class.getName();
-      var maxVersions = "1";
-      assertEquals(iterClass,
-          fateTableProps.get(Property.TABLE_ITERATOR_PREFIX.getKey() + "scan.vers"));
-      assertEquals(maxVersions, fateTableProps
-          .get(Property.TABLE_ITERATOR_PREFIX.getKey() + "scan.vers.opt.maxVersions"));
-      assertEquals(iterClass,
-          fateTableProps.get(Property.TABLE_ITERATOR_PREFIX.getKey() + "minc.vers"));
-      assertEquals(maxVersions, fateTableProps
-          .get(Property.TABLE_ITERATOR_PREFIX.getKey() + "minc.vers.opt.maxVersions"));
-      assertEquals(iterClass,
-          fateTableProps.get(Property.TABLE_ITERATOR_PREFIX.getKey() + "majc.vers"));
-      assertEquals(maxVersions, fateTableProps
-          .get(Property.TABLE_ITERATOR_PREFIX.getKey() + "majc.vers.opt.maxVersions"));
+    // Verify VersioningIterator related properties are correct
+    var iterClass = "10," + VersioningIterator.class.getName();
+    var maxVersions = "1";
+    assertEquals(iterClass,
+        fateTableProps.get(Property.TABLE_ITERATOR_PREFIX.getKey() + "scan.vers"));
+    assertEquals(maxVersions,
+        fateTableProps.get(Property.TABLE_ITERATOR_PREFIX.getKey() + "scan.vers.opt.maxVersions"));
+    assertEquals(iterClass,
+        fateTableProps.get(Property.TABLE_ITERATOR_PREFIX.getKey() + "minc.vers"));
+    assertEquals(maxVersions,
+        fateTableProps.get(Property.TABLE_ITERATOR_PREFIX.getKey() + "minc.vers.opt.maxVersions"));
+    assertEquals(iterClass,
+        fateTableProps.get(Property.TABLE_ITERATOR_PREFIX.getKey() + "majc.vers"));
+    assertEquals(maxVersions,
+        fateTableProps.get(Property.TABLE_ITERATOR_PREFIX.getKey() + "majc.vers.opt.maxVersions"));
 
-      // Verify all tablets are HOSTED
-      try (var tablets =
-          client.getAmple().readTablets().forTable(SystemTables.FATE.tableId()).build()) {
-        assertTrue(tablets.stream()
-            .allMatch(tm -> tm.getTabletAvailability() == TabletAvailability.HOSTED));
-      }
+    // Verify all tablets are HOSTED
+    try (var tablets = getCluster().getServerContext().getAmple().readTablets()
+        .forTable(SystemTables.FATE.tableId()).build()) {
+      assertTrue(
+          tablets.stream().allMatch(tm -> tm.getTabletAvailability() == TabletAvailability.HOSTED));
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateOpsCommandsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateOpsCommandsIT.java
@@ -22,9 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.function.Predicate;
 
-import org.apache.accumulo.core.client.Accumulo;
-import org.apache.accumulo.core.client.AccumuloClient;
-import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.fate.AbstractFateStore;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.FateInstanceType;
@@ -43,9 +40,8 @@ public class UserFateOpsCommandsIT extends FateOpsCommandsITBase {
   @AfterEach
   public void afterEachTeardown() throws Exception {
     // remove any lingering fate data after each test
-    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build();
-        Scanner scanner =
-            client.createScanner(SystemTables.FATE.tableName(), Authorizations.EMPTY)) {
+    try (var scanner = getCluster().getServerContext().createScanner(SystemTables.FATE.tableName(),
+        Authorizations.EMPTY)) {
       for (var entry : scanner) {
         String fateUUID = entry.getKey().getRow().toString();
         fateOpsToCleanup.add(FateId.from(FateInstanceType.USER, fateUUID).canonical());

--- a/test/src/main/java/org/apache/accumulo/test/fate/user/UserFatePoolsWatcherIT_SimpleSuite.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/user/UserFatePoolsWatcherIT_SimpleSuite.java
@@ -51,7 +51,7 @@ public class UserFatePoolsWatcherIT_SimpleSuite extends FatePoolsWatcherITBase {
     table = getUniqueNames(1)[0];
     try (ClientContext client =
         (ClientContext) Accumulo.newClient().from(getClientProps()).build()) {
-      createFateTable(client, table);
+      createFateTable(client, getCluster().getServerContext(), table);
       try (FateStore<PoolResizeTestEnv> fs = new UserFateStore<>(client, table, createDummyLockID(),
           null, maxDeferred, fateIdGenerator)) {
         testMethod.execute(fs, getCluster().getServerContext());

--- a/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateStatusEnforcementIT_SimpleSuite.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateStatusEnforcementIT_SimpleSuite.java
@@ -49,7 +49,7 @@ public class UserFateStatusEnforcementIT_SimpleSuite extends FateStatusEnforceme
   public void beforeEachSetup() throws Exception {
     client = (ClientContext) Accumulo.newClient().from(getClientProps()).build();
     table = getUniqueNames(1)[0];
-    createFateTable(client, table);
+    createFateTable(client, getCluster().getServerContext(), table);
     store = new UserFateStore<>(client, table, createDummyLockID(), null);
     fateId = store.create();
     txStore = store.reserve(fateId);

--- a/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateStoreFateIT_SimpleSuite.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/user/UserFateStoreFateIT_SimpleSuite.java
@@ -57,7 +57,7 @@ public class UserFateStoreFateIT_SimpleSuite extends FateStoreITBase {
     String table = getUniqueNames(1)[0] + "fatestore";
     try (ClientContext client =
         (ClientContext) Accumulo.newClient().from(getClientProps()).build()) {
-      createFateTable(client, table);
+      createFateTable(client, getCluster().getServerContext(), table);
       try (FateStore<TestEnv> fs = new UserFateStore<>(client, table, createDummyLockID(), null,
           maxDeferred, fateIdGenerator)) {
         testMethod.execute(fs, getCluster().getServerContext());

--- a/test/src/main/java/org/apache/accumulo/test/fate/user/UserMultipleStoresIT_SimpleSuite.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/user/UserMultipleStoresIT_SimpleSuite.java
@@ -50,7 +50,7 @@ public class UserMultipleStoresIT_SimpleSuite extends MultipleStoresITBase {
   public void beforeEachSetup() throws Exception {
     tableName = getUniqueNames(1)[0];
     client = (ClientContext) Accumulo.newClient().from(getClientProps()).build();
-    createFateTable(client, tableName);
+    createFateTable(client, getCluster().getServerContext(), tableName);
   }
 
   @AfterAll

--- a/test/src/main/java/org/apache/accumulo/test/functional/ConfigurableMacBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ConfigurableMacBase.java
@@ -30,8 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import org.apache.accumulo.core.client.Accumulo;
-import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.conf.ClientProperty;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
@@ -138,10 +136,6 @@ public class ConfigurableMacBase extends AccumuloITBase {
     for (int i = 0; i < 3; i++) {
       try {
         cluster.start();
-        try (AccumuloClient ac = Accumulo.newClient().from(getClientProperties()).build()) {
-          AccumuloITBase.setSystemTablePermsForITs(ac,
-              cluster.getServerContext().securityOperations());
-        }
         return;
       } catch (ZooKeeperBindException e) {
         lastException = e;

--- a/test/src/main/java/org/apache/accumulo/test/functional/PermissionsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/PermissionsIT.java
@@ -44,7 +44,6 @@ import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
-import org.apache.accumulo.core.client.admin.SecurityOperations;
 import org.apache.accumulo.core.client.security.SecurityErrorCode;
 import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
@@ -76,13 +75,6 @@ public class PermissionsIT extends AccumuloClusterHarness {
   @Override
   protected Duration defaultTimeout() {
     return Duration.ofSeconds(90);
-  }
-
-  @Override
-  protected void setSystemTablePerms(AccumuloClient client, SecurityOperations sops)
-      throws AccumuloException, AccumuloSecurityException {
-    // overridden to do nothing. The parent class gives read permissions to the
-    // system tables for the ITs. We want to test the default behavior
   }
 
   @BeforeEach


### PR DESCRIPTION
Fixes #6258 

* reverts #6258 and #6257 
* Uses ServerContext when reading from internal tables
