### PR TITLE
Modified Monitor to always show table structure

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/coordinator.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/coordinator.js
@@ -49,10 +49,6 @@ function refresh() {
     refreshTable(queuesHtmlTable, COORDINATOR_QUEUE_PROCESS_VIEW);
     ajaxReloadTable(tableRunning);
     ajaxReloadTable(queueRunning);
-    $(coordinatorHtmlTable).hide();
-    $(queuesHtmlTable).hide();
-    $(runningTableHtmlTable).hide();
-    $(runningQueueHtmlTable).hide();
   });
 }
 

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/ec.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/ec.js
@@ -290,6 +290,7 @@ $(function () {
     }
   });
 
+  refreshManagerStatus();
   refreshRunningCompactions();
 });
 
@@ -297,6 +298,7 @@ $(function () {
  * Used to redraw the page
  */
 function refresh() {
+  refreshManagerStatus();
   refreshRunningCompactions();
 }
 
@@ -304,10 +306,8 @@ function refresh() {
  * Refreshes the running compactions
  */
 function refreshRunningCompactions() {
-  refreshManagerStatus().then(function (managerStatus) {
-    // user paging is not reset on reload
-    ajaxReloadTable(runningTable);
-  });
+  // user paging is not reset on reload
+  ajaxReloadTable(runningTable);
 }
 
 /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/ec.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/ec.js
@@ -307,6 +307,7 @@ function refreshRunningCompactions() {
   refreshManagerStatus().then(function (managerStatus) {
     // tables will not be shown, avoid reloading
     if (managerStatus === 'ERROR') {
+      runningTable.clear().draw();
       return;
     }
 
@@ -316,20 +317,15 @@ function refreshRunningCompactions() {
 }
 
 /**
- * Updates session storage then checks if the manager is running. If it is,
- * show the tables and hide the 'manager not running' banner. Else, vice-versa.
+ * Updates session storage then checks if the manager is running and updates the banner.
  */
 async function refreshManagerStatus() {
   return getStatus().then(function () {
     var managerStatus = getComponentStatus(getStoredStatusData(), 'MANAGER');
     if (managerStatus === 'ERROR') {
-      // show banner and hide tables
       $('#managerBanner').show();
-      $('#runningDiv').hide();
     } else {
-      // otherwise, hide banner and show tables
       $('#managerBanner').hide();
-      $('#runningDiv').show();
     }
     return managerStatus;
   });

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/ec.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/ec.js
@@ -305,12 +305,6 @@ function refresh() {
  */
 function refreshRunningCompactions() {
   refreshManagerStatus().then(function (managerStatus) {
-    // tables will not be shown, avoid reloading
-    if (managerStatus === 'ERROR') {
-      runningTable.clear().draw();
-      return;
-    }
-
     // user paging is not reset on reload
     ajaxReloadTable(runningTable);
   });

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/manager.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/manager.js
@@ -45,13 +45,9 @@ function refreshManagerBanners() {
   if (!Array.isArray(managerRows) || managerRows.length === 0) {
     // show the manager error banner and hide manager table
     $(runningBanner).show();
-    $(htmlTable).hide();
-    $(fateHtmlTable).hide();
   } else {
     // otherwise, hide the error banner and show manager table
     $(runningBanner).hide();
-    $(fateHtmlTable).show();
-    $(htmlTable).show();
   }
   updateManagerGoalStateBanner();
 }
@@ -74,8 +70,6 @@ function refresh() {
     refreshTable(htmlTable, MANAGER_SERVER_PROCESS_VIEW);
     refreshTable(fateHtmlTable, MANAGER_FATE_SERVER_PROCESS_VIEW);
     $(runningBanner).show();
-    $(htmlTable).hide();
-    $(fateHtmlTable).hide();
     $(managerStateBanner).hide();
     showBannerError(htmlBanner, htmlBannerMessage);
   });

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/manager.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/manager.js
@@ -43,10 +43,8 @@ function updateManagerGoalStateBanner() {
 function refreshManagerBanners() {
   var managerRows = getStoredRows(MANAGER_SERVER_PROCESS_VIEW);
   if (!Array.isArray(managerRows) || managerRows.length === 0) {
-    // show the manager error banner and hide manager table
     $(runningBanner).show();
   } else {
-    // otherwise, hide the error banner and show manager table
     $(runningBanner).hide();
   }
   updateManagerGoalStateBanner();

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/recovery.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/recovery.js
@@ -52,14 +52,6 @@ function getReplaying() {
   return getStoredView(RECOVERY).serversRecoveringTablets;
 }
 
-function showOrHide(divElement, dataArray) {
-  if (dataArray.length == 0) {
-    $(divElement).hide();
-  } else {
-    $(divElement).show();
-  }
-}
-
 function refresh() {
   $.when(getRecoveryInformation()).then(function () {
     ajaxReloadTable(overviewDataTable);
@@ -82,10 +74,6 @@ function refresh() {
     ajaxReloadTable(sortingDataTable);
     ajaxReloadTable(replayingDataTable);
   });
-  showOrHide(overviewTableDivElement, getOverview());
-  showOrHide(tabletRecoveryDivElement, getTablets());
-  showOrHide(sortingServersDivElement, getSorting());
-  showOrHide(replayingServersDivElement, getReplaying());
 }
 
 $(function () {

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/tservers.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/tservers.js
@@ -32,11 +32,9 @@ function refreshTServersBanner() {
     if (getComponentStatus(statusData, 'MANAGER') === 'ERROR') {
       $('#tserversManagerBanner').show();
       $(htmlBanner).hide();
-      $('#tservers_wrapper').hide();
       $('#recovery-caption').hide();
     } else {
       $('#tserversManagerBanner').hide();
-      $('#tservers_wrapper').show();
     }
   });
 }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/ec.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/ec.ftl
@@ -23,7 +23,7 @@
           <h3>${title}</h3>
         </div>
       </div>
-      <div id="runningDiv" style="display: none;">
+      <div id="runningDiv">
         <div class="row">
           <div class="col-xs-12">
             <table id="runningTable" class="table caption-top table-bordered table-striped table-condensed">


### PR DESCRIPTION
This change modifies the Monitor to always show the structure of the tables on the page, even if they are empty.