### PR TITLE
Display information collection time on Monitor pages

### DIFF
--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/Endpoints.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/Endpoints.java
@@ -61,6 +61,7 @@ import org.apache.accumulo.monitor.next.SystemInformation.AlertPriority;
 import org.apache.accumulo.monitor.next.SystemInformation.CompactionGroupSummary;
 import org.apache.accumulo.monitor.next.SystemInformation.CompactionTableSummary;
 import org.apache.accumulo.monitor.next.SystemInformation.FateTransaction;
+import org.apache.accumulo.monitor.next.SystemInformation.FetchCycleTimes;
 import org.apache.accumulo.monitor.next.SystemInformation.RecoveryInformation;
 import org.apache.accumulo.monitor.next.SystemInformation.TableSummary;
 import org.apache.accumulo.monitor.next.SystemInformation.TimeOrderedRunningCompactionSet;
@@ -182,7 +183,7 @@ public class Endpoints {
   public MonitorStatus getStatus() {
     SystemInformation summary = monitor.getInformationFetcher().getSummaryForEndpoint();
     return new MonitorStatus(summary.getManagerGoalState(), summary.getComponentStatuses(),
-        summary.getTimestamp());
+        summary.getCollectionTiming().finishTime());
   }
 
   @GET
@@ -385,7 +386,8 @@ public class Endpoints {
   @Description("Returns External Compactor process details")
   public CompactorsSummary getExternalCompactors() {
     var summary = monitor.getInformationFetcher().getSummaryForEndpoint();
-    return new CompactorsSummary(summary.getCompactorServers(), summary.getTimestamp());
+    return new CompactorsSummary(summary.getCompactorServers(),
+        summary.getCollectionTiming().finishTime());
   }
 
   @GET
@@ -518,8 +520,8 @@ public class Endpoints {
   @Path("lastUpdate")
   @Produces(MediaType.APPLICATION_JSON)
   @Description("Returns the timestamp of when the monitor information was last refreshed")
-  public long getTimestamp() {
-    return monitor.getInformationFetcher().getSummaryForEndpoint().getTimestamp();
+  public FetchCycleTimes getTimestamp() {
+    return monitor.getInformationFetcher().getSummaryForEndpoint().getCollectionTiming();
   }
 
   @GET

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/InformationFetcher.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/InformationFetcher.java
@@ -739,6 +739,7 @@ public class InformationFetcher implements RemovalListener<ServerId,MetricRespon
       newConnectionEvent.compareAndExchange(true, false);
 
       LOG.info("Fetching information from servers");
+      long fetchCycleStart = System.currentTimeMillis();
 
       final UpdateTasks futures = new UpdateTasks();
       final SystemInformation summary = new SystemInformation(allMetrics, this.ctx);
@@ -873,7 +874,7 @@ public class InformationFetcher implements RemovalListener<ServerId,MetricRespon
       lastRunTime = NanoTime.now();
 
       retainedProblemServers.asMap().keySet().forEach(summary::retainProblemServer);
-      summary.finish(failures, cancelled);
+      summary.finish(failures, cancelled, fetchCycleStart);
 
       LOG.info("Finished fetching metrics from servers");
       LOG.info(

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/SystemInformation.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/SystemInformation.java
@@ -545,7 +545,7 @@ public class SystemInformation {
       new EnumMap<>(ServerId.Type.class);
   private final EnumMap<TableDataFactory.TableName,Supplier<TableData>> serverMetricsView =
       new EnumMap<>(TableDataFactory.TableName.class);
-  private DeploymentOverview deploymentOverview = new DeploymentOverview(0L, List.of());
+  private DeploymentOverview deploymentOverview = new DeploymentOverview(List.of());
   private String managerGoalState;
   private final int rgLongRunningCompactionSize;
 
@@ -788,9 +788,9 @@ public class SystemInformation {
 
     if (!qm.isEmpty()) {
       // Create a ServersView object from the MetricResponse for each queue
-      return TableDataFactory.forColumns(qm.keySet(), qm, timestamp.get(), cols);
+      return TableDataFactory.forColumns(qm.keySet(), qm, cols);
     }
-    return TableDataFactory.forColumns(Set.of(), Map.of(), timestamp.get(), cols);
+    return TableDataFactory.forColumns(Set.of(), Map.of(), cols);
   }
 
   public void processResponse(final ServerId server, final MetricResponse response,
@@ -1173,7 +1173,6 @@ public class SystemInformation {
 
     computeMessages(failures, cancelled);
 
-    timestamp.set(System.currentTimeMillis());
     componentStatuses.clear();
     for (final ServerId.Type type : ServerId.Type.values()) {
       if (type == ServerId.Type.MONITOR) {
@@ -1226,8 +1225,9 @@ public class SystemInformation {
           break;
       }
     }
-    deploymentOverview = DeploymentOverview.fromSummary(deployment, timestamp);
+    deploymentOverview = DeploymentOverview.fromSummary(deployment);
     computeMessageCounts();
+    timestamp.set(System.currentTimeMillis());
   }
 
   public Set<String> getResourceGroups() {
@@ -1415,8 +1415,8 @@ public class SystemInformation {
    * Cache a ServersView for the given table and set of servers.
    */
   private void cacheServerProcessView(TableDataFactory.TableName table, Set<ServerId> servers) {
-    serverMetricsView.put(table, memoize(
-        () -> TableDataFactory.forTable(table, servers, allMetrics.asMap(), timestamp.get())));
+    serverMetricsView.put(table,
+        memoize(() -> TableDataFactory.forTable(table, servers, allMetrics.asMap())));
   }
 
   public TableData getServerProcessView(TableDataFactory.TableName table) {

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/SystemInformation.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/SystemInformation.java
@@ -469,6 +469,9 @@ public class SystemInformation {
       long created, List<String> heldLocks, List<String> waitingLocks, LockRangeType lockRange) {
   }
 
+  public record FetchCycleTimes(long durationMs, long finishTime) {
+  }
+
   private static final Logger LOG = LoggerFactory.getLogger(SystemInformation.class);
 
   private final DistributionStatisticConfig DSC =
@@ -539,7 +542,6 @@ public class SystemInformation {
 
   private final List<FateTransaction> fateTransactions = new ArrayList<>();
 
-  private final AtomicLong timestamp = new AtomicLong(0);
   private final EnumMap<ServerId.Type,Status> componentStatuses =
       new EnumMap<>(ServerId.Type.class);
   private final EnumMap<TableDataFactory.TableName,Supplier<TableData>> serverMetricsView =
@@ -547,6 +549,7 @@ public class SystemInformation {
   private DeploymentOverview deploymentOverview = new DeploymentOverview(List.of());
   private String managerGoalState;
   private final int rgLongRunningCompactionSize;
+  private FetchCycleTimes timing = null;
 
   public SystemInformation(Cache<ServerId,MetricResponse> allMetrics, ServerContext ctx) {
     this.allMetrics = allMetrics;
@@ -1164,8 +1167,8 @@ public class SystemInformation {
 
   }
 
-  public void finish(final List<UpdateTaskFuture> failures,
-      final List<UpdateTaskFuture> cancelled) {
+  public void finish(final List<UpdateTaskFuture> failures, final List<UpdateTaskFuture> cancelled,
+      long fetchCycleStart) {
     // Update the deployment not-responded numbers based
     // on metric fetch failures for this refresh.
     metricProblemHosts.forEach(serverId -> {
@@ -1229,7 +1232,8 @@ public class SystemInformation {
     }
     deploymentOverview = DeploymentOverview.fromSummary(deployment);
     computeAlertCounts();
-    timestamp.set(System.currentTimeMillis());
+    long fetchCycleFinish = System.currentTimeMillis();
+    timing = new FetchCycleTimes((fetchCycleFinish - fetchCycleStart), fetchCycleFinish);
   }
 
   public Set<String> getResourceGroups() {
@@ -1409,8 +1413,8 @@ public class SystemInformation {
     return this.alertCounts;
   }
 
-  public long getTimestamp() {
-    return this.timestamp.get();
+  public FetchCycleTimes getCollectionTiming() {
+    return this.timing;
   }
 
   /**

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/deployment/DeploymentOverview.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/deployment/DeploymentOverview.java
@@ -21,7 +21,6 @@ package org.apache.accumulo.monitor.next.deployment;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.accumulo.core.client.admin.servers.ServerId;
 import org.apache.accumulo.core.data.ResourceGroupId;
@@ -30,7 +29,7 @@ import org.apache.accumulo.monitor.next.SystemInformation.ProcessSummary;
 /**
  * Data Transfer Object for the Monitor Deployment page.
  */
-public record DeploymentOverview(long lastUpdate, List<DeploymentRow> breakdown) {
+public record DeploymentOverview(List<DeploymentRow> breakdown) {
 
   /**
    * Data Transfer Object containing counts of total and responding servers for a given resource
@@ -40,10 +39,10 @@ public record DeploymentOverview(long lastUpdate, List<DeploymentRow> breakdown)
       long responding) {
   }
 
-  public static DeploymentOverview fromSummary(
-      Map<ResourceGroupId,Map<ServerId.Type,ProcessSummary>> deployment, AtomicLong lastUpdate) {
+  public static DeploymentOverview
+      fromSummary(Map<ResourceGroupId,Map<ServerId.Type,ProcessSummary>> deployment) {
     if (deployment == null || deployment.isEmpty()) {
-      return new DeploymentOverview(lastUpdate.get(), List.of());
+      return new DeploymentOverview(List.of());
     }
 
     var breakdown =
@@ -64,7 +63,7 @@ public record DeploymentOverview(long lastUpdate, List<DeploymentRow> breakdown)
               });
         }).toList();
 
-    return new DeploymentOverview(lastUpdate.get(), breakdown);
+    return new DeploymentOverview(breakdown);
   }
 
   /**

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/views/TableData.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/views/TableData.java
@@ -35,7 +35,7 @@ import java.util.Map;
  * </pre>
  *
  */
-public record TableData(List<Column> columns, List<Map<String,Object>> data, long timestamp) {
+public record TableData(List<Column> columns, List<Map<String,Object>> data) {
 
   /**
    * Definition of a column to be rendered in the UI

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/views/TableDataFactory.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/views/TableDataFactory.java
@@ -129,8 +129,7 @@ public class TableDataFactory {
   }
 
   public static TableData forColumns(final Set<ServerId> servers,
-      final Map<ServerId,MetricResponse> allMetrics, final long timestamp,
-      List<ColumnFactory> requestedColumns) {
+      final Map<ServerId,MetricResponse> allMetrics, List<ColumnFactory> requestedColumns) {
 
     List<Column> columns = requestedColumns.stream().map(ColumnFactory::getColumn).toList();
 
@@ -154,15 +153,15 @@ public class TableDataFactory {
       data.add(row);
     });
 
-    return new TableData(columns, data, timestamp);
+    return new TableData(columns, data);
 
   }
 
   public static TableData forTable(final TableName table, final Set<ServerId> servers,
-      final Map<ServerId,MetricResponse> allMetrics, final long timestamp) {
+      final Map<ServerId,MetricResponse> allMetrics) {
 
     List<ColumnFactory> requestedColumns = columnsFor(table);
-    return forColumns(servers, allMetrics, timestamp, requestedColumns);
+    return forColumns(servers, allMetrics, requestedColumns);
   }
 
   /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
@@ -95,10 +95,11 @@ TIMER = setInterval(function () {
 
 function refreshLastUpdate() {
   getLastUpdate().then(function () {
-    var timestamp = getStoredJson(LAST_UPDATE, 0);
+    var timing = getStoredJson(LAST_UPDATE, {});
     $('#lastUpdateDiv').empty();
     var msg = $(document.createElement("span"));
-    msg.text('Displayed information was calculated at ' + dateFormat(timestamp).replace(/&nbsp;/g, ' '));
+    msg.text('Data as of ' + dateFormat(timing.finishTime).replace(/&nbsp;/g, ' ') +
+      '. Took ' + timeDuration(timing.durationMs).replace(/&nbsp;/g, ' ') + ' to collect.');
     $('#lastUpdateDiv').append(msg);
   });
 }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
@@ -43,6 +43,7 @@ const MESSAGES = 'messages';
 const FATE = 'fate';
 const MESSAGE_COUNTS = 'messageCounts'
 const RECOVERY = 'recovery';
+const LAST_UPDATE = 'lastUpdate';
 
 // Override Length Menu options for dataTables
 if ($.fn && $.fn.dataTable) {
@@ -87,9 +88,20 @@ TIMER = setInterval(function () {
   if (localStorage.getItem(AUTO_REFRESH_KEY) === 'true') {
     refresh();
     refreshNavBar();
+    refreshLastUpdate();
   }
 }, 5000);
 
+
+function refreshLastUpdate() {
+  getLastUpdate().then(function () {
+    var timestamp = getStoredJson(LAST_UPDATE, 0);
+    $('#lastUpdateDiv').empty();
+    var msg = $(document.createElement("span"));
+    msg.text('Displayed information was calculated at ' + dateFormat(timestamp).replace(/&nbsp;/g, ' '));
+    $('#lastUpdateDiv').append(msg);
+  });
+}
 /**
  * Adds the suffix to the number, converts the number to one close to the base
  *
@@ -838,6 +850,14 @@ function getRunningCompactionsByTable() {
  */
 function getRunningCompactionsByGroup() {
   return getJSONForTable(REST_V2_PREFIX + '/compactions/running/group', RUNNING_COMPACTIONS_BY_GROUP);
+}
+
+/**
+ * REST GET call for /lastUpdate,
+ * stores it on a sessionStorage variable
+ */
+function getLastUpdateTime() {
+  return getJSONForTable(REST_V2_PREFIX + '/lastUpdate', LAST_UPDATE);
 }
 
 

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/server_process_common.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/server_process_common.js
@@ -47,8 +47,7 @@
  *       "description": "Description of Column B",
  *       "uiClass": ""
  *     }
- *   ],
- *   timestamp: long
+ *   ]
  * }
  *
  * The value for the 'columns' key is an array of column definitions. The value for the

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/default.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/default.ftl
@@ -64,6 +64,7 @@
        */
       $(function() {
         setupAutoRefresh();
+        refreshLastUpdate();
       });
     </script>
     <#if js??>
@@ -78,8 +79,12 @@
 
     <div id="main" class="container-fluid">
       <#include "${template}">
+      <br />
+      <div id="lastUpdateDiv" class="center">
+      </div>
     </div>
 
     <#include "modals.ftl">
+
   </body>
 </html>


### PR DESCRIPTION
This change removes the timestamp from some REST API responses because it was not being used and instead displays the timestamp at the bottom of each page.