### PR TITLE
Rename monitor 'Messages' to 'Alerts' in UI and supporting code

### DIFF
--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/Endpoints.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/Endpoints.java
@@ -56,11 +56,11 @@ import org.apache.accumulo.core.process.thrift.MetricResponse;
 import org.apache.accumulo.core.util.compaction.RunningCompactionInfo;
 import org.apache.accumulo.monitor.Monitor;
 import org.apache.accumulo.monitor.next.InformationFetcher.InstanceSummary;
+import org.apache.accumulo.monitor.next.SystemInformation.AlertCategory;
+import org.apache.accumulo.monitor.next.SystemInformation.AlertPriority;
 import org.apache.accumulo.monitor.next.SystemInformation.CompactionGroupSummary;
 import org.apache.accumulo.monitor.next.SystemInformation.CompactionTableSummary;
 import org.apache.accumulo.monitor.next.SystemInformation.FateTransaction;
-import org.apache.accumulo.monitor.next.SystemInformation.MessageCategory;
-import org.apache.accumulo.monitor.next.SystemInformation.MessagePriority;
 import org.apache.accumulo.monitor.next.SystemInformation.RecoveryInformation;
 import org.apache.accumulo.monitor.next.SystemInformation.TableSummary;
 import org.apache.accumulo.monitor.next.SystemInformation.TimeOrderedRunningCompactionSet;
@@ -448,52 +448,52 @@ public class Endpoints {
   }
 
   @GET
-  @Path("message/categories")
+  @Path("alerts/categories")
   @Produces(MediaType.APPLICATION_JSON)
