### PR TITLE
added trace level logging for Fate statuses

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/BulkImportMove.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/BulkImportMove.java
@@ -40,7 +40,10 @@ import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.zookeeper.TransactionWatcher.ZooArbitrator;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Bulk import makes requests of tablet servers, and those requests can take a long time. Our
@@ -61,6 +64,7 @@ class BulkImportMove extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;
 
+  private static final Logger log = LoggerFactory.getLogger(BulkImportMove.class);
   private final BulkInfo bulkInfo;
 
   public BulkImportMove(BulkInfo bulkInfo) {
@@ -73,6 +77,12 @@ class BulkImportMove extends ManagerRepo {
     final Path sourceDir = new Path(bulkInfo.sourceDir);
 
     VolumeManager fs = manager.getVolumeManager();
+
+    if (log.isTraceEnabled()) {
+      FileStatus[] files = fs.listStatus(sourceDir);
+      log.trace("{} bulk import move starting. source:{} dest:{} files to move:{}",
+          FateTxId.formatTid(tid), sourceDir, bulkDir, files == null ? 0 : files.length);
+    }
 
     if (bulkInfo.tableState == TableState.ONLINE) {
       ZooArbitrator.start(manager.getContext(), Constants.BULK_ARBITRATOR_TYPE, tid);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriver.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriver.java
@@ -23,6 +23,9 @@ import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LOCATION;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.PREV_ROW;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
 import org.apache.accumulo.core.clientImpl.TableOperationsImpl;
@@ -109,6 +112,7 @@ class CompactionDriver extends ManagerRepo {
 
     int tabletsToWaitFor = 0;
     int tabletCount = 0;
+    List<String> waitingDetail = log.isTraceEnabled() ? new ArrayList<>() : null;
 
     TabletsMetadata tablets = TabletsMetadata.builder(manager.getContext()).forTable(tableId)
         .overlapping(startRow, endRow).fetch(LOCATION, PREV_ROW, COMPACT_ID).build();
@@ -118,6 +122,11 @@ class CompactionDriver extends ManagerRepo {
         tabletsToWaitFor++;
         if (tablet.hasCurrent()) {
           serversToFlush.increment(tablet.getLocation().getServerInstance(), 1);
+        }
+        if (waitingDetail != null && waitingDetail.size() < 5) {
+          String loc = tablet.hasCurrent() ? tablet.getLocation().getServerInstance().getHostPort()
+              : "no location";
+          waitingDetail.add(tablet.getExtent() + "@" + loc);
         }
       }
 
@@ -179,6 +188,15 @@ class CompactionDriver extends ManagerRepo {
           "{} tablets compacted:{}/{} servers contacted:{} expected id:{} compaction extent:{} sleepTime:{}",
           FateTxId.formatTid(tid), tabletCount - tabletsToWaitFor, tabletCount,
           serversToFlush.size(), compactId, extent, sleepTime);
+
+      StringBuilder sb = new StringBuilder();
+      waitingDetail.forEach(d -> sb.append("\n    waiting on ").append(d));
+      if (tabletsToWaitFor > waitingDetail.size()) {
+        sb.append(String.format("\n    ... and %d more", tabletsToWaitFor - waitingDetail.size()));
+      }
+      if (sb.length() > 0) {
+        log.trace("{}", sb);
+      }
     }
 
     return sleepTime;


### PR DESCRIPTION
Closes [issue #6017 ](https://github.com/apache/accumulo/issues/6017)

Added trace level to `CompactionDriver` and `BulkImportMove` to help diagnose stuck Fate transaction.  To use, enable trace logging for the relevant class on the manager and wait for operations to retry. The output will show which tables are still waiting and where they are located. 