### PR TITLE
Use the correct variable when printing fate op merge message

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
@@ -466,7 +466,7 @@ class FateServiceHandler implements FateService.Iface {
         }
 
         String startRowStr = StringUtils.defaultIfBlank(startRow.toString(), "-inf");
-        String endRowStr = StringUtils.defaultIfBlank(startRow.toString(), "+inf");
+        String endRowStr = StringUtils.defaultIfBlank(endRow.toString(), "+inf");
 
         Manager.log.debug("Creating merge op: {} from startRow: {} to endRow: {}", tableId,
             startRowStr, endRowStr);


### PR DESCRIPTION
The merge command should be returning the start and end rows for the merge op message.
However, if a user only defined an `endRow` arg, then the op message would state that they were merging "-inf" to "+inf".

If a user did specify a startRow, then the code would just show that start row twice.