-  @Description("Returns a list of message categories")
-  public Set<MessageCategory> getMessageCategories() {
-    return EnumSet.allOf(SystemInformation.MessageCategory.class);
+  @Description("Returns a list of alert categories")
+  public Set<AlertCategory> getAlertCategories() {
+    return EnumSet.allOf(SystemInformation.AlertCategory.class);
   }
 
-  public record Message(String priority, String category, String message) {
-  }
-
-  @GET
-  @Path("message/counts")
-  @Produces(MediaType.APPLICATION_JSON)
-  @Description("Returns count of messages by priority")
-  public Map<MessagePriority,AtomicLong> getMessageCounts() {
-    return monitor.getInformationFetcher().getSummaryForEndpoint().getMessageCounts();
+  public record Alert(String priority, String category, String message) {
   }
 
   @GET
-  @Path("messages")
+  @Path("alerts/counts")
   @Produces(MediaType.APPLICATION_JSON)
-  @Description("Returns a list of messages")
-  public List<Message> getMessages(@QueryParam("high") boolean includeHigh,
+  @Description("Returns count of alerts by priority")
+  public Map<AlertPriority,AtomicLong> getAlertCounts() {
+    return monitor.getInformationFetcher().getSummaryForEndpoint().getAlertCounts();
+  }
+
+  @GET
+  @Path("alerts")
+  @Produces(MediaType.APPLICATION_JSON)
+  @Description("Returns a list of alerts")
+  public List<Alert> getAlerts(@QueryParam("high") boolean includeHigh,
       @QueryParam("info") boolean includeInfo, @QueryParam("category") List<String> categories) {
-    List<Message> results = new ArrayList<>();
+    List<Alert> results = new ArrayList<>();
 
-    Map<MessagePriority,Map<MessageCategory,Set<String>>> messages =
-        monitor.getInformationFetcher().getSummaryForEndpoint().getMessages();
+    Map<AlertPriority,Map<AlertCategory,Set<String>>> alerts =
+        monitor.getInformationFetcher().getSummaryForEndpoint().getAlerts();
 
-    for (Entry<MessagePriority,Map<MessageCategory,Set<String>>> e : messages.entrySet()) {
-      MessagePriority prio = e.getKey();
-      Map<MessageCategory,Set<String>> value = e.getValue();
+    for (Entry<AlertPriority,Map<AlertCategory,Set<String>>> e : alerts.entrySet()) {
+      AlertPriority prio = e.getKey();
+      Map<AlertCategory,Set<String>> value = e.getValue();
       switch (prio) {
         case Critical:
-          // Always include critical messages
-          value.forEach((cat, msgs) -> {
-            msgs.forEach(m -> results.add(new Message(prio.name(), cat.name(), m)));
+          // Always include critical alerts
+          value.forEach((cat, messages) -> {
+            messages.forEach(m -> results.add(new Alert(prio.name(), cat.name(), m)));
           });
           break;
         case High:
           if (!includeHigh) {
             break;
           }
-          value.forEach((cat, msgs) -> {
+          value.forEach((cat, messages) -> {
             if (categories.contains(cat.name())) {
-              msgs.forEach(m -> results.add(new Message(prio.name(), cat.name(), m)));
+              messages.forEach(m -> results.add(new Alert(prio.name(), cat.name(), m)));
             }
           });
           break;
@@ -501,9 +501,9 @@ public class Endpoints {
           if (!includeInfo) {
             break;
           }
-          value.forEach((cat, msgs) -> {
+          value.forEach((cat, messages) -> {
             if (categories.contains(cat.name())) {
-              msgs.forEach(m -> results.add(new Message(prio.name(), cat.name(), m)));
+              messages.forEach(m -> results.add(new Alert(prio.name(), cat.name(), m)));
             }
           });
           break;

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/InformationFetcher.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/InformationFetcher.java
@@ -20,10 +20,10 @@ package org.apache.accumulo.monitor.next;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.apache.accumulo.monitor.next.SystemInformation.MessageCategory.Monitor;
-import static org.apache.accumulo.monitor.next.SystemInformation.MessageCategory.Table;
-import static org.apache.accumulo.monitor.next.SystemInformation.MessagePriority.Critical;
-import static org.apache.accumulo.monitor.next.SystemInformation.MessagePriority.Info;
+import static org.apache.accumulo.monitor.next.SystemInformation.AlertCategory.Monitor;
+import static org.apache.accumulo.monitor.next.SystemInformation.AlertCategory.Table;
+import static org.apache.accumulo.monitor.next.SystemInformation.AlertPriority.Critical;
+import static org.apache.accumulo.monitor.next.SystemInformation.AlertPriority.Info;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -708,11 +708,10 @@ public class InformationFetcher implements RemovalListener<ServerId,MetricRespon
         }
 
       } else {
-        summary.addMessage(Critical, Table,
-            metadataNoLocation + " metadata tablets are not hosted");
+        summary.addAlert(Critical, Table, metadataNoLocation + " metadata tablets are not hosted");
       }
     } else {
-      summary.addMessage(Critical, Table, "The root tablet is not currently hosted");
+      summary.addAlert(Critical, Table, "The root tablet is not currently hosted");
     }
   }
 
@@ -850,7 +849,7 @@ public class InformationFetcher implements RemovalListener<ServerId,MetricRespon
           }
         }
         if (!firstIteration) {
-          // Update current messages on the Monitor that we are
+          // Update current alerts on the Monitor that we are
           // waiting on tasks to complete to complete a refresh
           final String waitingMsg = "Waiting on " + futures.size()
               + " tasks to complete. Time remaining before cancellation: "
@@ -859,9 +858,9 @@ public class InformationFetcher implements RemovalListener<ServerId,MetricRespon
               + " seconds";
           SystemInformation currentSummary = summaryRef.get();
           if (currentSummary != null) {
-            currentSummary.removeMessage(Info, Monitor,
+            currentSummary.removeAlert(Info, Monitor,
                 " tasks to complete. Time remaining before cancellation: ");
-            currentSummary.addMessage(Info, Monitor, waitingMsg);
+            currentSummary.addAlert(Info, Monitor, waitingMsg);
           }
         }
 

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/SystemInformation.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/SystemInformation.java
@@ -20,13 +20,13 @@ package org.apache.accumulo.monitor.next;
 
 import static com.google.common.base.Suppliers.memoize;
 import static org.apache.accumulo.core.metrics.MetricsInfo.QUEUE_TAG_KEY;
-import static org.apache.accumulo.monitor.next.SystemInformation.MessageCategory.Configuration;
-import static org.apache.accumulo.monitor.next.SystemInformation.MessageCategory.Monitor;
-import static org.apache.accumulo.monitor.next.SystemInformation.MessageCategory.Resource;
-import static org.apache.accumulo.monitor.next.SystemInformation.MessageCategory.Table;
-import static org.apache.accumulo.monitor.next.SystemInformation.MessagePriority.Critical;
-import static org.apache.accumulo.monitor.next.SystemInformation.MessagePriority.High;
-import static org.apache.accumulo.monitor.next.SystemInformation.MessagePriority.Info;
+import static org.apache.accumulo.monitor.next.SystemInformation.AlertCategory.Configuration;
+import static org.apache.accumulo.monitor.next.SystemInformation.AlertCategory.Monitor;
+import static org.apache.accumulo.monitor.next.SystemInformation.AlertCategory.Resource;
+import static org.apache.accumulo.monitor.next.SystemInformation.AlertCategory.Table;
+import static org.apache.accumulo.monitor.next.SystemInformation.AlertPriority.Critical;
+import static org.apache.accumulo.monitor.next.SystemInformation.AlertPriority.High;
+import static org.apache.accumulo.monitor.next.SystemInformation.AlertPriority.Info;
 
 import java.nio.ByteBuffer;
 import java.time.Duration;
@@ -387,11 +387,11 @@ public class SystemInformation {
   public record CompactionGroupSummary(String groupId, long running) {
   }
 
-  public enum MessagePriority {
+  public enum AlertPriority {
     Critical, High, Info;
   }
 
-  public enum MessageCategory {
+  public enum AlertCategory {
     Configuration, Monitor, Resource, Table;
   }
 
@@ -531,10 +531,9 @@ public class SystemInformation {
   private final Map<ResourceGroupId,Map<ServerId.Type,ProcessSummary>> deployment =
       new ConcurrentHashMap<>();
 
-  private final Map<MessagePriority,Map<MessageCategory,Set<String>>> messages =
-      new EnumMap<>(MessagePriority.class);
-  private final EnumMap<MessagePriority,AtomicLong> messageCounts =
-      new EnumMap<>(MessagePriority.class);
+  private final Map<AlertPriority,Map<AlertCategory,Set<String>>> alerts =
+      new EnumMap<>(AlertPriority.class);
+  private final EnumMap<AlertPriority,AtomicLong> alertCounts = new EnumMap<>(AlertPriority.class);
 
   private final Set<String> configuredCompactionResourceGroups = ConcurrentHashMap.newKeySet();
 
@@ -554,9 +553,7 @@ public class SystemInformation {
     this.ctx = ctx;
     this.rgLongRunningCompactionSize =
         this.ctx.getConfiguration().getCount(Property.MONITOR_LONG_RUNNING_COMPACTION_LIMIT);
-    for (MessagePriority p : MessagePriority.values()) {
-      messageCounts.put(p, new AtomicLong(0));
-    }
+    resetAlertCounts();
   }
 
   public void clear() {
@@ -580,7 +577,7 @@ public class SystemInformation {
     tables.clear();
     tablets.clear();
     deployment.clear();
-    messages.clear();
+    alerts.clear();
     runningCompactionsPerGroup.clear();
     runningCompactionsPerTable.clear();
     tableCompactions.clear();
@@ -590,32 +587,38 @@ public class SystemInformation {
     managerGoalState = null;
     serverMetricsView.clear();
     fateTransactions.clear();
-    messageCounts.clear();
+    resetAlertCounts();
   }
 
-  public void addMessage(MessagePriority pri, MessageCategory cat, String msg) {
-    messages.computeIfAbsent(pri, k -> new EnumMap<>(MessageCategory.class))
+  public void addAlert(AlertPriority pri, AlertCategory cat, String msg) {
+    alerts.computeIfAbsent(pri, k -> new EnumMap<>(AlertCategory.class))
         .computeIfAbsent(cat, k -> new TreeSet<>()).add(msg);
   }
 
-  public void removeMessage(MessagePriority pri, MessageCategory cat, String part) {
-    messages.getOrDefault(pri, new EnumMap<>(MessageCategory.class))
+  public void removeAlert(AlertPriority pri, AlertCategory cat, String part) {
+    alerts.getOrDefault(pri, new EnumMap<>(AlertCategory.class))
         .getOrDefault(cat, new HashSet<String>()).removeIf(s -> s.contains(part));
   }
 
-  private void computeMessageCounts() {
-    for (MessagePriority pri : MessagePriority.values()) {
+  private void resetAlertCounts() {
+    for (AlertPriority pri : AlertPriority.values()) {
+      alertCounts.computeIfAbsent(pri, k -> new AtomicLong(0)).set(0);
+    }
+  }
+
+  private void computeAlertCounts() {
+    for (AlertPriority pri : AlertPriority.values()) {
       long count = 0;
-      Map<MessageCategory,Set<String>> cats = messages.get(pri);
+      Map<AlertCategory,Set<String>> cats = alerts.get(pri);
       if (cats != null) {
-        for (MessageCategory cat : MessageCategory.values()) {
-          Set<String> msgs = cats.get(cat);
-          if (msgs != null) {
-            count += msgs.size();
+        for (AlertCategory cat : AlertCategory.values()) {
+          Set<String> messages = cats.get(cat);
+          if (messages != null) {
+            count += messages.size();
           }
         }
       }
-      messageCounts.get(pri).set(count);
+      alertCounts.get(pri).set(count);
     }
   }
 
@@ -825,21 +828,20 @@ public class SystemInformation {
             boolean recovering = getMetricValue(flatbuffer).longValue() > 0;
             this.recoveries.getOverview().setRootTabletRecovering(recovering);
             if (recovering) {
-              addMessage(Critical, Table, "The root table requires recovery");
+              addAlert(Critical, Table, "The root table requires recovery");
             }
           } else if (metricName.equals(Metric.MANAGER_META_TGW_RECOVERY.getName())) {
             long tablets = getMetricValue(flatbuffer).longValue();
             this.recoveries.getOverview().setMetadataTabletsRecovering(tablets);
             if (tablets > 0) {
-              addMessage(Critical, Table,
+              addAlert(Critical, Table,
                   "At least " + tablets + " metadata table tablets require recovery");
             }
           } else if (metricName.equals(Metric.MANAGER_USER_TGW_RECOVERY.getName())) {
             long tablets = getMetricValue(flatbuffer).longValue();
             this.recoveries.getOverview().setUserTabletsRecovering(tablets);
             if (tablets > 0) {
-              addMessage(High, Table,
-                  "At least " + tablets + " user table tablets require recovery");
+              addAlert(High, Table, "At least " + tablets + " user table tablets require recovery");
             }
           }
         }
@@ -954,11 +956,11 @@ public class SystemInformation {
     configuredCompactionResourceGroups.addAll(groups);
   }
 
-  private void computeMessages(final List<UpdateTaskFuture> failures,
+  private void computeAlerts(final List<UpdateTaskFuture> failures,
       final List<UpdateTaskFuture> cancelled) {
 
     if (failures.size() > 0) {
-      addMessage(High, Monitor,
+      addAlert(High, Monitor,
           "There were " + failures.size() + " failures in the last monitor update cycle."
               + " Information displayed may be out of date or missing.");
     }
@@ -969,7 +971,7 @@ public class SystemInformation {
       String message =
           "Fetching information for Monitor has taken longer than %1$d ms. (%2$d) tasks were cancelled."
               + " Information displayed may be out of date or missing. Resolve the issue causing this or increase property `%3$s`.";
-      addMessage(High, Monitor, String.format(message, monitorFetchTimeout, cancelled.size(),
+      addAlert(High, Monitor, String.format(message, monitorFetchTimeout, cancelled.size(),
           Property.MONITOR_FETCH_TIMEOUT.getKey()));
     }
 
@@ -978,11 +980,11 @@ public class SystemInformation {
     for (UpdateTaskFuture f : failures) {
       switch (f.task().getType()) {
         case COMPACTION:
-          addMessage(Info, Monitor,
+          addAlert(Info, Monitor,
               "The task to get information about currently running compactions failed");
           break;
         case COMPACTION_RGS:
-          addMessage(Info, Monitor,
+          addAlert(Info, Monitor,
               "The task to get information about configured compaction resource groups failed");
           break;
         case METRIC:
@@ -1001,11 +1003,11 @@ public class SystemInformation {
     for (UpdateTaskFuture f : cancelled) {
       switch (f.task().getType()) {
         case COMPACTION:
-          addMessage(Info, Monitor,
+          addAlert(Info, Monitor,
               "The task to get information about currently running compactions was cancelled");
           break;
         case COMPACTION_RGS:
-          addMessage(Info, Monitor,
+          addAlert(Info, Monitor,
               "The task to get information about configured compaction resource groups was cancelled");
           break;
         case METRIC:
@@ -1022,36 +1024,36 @@ public class SystemInformation {
     }
 
     if (failedOrCancelledServers.size() > 0) {
-      addMessage(High, Monitor, failedOrCancelledServers.size()
+      addAlert(High, Monitor, failedOrCancelledServers.size()
           + " tasks to get information from servers were failed or cancelled.");
-      addMessage(Info, Monitor,
+      addAlert(Info, Monitor,
           "The Monitor is not displaying updated information for the following servers: "
               + failedOrCancelledServers);
     }
 
     if (failedOrCancelledTables.size() > 0) {
-      addMessage(High, Monitor, failedOrCancelledTables.size()
+      addAlert(High, Monitor, failedOrCancelledTables.size()
           + " tasks to get information for tables were failed or cancelled.");
-      addMessage(Info, Monitor,
+      addAlert(Info, Monitor,
           "The Monitor is not displaying updated information for the following tables: "
               + failedOrCancelledTables);
     }
 
     if (managers.isEmpty()) {
-      addMessage(Critical, Resource, "No Managers are running");
+      addAlert(Critical, Resource, "No Managers are running");
     }
 
     if (gc.get() == null) {
-      addMessage(Critical, Resource, "Garbage Collector is not running");
+      addAlert(Critical, Resource, "Garbage Collector is not running");
     }
 
     if (problemHosts.size() > 0) {
-      addMessage(Info, Resource, "Monitor has not received a response from " + problemHosts.size()
+      addAlert(Info, Resource, "Monitor has not received a response from " + problemHosts.size()
           + " servers recently: " + problemHosts);
     }
 
     if (metricProblemHosts.size() > 0) {
-      addMessage(Info, Resource,
+      addAlert(Info, Resource,
           "Unable to gather information from " + metricProblemHosts.size() + " servers");
     }
 
@@ -1061,7 +1063,7 @@ public class SystemInformation {
       }
       if (!compactors.containsKey(rg.canonical()) && !sservers.containsKey(rg.canonical())
           && !tservers.containsKey(rg.canonical())) {
-        addMessage(Info, Configuration, "Resource Group " + rg
+        addAlert(Info, Configuration, "Resource Group " + rg
             + " exists, but no resources assigned. Consider removing the resource group with command `accumulo inst init --remove-resource-groups`");
       }
     }
@@ -1074,7 +1076,7 @@ public class SystemInformation {
         }
       }
       if (empty > 0) {
-        addMessage(Info, Table,
+        addAlert(Info, Table,
             "Table " + tid + " may have " + empty + " tablets that could be merged.");
       }
     });
@@ -1084,7 +1086,7 @@ public class SystemInformation {
       String balancerRG = tconf.get(TableLoadBalancer.TABLE_ASSIGNMENT_GROUP_PROPERTY);
       balancerRG = balancerRG == null ? Constants.DEFAULT_RESOURCE_GROUP_NAME : balancerRG;
       if (!tservers.containsKey(balancerRG)) {
-        addMessage(Critical, Table,
+        addAlert(Critical, Table,
             "Table " + table.tableName() + " configured to balance tablets in resource group "
                 + balancerRG + ", but there are no TabletServers.");
       }
@@ -1111,7 +1113,7 @@ public class SystemInformation {
       }
     }
     if (serversWithZombieScans > 0) {
-      addMessage(High, Resource,
+      addAlert(High, Resource,
           "There are " + serversWithZombieScans + " servers with zombie scan threads");
     }
 
@@ -1128,7 +1130,7 @@ public class SystemInformation {
         Number numQueued = getMetricValue(queued.orElseThrow());
         if (numQueued.longValue() > 0) {
           if (rgCompactors == null || rgCompactors.size() == 0) {
-            addMessage(Critical, Configuration, "Compactor group " + rg + " has "
+            addAlert(Critical, Configuration, "Compactor group " + rg + " has "
                 + numQueued.longValue() + " queued compactions but no running compactors");
           } else {
             // Check for idle compactors.
@@ -1143,7 +1145,7 @@ public class SystemInformation {
             if (idleMetric.isPresent()) {
               var metric = idleMetric.orElseThrow().getValue();
               if (metric.max() == 1.0D) {
-                addMessage(High, Resource,
+                addAlert(High, Resource,
                     "Compactor group " + rg + " has queued jobs and idle compactors.");
               }
             }
@@ -1155,7 +1157,7 @@ public class SystemInformation {
 
     for (var compactorGroup : compactors.keySet()) {
       if (!configuredCompactionResourceGroups.contains(compactorGroup)) {
-        addMessage(High, Configuration, "Compactor group " + compactorGroup
+        addAlert(High, Configuration, "Compactor group " + compactorGroup
             + " has running compactors, but no configuration uses them.");
       }
     }
@@ -1171,7 +1173,7 @@ public class SystemInformation {
           .computeIfAbsent(serverId.getType(), t -> new ProcessSummary()).addNotResponded(serverId);
     });
 
-    computeMessages(failures, cancelled);
+    computeAlerts(failures, cancelled);
 
     timestamp.set(System.currentTimeMillis());
     componentStatuses.clear();
@@ -1227,7 +1229,7 @@ public class SystemInformation {
       }
     }
     deploymentOverview = DeploymentOverview.fromSummary(deployment, timestamp);
-    computeMessageCounts();
+    computeAlertCounts();
   }
 
   public Set<String> getResourceGroups() {
@@ -1395,16 +1397,16 @@ public class SystemInformation {
     return this.deploymentOverview;
   }
 
-  public Map<MessagePriority,Map<MessageCategory,Set<String>>> getMessages() {
-    return this.messages;
+  public Map<AlertPriority,Map<AlertCategory,Set<String>>> getAlerts() {
+    return this.alerts;
   }
 
   public List<FateTransaction> getFateTransactions() {
     return this.fateTransactions;
   }
 
-  public Map<MessagePriority,AtomicLong> getMessageCounts() {
-    return this.messageCounts;
+  public Map<AlertPriority,AtomicLong> getAlertCounts() {
+    return this.alertCounts;
   }
 
   public long getTimestamp() {

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/view/WebViews.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/view/WebViews.java
@@ -163,20 +163,20 @@ public class WebViews {
   }
 
   /**
-   * Returns the messages template
+   * Returns the alerts template
    *
-   * @return Messages model
+   * @return Alerts model
    */
   @GET
-  @Path("messages")
+  @Path("alerts")
   @Template(name = "/default.ftl")
-  public Map<String,Object> getMessages() {
+  public Map<String,Object> getAlerts() {
 
     Map<String,Object> model = getModel();
-    model.put("title", "Messages"); // Need this for the browser tab title
-    model.put("tablesTitle", "Messages");
-    model.put("template", "messages.ftl");
-    model.put("js", "messages.js");
+    model.put("title", "Alerts"); // Need this for the browser tab title
+    model.put("tablesTitle", "Alerts");
+    model.put("template", "alerts.ftl");
+    model.put("js", "alerts.js");
     return model;
   }
 

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/alerts.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/alerts.js
@@ -18,52 +18,52 @@
  */
 "use strict";
 
-const messageHtmlTable = '#messagesTable';
+const alertHtmlTable = '#alertsTable';
 
 var dataTableRef;
 var categories;
 
 function fetchTableData() {
 
-  var highSwitchId = "msg-pri-switch-High";
+  var highSwitchId = "alert-pri-switch-High";
   var savedValue = localStorage.getItem(highSwitchId + "-state");
   var high = false;
   if (savedValue === null || savedValue === 'true') {
     high = true;
   }
 
-  var InfoSwitchId = "msg-pri-switch-Info";
-  savedValue = localStorage.getItem(InfoSwitchId + "-state");
+  var infoSwitchId = "alert-pri-switch-Info";
+  savedValue = localStorage.getItem(infoSwitchId + "-state");
   var info = false;
   if (savedValue === null || savedValue === 'true') {
     info = true;
   }
 
-  var categories = getStoredArray(MESSAGE_CATEGORIES);
+  var categories = getStoredArray(ALERT_CATEGORIES);
   if (categories.length === 0) {
-    sessionStorage.setItem(MESSAGES, JSON.stringify([]));
+    sessionStorage.setItem(ALERTS, JSON.stringify([]));
     return $.Deferred().resolve().promise();
   }
 
   var cats = [];
   $.each(categories, function (index, cat) {
-    var savedValue = localStorage.getItem("msg-cat-switch-" + cat + "-state");
+    var savedValue = localStorage.getItem("alert-cat-switch-" + cat + "-state");
     if (savedValue === null || savedValue === 'true') {
       cats.push(cat);
     }
   });
-  return getMessages(high, info, cats);
+  return getAlerts(high, info, cats);
 }
 
 function getTableData() {
-  return getStoredArray(MESSAGES);
+  return getStoredArray(ALERTS);
 }
 
-function loadMessagesPageData() {
+function loadAlertsPageData() {
 
-  categories = getStoredArray(MESSAGE_CATEGORIES);
+  categories = getStoredArray(ALERT_CATEGORIES);
   if (categories.length === 0) {
-    return getMessageCategories().then(function () {
+    return getAlertCategories().then(function () {
       return fetchTableData();
     });
   } else {
@@ -72,7 +72,7 @@ function loadMessagesPageData() {
 }
 
 function refresh() {
-  return loadMessagesPageData().then(function () {
+  return loadAlertsPageData().then(function () {
     if (dataTableRef) {
       ajaxReloadTable(dataTableRef);
     }
@@ -80,7 +80,7 @@ function refresh() {
 }
 
 function createDataTable() {
-  dataTableRef = $(messageHtmlTable).DataTable({
+  dataTableRef = $(alertHtmlTable).DataTable({
     "autoWidth": false,
     "ajax": function (data, callback) {
       callback({
@@ -107,7 +107,7 @@ function createDataTable() {
 }
 
 $(function () {
-  loadMessagesPageData().then(function () {
+  loadAlertsPageData().then(function () {
     createDataTable();
   });
 });

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
@@ -38,10 +38,10 @@ var STATUS_REQUEST = null;
 const RUNNING_COMPACTIONS_BY_TABLE = 'runningCompactionsByTable';
 const RUNNING_COMPACTIONS_BY_GROUP = 'runningCompactionsByGroup';
 const AUTO_REFRESH_KEY = 'auto-refresh';
-const MESSAGE_CATEGORIES = 'messageCategories';
-const MESSAGES = 'messages';
 const FATE = 'fate';
-const MESSAGE_COUNTS = 'messageCounts'
+const ALERT_CATEGORIES = 'alertCategories';
+const ALERTS = 'alerts';
+const ALERT_COUNTS = 'alertCounts';
 const RECOVERY = 'recovery';
 
 // Override Length Menu options for dataTables
@@ -542,28 +542,28 @@ function getTserversSummary(group) {
 }
 
 /**
- * REST GET call for /message/categories
+ * REST GET call for /alerts/categories
  * store it on a sessionStorage variable
  */
-function getMessageCategories() {
-  return getJSONForTable(REST_V2_PREFIX + '/message/categories', MESSAGE_CATEGORIES);
+function getAlertCategories() {
+  return getJSONForTable(REST_V2_PREFIX + '/alerts/categories', ALERT_CATEGORIES);
 }
 
 /**
- * REST GET call for /message/counts
+ * REST GET call for /alerts/counts
  * store it on a sessionStorage variable
  */
-function getMessageCounts() {
-  return getJSONForTable(REST_V2_PREFIX + '/message/counts', MESSAGE_COUNTS);
+function getAlertCounts() {
+  return getJSONForTable(REST_V2_PREFIX + '/alerts/counts', ALERT_COUNTS);
 }
 
 /**
- * REST GET call for /messages,
+ * REST GET call for /alerts,
  * results are not stored in session as this
  * function takes parameters driven by toggles
  * in the UI.
  */
-function getMessages(high, info, cats) {
+function getAlerts(high, info, cats) {
 
   const params = new URLSearchParams();
   params.append('high', high);
@@ -572,8 +572,8 @@ function getMessages(high, info, cats) {
     params.append('category', cat);
   });
 
-  var call = REST_V2_PREFIX + '/messages?' + params.toString();
-  return getJSONForTable(call, MESSAGES);
+  var call = REST_V2_PREFIX + '/alerts?' + params.toString();
+  return getJSONForTable(call, ALERTS);
 }
 
 /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
@@ -150,18 +150,18 @@ function updateServerNotifications(statusData) {
 $(function () {
   setTheme();
   updateDarkThemeSwitch();
-  updateMessagePriorities();
+  updateAlertPriorities();
   refreshSidebar();
-  refreshMessageBadge();
+  refreshAlertBadge();
 
-  categories = getStoredArray(MESSAGE_CATEGORIES);
+  categories = getStoredArray(ALERT_CATEGORIES);
   if (categories.length === 0) {
-    getMessageCategories().then(function () {
-      categories = getStoredArray(MESSAGE_CATEGORIES);
-      updateMessageCategories();
+    getAlertCategories().then(function () {
+      categories = getStoredArray(ALERT_CATEGORIES);
+      updateAlertCategories();
     });
   } else {
-    updateMessageCategories();
+    updateAlertCategories();
   }
 });
 
@@ -179,7 +179,7 @@ function refreshSidebar() {
  */
 function refreshNavBar() {
   refreshSidebar();
-  refreshMessageBadge();
+  refreshAlertBadge();
 }
 
 /**
@@ -238,41 +238,41 @@ function updateDarkThemeSwitch() {
 }
 
 /**
- * Updates the badge on the Messages label on the Nav Bar
+ * Updates the badge on the Alerts label on the Nav Bar
  */
-function refreshMessageBadge() {
-  getMessageCounts().then(function () {
+function refreshAlertBadge() {
+  getAlertCounts().then(function () {
 
-    var messageAnchor = $('#message-anchor');
+    var alertAnchor = $('#alert-anchor');
 
-    var msgCounts = getStoredJson(MESSAGE_COUNTS, {
+    var alertCounts = getStoredJson(ALERT_COUNTS, {
       "Critical": 0,
       "High": 0,
       "Info": 0
     });
-    var critMsgCount = msgCounts.Critical;
-    var highMsgCount = msgCounts.High;
+    var criticalAlertCount = alertCounts.Critical;
+    var highAlertCount = alertCounts.High;
 
-    messageAnchor.find('span').remove();
+    alertAnchor.find('span').remove();
 
-    if (critMsgCount > 0) {
-      messageAnchor.append('<span class="badge position-relative top-0 start-0 translate-middle-y rounded-pill bg-danger">' +
-        critMsgCount + '</span>');
-    } else if (highMsgCount > 0) {
-      messageAnchor.append(
+    if (criticalAlertCount > 0) {
+      alertAnchor.append('<span class="badge position-relative top-0 start-0 translate-middle-y rounded-pill bg-danger">' +
+        criticalAlertCount + '</span>');
+    } else if (highAlertCount > 0) {
+      alertAnchor.append(
         '<span class="badge position-relative top-0 start-0 translate-middle-y rounded-pill bg-warning">' +
-        highMsgCount + '</span>');
+        highAlertCount + '</span>');
     }
   });
 }
 
 /**
- * Update the High and Info Message Category Switches
+ * Update the High and Info Alert Priority Switches
  */
-function updateMessagePriorities() {
-  var messagePriorities = ['High', 'Info'];
-  $.each(messagePriorities, function (index, pri) {
-    var switchId = "msg-pri-switch-" + pri;
+function updateAlertPriorities() {
+  var alertPriorities = ['High', 'Info'];
+  $.each(alertPriorities, function (index, pri) {
+    var switchId = "alert-pri-switch-" + pri;
     var switchElement = "#" + switchId;
     var savedValue = localStorage.getItem(switchId + "-state");
 
@@ -284,8 +284,8 @@ function updateMessagePriorities() {
     }
 
     $(switchElement).on("change", function () {
-      localStorage.setItem("msg-pri-switch-" + pri + "-state", $(this).is(':checked'));
-      if (window.location.pathname.endsWith('/messages')) {
+      localStorage.setItem("alert-pri-switch-" + pri + "-state", $(this).is(':checked'));
+      if (window.location.pathname.endsWith('/alerts')) {
         refresh();
       }
     });
@@ -293,15 +293,15 @@ function updateMessagePriorities() {
 }
 
 /**
- * Update the High and Info Message Category Switches
+ * Update the Alert Category Switches
  */
-function updateMessageCategories() {
-  const messageCategoryList = '#categories-list';
+function updateAlertCategories() {
+  const alertCategoryList = '#categories-list';
 
-  var categoryList = $(messageCategoryList);
+  var categoryList = $(alertCategoryList);
   $.each(categories, function (index, cat) {
 
-    var switchId = "msg-cat-switch-" + cat;
+    var switchId = "alert-cat-switch-" + cat;
     var switchElement = "#" + switchId;
     var savedValue = localStorage.getItem(switchId + "-state");
 
@@ -335,8 +335,8 @@ function updateMessageCategories() {
       }
 
       input.on("change", function () {
-        localStorage.setItem("msg-cat-switch-" + cat + "-state", $(this).is(':checked'));
-        if (window.location.pathname.endsWith('/messages')) {
+        localStorage.setItem("alert-cat-switch-" + cat + "-state", $(this).is(':checked'));
+        if (window.location.pathname.endsWith('/alerts')) {
           refresh();
         }
       });

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/alerts.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/alerts.ftl
@@ -27,7 +27,7 @@
           <tr>
             <th class="col-xs-2">Priority</th>
             <th class="col-xs-2">Category</th>
-            <th class="col-xs-8">Alert</th>
+            <th class="col-xs-8">Message</th>
           </tr>
         </thead>
         <tbody></tbody>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/alerts.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/alerts.ftl
@@ -19,15 +19,15 @@
 
 -->
     <br />
-    <div class="col-xs-12" id="messages">
-      <h5>Messages</h5>
-      <table id="messagesTable"
+    <div class="col-xs-12" id="alerts">
+      <h5>Alerts</h5>
+      <table id="alertsTable"
         class="table table-bordered table-striped table-condensed" style="width: 100%;">
         <thead>
           <tr>
             <th class="col-xs-2">Priority</th>
             <th class="col-xs-2">Category</th>
-            <th class="col-xs-8">Message</th>
+            <th class="col-xs-8">Alert</th>
           </tr>
         </thead>
         <tbody></tbody>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/navbar.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/navbar.ftl
@@ -63,7 +63,7 @@
               </ul>
             </li>
             <li>
-              <a id="message-anchor" class="nav-link" aria-current="page" href="messages">Messages</a>
+              <a id="alert-anchor" class="nav-link" aria-current="page" href="alerts">Alerts</a>
             </li>            
             <li class="dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown"
@@ -98,25 +98,25 @@
                   </div>
                 </li>
                 <li><hr class="dropdown-divider"></li>
-                <li><h6 class="dropdown-header fw-semibold pb-1">Message Priorities</h6></li>
+                <li><h6 class="dropdown-header fw-semibold pb-1">Alert Priorities</h6></li>
                 <li>
                   <div class="dropdown-item d-flex justify-content-between align-items-center small">
-                    <label class="form-check-label" for="msg-pri-switch-High">High</label>
+                    <label class="form-check-label" for="alert-pri-switch-High">High</label>
                     <div class="form-check form-switch d-flex align-items-center mb-0 p-0 fs-6">
-                      <input id="msg-pri-switch-High" class="form-check-input float-none m-0" type="checkbox" role="switch">
+                      <input id="alert-pri-switch-High" class="form-check-input float-none m-0" type="checkbox" role="switch">
                     </div>
                   </div>
                 </li>
                 <li>
                   <div class="dropdown-item d-flex justify-content-between align-items-center small">
-                    <label class="form-check-label" for="msg-pri-switch-Info">Info</label>
+                    <label class="form-check-label" for="alert-pri-switch-Info">Info</label>
                     <div class="form-check form-switch d-flex align-items-center mb-0 p-0 fs-6">
-                      <input id="msg-pri-switch-Info" class="form-check-input float-none m-0" type="checkbox" role="switch">
+                      <input id="alert-pri-switch-Info" class="form-check-input float-none m-0" type="checkbox" role="switch">
                     </div>
                   </div>
                 </li>
                 <li><hr class="dropdown-divider"></li>
-                <li><h6 class="dropdown-header fw-semibold pb-1">Message Categories</h6></li>
+                <li><h6 class="dropdown-header fw-semibold pb-1">Alert Categories</h6></li>
                 <div id="categories-list">
                 </div>
                 <li><hr class="dropdown-divider"></li>


### PR DESCRIPTION
Fixes #6380

Refactors the feature added in #6346 to replace "Message" with "Alert" in both the UI and the supporting code. This does not change any functionality and is purely a renaming pass.

Here is a screenshot of the Alerts page with the settings dropdown open:

<img width="1828" height="802" alt="image" src="https://github.com/user-attachments/assets/f0a4d60b-cc4f-4380-9be2-ac98ca424e53" />
