### PR TITLE
Updates command description statements

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
@@ -269,7 +269,9 @@ public interface TableOperations {
 
   /**
    * @param tableName the name of the table
-   * @param maxSplits specifies the maximum number of splits to return
+   * @param maxSplits specifies the maximum number of selected splits to return. The selection of
+   *        split points is defined by the implementation and may not always be in immediate
+   *        sequential order.
    * @throws AccumuloException if a general error occurs
    * @throws AccumuloSecurityException if the user does not have permission
    * @return the split points (end-row names) for the table's current split profile, grouped into

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ZooKeeperMain.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ZooKeeperMain.java
@@ -56,7 +56,7 @@ public class ZooKeeperMain implements KeywordExecutable {
 
   @Override
   public String description() {
-    return "Starts an Apache Zookeeper client rooted at the current instance.";
+    return "Starts an Apache ZooKeeper client rooted at the current instance";
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ZooKeeperMain.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ZooKeeperMain.java
@@ -56,7 +56,7 @@ public class ZooKeeperMain implements KeywordExecutable {
 
   @Override
   public String description() {
-    return "Starts Apache Zookeeper instance";
+    return "Starts Apache Zookeeper session set to root of the configured accumulo instance";
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ZooKeeperMain.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ZooKeeperMain.java
@@ -56,7 +56,7 @@ public class ZooKeeperMain implements KeywordExecutable {
 
   @Override
   public String description() {
-    return "Starts Apache Zookeeper session set to root of the configured accumulo instance";
+    return "Starts an Apache Zookeeper client rooted at the current instance.";
   }
 
   @Override

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/GetSplitsCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/GetSplitsCommand.java
@@ -90,7 +90,7 @@ public class GetSplitsCommand extends Command {
           if (TabletColumnFamily.PREV_ROW_COLUMN.hasColumns(next.getKey())) {
             KeyExtent extent = KeyExtent.fromMetaPrevRow(next);
             final String obscured = extent.obscured();
-            if (matches.size() == 0 || matches.contains(obscured)) {
+            if (matches.isEmpty() || matches.contains(obscured)) {
               final String pr = encode(encode, extent.prevEndRow());
               final String er = encode(encode, extent.endRow());
               final String line =
@@ -139,8 +139,8 @@ public class GetSplitsCommand extends Command {
     outputFileOpt = new Option("o", "output", true, "local file to write the splits to");
     outputFileOpt.setArgName("file");
 
-    maxSplitsOpt =
-        new Option("m", "max", true, "maximum number of splits to return (evenly spaced)");
+    maxSplitsOpt = new Option("m", "max", true, "maximum number of splits to return that are "
+        + "\"evenly\" selected from the existing splits based upon the algorithm implemented in TableOperations.listSplits");
     maxSplitsOpt.setArgName("num");
 
     base64Opt = new Option("b64", "base64encoded", false, "encode the split points");

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/GetSplitsCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/GetSplitsCommand.java
@@ -139,8 +139,8 @@ public class GetSplitsCommand extends Command {
     outputFileOpt = new Option("o", "output", true, "local file to write the splits to");
     outputFileOpt.setArgName("file");
 
-    maxSplitsOpt = new Option("m", "max", true, "maximum number of splits to return that are "
-        + "\"evenly\" selected from the existing splits based upon the algorithm implemented in TableOperations.listSplits");
+    maxSplitsOpt = new Option("m", "max", true, "maximum number of splits to return that are"
+        + " selected from the existing splits; see TableOperations.listSplits");
     maxSplitsOpt.setArgName("num");
 
     base64Opt = new Option("b64", "base64encoded", false, "encode the split points");


### PR DESCRIPTION
Updates the ./accumulo zookeeper command description to be less vauge about the "Zookeeper instance".

Updates the "(evenly spaced)" message from the `getSplits` command in the shell to describe what that actually means.