### PR TITLE
Dead tables always render on tserver monitor page

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/tservers.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/tservers.js
@@ -306,16 +306,7 @@ $(document).ready(function () {
           return data;
         }
       }
-    ],
-  // Hide the dead tablet servers table when none are reported
-    "drawCallback": function () {
-        if (this.api().rows().data().length === 0) {
-          $('#deadtservers_wrapper').hide();
-        }
-        else {
-          $('#deadtservers_wrapper').show();
-        }
-    }
+    ]
   });
 
   // Create a table for badServers list

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/tservers.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/tservers.js
@@ -307,15 +307,14 @@ $(document).ready(function () {
         }
       }
     ],
-
-  // Only show the table if there are non-empty rows
+  // Hide the dead tablet servers table when none are reported
     "drawCallback": function () {
         if (this.api().rows().data().length === 0) {
           $('#deadtservers_wrapper').hide();
         }
         else {
           $('#deadtservers_wrapper').show();
-          }
+        }
     }
   });
 

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/tservers.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/tservers.js
@@ -75,12 +75,6 @@ function refreshTServersTable() {
 function refreshDeadTServersTable() {
   ajaxReloadTable(deadTServersTable);
 
-  // Only show the table if there are non-empty rows
-  if ($('#deadtservers tbody .dataTables_empty').length) {
-    $('#deadtservers_wrapper').hide();
-  } else {
-    $('#deadtservers_wrapper').show();
-  }
 }
 
 /**
@@ -312,7 +306,17 @@ $(document).ready(function () {
           return data;
         }
       }
-    ]
+    ],
+
+  // Only show the table if there are non-empty rows
+    "drawCallback": function () {
+        if (this.api().rows().data().length === 0) {
+          $('#deadtservers_wrapper').hide();
+        }
+        else {
+          $('#deadtservers_wrapper').show();
+          }
+    }
   });
 
   // Create a table for badServers list


### PR DESCRIPTION
closes [issue #6379 ](https://github.com/apache/accumulo/issues/6379)

Added a `drawCallback` function to the Dead Tablet Servers DataTable initialization so that the table's visibility is explicitly toggled based on whether it has rows to display. 