### PR TITLE
Added option to print Fate tx details in fate list cmd

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/AdminUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/AdminUtil.java
@@ -74,10 +74,11 @@ public class AdminUtil<T> {
     private final String top;
     private final long timeCreated;
     private final LockRange lockRange;
+    private final String details;
 
     private TransactionStatus(FateId fateId, FateInstanceType instanceType, TStatus status,
         Fate.FateOperation fateOp, List<String> hlocks, List<String> wlocks, String top,
-        Long timeCreated, LockRange lockRange) {
+        Long timeCreated, LockRange lockRange, String details) {
 
       this.fateId = fateId;
       this.instanceType = instanceType;
@@ -88,7 +89,7 @@ public class AdminUtil<T> {
       this.top = top;
       this.timeCreated = timeCreated;
       this.lockRange = lockRange;
-
+      this.details = details;
     }
 
     /**
@@ -153,6 +154,13 @@ public class AdminUtil<T> {
     public LockRange getLockRange() {
       return lockRange;
     }
+
+    /**
+     * @return details of transaction, may contain protected information
+     */
+    public String getDetails() {
+      return details;
+    }
   }
 
   public static class FateStatus {
@@ -214,7 +222,7 @@ public class AdminUtil<T> {
 
     FateStatus status = getTransactionStatus(readOnlyFateStores, fateIdFilter, statusFilter,
         typesFilter, Collections.<FateId,List<String>>emptyMap(),
-        Collections.<FateId,List<String>>emptyMap(), Map.of());
+        Collections.<FateId,List<String>>emptyMap(), Map.of(), false);
 
     return status.getTransactions();
   }
@@ -243,7 +251,7 @@ public class AdminUtil<T> {
     findLocks(zk, lockPath, heldLocks, waitingLocks, lockRanges);
 
     return getTransactionStatus(Map.of(FateInstanceType.META, readOnlyMFS), fateIdFilter,
-        statusFilter, typesFilter, heldLocks, waitingLocks, lockRanges);
+        statusFilter, typesFilter, heldLocks, waitingLocks, lockRanges, false);
   }
 
   public FateStatus getStatus(ReadOnlyFateStore<T> readOnlyUFS, Set<FateId> fateIdFilter,
@@ -251,12 +259,12 @@ public class AdminUtil<T> {
       throws KeeperException, InterruptedException {
 
     return getTransactionStatus(Map.of(FateInstanceType.USER, readOnlyUFS), fateIdFilter,
-        statusFilter, typesFilter, new HashMap<>(), new HashMap<>(), Map.of());
+        statusFilter, typesFilter, new HashMap<>(), new HashMap<>(), Map.of(), false);
   }
 
   public FateStatus getStatus(Map<FateInstanceType,ReadOnlyFateStore<T>> readOnlyFateStores,
       ZooSession zk, ServiceLockPath lockPath, Set<FateId> fateIdFilter,
-      EnumSet<TStatus> statusFilter, EnumSet<FateInstanceType> typesFilter)
+      EnumSet<TStatus> statusFilter, EnumSet<FateInstanceType> typesFilter, boolean includeDetails)
       throws KeeperException, InterruptedException {
     Map<FateId,List<String>> heldLocks = new HashMap<>();
     Map<FateId,List<String>> waitingLocks = new HashMap<>();
@@ -265,7 +273,7 @@ public class AdminUtil<T> {
     findLocks(zk, lockPath, heldLocks, waitingLocks, lockRanges);
 
     return getTransactionStatus(readOnlyFateStores, fateIdFilter, statusFilter, typesFilter,
-        heldLocks, waitingLocks, lockRanges);
+        heldLocks, waitingLocks, lockRanges, includeDetails);
   }
 
   /**
@@ -363,7 +371,7 @@ public class AdminUtil<T> {
       Map<FateInstanceType,ReadOnlyFateStore<T>> readOnlyFateStores, Set<FateId> fateIdFilter,
       EnumSet<TStatus> statusFilter, EnumSet<FateInstanceType> typesFilter,
       Map<FateId,List<String>> heldLocks, Map<FateId,List<String>> waitingLocks,
-      Map<FateId,LockRange> lockRanges) {
+      Map<FateId,LockRange> lockRanges, boolean includeDetails) {
     final List<TransactionStatus> statuses = new ArrayList<>();
 
     readOnlyFateStores.forEach((type, store) -> {
@@ -388,9 +396,13 @@ public class AdminUtil<T> {
           }
 
           String top = null;
+          String details = null;
           ReadOnlyRepo<T> repo = txStore.top();
           if (repo != null) {
             top = repo.getName();
+            if (includeDetails) {
+              details = repo.getDetails();
+            }
           }
 
           TStatus status = txStore.getStatus();
@@ -400,7 +412,7 @@ public class AdminUtil<T> {
           if (includeByStatus(status, statusFilter) && includeByFateId(fateId, fateIdFilter)
               && includeByInstanceType(fateId.getType(), typesFilter)) {
             statuses.add(new TransactionStatus(fateId, type, status, fateOp, hlocks, wlocks, top,
-                timeCreated, lockRanges.getOrDefault(fateId, LockRange.infinite())));
+                timeCreated, lockRanges.getOrDefault(fateId, LockRange.infinite()), details));
           }
         });
       }
@@ -423,10 +435,10 @@ public class AdminUtil<T> {
 
   public void print(Map<FateInstanceType,ReadOnlyFateStore<T>> readOnlyFateStores, ZooSession zk,
       ServiceLockPath tableLocksPath, Formatter fmt, Set<FateId> fateIdFilter,
-      EnumSet<TStatus> statusFilter, EnumSet<FateInstanceType> typesFilter)
+      EnumSet<TStatus> statusFilter, EnumSet<FateInstanceType> typesFilter, boolean includeDetails)
       throws KeeperException, InterruptedException {
-    FateStatus fateStatus =
-        getStatus(readOnlyFateStores, zk, tableLocksPath, fateIdFilter, statusFilter, typesFilter);
+    FateStatus fateStatus = getStatus(readOnlyFateStores, zk, tableLocksPath, fateIdFilter,
+        statusFilter, typesFilter, includeDetails);
 
     for (TransactionStatus txStatus : fateStatus.getTransactions()) {
       fmt.format(
@@ -434,6 +446,10 @@ public class AdminUtil<T> {
           txStatus.getFateOp(), txStatus.getFateId(), txStatus.getStatus(), txStatus.getHeldLocks(),
           txStatus.getWaitingLocks(), txStatus.getTop(), txStatus.getTimeCreatedFormatted(),
           txStatus.getLockRange());
+      if (includeDetails) {
+        fmt.format("\t Transaction details: %s%n",
+            txStatus.getDetails() == null ? "" : txStatus.getDetails());
+      }
     }
     fmt.format(" %s transactions", fateStatus.getTransactions().size());
   }

--- a/core/src/main/java/org/apache/accumulo/core/fate/ReadOnlyRepo.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/ReadOnlyRepo.java
@@ -29,4 +29,12 @@ public interface ReadOnlyRepo<T> {
 
   String getName();
 
+  /**
+   * Returns detailed information about the transaction. This information may include protected
+   * information and should only be used in server-side tools (not the Monitor).
+   *
+   * @return json details
+   */
+  String getDetails();
+
 }

--- a/core/src/main/java/org/apache/accumulo/core/fate/TraceRepo.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/TraceRepo.java
@@ -119,4 +119,10 @@ public class TraceRepo<T> implements Repo<T> {
 
     return repo.getClass() + " " + repo.getName();
   }
