### PR TITLE
Make font larger in Monitor overview matrix badges

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/css/screen.css
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/css/screen.css
@@ -320,8 +320,10 @@ pre.logevent {
 }
 
 .deployment-count-badge {
-  min-width: 2.35rem;
-  padding: 0.3em 0.55em;
+  --bs-badge-font-size: 1em;
+  --bs-badge-padding-x: 0.65em;
+  --bs-badge-padding-y: 0.2em;
+  min-width: 2rem;
   color: #333333;
   font-variant-numeric: tabular-nums;
 }


### PR DESCRIPTION
Fixes #6368 

This increases the font of the text within the badges from 9px -> 12px. For reference the header font is 13.333px

Before:
<img width="963" height="123" alt="Screenshot_2026-05-28_12-51-16cropped" src="https://github.com/user-attachments/assets/267e2263-3cbb-40cb-9fba-ad0538d8b92b" />
After:
<img width="969" height="129" alt="Screenshot_2026-05-28_14-02-53" src="https://github.com/user-attachments/assets/5f44f16d-8ca0-41e5-a82a-c3c349fddc05" />
