### PR TITLE
Use '&mdash;' vs '-' consistently in Monitor code

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/bulkImport.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/bulkImport.js
@@ -68,7 +68,7 @@ $(function () {
         "render": function (data, type) {
           var age = Number(data);
           if (type === 'display') {
-            return age > 0 ? new Date(age) : "-";
+            return age > 0 ? new Date(age) : '&mdash;';
           }
           return age > 0 ? age : 0;
         }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/coordinator.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/coordinator.js
@@ -81,7 +81,7 @@ $(function () {
     "colReorder": true,
     "columnDefs": [{
         targets: '_all',
-        defaultContent: '-'
+        defaultContent: '&mdash;'
       },
       {
         "targets": 0,
@@ -112,7 +112,7 @@ $(function () {
     "colReorder": true,
     "columnDefs": [{
       targets: '_all',
-      defaultContent: '-'
+      defaultContent: '&mdash;'
     }],
     "columns": [{
         "data": "groupId"

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/fate.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/fate.js
@@ -56,7 +56,7 @@ function createDataTable() {
     "colReorder": true,
     "columnDefs": [{
       targets: '_all',
-      defaultContent: '-'
+      defaultContent: '&mdash;'
     }],
     "columns": [{
         "data": "type",

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/messages.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/messages.js
@@ -91,7 +91,7 @@ function createDataTable() {
     "colReorder": true,
     "columnDefs": [{
       targets: '_all',
-      defaultContent: '-'
+      defaultContent: '&mdash;'
     }],
     "columns": [{
         "data": "priority"

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/recovery.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/recovery.js
@@ -114,7 +114,7 @@ $(function () {
     "colReorder": true,
     "columnDefs": [{
       targets: '_all',
-      defaultContent: '-'
+      defaultContent: '&mdash;'
     }],
     "columns": [{
         "data": "rootTabletRecovering"
@@ -138,7 +138,7 @@ $(function () {
     "colReorder": true,
     "columnDefs": [{
       targets: '_all',
-      defaultContent: '-'
+      defaultContent: '&mdash;'
     }],
     "columns": [{
         "data": "tableId"
@@ -165,7 +165,7 @@ $(function () {
     "colReorder": true,
     "columnDefs": [{
       targets: '_all',
-      defaultContent: '-'
+      defaultContent: '&mdash;'
     }],
     "columns": [{
         "data": "server"
@@ -221,7 +221,7 @@ $(function () {
     "colReorder": true,
     "columnDefs": [{
       targets: '_all',
-      defaultContent: '-'
+      defaultContent: '&mdash;'
     }],
     "columns": [{
         "data": "server"

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/server.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/server.js
@@ -112,7 +112,7 @@ function initServerTables(serv) {
         "render": function (data, type) {
           if (type === 'display') {
             if (data === null) {
-              data = '-';
+              data = '&mdash;';
             } else {
               data = timeDuration(data * 1000.0);
             }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/server_process_common.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/server_process_common.js
@@ -257,7 +257,7 @@ function createDataTable(table, storageKey) {
     "colReorder": true,
     "columnDefs": [{
         targets: '_all',
-        defaultContent: '-'
+        defaultContent: '&mdash;'
       },
       {
         "targets": "big-num",


### PR DESCRIPTION
This PR replaces useages of the regular dash character `-` with the `&mdash;` character `—`