+
+  @Override
+  public String getDetails() {
+    return repo.getDetails();
+  }
+
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/adminCommand/Fate.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/adminCommand/Fate.java
@@ -148,6 +148,10 @@ public class Fate extends ServerKeywordExecutable<FateOpts> {
     @Parameter(names = {"-t", "--type"},
         description = "<type>... Print transactions of fate instance type(s) {USER, META}")
     List<String> instanceTypes = new ArrayList<>();
+
+    @Parameter(names = {"-i", "--info"},
+        description = "Includes detailed transaction information when printing")
+    boolean printDetails;
   }
 
   private final CountDownLatch lockAcquiredLatch = new CountDownLatch(1);
@@ -245,7 +249,7 @@ public class Fate extends ServerKeywordExecutable<FateOpts> {
             getCmdLineInstanceTypeFilters(options.instanceTypes);
         readOnlyFateStores = createReadOnlyFateStores(context, zk);
         admin.print(readOnlyFateStores, zk, zTableLocksPath, new Formatter(System.out),
-            fateIdFilter, statusFilter, typesFilter);
+            fateIdFilter, statusFilter, typesFilter, options.printDetails);
         // print line break at the end
         System.out.println();
       }
@@ -354,7 +358,7 @@ public class Fate extends ServerKeywordExecutable<FateOpts> {
       NamespaceNotFoundException {
 
     var zk = context.getZooSession();
-    var transactions = admin.getStatus(fateStores, zk, tableLocksPath, null, null, null);
+    var transactions = admin.getStatus(fateStores, zk, tableLocksPath, null, null, null, false);
 
     // build id map - relies on unique ids for tables and namespaces
     // used to look up the names of either table or namespace by id.

--- a/server/base/src/main/java/org/apache/accumulo/server/util/checkCommand/TableLocksCheckRunner.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/checkCommand/TableLocksCheckRunner.java
@@ -87,7 +87,7 @@ public class TableLocksCheckRunner implements CheckRunner {
       if (locksExist) {
         final var fateStatus =
             admin.getStatus(Map.of(FateInstanceType.META, mfs, FateInstanceType.USER, ufs), zk,
-                zTableLocksPath, null, null, null);
+                zTableLocksPath, null, null, null, false);
         if (!fateStatus.getDanglingHeldLocks().isEmpty()
             || !fateStatus.getDanglingWaitingLocks().isEmpty()) {
           status &= false;

--- a/server/manager/pom.xml
+++ b/server/manager/pom.xml
@@ -39,6 +39,10 @@
       <artifactId>caffeine</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/CommitCompaction.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/CommitCompaction.java
@@ -24,6 +24,7 @@ import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LOCATION;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.OPID;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.SELECTED;
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
 
 import java.time.Duration;
 import java.util.HashSet;
@@ -55,6 +56,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 
 public class CommitCompaction extends AbstractFateOperation {
   private static final long serialVersionUID = 1L;
@@ -280,4 +283,13 @@ public class CommitCompaction extends AbstractFateOperation {
 
     return true;
   }
+
+  @Override
+  public String getDetails() {
+    Gson gson = GSON.get();
+    JsonObject details = gson.toJsonTree(commitData).getAsJsonObject();
+    details.addProperty("NewDataFile", newDatafile);
+    return gson.toJson(details);
+  }
+
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/CompactionCommitData.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/CompactionCommitData.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.manager.compaction.coordinator.commit;
 
 import java.io.Serializable;
+import java.lang.reflect.Type;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -31,8 +32,39 @@ import org.apache.accumulo.core.metadata.schema.CompactionMetadata;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
 import org.apache.accumulo.core.spi.compaction.CompactionKind;
 import org.apache.accumulo.core.tabletserver.thrift.TCompactionStats;
+import org.apache.accumulo.manager.compaction.coordinator.commit.CompactionCommitData.CompactionCommitDataSerializer;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.annotations.JsonAdapter;
+
+@JsonAdapter(CompactionCommitDataSerializer.class)
 public class CompactionCommitData implements Serializable {
+
+  public static class CompactionCommitDataSerializer
+      implements JsonSerializer<CompactionCommitData> {
+
+    @Override
+    public JsonElement serialize(CompactionCommitData src, Type typeOfSrc,
+        JsonSerializationContext context) {
+      JsonObject obj = new JsonObject();
+      obj.addProperty("kind", src.kind.name());
+      obj.addProperty("ecid", src.ecid);
+      obj.addProperty("extent", src.textent.toString());
+      obj.addProperty("outputTmpPath", src.outputTmpPath);
+      obj.addProperty("entriesRead", src.stats.entriesRead);
+      obj.addProperty("entriesWritten", src.stats.entriesWritten);
+      obj.addProperty("fileSize", src.stats.fileSize);
+      JsonArray arr = new JsonArray();
+      src.inputPaths.forEach(arr::add);
+      obj.add("inputs", arr);
+      return obj;
+    }
+  }
+
   private static final long serialVersionUID = 1L;
   final CompactionKind kind;
   final HashSet<String> inputPaths; // type must be serializable

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/PutGcCandidates.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/PutGcCandidates.java
@@ -18,10 +18,15 @@
  */
 package org.apache.accumulo.manager.compaction.coordinator.commit;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.manager.tableOps.AbstractFateOperation;
 import org.apache.accumulo.manager.tableOps.FateEnv;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 
 public class PutGcCandidates extends AbstractFateOperation {
   private static final long serialVersionUID = 1L;
@@ -47,4 +52,13 @@ public class PutGcCandidates extends AbstractFateOperation {
     // refresh as part of this compaction commit as it may run sooner.
     return new RefreshTablet(commitData.textent, refreshLocation);
   }
+
+  @Override
+  public String getDetails() {
+    Gson gson = GSON.get();
+    JsonObject details = gson.toJsonTree(commitData).getAsJsonObject();
+    details.addProperty("refreshLocation", refreshLocation);
+    return gson.toJson(details);
+  }
+
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/RefreshTablet.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/RefreshTablet.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.compaction.coordinator.commit;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -33,6 +35,7 @@ import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.bulkVer2.TabletRefresher;
 
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.gson.JsonObject;
 
 public class RefreshTablet extends AbstractFateOperation {
   private static final long serialVersionUID = 1L;
@@ -62,4 +65,13 @@ public class RefreshTablet extends AbstractFateOperation {
 
     return null;
   }
+
+  @Override
+  public String getDetails() {
+    JsonObject details = new JsonObject();
+    details.addProperty("extent", extent.toString());
+    details.addProperty("TServerInstance", tserverInstance);
+    return GSON.get().toJson(details);
+  }
+
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/RenameCompactionFile.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/RenameCompactionFile.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.compaction.coordinator.commit;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import java.io.IOException;
 
 import org.apache.accumulo.core.dataImpl.KeyExtent;
@@ -96,4 +98,10 @@ public class RenameCompactionFile extends AbstractFateOperation {
     return new CommitCompaction(commitData,
         newDatafile == null ? null : newDatafile.getNormalizedPathStr());
   }
+
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(commitData);
+  }
+
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/ChangeTableState.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/ChangeTableState.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import java.util.EnumSet;
 
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
@@ -29,6 +31,8 @@ import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType
 import org.apache.accumulo.core.fate.zookeeper.LockRange;
 import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonObject;
 
 public class ChangeTableState extends AbstractFateOperation {
 
@@ -79,4 +83,14 @@ public class ChangeTableState extends AbstractFateOperation {
     Utils.unreserveNamespace(env.getContext(), namespaceId, fateId, LockType.READ);
     Utils.unreserveTable(env.getContext(), tableId, fateId, LockType.WRITE);
   }
+
+  @Override
+  public String getDetails() {
+    JsonObject details = new JsonObject();
+    details.addProperty("namespaceId", namespaceId.canonical());
+    details.addProperty("tableId", tableId.canonical());
+    details.addProperty("newState", top.name());
+    return GSON.get().toJson(details);
+  }
+
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/availability/LockTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/availability/LockTable.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.availability;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import org.apache.accumulo.core.client.admin.TabletAvailability;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.data.NamespaceId;
@@ -36,6 +38,8 @@ import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonObject;
 
 public class LockTable extends AbstractFateOperation {
   private static final long serialVersionUID = 1L;
@@ -110,4 +114,15 @@ public class LockTable extends AbstractFateOperation {
       return LockRange.infinite();
     }
   }
+
+  @Override
+  public String getDetails() {
+    JsonObject details = new JsonObject();
+    details.addProperty("namespaceId", namespaceId.canonical());
+    details.addProperty("tableId", tableId.canonical());
+    details.addProperty("availability", tabletAvailability.name());
+    details.addProperty("tabletRange", tRange.toString());
+    return GSON.get().toJson(details);
+  }
+
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/availability/SetTabletAvailability.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/availability/SetTabletAvailability.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.manager.tableOps.availability;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
 
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
@@ -49,6 +50,8 @@ import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonObject;
 
 public class SetTabletAvailability extends AbstractFateOperation {
 
@@ -154,4 +157,15 @@ public class SetTabletAvailability extends AbstractFateOperation {
     Utils.unreserveTable(env.getContext(), tableId, fateId, LockType.WRITE);
     return null;
   }
+
+  @Override
+  public String getDetails() {
+    JsonObject details = new JsonObject();
+    details.addProperty("namespaceId", namespaceId.canonical());
+    details.addProperty("tableId", tableId.canonical());
+    details.addProperty("availability", tabletAvailability.name());
+    details.addProperty("tabletRange", tRange.toString());
+    return GSON.get().toJson(details);
+  }
+
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/AbstractBulkFateOperation.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/AbstractBulkFateOperation.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.bulkVer2;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import java.time.Instant;
 
 import org.apache.accumulo.core.data.TableId;
@@ -56,4 +58,10 @@ public abstract class AbstractBulkFateOperation extends AbstractFateOperation
   public Instant getCreationTime() {
     return creation;
   }
+
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(bulkInfo);
+  }
+
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/BulkInfo.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/BulkInfo.java
@@ -19,13 +19,44 @@
 package org.apache.accumulo.manager.tableOps.bulkVer2;
 
 import java.io.Serializable;
+import java.lang.reflect.Type;
 
 import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.manager.tableOps.bulkVer2.BulkInfo.BulkInfoSerializer;
+import org.apache.hadoop.io.Text;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.annotations.JsonAdapter;
 
 /**
  * Package private class to hold all the information used for bulk import2
  */
+@JsonAdapter(BulkInfoSerializer.class)
 class BulkInfo implements Serializable {
+
+  public static class BulkInfoSerializer implements JsonSerializer<BulkInfo> {
+
+    @Override
+    public JsonElement serialize(BulkInfo src, Type typeOfSrc, JsonSerializationContext context) {
+      JsonObject obj = new JsonObject();
+      obj.addProperty("tableId", src.tableId.canonical());
+      obj.addProperty("sourceDir", src.sourceDir);
+      obj.addProperty("bulkDir", src.bulkDir);
+      obj.addProperty("setTime", src.setTime);
+      if (src.firstSplit != null) {
+        obj.addProperty("firstSplit", new Text(src.firstSplit).toString());
+      }
+      if (src.lastSplit != null) {
+        obj.addProperty("lastSplit", new Text(src.lastSplit).toString());
+      }
+      return obj;
+    }
+
+  }
+
   private static final long serialVersionUID = 1L;
 
   TableId tableId;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneMetadata.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneMetadata.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.clone;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.manager.tableOps.AbstractFateOperation;
@@ -59,4 +61,8 @@ class CloneMetadata extends AbstractFateOperation {
         environment.getServiceLock());
   }
 
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(cloneInfo);
+  }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/ClonePermissions.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/ClonePermissions.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.clone;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import org.apache.accumulo.core.client.NamespaceNotFoundException;
 import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
@@ -75,5 +77,10 @@ class ClonePermissions extends AbstractFateOperation {
   public void undo(FateId fateId, FateEnv environment) throws Exception {
     environment.getContext().getSecurityOperation().deleteTable(environment.getContext().rpcCreds(),
         cloneInfo.getTableId(), cloneInfo.getNamespaceId());
+  }
+
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(cloneInfo);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneTable.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.clone;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import java.util.Map;
 import java.util.Set;
 
@@ -68,4 +70,8 @@ public class CloneTable extends AbstractFateOperation {
         LockType.READ);
   }
 
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(cloneInfo);
+  }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneZookeeper.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/CloneZookeeper.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.clone;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import org.apache.accumulo.core.client.NamespaceNotFoundException;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
@@ -76,4 +78,8 @@ class CloneZookeeper extends AbstractFateOperation {
     environment.getContext().clearTableListCache();
   }
 
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(cloneInfo);
+  }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/FinishCloneTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/FinishCloneTable.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.clone;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import java.util.EnumSet;
 
 import org.apache.accumulo.core.fate.FateId;
@@ -85,4 +87,8 @@ class FinishCloneTable extends AbstractFateOperation {
   @Override
   public void undo(FateId fateId, FateEnv environment) {}
 
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(cloneInfo);
+  }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CleanUp.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CleanUp.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.manager.tableOps.compact;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.COMPACTED;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.PREV_ROW;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.USER_COMPACTION_REQUESTED;
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -39,8 +40,11 @@ import org.apache.accumulo.manager.tableOps.AbstractFateOperation;
 import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.accumulo.server.compaction.CompactionConfigStorage;
+import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonObject;
 
 public class CleanUp extends AbstractFateOperation {
 
@@ -122,5 +126,15 @@ public class CleanUp extends AbstractFateOperation {
     Utils.getReadLock(env.getContext(), tableId, fateId, LockRange.infinite()).unlock();
     Utils.getReadLock(env.getContext(), namespaceId, fateId, LockRange.infinite()).unlock();
     return null;
+  }
+
+  @Override
+  public String getDetails() {
+    JsonObject details = new JsonObject();
+    details.addProperty("namespaceId", namespaceId.canonical());
+    details.addProperty("tableId", tableId.canonical());
+    details.addProperty("startRow", startRow == null ? null : new Text(startRow).toString());
+    details.addProperty("endRow", endRow == null ? null : new Text(endRow).toString());
+    return GSON.get().toJson(details);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactRange.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactRange.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.manager.tableOps.compact;
 
 import static java.util.Objects.requireNonNull;
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
 
 import java.util.Optional;
 
@@ -43,6 +44,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
+import com.google.gson.JsonObject;
 
 public class CompactRange extends AbstractFateOperation {
 
@@ -115,4 +117,13 @@ public class CompactRange extends AbstractFateOperation {
     }
   }
 
+  @Override
+  public String getDetails() {
+    JsonObject details = new JsonObject();
+    details.addProperty("namespaceId", namespaceId.canonical());
+    details.addProperty("tableId", tableId.canonical());
+    details.addProperty("startRow", startRow == null ? null : new Text(startRow).toString());
+    details.addProperty("endRow", endRow == null ? null : new Text(endRow).toString());
+    return GSON.get().toJson(details);
+  }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriver.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriver.java
@@ -25,6 +25,7 @@ import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.PREV_ROW;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.SELECTED;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.USER_COMPACTION_REQUESTED;
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
 
 import java.time.Duration;
 import java.util.Set;
@@ -68,6 +69,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
+import com.google.gson.JsonObject;
 
 public class CompactionDriver extends AbstractFateOperation {
 
@@ -419,4 +421,13 @@ public class CompactionDriver extends AbstractFateOperation {
     }
   }
 
+  @Override
+  public String getDetails() {
+    JsonObject details = new JsonObject();
+    details.addProperty("namespaceId", namespaceId.canonical());
+    details.addProperty("tableId", tableId.canonical());
+    details.addProperty("startRow", startRow == null ? null : new Text(startRow).toString());
+    details.addProperty("endRow", endRow == null ? null : new Text(endRow).toString());
+    return GSON.get().toJson(details);
+  }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/RefreshTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/RefreshTablets.java
@@ -19,6 +19,8 @@
 
 package org.apache.accumulo.manager.tableOps.compact;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.FateId;
@@ -26,6 +28,9 @@ import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.manager.tableOps.AbstractFateOperation;
 import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.bulkVer2.TabletRefresher;
+import org.apache.hadoop.io.Text;
+
+import com.google.gson.JsonObject;
 
 public class RefreshTablets extends AbstractFateOperation {
 
@@ -48,5 +53,15 @@ public class RefreshTablets extends AbstractFateOperation {
     TabletRefresher.refresh(env, fateId, tableId, startRow, endRow, tabletMetadata -> true);
 
     return new CleanUp(tableId, namespaceId, startRow, endRow);
+  }
+
+  @Override
+  public String getDetails() {
+    JsonObject details = new JsonObject();
+    details.addProperty("namespaceId", namespaceId.canonical());
+    details.addProperty("tableId", tableId.canonical());
+    details.addProperty("startRow", startRow == null ? null : new Text(startRow).toString());
+    details.addProperty("endRow", endRow == null ? null : new Text(endRow).toString());
+    return GSON.get().toJson(details);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/cancel/CancelCompactions.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/cancel/CancelCompactions.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.compact.cancel;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
@@ -30,6 +32,8 @@ import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.accumulo.server.compaction.CompactionConfigStorage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonObject;
 
 public class CancelCompactions extends AbstractFateOperation {
 
@@ -70,4 +74,11 @@ public class CancelCompactions extends AbstractFateOperation {
     Utils.unreserveNamespace(env.getContext(), namespaceId, fateId, LockType.READ);
   }
 
+  @Override
+  public String getDetails() {
+    JsonObject details = new JsonObject();
+    details.addProperty("namespaceId", namespaceId.canonical());
+    details.addProperty("tableId", tableId.canonical());
+    return GSON.get().toJson(details);
+  }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/cancel/FinishCancelCompaction.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/cancel/FinishCancelCompaction.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.compact.cancel;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.FateId;
@@ -26,6 +28,8 @@ import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType
 import org.apache.accumulo.manager.tableOps.AbstractFateOperation;
 import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.Utils;
+
+import com.google.gson.JsonObject;
 
 class FinishCancelCompaction extends AbstractFateOperation {
   private static final long serialVersionUID = 1L;
@@ -47,5 +51,13 @@ class FinishCancelCompaction extends AbstractFateOperation {
   @Override
   public void undo(FateId fateId, FateEnv environment) {
 
+  }
+
+  @Override
+  public String getDetails() {
+    JsonObject details = new JsonObject();
+    details.addProperty("namespaceId", namespaceId.canonical());
+    details.addProperty("tableId", tableId.canonical());
+    return GSON.get().toJson(details);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/ChooseDir.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/ChooseDir.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.manager.tableOps.create;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -127,4 +128,8 @@ class ChooseDir extends AbstractFateOperation {
     }
   }
 
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(tableInfo);
+  }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/CreateTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/CreateTable.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.manager.tableOps.create;
 
 import static java.util.Objects.requireNonNull;
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -102,4 +103,8 @@ public class CreateTable extends AbstractFateOperation {
     }
   }
 
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(tableInfo);
+  }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/FinishCreateTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/FinishCreateTable.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.create;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import java.io.IOException;
 import java.util.EnumSet;
 
@@ -97,4 +99,8 @@ class FinishCreateTable extends AbstractFateOperation {
   @Override
   public void undo(FateId fateId, FateEnv env) {}
 
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(tableInfo);
+  }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/PopulateMetadata.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/PopulateMetadata.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.create;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -131,5 +133,10 @@ class PopulateMetadata extends AbstractFateOperation {
       data.put(s.next(), d.next());
     }
     return data;
+  }
+
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(tableInfo);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/PopulateZookeeper.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/PopulateZookeeper.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.create;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
 import org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException;
@@ -78,4 +80,8 @@ class PopulateZookeeper extends AbstractFateOperation {
     env.getContext().clearTableListCache();
   }
 
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(tableInfo);
+  }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/SetupPermissions.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/SetupPermissions.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.create;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
@@ -66,4 +68,8 @@ class SetupPermissions extends AbstractFateOperation {
         tableInfo.getTableId(), tableInfo.getNamespaceId());
   }
 
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(tableInfo);
+  }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/CleanUp.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/CleanUp.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.delete;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.Arrays;
@@ -48,6 +50,8 @@ import org.apache.accumulo.server.util.MetadataTableUtil;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonObject;
 
 class CleanUp extends AbstractFateOperation {
 
@@ -160,4 +164,11 @@ class CleanUp extends AbstractFateOperation {
     // nothing to do
   }
 
+  @Override
+  public String getDetails() {
+    JsonObject details = new JsonObject();
+    details.addProperty("namespaceId", namespaceId.canonical());
+    details.addProperty("tableId", tableId.canonical());
+    return GSON.get().toJson(details);
+  }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/DeleteTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/DeleteTable.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.delete;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import java.util.EnumSet;
 
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
@@ -30,6 +32,8 @@ import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.manager.tableOps.AbstractFateOperation;
 import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.Utils;
+
+import com.google.gson.JsonObject;
 
 public class DeleteTable extends AbstractFateOperation {
 
@@ -64,5 +68,13 @@ public class DeleteTable extends AbstractFateOperation {
   public void undo(FateId fateId, FateEnv env) {
     Utils.unreserveTable(env.getContext(), tableId, fateId, LockType.WRITE);
     Utils.unreserveNamespace(env.getContext(), namespaceId, fateId, LockType.READ);
+  }
+
+  @Override
+  public String getDetails() {
+    JsonObject details = new JsonObject();
+    details.addProperty("namespaceId", namespaceId.canonical());
+    details.addProperty("tableId", tableId.canonical());
+    return GSON.get().toJson(details);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/PreDeleteTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/PreDeleteTable.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.delete;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.data.InstanceId;
@@ -34,6 +36,8 @@ import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.compaction.CompactionConfigStorage;
 import org.apache.zookeeper.KeeperException;
+
+import com.google.gson.JsonObject;
 
 public class PreDeleteTable extends AbstractFateOperation {
 
@@ -90,4 +94,11 @@ public class PreDeleteTable extends AbstractFateOperation {
     Utils.unreserveNamespace(env.getContext(), namespaceId, fateId, LockType.READ);
   }
 
+  @Override
+  public String getDetails() {
+    JsonObject details = new JsonObject();
+    details.addProperty("namespaceId", namespaceId.canonical());
+    details.addProperty("tableId", tableId.canonical());
+    return GSON.get().toJson(details);
+  }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/ReserveTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/ReserveTablets.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.manager.tableOps.delete;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LOCATION;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.OPID;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.PREV_ROW;
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
 
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
@@ -36,6 +37,8 @@ import org.apache.accumulo.manager.tableOps.AbstractFateOperation;
 import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonObject;
 
 public class ReserveTablets extends AbstractFateOperation {
 
@@ -119,5 +122,13 @@ public class ReserveTablets extends AbstractFateOperation {
   @Override
   public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
     return new CleanUp(tableId, namespaceId);
+  }
+
+  @Override
+  public String getDetails() {
+    JsonObject details = new JsonObject();
+    details.addProperty("namespaceId", namespaceId.canonical());
+    details.addProperty("tableId", tableId.canonical());
+    return GSON.get().toJson(details);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/CountFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/CountFiles.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.manager.tableOps.merge;
 
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.FILES;
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
 import static org.apache.accumulo.manager.tableOps.merge.MergeInfo.Operation.SYSTEM_MERGE;
 
 import org.apache.accumulo.core.conf.Property;
@@ -87,5 +88,10 @@ public class CountFiles extends AbstractFateOperation {
         default -> throw new IllegalStateException("Unknown op " + data.op);
       };
     }
+  }
+
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(data);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/DeleteRows.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/DeleteRows.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.manager.tableOps.merge;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
 import static org.apache.accumulo.manager.tableOps.merge.MergeTablets.validateTablet;
 
 import java.util.ArrayList;
@@ -312,5 +313,10 @@ public class DeleteRows extends AbstractFateOperation {
     }
 
     return ranges;
+  }
+
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(data);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/DeleteTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/DeleteTablets.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.merge;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
@@ -36,6 +38,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 
 /**
  * Delete tablets that were merged into another tablet.
@@ -123,5 +127,14 @@ public class DeleteTablets extends AbstractFateOperation {
     log.debug("{} deleted {} tablets", fateId, submitted);
 
     return new FinishTableRangeOp(data);
+  }
+
+  @Override
+  public String getDetails() {
+    Gson gson = GSON.get();
+    JsonObject details = gson.toJsonTree(data).getAsJsonObject();
+    details.addProperty("lastTabletEndRow",
+        lastTabletEndRow == null ? null : new Text(lastTabletEndRow).toString());
+    return gson.toJson(details);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/FinishTableRangeOp.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/FinishTableRangeOp.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.manager.tableOps.merge;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LOCATION;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.OPID;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.PREV_ROW;
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
 
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
@@ -107,4 +108,8 @@ class FinishTableRangeOp extends AbstractFateOperation {
         rejectedCount.get());
   }
 
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(data);
+  }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/MergeInfo.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/MergeInfo.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.manager.tableOps.merge;
 
 import java.io.Serializable;
+import java.lang.reflect.Type;
 import java.util.Objects;
 
 import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
@@ -30,11 +31,37 @@ import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.util.TextUtil;
+import org.apache.accumulo.manager.tableOps.merge.MergeInfo.MergeInfoSerializer;
 import org.apache.hadoop.io.Text;
 
 import com.google.common.base.Preconditions;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.annotations.JsonAdapter;
 
+@JsonAdapter(MergeInfoSerializer.class)
 public class MergeInfo implements Serializable {
+
+  public static class MergeInfoSerializer implements JsonSerializer<MergeInfo> {
+
+    @Override
+    public JsonElement serialize(MergeInfo src, Type typeOfSrc, JsonSerializationContext context) {
+      JsonObject obj = new JsonObject();
+      obj.addProperty("namespaceId", src.namespaceId.canonical());
+      obj.addProperty("tableId", src.tableId.canonical());
+      obj.addProperty("operation", src.op.name());
+      obj.addProperty("startRow", new Text(src.startRow).toString());
+      obj.addProperty("endRow", new Text(src.endRow).toString());
+      if (src.mergeRangeSet) {
+        obj.addProperty("mergeStartRow", new Text(src.mergeStartRow).toString());
+        obj.addProperty("mergeEndRow", new Text(src.mergeEndRow).toString());
+      }
+      return obj;
+    }
+  }
+
   private static final long serialVersionUID = 1L;
 
   public enum Operation {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/MergeTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/MergeTablets.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.manager.tableOps.merge;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
 import static org.apache.accumulo.manager.tableOps.merge.DeleteRows.verifyAccepted;
 
 import java.util.ArrayList;
@@ -295,5 +296,10 @@ public class MergeTablets extends AbstractFateOperation {
     // Clip range if exists
     fenced = file.hasRange() ? file.getRange().clip(fenced) : fenced;
     return StoredTabletFile.of(file.getPath(), fenced);
+  }
+
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(data);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/ReserveTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/ReserveTablets.java
@@ -23,6 +23,7 @@ import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LOGS;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.OPID;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.PREV_ROW;
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
 
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
@@ -136,5 +137,10 @@ public class ReserveTablets extends AbstractFateOperation {
       case SYSTEM_MERGE -> new VerifyMergeability(data);
       case MERGE, DELETE -> new CountFiles(data);
     };
+  }
+
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(data);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/TableRangeOp.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/TableRangeOp.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.manager.tableOps.merge;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
 import static org.apache.accumulo.manager.ManagerClientServiceHandler.mustBeOnline;
 
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
@@ -77,5 +78,10 @@ public class TableRangeOp extends AbstractFateOperation {
   public void undo(FateId fateId, FateEnv env) throws Exception {
     Utils.unreserveNamespace(env.getContext(), data.namespaceId, fateId, LockType.READ);
     Utils.unreserveTable(env.getContext(), data.tableId, fateId, LockType.WRITE);
+  }
+
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(data);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/UnreserveAndError.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/UnreserveAndError.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.merge;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
@@ -27,6 +29,9 @@ import org.apache.accumulo.manager.tableOps.AbstractFateOperation;
 import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 
 public class UnreserveAndError extends AbstractFateOperation {
   private static final long serialVersionUID = 1L;
@@ -50,5 +55,14 @@ public class UnreserveAndError extends AbstractFateOperation {
         TableOperationExceptionType.OTHER,
         "Aborted merge because it would produce a tablets with more files than the configured limit of "
             + maxFiles + ". Observed " + totalFiles + " files in the merge range.");
+  }
+
+  @Override
+  public String getDetails() {
+    Gson gson = GSON.get();
+    JsonObject details = gson.toJsonTree(mergeInfo).getAsJsonObject();
+    details.addProperty("totalFiles", totalFiles);
+    details.addProperty("maxFiles", maxFiles);
+    return gson.toJson(details);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/UnreserveSystemMerge.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/UnreserveSystemMerge.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.merge;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
@@ -28,6 +30,9 @@ import org.apache.accumulo.manager.tableOps.AbstractFateOperation;
 import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 
 public class UnreserveSystemMerge extends AbstractFateOperation {
 
@@ -74,5 +79,15 @@ public class UnreserveSystemMerge extends AbstractFateOperation {
         "Aborted merge because the tablets in a range do not form a linked list.";
     };
 
+  }
+
+  @Override
+  public String getDetails() {
+    Gson gson = GSON.get();
+    JsonObject details = gson.toJsonTree(mergeInfo).getAsJsonObject();
+    details.addProperty("maxTotalSize", maxTotalSize);
+    details.addProperty("maxFiles", maxFileCount);
+    details.addProperty("reason", reason.name());
+    return gson.toJson(details);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/VerifyMergeability.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/merge/VerifyMergeability.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.manager.tableOps.merge;
 
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.FILES;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.MERGEABILITY;
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
 
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.fate.FateId;
@@ -77,4 +78,8 @@ public class VerifyMergeability extends AbstractFateOperation {
     return new MergeTablets(data);
   }
 
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(data);
+  }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/CreateNamespace.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/CreateNamespace.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.manager.tableOps.namespace.create;
 
 import static java.util.Objects.requireNonNull;
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -60,4 +61,8 @@ public class CreateNamespace extends AbstractFateOperation {
     // nothing to do, the namespace id was allocated!
   }
 
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(namespaceInfo);
+  }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/FinishCreateNamespace.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/FinishCreateNamespace.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.namespace.create;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
@@ -62,4 +64,8 @@ class FinishCreateNamespace extends AbstractFateOperation {
   @Override
   public void undo(FateId fateId, FateEnv env) {}
 
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(namespaceInfo);
+  }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/PopulateZookeeperWithNamespace.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/PopulateZookeeperWithNamespace.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.namespace.create;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
@@ -68,4 +70,8 @@ class PopulateZookeeperWithNamespace extends AbstractFateOperation {
     Utils.unreserveNamespace(env.getContext(), namespaceInfo.namespaceId, fateId, LockType.WRITE);
   }
 
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(namespaceInfo);
+  }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/SetupNamespacePermissions.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/SetupNamespacePermissions.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.namespace.create;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
@@ -56,5 +58,10 @@ class SetupNamespacePermissions extends AbstractFateOperation {
     // this way concurrent users will not get a spurious permission denied
     // error
     return new PopulateZookeeperWithNamespace(namespaceInfo);
+  }
+
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(namespaceInfo);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/delete/DeleteNamespace.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/delete/DeleteNamespace.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.namespace.delete;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.fate.FateId;
@@ -26,6 +28,8 @@ import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType
 import org.apache.accumulo.manager.tableOps.AbstractFateOperation;
 import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.Utils;
+
+import com.google.gson.JsonObject;
 
 public class DeleteNamespace extends AbstractFateOperation {
 
@@ -54,4 +58,10 @@ public class DeleteNamespace extends AbstractFateOperation {
     Utils.unreserveNamespace(environment.getContext(), namespaceId, fateId, LockType.WRITE);
   }
 
+  @Override
+  public String getDetails() {
+    JsonObject details = new JsonObject();
+    details.addProperty("namespaceId", namespaceId.canonical());
+    return GSON.get().toJson(details);
+  }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/delete/NamespaceCleanUp.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/delete/NamespaceCleanUp.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.namespace.delete;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.fate.FateId;
@@ -28,6 +30,8 @@ import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonObject;
 
 class NamespaceCleanUp extends AbstractFateOperation {
 
@@ -77,4 +81,10 @@ class NamespaceCleanUp extends AbstractFateOperation {
     // nothing to do
   }
 
+  @Override
+  public String getDetails() {
+    JsonObject details = new JsonObject();
+    details.addProperty("namespaceId", namespaceId.canonical());
+    return GSON.get().toJson(details);
+  }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/rename/RenameNamespace.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/rename/RenameNamespace.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.namespace.rename;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.fate.FateId;
@@ -27,6 +29,8 @@ import org.apache.accumulo.manager.tableOps.AbstractFateOperation;
 import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonObject;
 
 public class RenameNamespace extends AbstractFateOperation {
 
@@ -68,4 +72,12 @@ public class RenameNamespace extends AbstractFateOperation {
     Utils.unreserveNamespace(env.getContext(), namespaceId, fateId, LockType.WRITE);
   }
 
+  @Override
+  public String getDetails() {
+    JsonObject details = new JsonObject();
+    details.addProperty("namespaceId", namespaceId.canonical());
+    details.addProperty("oldName", oldName);
+    details.addProperty("newName", newName);
+    return GSON.get().toJson(details);
+  }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/rename/RenameTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/rename/RenameTable.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.rename;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import org.apache.accumulo.core.client.NamespaceNotFoundException;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.data.NamespaceId;
@@ -31,6 +33,8 @@ import org.apache.accumulo.manager.tableOps.AbstractFateOperation;
 import org.apache.accumulo.manager.tableOps.FateEnv;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonObject;
 
 public class RenameTable extends AbstractFateOperation {
 
@@ -85,4 +89,13 @@ public class RenameTable extends AbstractFateOperation {
     Utils.unreserveNamespace(env.getContext(), namespaceId, fateId, LockType.READ);
   }
 
+  @Override
+  public String getDetails() {
+    JsonObject details = new JsonObject();
+    details.addProperty("namespaceId", namespaceId.canonical());
+    details.addProperty("tableId", tableId.canonical());
+    details.addProperty("oldName", oldTableName);
+    details.addProperty("newName", newTableName);
+    return GSON.get().toJson(details);
+  }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/AllocateDirsAndEnsureOnline.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/AllocateDirsAndEnsureOnline.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.split;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import java.util.ArrayList;
 
 import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
@@ -104,5 +106,10 @@ public class AllocateDirsAndEnsureOnline extends AbstractFateOperation {
       });
       return new UpdateTablets(splitInfo, dirs);
     }
+  }
+
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(splitInfo);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/DeleteOperationIds.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/DeleteOperationIds.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.split;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.clientImpl.TableOperationsImpl;
@@ -81,5 +83,10 @@ public class DeleteOperationIds extends AbstractFateOperation {
   @Override
   public String getReturn() {
     return TableOperationsImpl.SPLIT_SUCCESS_MSG;
+  }
+
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(splitInfo);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/FindSplits.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/FindSplits.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.manager.tableOps.split;
 
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.FILES;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.UNSPLITTABLE;
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
 
 import java.util.Optional;
 import java.util.SortedSet;
@@ -159,4 +160,8 @@ public class FindSplits extends AbstractFateOperation {
     return new PreSplit(extent, splits);
   }
 
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(splitInfo);
+  }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/PreSplit.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/PreSplit.java
@@ -22,6 +22,7 @@ import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LOGS;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.OPID;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.PREV_ROW;
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
 
 import java.util.Map;
 import java.util.Objects;
@@ -153,4 +154,9 @@ public class PreSplit extends AbstractFateOperation {
 
   @Override
   public void undo(FateId fateId, FateEnv env) throws Exception {}
+
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(splitInfo);
+  }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/SplitInfo.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/SplitInfo.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.manager.tableOps.split;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.Serializable;
+import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
 import java.util.NavigableMap;
 import java.util.SortedMap;
@@ -31,11 +32,39 @@ import org.apache.accumulo.core.clientImpl.TabletMergeabilityUtil;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.util.TextUtil;
+import org.apache.accumulo.manager.tableOps.split.SplitInfo.SplitInfoSerializer;
 import org.apache.hadoop.io.Text;
 
 import com.google.common.base.Preconditions;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.annotations.JsonAdapter;
 
+@JsonAdapter(SplitInfoSerializer.class)
 public class SplitInfo implements Serializable {
+
+  public static class SplitInfoSerializer implements JsonSerializer<SplitInfo> {
+
+    @Override
+    public JsonElement serialize(SplitInfo src, Type typeOfSrc, JsonSerializationContext context) {
+      JsonObject obj = new JsonObject();
+      obj.addProperty("tableId", src.tableId.canonical());
+      obj.addProperty("prevEndRow", new Text(src.prevEndRow).toString());
+      obj.addProperty("endRow", new Text(src.endRow).toString());
+      if (src.splits.length > 0) {
+        JsonArray arr = new JsonArray();
+        for (byte[] split : src.splits) {
+          arr.add(new Text(split).toString());
+        }
+        obj.add("splits", arr);
+      }
+      return obj;
+    }
+  }
+
   private static final long serialVersionUID = 1L;
 
   private final TableId tableId;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/UpdateTablets.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/UpdateTablets.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.split;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -52,6 +54,9 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 
 public class UpdateTablets extends AbstractFateOperation {
   private static final Logger log = LoggerFactory.getLogger(UpdateTablets.class);
@@ -360,4 +365,15 @@ public class UpdateTablets extends AbstractFateOperation {
           result.getExtent());
     }
   }
+
+  @Override
+  public String getDetails() {
+    Gson gson = GSON.get();
+    JsonObject details = gson.toJsonTree(splitInfo).getAsJsonObject();
+    JsonArray dirs = new JsonArray(dirNames.size());
+    dirNames.forEach(dirs::add);
+    details.add("dirs", dirs);
+    return gson.toJson(details);
+  }
+
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableExport/ExportTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableExport/ExportTable.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.tableExport;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.FateId;
@@ -70,4 +72,8 @@ public class ExportTable extends AbstractFateOperation {
   public static final String DATA_VERSION_PROP = "srcDataVersion";
   public static final String EXPORT_VERSION_PROP = "exportVersion";
 
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(tableInfo);
+  }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableExport/WriteExportFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableExport/WriteExportFiles.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.manager.tableOps.tableExport;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
 
 import java.io.BufferedOutputStream;
 import java.io.BufferedWriter;
@@ -297,5 +298,10 @@ class WriteExportFiles extends AbstractFateOperation {
     }
 
     osw.flush();
+  }
+
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(tableInfo);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/CreateImportDir.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/CreateImportDir.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.tableImport;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Set;
@@ -84,5 +86,10 @@ class CreateImportDir extends AbstractFateOperation {
 
       log.info("Using import dir: {}", dm.importDir);
     }
+  }
+
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(tableInfo);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/FinishImportTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/FinishImportTable.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.manager.tableOps.tableImport;
 
 import static org.apache.accumulo.core.Constants.IMPORT_MAPPINGS_FILE;
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
 
 import java.util.EnumSet;
 
@@ -83,4 +84,8 @@ class FinishImportTable extends AbstractFateOperation {
   @Override
   public void undo(FateId fateId, FateEnv env) {}
 
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(tableInfo);
+  }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportPopulateZookeeper.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportPopulateZookeeper.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.tableImport;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import java.io.IOException;
 import java.util.Map;
 
@@ -97,5 +99,10 @@ class ImportPopulateZookeeper extends AbstractFateOperation {
     env.getTableManager().removeTable(tableInfo.tableId, tableInfo.namespaceId);
     Utils.unreserveTable(env.getContext(), tableInfo.tableId, fateId, LockType.WRITE);
     context.clearTableListCache();
+  }
+
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(tableInfo);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportSetupPermissions.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportSetupPermissions.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.tableImport;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
@@ -65,5 +67,10 @@ class ImportSetupPermissions extends AbstractFateOperation {
   public void undo(FateId fateId, FateEnv env) throws Exception {
     env.getContext().getSecurityOperation().deleteTable(env.getContext().rpcCreds(),
         tableInfo.tableId, tableInfo.namespaceId);
+  }
+
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(tableInfo);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportTable.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.manager.tableOps.tableImport;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.function.Predicate.not;
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -171,5 +172,10 @@ public class ImportTable extends AbstractFateOperation {
     return exportDirs.stream().filter(not(String::isEmpty))
         .map(ImportedTableInfo.DirectoryMapping::new)
         .collect(Collectors.toCollection(ArrayList::new));
+  }
+
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(tableInfo);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/MapImportFileNames.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/MapImportFileNames.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.manager.tableOps.tableImport;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.core.Constants.IMPORT_MAPPINGS_FILE;
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -124,5 +125,10 @@ class MapImportFileNames extends AbstractFateOperation {
     for (ImportedTableInfo.DirectoryMapping dm : tableInfo.directories) {
       env.getVolumeManager().deleteRecursively(new Path(dm.importDir));
     }
+  }
+
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(tableInfo);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/MoveExportedFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/MoveExportedFiles.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.tableImport;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -115,5 +117,10 @@ class MoveExportedFiles extends AbstractFateOperation {
     }
 
     return new FinishImportTable(tableInfo);
+  }
+
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(tableInfo);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/PopulateMetadataTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/PopulateMetadataTable.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.manager.tableOps.tableImport;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.core.Constants.IMPORT_MAPPINGS_FILE;
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
 import static org.apache.accumulo.manager.tableOps.tableExport.ExportTable.VERSION_2;
 
 import java.io.BufferedInputStream;
@@ -214,5 +215,10 @@ class PopulateMetadataTable extends AbstractFateOperation {
   public void undo(FateId fateId, FateEnv environment) throws Exception {
     MetadataTableUtil.deleteTable(tableInfo.tableId, false, environment.getContext(),
         environment.getServiceLock());
+  }
+
+  @Override
+  public String getDetails() {
+    return GSON.get().toJson(tableInfo);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tserverOps/BeginTserverShutdown.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tserverOps/BeginTserverShutdown.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.manager.tserverOps;
 
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
+
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.data.ResourceGroupId;
 import org.apache.accumulo.core.fate.FateId;
@@ -30,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.net.HostAndPort;
+import com.google.gson.JsonObject;
 
 public class BeginTserverShutdown extends AbstractFateOperation {
 
@@ -76,5 +79,15 @@ public class BeginTserverShutdown extends AbstractFateOperation {
       environment.getContext().getZooSession().asReaderWriter().delete(path);
       log.trace("{} removed {}", fateId, path);
     }
+  }
+
+  @Override
+  public String getDetails() {
+    JsonObject details = new JsonObject();
+    details.addProperty("resourceGroup", resourceGroup.canonical());
+    details.addProperty("hostAndPort", hostAndPort.toString());
+    details.addProperty("serverSession", serverSession);
+    details.addProperty("force", force);
+    return GSON.get().toJson(details);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tserverOps/ShutdownTServer.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tserverOps/ShutdownTServer.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.manager.tserverOps;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
 import static org.apache.accumulo.manager.tserverOps.BeginTserverShutdown.createPath;
 
 import org.apache.accumulo.core.data.ResourceGroupId;
@@ -40,6 +41,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.net.HostAndPort;
+import com.google.gson.JsonObject;
 
 public class ShutdownTServer extends AbstractFateOperation {
 
@@ -126,4 +128,14 @@ public class ShutdownTServer extends AbstractFateOperation {
 
   @Override
   public void undo(FateId fateId, FateEnv env) {}
+
+  @Override
+  public String getDetails() {
+    JsonObject details = new JsonObject();
+    details.addProperty("resourceGroup", resourceGroup.canonical());
+    details.addProperty("hostAndPort", hostAndPort.toString());
+    details.addProperty("serverSession", serverSession);
+    details.addProperty("force", force);
+    return GSON.get().toJson(details);
+  }
 }

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/InformationFetcher.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/InformationFetcher.java
@@ -435,7 +435,7 @@ public class InformationFetcher implements RemovalListener<ServerId,MetricRespon
         AdminUtil<Fate> admin = new AdminUtil<>();
         var zTableLocksPath = ctx.getServerPaths().createTableLocksPath();
         var zk = ctx.getZooSession();
-        FateStatus status = admin.getStatus(stores, zk, zTableLocksPath, null, null, null);
+        FateStatus status = admin.getStatus(stores, zk, zTableLocksPath, null, null, null, false);
         summary.processFateTransactions(status.getTransactions());
       } catch (KeeperException | InterruptedException e) {
         throw new IllegalStateException(e);

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/fate.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/fate.ftl
@@ -22,7 +22,7 @@
         <div class="col-xs-12">
           <table id="fateTable" class="table caption-top table-bordered table-striped table-condensed">
             <caption><span class="table-caption">Fate Transaction Details</span><br />
-              <span class="table-subcaption">The table contains the last known Fate transaction status.</span><br />
+              <span class="table-subcaption">Use the <strong>accumulo inst fate</strong> server-side utility with the <strong>-l</strong> and <strong>-i</strong> options to see detailed information about a transaction.</span><br />
             </caption>
             <#include "table_loading.ftl" >
           </table>

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_1_IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_1_IT.java
@@ -377,6 +377,12 @@ public class ExternalCompaction_1_IT extends SharedMiniClusterBase {
     public Repo<FateEnv> call(FateId fateId, FateEnv environment) throws Exception {
       return null;
     }
+
+    @Override
+    public String getDetails() {
+      return null;
+    }
+
   }
 
   private FateId createCompactionCommitAndDeadMetadata(AccumuloClient c,

--- a/test/src/main/java/org/apache/accumulo/test/fate/FateExecutionOrderITBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FateExecutionOrderITBase.java
@@ -141,6 +141,11 @@ public abstract class FateExecutionOrderITBase extends SharedMiniClusterBase
     public String getReturn() {
       return "";
     }
+
+    @Override
+    public String getDetails() {
+      return null;
+    }
   }
 
   public static class SecondOp extends FirstOp {

--- a/test/src/main/java/org/apache/accumulo/test/fate/FateITBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FateITBase.java
@@ -26,6 +26,7 @@ import static org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus.NEW;
 import static org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus.SUBMITTED;
 import static org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus.SUCCESSFUL;
 import static org.apache.accumulo.core.fate.ReadOnlyFateStore.TStatus.UNKNOWN;
+import static org.apache.accumulo.core.util.LazySingletons.GSON;
 import static org.apache.accumulo.test.fate.FateTestUtil.TEST_FATE_OP;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -66,6 +67,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonObject;
 
 public abstract class FateITBase extends SharedMiniClusterBase implements FateTestRunner<TestEnv> {
 
@@ -122,6 +125,13 @@ public abstract class FateITBase extends SharedMiniClusterBase implements FateTe
     @Override
     public String getReturn() {
       return data + "_ret";
+    }
+
+    @Override
+    public String getDetails() {
+      JsonObject details = new JsonObject();
+      details.addProperty("data", data);
+      return GSON.get().toJson(details);
     }
   }
 
@@ -184,6 +194,14 @@ public abstract class FateITBase extends SharedMiniClusterBase implements FateTe
     public String getReturn() {
       return "none";
     }
+
+    @Override
+    public String getDetails() {
+      JsonObject details = new JsonObject();
+      details.addProperty("opName", opName);
+      details.addProperty("opNum", opNum);
+      return GSON.get().toJson(details);
+    }
   }
 
   /**
@@ -230,6 +248,13 @@ public abstract class FateITBase extends SharedMiniClusterBase implements FateTe
     @Override
     public String getReturn() {
       return data + "_ret";
+    }
+
+    @Override
+    public String getDetails() {
+      JsonObject details = new JsonObject();
+      details.addProperty("data", data);
+      return GSON.get().toJson(details);
     }
   }
 
@@ -665,6 +690,11 @@ public abstract class FateITBase extends SharedMiniClusterBase implements FateTe
     @Override
     public String getName() {
       return "none";
+    }
+
+    @Override
+    public String getDetails() {
+      return null;
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/fate/FateOpsCommandsITBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FateOpsCommandsITBase.java
@@ -813,7 +813,7 @@ public abstract class FateOpsCommandsITBase extends SharedMiniClusterBase
     AdminUtil.FateStatus status = null;
     try {
       status = AdminUtil.getTransactionStatus(Map.of(store.type(), mockedStore), null, null, null,
-          new HashMap<>(), new HashMap<>(), Map.of());
+          new HashMap<>(), new HashMap<>(), Map.of(), false);
     } catch (Exception e) {
       fail("An unexpected error occurred in getTransactionStatus():\n" + e);
     }

--- a/test/src/main/java/org/apache/accumulo/test/fate/FatePoolsWatcherITBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FatePoolsWatcherITBase.java
@@ -809,6 +809,11 @@ public abstract class FatePoolsWatcherITBase extends SharedMiniClusterBase
     public String getReturn() {
       return null;
     }
+
+    @Override
+    public String getDetails() {
+      return null;
+    }
   }
 
   public static class PoolResizeTestEnv extends FateTestRunner.TestEnv {

--- a/test/src/main/java/org/apache/accumulo/test/fate/MultipleStoresITBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/MultipleStoresITBase.java
@@ -428,6 +428,11 @@ public abstract class MultipleStoresITBase extends SharedMiniClusterBase {
     public String getReturn() {
       return null;
     }
+
+    @Override
+    public String getDetails() {
+      return null;
+    }
   }
 
   public static class SleepingTestEnv extends MultipleStoresTestEnv {
@@ -469,6 +474,11 @@ public abstract class MultipleStoresITBase extends SharedMiniClusterBase {
 
     @Override
     public String getReturn() {
+      return null;
+    }
+
+    @Override
+    public String getDetails() {
       return null;
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/FateConcurrencyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FateConcurrencyIT.java
@@ -264,7 +264,7 @@ public class FateConcurrencyIT extends AccumuloClusterHarness {
         Map<FateInstanceType,ReadOnlyFateStore<String>> readOnlyFateStores =
             Map.of(FateInstanceType.META, readOnlyMFS, FateInstanceType.USER, readOnlyUFS);
 
-        withLocks = admin.getStatus(readOnlyFateStores, zk, lockPath, null, null, null);
+        withLocks = admin.getStatus(readOnlyFateStores, zk, lockPath, null, null, null, true);
 
         // call method that does not use locks.
         noLocks = admin.getTransactionStatus(readOnlyFateStores, null, null, null);
@@ -299,7 +299,10 @@ public class FateConcurrencyIT extends AccumuloClusterHarness {
 
       if (isCompaction(tx)) {
 
-        log.trace("Fate id: {}, status: {}", tx.getFateId(), tx.getStatus());
+        log.info("Fate id: {}, status: {}, details: {}", tx.getFateId(), tx.getStatus(),
+            tx.getDetails());
+
+        assertNotNull(tx.getDetails());
 
         for (AdminUtil.TransactionStatus tx2 : noLocks) {
           if (tx2.getFateId().equals(tx.getFateId())) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/FunctionalTestUtils.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FunctionalTestUtils.java
@@ -226,7 +226,7 @@ public class FunctionalTestUtils {
       Map<FateInstanceType,ReadOnlyFateStore<String>> readOnlyFateStores =
           Map.of(FateInstanceType.META, readOnlyMFS, FateInstanceType.USER, readOnlyUFS);
       var lockPath = context.getServerPaths().createTableLocksPath();
-      return admin.getStatus(readOnlyFateStores, zk, lockPath, null, null, null);
+      return admin.getStatus(readOnlyFateStores, zk, lockPath, null, null, null, false);
     } catch (KeeperException | InterruptedException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
This change adds an option to the `fate --list` command to print transaction details that give more context which objects are being modified in the fate command. The addition of the `--info` option will include an additional line in the output for each fate transaction that includes the detail information.

Related to #6017