### PR TITLE
Remove Experimental property feature flag

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -996,11 +996,6 @@ public enum Property {
       "The number of threads used to delete write-ahead logs and recovery files.", "2.1.4"),
   GC_DELETE_THREADS("gc.threads.delete", "16", PropertyType.COUNT,
       "The number of threads used to delete RFiles.", "1.3.5"),
-  @Experimental
-  GC_REMOVE_IN_USE_CANDIDATES("gc.remove.in.use.candidates", "false", PropertyType.BOOLEAN,
-      "GC will remove deletion candidates that are in-use from the metadata location. "
-          + "This is expected to increase the speed of subsequent GC runs.",
-      "2.1.3"),
   @Deprecated(since = "2.1.1", forRemoval = true)
   GC_TRASH_IGNORE("gc.trash.ignore", "false", PropertyType.BOOLEAN,
       "Do not use the Trash, even if it is configured.", "1.5.0"),

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
@@ -530,16 +530,6 @@ public class GCRun implements GarbageCollectionEnvironment {
   }
 
   /**
-   * Checks if InUse Candidates can be removed.
-   *
-   * @return value of {@link Property#GC_REMOVE_IN_USE_CANDIDATES}
-   */
-  @Override
-  public boolean canRemoveInUseCandidates() {
-    return context.getConfiguration().getBoolean(Property.GC_REMOVE_IN_USE_CANDIDATES);
-  }
-
-  /**
    * Moves a file to trash. If this garbage collector is not using trash, this method returns false
    * and leaves the file alone. If the file is missing, this method returns false as opposed to
    * throwing an exception.

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
@@ -198,9 +198,7 @@ public class GarbageCollectionAlgorithm {
     Set<TableId> tableIdsAfter = gce.getCandidateTableIDs();
     ensureAllTablesChecked(Collections.unmodifiableSet(tableIdsBefore),
         Collections.unmodifiableSet(tableIdsSeen), Collections.unmodifiableSet(tableIdsAfter));
-    if (gce.canRemoveInUseCandidates()) {
-      gce.deleteGcCandidates(candidateEntriesToBeDeleted, GcCandidateType.INUSE);
-    }
+    gce.deleteGcCandidates(candidateEntriesToBeDeleted, GcCandidateType.INUSE);
   }
 
   private long removeBlipCandidates(GarbageCollectionEnvironment gce,

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionEnvironment.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionEnvironment.java
@@ -29,7 +29,6 @@ import java.util.SortedMap;
 import java.util.stream.Stream;
 
 import org.apache.accumulo.core.client.TableNotFoundException;
-import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.gc.GcCandidate;
 import org.apache.accumulo.core.gc.Reference;
@@ -50,13 +49,6 @@ public interface GarbageCollectionEnvironment {
    * @return an iterator referencing a List containing deletion candidates
    */
   Iterator<GcCandidate> getCandidates() throws TableNotFoundException;
