### PR TITLE
Update dump-zoo command

### DIFF
--- a/assemble/bin/accumulo-util
+++ b/assemble/bin/accumulo-util
@@ -149,7 +149,7 @@ function main() {
       build_native "${@:2}"
       ;;
     dump-zoo)
-      "$bin"/accumulo config dump-zoo "${@:2}"
+      "$bin"/accumulo zk dump "${@:2}"
       ;;
     gen-monitor-cert)
       gen_monitor_cert


### PR DESCRIPTION
* accumulo-util dump-zoo was still calling the old accumulo config dump-zoo path
* updated to use the correct location