### PR TITLE
Add critical alert banner to Monitor UI

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/css/screen.css
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/css/screen.css
@@ -71,6 +71,22 @@ body {
   width: 90%;
 }
 
+.critical-alert-banner {
+  align-items: center;
+  border-radius: 0;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  margin: 0;
+  text-align: center;
+  text-decoration: none;
+}
+
+.critical-alert-banner:hover,
+.critical-alert-banner:focus {
+  text-decoration: none;
+}
+
 h1 {
   font-size: 2.2em;
   text-align: center;

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
@@ -245,7 +245,7 @@ function refreshAlerts() {
 
     const alertAnchor = $('#alert-anchor');
     const criticalAlertBanner = $('#critical-alert-banner');
-    const criticalAlertCountElement = $('#critical-alert-count');
+    const criticalAlertMessageElement = $('#critical-alert-message');
 
     const alertCounts = getStoredJson(ALERT_COUNTS, {
       "Critical": 0,
@@ -267,7 +267,8 @@ function refreshAlerts() {
     }
 
     if (criticalAlertCount > 0 && !window.location.pathname.endsWith('/alerts')) {
-      criticalAlertCountElement.text(criticalAlertCount);
+      const alertLabel = criticalAlertCount <= 1 ? 'alert' : 'alerts';
+      criticalAlertMessageElement.text(criticalAlertCount + ' critical ' + alertLabel + ' present');
       criticalAlertBanner.removeClass('d-none');
     } else {
       criticalAlertBanner.addClass('d-none');

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
@@ -152,7 +152,7 @@ $(function () {
   updateDarkThemeSwitch();
   updateAlertPriorities();
   refreshSidebar();
-  refreshAlertBadge();
+  refreshAlerts();
 
   categories = getStoredArray(ALERT_CATEGORIES);
   if (categories.length === 0) {
@@ -179,7 +179,7 @@ function refreshSidebar() {
  */
 function refreshNavBar() {
   refreshSidebar();
-  refreshAlertBadge();
+  refreshAlerts();
 }
 
 /**
@@ -238,20 +238,22 @@ function updateDarkThemeSwitch() {
 }
 
 /**
- * Updates the badge on the Alerts label on the Nav Bar
+ * Updates the badge on the Alerts label on the Nav Bar and the global critical alert banner
  */
-function refreshAlertBadge() {
+function refreshAlerts() {
   getAlertCounts().then(function () {
 
-    var alertAnchor = $('#alert-anchor');
+    const alertAnchor = $('#alert-anchor');
+    const criticalAlertBanner = $('#critical-alert-banner');
+    const criticalAlertCountElement = $('#critical-alert-count');
 
-    var alertCounts = getStoredJson(ALERT_COUNTS, {
+    const alertCounts = getStoredJson(ALERT_COUNTS, {
       "Critical": 0,
       "High": 0,
       "Info": 0
     });
-    var criticalAlertCount = alertCounts.Critical;
-    var highAlertCount = alertCounts.High;
+    const criticalAlertCount = alertCounts.Critical;
+    const highAlertCount = alertCounts.High;
 
     alertAnchor.find('span').remove();
 
@@ -262,6 +264,13 @@ function refreshAlertBadge() {
       alertAnchor.append(
         '<span class="badge position-relative top-0 start-0 translate-middle-y rounded-pill bg-warning">' +
         highAlertCount + '</span>');
+    }
+
+    if (criticalAlertCount > 0 && !window.location.pathname.endsWith('/alerts')) {
+      criticalAlertCountElement.text(criticalAlertCount);
+      criticalAlertBanner.removeClass('d-none');
+    } else {
+      criticalAlertBanner.addClass('d-none');
     }
   });
 }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/default.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/default.ftl
@@ -76,6 +76,15 @@
   <body>
     <#include "navbar.ftl">
 
+    <a id="critical-alert-banner" class="critical-alert-banner alert alert-danger d-none" href="alerts" aria-live="polite">
+      <span>
+        <i class="bi bi-exclamation-triangle-fill" aria-hidden="true"></i>
+        <strong>Critical alerts are present:</strong>
+        <span id="critical-alert-count">0</span>
+      </span>
+      <span class="btn btn-danger btn-sm fw-semibold">View alerts</span>
+    </a>
+
     <div id="main" class="container-fluid">
       <#include "${template}">
     </div>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/default.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/default.ftl
@@ -79,8 +79,7 @@
     <a id="critical-alert-banner" class="critical-alert-banner alert alert-danger d-none" href="alerts" aria-live="polite">
       <span>
         <i class="bi bi-exclamation-triangle-fill" aria-hidden="true"></i>
-        <strong>Critical alerts are present:</strong>
-        <span id="critical-alert-count">0</span>
+        <strong id="critical-alert-message">0 critical alerts present</strong>
       </span>
       <span class="btn btn-danger btn-sm fw-semibold">View alerts</span>
     </a>


### PR DESCRIPTION
Fixes #6384 

This PR adds a banner to all monitor pages (except the Alerts page) when critical alerts are present.

The whole banner is clickable.

<img width="1708" height="398" alt="Screenshot_2026-05-21_13-10-10" src="https://github.com/user-attachments/assets/eccde1fa-32da-488f-b0fb-8d0477d4a01e" />
<img width="1708" height="533" alt="Screenshot_2026-05-21_13-10-27" src="https://github.com/user-attachments/assets/bd5207fb-4d17-4fdc-91c0-1753c90181aa" />
