### PR TITLE
Added msg count endpoint and badge

### DIFF
--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/Endpoints.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/Endpoints.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 import jakarta.inject.Inject;
@@ -446,6 +447,14 @@ public class Endpoints {
   }
 
   public record Message(String priority, String category, String message) {
+  }
+
+  @GET
+  @Path("message/counts")
+  @Produces(MediaType.APPLICATION_JSON)
+  @Description("Returns count of messages by priority")
+  public Map<MessagePriority,AtomicLong> getMessageCounts() {
+    return monitor.getInformationFetcher().getSummaryForEndpoint().getMessageCounts();
   }
 
   @GET

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/SystemInformation.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/SystemInformation.java
@@ -581,19 +581,27 @@ public class SystemInformation {
   public void addMessage(MessagePriority pri, MessageCategory cat, String msg) {
     messages.computeIfAbsent(pri, k -> new EnumMap<>(MessageCategory.class))
         .computeIfAbsent(cat, k -> new TreeSet<>()).add(msg);
-    messageCounts.get(pri).incrementAndGet();
   }
 
   public void removeMessage(MessagePriority pri, MessageCategory cat, String part) {
     messages.getOrDefault(pri, new EnumMap<>(MessageCategory.class))
         .getOrDefault(cat, new HashSet<String>()).removeIf(s -> s.contains(part));
-    messageCounts.get(pri).updateAndGet(val -> {
-      if (val > 0) {
-        return val - 1;
-      } else {
-        return 0;
+  }
+
+  private void computeMessageCounts() {
+    for (MessagePriority pri : MessagePriority.values()) {
+      long count = 0;
+      Map<MessageCategory,Set<String>> cats = messages.get(pri);
+      if (cats != null) {
+        for (MessageCategory cat : MessageCategory.values()) {
+          Set<String> msgs = cats.get(cat);
+          if (msgs != null) {
+            count += msgs.size();
+          }
+        }
       }
-    });
+      messageCounts.get(pri).set(count);
+    }
   }
 
   private void updateAggregates(final MetricResponse response,
@@ -1195,6 +1203,7 @@ public class SystemInformation {
       }
     }
     deploymentOverview = DeploymentOverview.fromSummary(deployment, timestamp);
+    computeMessageCounts();
   }
 
   public Set<String> getResourceGroups() {

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/SystemInformation.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/SystemInformation.java
@@ -521,6 +521,8 @@ public class SystemInformation {
 
   private final Map<MessagePriority,Map<MessageCategory,Set<String>>> messages =
       new EnumMap<>(MessagePriority.class);
+  private final EnumMap<MessagePriority,AtomicLong> messageCounts =
+      new EnumMap<>(MessagePriority.class);
 
   private final Set<String> configuredCompactionResourceGroups = ConcurrentHashMap.newKeySet();
 
@@ -538,6 +540,9 @@ public class SystemInformation {
     this.ctx = ctx;
     this.rgLongRunningCompactionSize =
         this.ctx.getConfiguration().getCount(Property.MONITOR_LONG_RUNNING_COMPACTION_LIMIT);
+    for (MessagePriority p : MessagePriority.values()) {
+      messageCounts.put(p, new AtomicLong(0));
+    }
   }
 
   public void clear() {
@@ -570,16 +575,25 @@ public class SystemInformation {
     componentStatuses.clear();
     managerGoalState = null;
     serverMetricsView.clear();
+    messageCounts.clear();
   }
 
   public void addMessage(MessagePriority pri, MessageCategory cat, String msg) {
     messages.computeIfAbsent(pri, k -> new EnumMap<>(MessageCategory.class))
         .computeIfAbsent(cat, k -> new TreeSet<>()).add(msg);
+    messageCounts.get(pri).incrementAndGet();
   }
 
   public void removeMessage(MessagePriority pri, MessageCategory cat, String part) {
     messages.getOrDefault(pri, new EnumMap<>(MessageCategory.class))
         .getOrDefault(cat, new HashSet<String>()).removeIf(s -> s.contains(part));
+    messageCounts.get(pri).updateAndGet(val -> {
+      if (val > 0) {
+        return val - 1;
+      } else {
+        return 0;
+      }
+    });
   }
 
   private void updateAggregates(final MetricResponse response,
@@ -1350,6 +1364,10 @@ public class SystemInformation {
 
   public Map<MessagePriority,Map<MessageCategory,Set<String>>> getMessages() {
     return this.messages;
+  }
+
+  public Map<MessagePriority,AtomicLong> getMessageCounts() {
+    return this.messageCounts;
   }
 
   public long getTimestamp() {

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
@@ -40,6 +40,7 @@ const RUNNING_COMPACTIONS_BY_GROUP = 'runningCompactionsByGroup';
 const AUTO_REFRESH_KEY = 'auto-refresh';
 const MESSAGE_CATEGORIES = 'messageCategories';
 const MESSAGES = 'messages';
+const MESSAGE_COUNTS = 'messageCounts'
 const RECOVERY = 'recovery';
 
 // Override Length Menu options for dataTables
@@ -545,6 +546,14 @@ function getTserversSummary(group) {
  */
 function getMessageCategories() {
   return getJSONForTable(REST_V2_PREFIX + '/message/categories', MESSAGE_CATEGORIES);
+}
+
+/**
+ * REST GET call for /message/counts
+ * store it on a sessionStorage variable
+ */
+function getMessageCounts() {
+  return getJSONForTable(REST_V2_PREFIX + '/message/counts', MESSAGE_COUNTS);
 }
 
 /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
@@ -149,6 +149,7 @@ $(function () {
   setTheme();
   updateDarkThemeSwitch();
   refreshSidebar();
+  refreshMessageBadge();
 });
 
 /**
@@ -165,6 +166,7 @@ function refreshSidebar() {
  */
 function refreshNavBar() {
   refreshSidebar();
+  refreshMessageBadge();
 }
 
 /**
@@ -218,5 +220,34 @@ function updateDarkThemeSwitch() {
     var enableDarkTheme = $(this).is(':checked');
     localStorage.setItem(storageKey, enableDarkTheme);
     document.documentElement.setAttribute('data-bs-theme', enableDarkTheme ? 'dark' : 'light');
+  });
+}
+
+/**
+ * Updates the badge on the Messages label on the Nav Bar
+ */
+function refreshMessageBadge() {
+  getMessageCounts().then(function () {
+
+    var messageAnchor = $('#message-anchor');
+
+    var msgCounts = getStoredJson(MESSAGE_COUNTS, {
+      "Critical": 0,
+      "High": 0,
+      "Info": 0
+    });
+    var critMsgCount = msgCounts.Critical;
+    var highMsgCount = msgCounts.High;
+
+    messageAnchor.find('span').remove();
+
+    if (critMsgCount > 0) {
+      messageAnchor.append('<span class="badge position-relative top-0 start-0 translate-middle-y rounded-pill bg-danger">' +
+        critMsgCount + '</span>');
+    } else if (highMsgCount > 0) {
+      messageAnchor.append(
+        '<span class="badge position-relative top-0 start-0 translate-middle-y rounded-pill bg-warning">' +
+        highMsgCount + '</span>');
+    }
   });
 }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/navbar.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/navbar.ftl
@@ -62,7 +62,7 @@
               </ul>
             </li>
             <li>
-              <a class="nav-link" aria-current="page" href="messages">Messages</a>
+              <a id="message-anchor" class="nav-link" aria-current="page" href="messages">Messages</a>
             </li>            
             <li class="dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown"


### PR DESCRIPTION
Adds a badge containing the count of critical or
high messages to the Messages link in the NavBar.
If the number of critical messages is > 0, then the
badge is red with the number of critical messages.
Otherwise, if there are high messages, then the
badge is yellow with the number of those messages.

Added an API endpoint to return the underlying counts
which does not use the same query parameters that are
used with the switches. This means that counts will reflect
messages that may not be seen on the messages page
if the user has a switch turned off. This will allow for users
to be notified that there are messages that they might not
be seeing.