-
-  /**
-   * Used for determining if deletion of InUse candidates is enabled.
-   *
-   * @return value of {@link Property#GC_REMOVE_IN_USE_CANDIDATES}
-   */
-  boolean canRemoveInUseCandidates();
 
   /**
    * Given an iterator to a deletion candidate list, return a sub-list of candidates which fit

--- a/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
@@ -62,7 +62,6 @@ public class GarbageCollectionTest {
     ArrayList<GcCandidate> fileDeletions = new ArrayList<>();
     ArrayList<TableId> tablesDirsToDelete = new ArrayList<>();
     TreeMap<String,Status> filesToReplicate = new TreeMap<>();
-    boolean deleteInUseRefs = false;
 
     private long timestamp = 0L;
 
@@ -90,11 +89,6 @@ public class GarbageCollectionTest {
     @Override
     public Iterator<GcCandidate> getCandidates() throws TableNotFoundException {
       return List.copyOf(candidates).iterator();
-    }
-
-    @Override
-    public boolean canRemoveInUseCandidates() {
-      return deleteInUseRefs;
     }
 
     @Override
@@ -239,7 +233,7 @@ public class GarbageCollectionTest {
 
   private void assertNoCandidatesRemoved(TestGCE gce) {
     assertEquals(0, gce.deletedCandidates.size(),
-        "Deleted Candidates not empty: " + gce.deleteInUseRefs);
+        "Deleted Candidates not empty: " + gce.deletedCandidates.entrySet());
   }
 
   private void assertCandidateRemoved(TestGCE gce, GcCandidateType gcCandidateType,
@@ -248,7 +242,7 @@ public class GarbageCollectionTest {
       assertEquals(gcCandidateType, gce.deletedCandidates.remove(gcCandidate));
     }
     assertEquals(0, gce.deletedCandidates.size(),
-        "Deleted Candidates not empty: " + gce.deleteInUseRefs);
+        "Deleted Candidates not empty: " + gce.deletedCandidates.entrySet());
   }
 
   // This test was created to help track down a ConcurrentModificationException error that was
@@ -258,10 +252,10 @@ public class GarbageCollectionTest {
   public void minimalDelete() throws Exception {
     TestGCE gce = new TestGCE();
 
-    gce.addCandidate("hdfs://foo:6000/accumulo/tables/4/t0/F000.rf");
-    gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/4/t0/F001.rf");
-    var candidate = gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/5/t0/F005.rf");
-    gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/6/t0/F006.rf");
+    var candOne = gce.addCandidate("hdfs://foo:6000/accumulo/tables/4/t0/F000.rf");
+    var candTwo = gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/4/t0/F001.rf");
+    var candThree = gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/5/t0/F005.rf");
+    var candFour = gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/6/t0/F006.rf");
 
     gce.addFileReference("4", null, "hdfs://foo.com:6000/accumulo/tables/4/t0/F000.rf");
     gce.addFileReference("4", null, "hdfs://foo.com:6000/accumulo/tables/4/t0/F001.rf");
@@ -270,7 +264,8 @@ public class GarbageCollectionTest {
     GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
     gca.collect(gce);
 
-    assertFileDeleted(gce, candidate);
+    assertFileDeleted(gce, candThree);
+    assertCandidateRemoved(gce, GcCandidateType.INUSE, candOne, candTwo, candFour);
   }
 
   @Test
@@ -279,7 +274,7 @@ public class GarbageCollectionTest {
 
     var candOne = gce.addCandidate("hdfs://foo:6000/accumulo/tables/4/t0/F000.rf");
     var candTwo = gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/4/t0/F001.rf");
-    gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/5/t0/F005.rf");
+    var candThree = gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/5/t0/F005.rf");
 
     gce.addFileReference("4", null, "hdfs://foo.com:6000/accumulo/tables/4/t0/F000.rf");
     gce.addFileReference("4", null, "hdfs://foo:6000/accumulo/tables/4/t0/F001.rf");
@@ -288,31 +283,31 @@ public class GarbageCollectionTest {
 
     GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
 
-    gca.collect(gce);
-    assertFileDeleted(gce);
-
-    // Remove the reference to this flush file, run the GC which should not trim it from the
-    // candidates, and assert that it's gone
+    // Remove the reference to a file in the candidates should cause it to be removed
     gce.removeFileReference("4", null, "hdfs://foo.com:6000/accumulo/tables/4/t0/F000.rf");
     gca.collect(gce);
     assertFileDeleted(gce, candOne);
+    assertCandidateRemoved(gce, GcCandidateType.INUSE, candTwo, candThree);
+
+    candTwo = gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/4/t0/F001.rf");
+    // Remove the reference to a file in the candidates should cause it to be removed
+    gce.removeFileReference("4", null, "hdfs://foo:6000/accumulo/tables/4/t0/F001.rf");
+    gca.collect(gce);
+    assertFileDeleted(gce, candTwo);
+    assertNoCandidatesRemoved(gce);
+
+    // Adding more candidates which do not have references should be removed
+    var candFour = gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/4/t0/F003.rf");
+    var candFive = gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/4/t0/F004.rf");
+    gca.collect(gce);
+    assertFileDeleted(gce, candFour, candFive);
+    assertNoCandidatesRemoved(gce);
 
     // Removing a reference to a file that wasn't in the candidates should do nothing
     gce.removeFileReference("4", null, "hdfs://foo.com:6000/accumulo/tables/4/t0/F002.rf");
     gca.collect(gce);
     assertFileDeleted(gce);
-
-    // Remove the reference to a file in the candidates should cause it to be removed
-    gce.removeFileReference("4", null, "hdfs://foo:6000/accumulo/tables/4/t0/F001.rf");
-    gca.collect(gce);
-    assertFileDeleted(gce, candTwo);
-
-    // Adding more candidates which do not have references should be removed
-    var candThree = gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/4/t0/F003.rf");
-    var candFour = gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/4/t0/F004.rf");
-    gca.collect(gce);
-    assertFileDeleted(gce, candThree, candFour);
-
+    assertNoCandidatesRemoved(gce);
   }
 
   /*
@@ -328,7 +323,7 @@ public class GarbageCollectionTest {
 
     var candOne = gce.addCandidate("hdfs://foo:6000/accumulo/tables/4/t0/F000.rf");
     var candTwo = gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/4/t0/F001.rf");
-    gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/5/t0/F005.rf");
+    var candThree = gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/5/t0/F005.rf");
 
     int counter = 0;
     // items to be removed from candidates
@@ -367,28 +362,35 @@ public class GarbageCollectionTest {
 
     gca.collect(gce);
     assertFileDeleted(gce, toBeRemoved);
+    assertCandidateRemoved(gce, GcCandidateType.INUSE, candOne, candTwo, candThree);
 
-    // Remove the reference to this flush file, run the GC which should not trim it from the
-    // candidates, and assert that it's gone
+    // Add the candidate back in for the file removal
+    candOne = gce.addCandidate("hdfs://foo:6000/accumulo/tables/4/t0/F000.rf");
+    // Remove the reference to a file in the candidates should cause it to be removed
     gce.removeFileReference("4", null, "hdfs://foo.com:6000/accumulo/tables/4/t0/F000.rf");
     gca.collect(gce);
     assertFileDeleted(gce, candOne);
+    assertNoCandidatesRemoved(gce);
 
     // Removing a reference to a file that wasn't in the candidates should do nothing
     gce.removeFileReference("4", null, "hdfs://foo.com:6000/accumulo/tables/4/t0/F002.rf");
     gca.collect(gce);
     assertFileDeleted(gce);
+    assertNoCandidatesRemoved(gce);
 
     // Remove the reference to a file in the candidates should cause it to be removed
+    candTwo = gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/4/t0/F001.rf");
     gce.removeFileReference("4", null, "hdfs://foo:6000/accumulo/tables/4/t0/F001.rf");
     gca.collect(gce);
     assertFileDeleted(gce, candTwo);
+    assertNoCandidatesRemoved(gce);
 
     // Adding more candidates which do no have references should be removed
-    var candThree = gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/4/t0/F003.rf");
-    var candFour = gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/4/t0/F004.rf");
+    var candFour = gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/4/t0/F003.rf");
+    var candFive = gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/4/t0/F004.rf");
     gca.collect(gce);
-    assertFileDeleted(gce, candThree, candFour);
+    assertFileDeleted(gce, candFour, candFive);
+    assertNoCandidatesRemoved(gce);
   }
 
   /**
@@ -398,10 +400,10 @@ public class GarbageCollectionTest {
   public void emptyPathsTest() throws Exception {
     TestGCE gce = new TestGCE();
 
-    gce.addCandidate("hdfs://foo:6000/accumulo/tables/4//t0//F000.rf");
-    gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/4//t0//F001.rf");
-    var candidate = gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/5//t0//F005.rf");
-    gce.addCandidate("hdfs://foo.com:6000/accumulo//tables//6/t0/F006.rf");
+    var candOne = gce.addCandidate("hdfs://foo:6000/accumulo/tables/4//t0//F000.rf");
+    var candTwo = gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/4//t0//F001.rf");
+    var candThree = gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/5//t0//F005.rf");
+    var candFour = gce.addCandidate("hdfs://foo.com:6000/accumulo//tables//6/t0/F006.rf");
 
     gce.addFileReference("4", null, "hdfs://foo.com:6000/accumulo/tables/4//t0//F000.rf");
     gce.addFileReference("4", null, "hdfs://foo.com:6000/accumulo/tables/4//t0//F001.rf");
@@ -410,7 +412,8 @@ public class GarbageCollectionTest {
     GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
     gca.collect(gce);
 
-    assertFileDeleted(gce, candidate);
+    assertFileDeleted(gce, candThree);
+    assertCandidateRemoved(gce, GcCandidateType.INUSE, candOne, candTwo, candFour);
   }
 
   @Test
@@ -432,7 +435,10 @@ public class GarbageCollectionTest {
     // All candidates currently have references
     gca.collect(gce);
     assertFileDeleted(gce);
+    assertCandidateRemoved(gce, GcCandidateType.INUSE, candOne, candTwo, candThree);
 
+    // Add a single reference but three possible locations for delete.
+    candOne = gce.addCandidate("/4/t0/F000.rf");
     List<String[]> refsToRemove = new ArrayList<>();
     refsToRemove.add(new String[] {"4", "/t0/F000.rf"});
     refsToRemove.add(new String[] {"5", "../4/t0/F000.rf"});
@@ -444,27 +450,37 @@ public class GarbageCollectionTest {
       gce.removeFileReference(refsToRemove.get(i)[0], null, refsToRemove.get(i)[1]);
       gca.collect(gce);
       assertFileDeleted(gce);
+      assertCandidateRemoved(gce, GcCandidateType.INUSE, candOne);
+      candOne = gce.addCandidate("/4/t0/F000.rf");
     }
 
     gce.removeFileReference(refsToRemove.get(2)[0], null, refsToRemove.get(2)[1]);
     gca.collect(gce);
     assertFileDeleted(gce, candOne);
+    assertNoCandidatesRemoved(gce);
 
+    candThree = gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/4/t0/F001.rf");
     gce.removeFileReference("4", null, "/t0/F001.rf");
     gca.collect(gce);
     assertFileDeleted(gce, candThree);
+    assertNoCandidatesRemoved(gce);
 
     // add absolute candidate for file that already has a relative candidate
     var candFour = gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/4/t0/F002.rf");
     gca.collect(gce);
     assertFileDeleted(gce);
+    assertCandidateRemoved(gce, GcCandidateType.INUSE, candFour);
 
+    candTwo = gce.addCandidate("/4/t0/F002.rf");
+    candFour = gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/4/t0/F002.rf");
     gce.removeFileReference("4", null, "/t0/F002.rf");
     gca.collect(gce);
     assertFileDeleted(gce, candFour);
+    assertNoCandidatesRemoved(gce);
 
     gca.collect(gce);
     assertFileDeleted(gce, candTwo);
+    assertNoCandidatesRemoved(gce);
   }
 
   @Test
@@ -925,14 +941,7 @@ public class GarbageCollectionTest {
     gce.addFileReference("6", null, "hdfs://foo.com:6000/accumulo/tables/4/t0/F000.rf");
 
     GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
-    gce.deleteInUseRefs = false;
     // All candidates currently have references
-    gca.collect(gce);
-    assertFileDeleted(gce);
-    assertNoCandidatesRemoved(gce);
-
-    // Enable InUseRefs to be removed if the file ref is found.
-    gce.deleteInUseRefs = true;
     gca.collect(gce);
     assertFileDeleted(gce);
     assertCandidateRemoved(gce, GcCandidateType.INUSE, candidate);
@@ -968,15 +977,6 @@ public class GarbageCollectionTest {
     gce.addFileReference("+r", null, "hdfs://foo.com:6000/accumulo/tables/4/t0/F000.rf");
 
     GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
-    gce.deleteInUseRefs = false;
-    // No InUse Candidates should be removed.
-    gca.collect(gce);
-    assertFileDeleted(gce);
-    assertNoCandidatesRemoved(gce);
-
-    gce.deleteInUseRefs = true;
-    // Due to the gce Datalevel of ROOT, InUse candidate deletion is not supported regardless of
-    // property setting.
     gca.collect(gce);
     assertFileDeleted(gce);
     assertNoCandidatesRemoved(gce);
@@ -1019,9 +1019,6 @@ public class GarbageCollectionTest {
 
     assertEquals(0, gce.candidates.size());
 
-    // Now enable InUse deletions
-    gce.deleteInUseRefs = true;
-
     // Add deletion candidate for a directory.
     var candidate = new GcCandidate("6/t-0/", 10L);
     gce.candidates.add(candidate);
@@ -1050,7 +1047,6 @@ public class GarbageCollectionTest {
     gce.addFileReference("4", null, "/t0/F000.rf");
 
     GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
-    gce.deleteInUseRefs = true;
 
     gca.collect(gce);
     assertFileDeleted(gce, candTwo);

--- a/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
@@ -257,9 +257,9 @@ public class GarbageCollectionTest {
     var candThree = gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/5/t0/F005.rf");
     var candFour = gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/6/t0/F006.rf");
 
-    gce.addFileReference("4", null, "hdfs://foo.com:6000/accumulo/tables/4/t0/F000.rf");
-    gce.addFileReference("4", null, "hdfs://foo.com:6000/accumulo/tables/4/t0/F001.rf");
-    gce.addFileReference("6", null, "hdfs://foo.com:6000/accumulo/tables/6/t0/F006.rf");
+    gce.addFileReference("4", null, candOne.getPath());
+    gce.addFileReference("4", null, candTwo.getPath());
+    gce.addFileReference("6", null, candFour.getPath());
 
     GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
     gca.collect(gce);
@@ -276,22 +276,22 @@ public class GarbageCollectionTest {
     var candTwo = gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/4/t0/F001.rf");
     var candThree = gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/5/t0/F005.rf");
 
-    gce.addFileReference("4", null, "hdfs://foo.com:6000/accumulo/tables/4/t0/F000.rf");
-    gce.addFileReference("4", null, "hdfs://foo:6000/accumulo/tables/4/t0/F001.rf");
+    gce.addFileReference("4", null, candOne.getPath());
+    gce.addFileReference("4", null, candTwo.getPath());
     gce.addFileReference("4", null, "hdfs://foo.com:6000/accumulo/tables/4/t0//F002.rf");
-    gce.addFileReference("5", null, "hdfs://foo.com:6000/accumulo/tables/5/t0/F005.rf");
+    gce.addFileReference("5", null, candThree.getPath());
 
     GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
 
     // Remove the reference to a file in the candidates should cause it to be removed
-    gce.removeFileReference("4", null, "hdfs://foo.com:6000/accumulo/tables/4/t0/F000.rf");
+    gce.removeFileReference("4", null, candOne.getPath());
     gca.collect(gce);
     assertFileDeleted(gce, candOne);
     assertCandidateRemoved(gce, GcCandidateType.INUSE, candTwo, candThree);
 
     candTwo = gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/4/t0/F001.rf");
     // Remove the reference to a file in the candidates should cause it to be removed
-    gce.removeFileReference("4", null, "hdfs://foo:6000/accumulo/tables/4/t0/F001.rf");
+    gce.removeFileReference("4", null, candTwo.getPath());
     gca.collect(gce);
     assertFileDeleted(gce, candTwo);
     assertNoCandidatesRemoved(gce);
@@ -353,10 +353,10 @@ public class GarbageCollectionTest {
       counter++;
     }
 
-    gce.addFileReference("4", null, "hdfs://foo.com:6000/accumulo/tables/4/t0/F000.rf");
-    gce.addFileReference("4", null, "hdfs://foo:6000/accumulo/tables/4/t0/F001.rf");
+    gce.addFileReference("4", null, candOne.getPath());
+    gce.addFileReference("4", null, candTwo.getPath());
     gce.addFileReference("4", null, "hdfs://foo.com:6000/accumulo/tables/4/t0//F002.rf");
-    gce.addFileReference("5", null, "hdfs://foo.com:6000/accumulo/tables/5/t0/F005.rf");
+    gce.addFileReference("5", null, candThree.getPath());
 
     GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
 
@@ -367,7 +367,7 @@ public class GarbageCollectionTest {
     // Add the candidate back in for the file removal
     candOne = gce.addCandidate("hdfs://foo:6000/accumulo/tables/4/t0/F000.rf");
     // Remove the reference to a file in the candidates should cause it to be removed
-    gce.removeFileReference("4", null, "hdfs://foo.com:6000/accumulo/tables/4/t0/F000.rf");
+    gce.removeFileReference("4", null, candOne.getPath());
     gca.collect(gce);
     assertFileDeleted(gce, candOne);
     assertNoCandidatesRemoved(gce);
@@ -380,7 +380,7 @@ public class GarbageCollectionTest {
 
     // Remove the reference to a file in the candidates should cause it to be removed
     candTwo = gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/4/t0/F001.rf");
-    gce.removeFileReference("4", null, "hdfs://foo:6000/accumulo/tables/4/t0/F001.rf");
+    gce.removeFileReference("4", null, candTwo.getPath());
     gca.collect(gce);
     assertFileDeleted(gce, candTwo);
     assertNoCandidatesRemoved(gce);
@@ -405,9 +405,9 @@ public class GarbageCollectionTest {
     var candThree = gce.addCandidate("hdfs://foo.com:6000/accumulo/tables/5//t0//F005.rf");
     var candFour = gce.addCandidate("hdfs://foo.com:6000/accumulo//tables//6/t0/F006.rf");
 
-    gce.addFileReference("4", null, "hdfs://foo.com:6000/accumulo/tables/4//t0//F000.rf");
-    gce.addFileReference("4", null, "hdfs://foo.com:6000/accumulo/tables/4//t0//F001.rf");
-    gce.addFileReference("6", null, "hdfs://foo.com:6000/accumulo//tables//6/t0/F006.rf");
+    gce.addFileReference("4", null, candOne.getPath());
+    gce.addFileReference("4", null, candTwo.getPath());
+    gce.addFileReference("6", null, candFour.getPath());
 
     GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
     gca.collect(gce);


### PR DESCRIPTION
Removes the `gc.remove.in.use.candidates` feature flag property that was restricting the gc behavior from removing gc candidates for files that were still referenced by other tablets.

Closes: #6412

This feature was originally created for the 2.1.3 release line and should be elevated to standard GC behavior in 2.1.5. 