### PR TITLE
Audit and fix thrift RPC problems

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
@@ -86,7 +86,6 @@ import org.apache.commons.lang3.mutable.MutableLong;
 import org.apache.hadoop.io.Text;
 import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TException;
-import org.apache.thrift.TServiceClient;
 import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -234,7 +233,7 @@ public class ConditionalWriterImpl implements ConditionalWriter {
 
     @Override
     public void run() {
-      TabletClientService.Iface client = null;
+      TabletClientService.Client client = null;
 
       for (SessionID sid : sessions) {
         if (!sid.isActive()) {
@@ -246,7 +245,7 @@ public class ConditionalWriterImpl implements ConditionalWriter {
           client = getClient(sid.location);
           client.closeConditionalUpdate(tinfo, sid.sessionID);
         } catch (Exception e) {} finally {
-          ThriftUtil.returnClient((TServiceClient) client, context);
+          ThriftUtil.returnClient(client, context);
         }
 
       }
@@ -487,7 +486,7 @@ public class ConditionalWriterImpl implements ConditionalWriter {
 
   private final HashMap<HostAndPort,SessionID> cachedSessionIDs = new HashMap<>();
 
-  private SessionID reserveSessionID(HostAndPort location, TabletClientService.Iface client,
+  private SessionID reserveSessionID(HostAndPort location, TabletClientService.Client client,
       TInfo tinfo) throws ThriftSecurityException, TException {
     // avoid cost of repeatedly making RPC to create sessions, reuse sessions
     synchronized (cachedSessionIDs) {
@@ -556,8 +555,8 @@ public class ConditionalWriterImpl implements ConditionalWriter {
     return activeSessions;
   }
 
-  private TabletClientService.Iface getClient(HostAndPort location) throws TTransportException {
-    TabletClientService.Iface client;
+  private TabletClientService.Client getClient(HostAndPort location) throws TTransportException {
+    TabletClientService.Client client;
     if (timeout < context.getClientTimeoutInMillis()) {
       client = ThriftUtil.getClient(ThriftClientTypes.TABLET_SERVER, location, context, timeout);
     } else {
@@ -567,7 +566,7 @@ public class ConditionalWriterImpl implements ConditionalWriter {
   }
 
   private void sendToServer(HostAndPort location, TabletServerMutations<QCMutation> mutations) {
-    TabletClientService.Iface client = null;
+    TabletClientService.Client client = null;
 
     TInfo tinfo = TraceUtil.traceInfo();
 
@@ -582,7 +581,7 @@ public class ConditionalWriterImpl implements ConditionalWriter {
       CompressedIterators compressedIters = new CompressedIterators();
       convertMutations(mutations, cmidToCm, cmid, tmutations, compressedIters);
 
-      // getClient() call must come after converMutations in case it throws a TException
+      // getClient() call must come after convertMutations in case it throws a TException
       client = getClient(location);
 
       List<TCMResult> tresults = null;
@@ -634,7 +633,7 @@ public class ConditionalWriterImpl implements ConditionalWriter {
       if (sessionId != null) {
         unreserveSessionID(location);
       }
-      ThriftUtil.returnClient((TServiceClient) client, context);
+      ThriftUtil.returnClient(client, context);
     }
   }
 
@@ -724,7 +723,7 @@ public class ConditionalWriterImpl implements ConditionalWriter {
   }
 
   private void invalidateSession(long sessionId, HostAndPort location) throws TException {
-    TabletClientService.Iface client = null;
+    TabletClientService.Client client = null;
 
     TInfo tinfo = TraceUtil.traceInfo();
 
@@ -732,7 +731,7 @@ public class ConditionalWriterImpl implements ConditionalWriter {
       client = getClient(location);
       client.invalidateConditionalUpdate(tinfo, sessionId);
     } finally {
-      ThriftUtil.returnClient((TServiceClient) client, context);
+      ThriftUtil.returnClient(client, context);
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
@@ -86,7 +86,6 @@ import org.apache.commons.lang3.mutable.MutableLong;
 import org.apache.hadoop.io.Text;
 import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TException;
-import org.apache.thrift.TServiceClient;
 import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -235,7 +234,7 @@ public class ConditionalWriterImpl implements ConditionalWriter {
 
     @Override
     public void run() {
-      TabletClientService.Iface client = null;
+      TabletClientService.Client client = null;
 
       for (SessionID sid : sessions) {
         if (!sid.isActive()) {
@@ -247,7 +246,7 @@ public class ConditionalWriterImpl implements ConditionalWriter {
           client = getClient(sid.location);
           client.closeConditionalUpdate(tinfo, sid.sessionID);
         } catch (Exception e) {} finally {
-          ThriftUtil.returnClient((TServiceClient) client, context);
+          ThriftUtil.returnClient(client, context);
         }
 
       }
@@ -488,7 +487,7 @@ public class ConditionalWriterImpl implements ConditionalWriter {
 
   private final HashMap<HostAndPort,SessionID> cachedSessionIDs = new HashMap<>();
 
-  private SessionID reserveSessionID(HostAndPort location, TabletClientService.Iface client,
+  private SessionID reserveSessionID(HostAndPort location, TabletClientService.Client client,
       TInfo tinfo) throws ThriftSecurityException, TException {
     // avoid cost of repeatedly making RPC to create sessions, reuse sessions
     synchronized (cachedSessionIDs) {
@@ -557,8 +556,8 @@ public class ConditionalWriterImpl implements ConditionalWriter {
     return activeSessions;
   }
 
-  private TabletClientService.Iface getClient(HostAndPort location) throws TTransportException {
-    TabletClientService.Iface client;
+  private TabletClientService.Client getClient(HostAndPort location) throws TTransportException {
+    TabletClientService.Client client;
     if (timeout < context.getClientTimeoutInMillis()) {
       client = ThriftUtil.getClient(ThriftClientTypes.TABLET_SERVER, location, context, timeout);
     } else {
@@ -568,7 +567,7 @@ public class ConditionalWriterImpl implements ConditionalWriter {
   }
 
   private void sendToServer(HostAndPort location, TabletServerMutations<QCMutation> mutations) {
-    TabletClientService.Iface client = null;
+    TabletClientService.Client client = null;
 
     TInfo tinfo = TraceUtil.traceInfo();
 
@@ -583,7 +582,7 @@ public class ConditionalWriterImpl implements ConditionalWriter {
       CompressedIterators compressedIters = new CompressedIterators();
       convertMutations(mutations, cmidToCm, cmid, tmutations, compressedIters);
 
-      // getClient() call must come after converMutations in case it throws a TException
+      // getClient() call must come after convertMutations in case it throws a TException
       client = getClient(location);
 
       List<TCMResult> tresults = null;
@@ -635,7 +634,7 @@ public class ConditionalWriterImpl implements ConditionalWriter {
       if (sessionId != null) {
         unreserveSessionID(location);
       }
-      ThriftUtil.returnClient((TServiceClient) client, context);
+      ThriftUtil.returnClient(client, context);
     }
   }
 
@@ -725,7 +724,7 @@ public class ConditionalWriterImpl implements ConditionalWriter {
   }
 
   private void invalidateSession(long sessionId, HostAndPort location) throws TException {
-    TabletClientService.Iface client = null;
+    TabletClientService.Client client = null;
 
     TInfo tinfo = TraceUtil.traceInfo();
 
@@ -733,7 +732,7 @@ public class ConditionalWriterImpl implements ConditionalWriter {
       client = getClient(location);
       client.invalidateConditionalUpdate(tinfo, sessionId);
     } finally {
-      ThriftUtil.returnClient((TServiceClient) client, context);
+      ThriftUtil.returnClient(client, context);
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchWriter.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchWriter.java
@@ -84,7 +84,6 @@ import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.core.util.threads.Threads;
 import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TException;
-import org.apache.thrift.TServiceClient;
 import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -947,7 +946,7 @@ public class TabletServerBatchWriter implements AutoCloseable {
       // happen after the batch writer closes. See #3721
       try {
         final HostAndPort parsedServer = HostAndPort.fromString(location);
-        final TabletClientService.Iface client;
+        final TabletClientService.Client client;
 
         if (timeoutTracker.getTimeOut() < context.getClientTimeoutInMillis()) {
           client = ThriftUtil.getClient(ThriftClientTypes.TABLET_SERVER, parsedServer, context,
@@ -1026,7 +1025,7 @@ public class TabletServerBatchWriter implements AutoCloseable {
 
           return allFailures;
         } finally {
-          ThriftUtil.returnClient((TServiceClient) client, context);
+          ThriftUtil.returnClient(client, context);
         }
       } catch (TTransportException e) {
         timeoutTracker.errorOccured();

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchWriter.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchWriter.java
@@ -84,7 +84,6 @@ import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.core.util.threads.Threads;
 import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TException;
-import org.apache.thrift.TServiceClient;
 import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -946,7 +945,7 @@ public class TabletServerBatchWriter implements AutoCloseable {
       // happen after the batch writer closes. See #3721
       try {
         final HostAndPort parsedServer = HostAndPort.fromString(location);
-        final TabletClientService.Iface client;
+        final TabletClientService.Client client;
 
         if (timeoutTracker.getTimeOut() < context.getClientTimeoutInMillis()) {
           client = ThriftUtil.getClient(ThriftClientTypes.TABLET_SERVER, parsedServer, context,
@@ -1025,7 +1024,7 @@ public class TabletServerBatchWriter implements AutoCloseable {
 
           return allFailures;
         } finally {
-          ThriftUtil.returnClient((TServiceClient) client, context);
+          ThriftUtil.returnClient(client, context);
         }
       } catch (TTransportException e) {
         timeoutTracker.errorOccured();

--- a/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
@@ -48,7 +48,6 @@ import org.apache.accumulo.core.util.ShutdownUtil;
 import org.apache.accumulo.core.util.Timer;
 import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.core.util.threads.ThreadPools;
-import org.apache.thrift.TApplicationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -393,8 +392,8 @@ public class Fate<T> {
           TStatus status = store.getStatus(tid);
           log.info("status is: {}", status);
           if (status == NEW || status == SUBMITTED) {
-            store.setTransactionInfo(tid, TxInfo.EXCEPTION, new TApplicationException(
-                TApplicationException.INTERNAL_ERROR, "Fate transaction cancelled by user"));
+            store.setTransactionInfo(tid, TxInfo.EXCEPTION,
+                new IllegalStateException("Fate transaction cancelled by user"));
             store.setStatus(tid, FAILED_IN_PROGRESS);
             log.info("Updated status for {} to FAILED_IN_PROGRESS because it was cancelled by user",
                 tidStr);

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/clientImpl/thrift/ClientService.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/clientImpl/thrift/ClientService.java
@@ -95,7 +95,7 @@ public class ClientService {
 
     public TVersionedProperties getVersionedNamespaceProperties(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String ns) throws ThriftTableOperationException, ThriftSecurityException, org.apache.thrift.TException;
 
-    public boolean checkClass(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String className, java.lang.String interfaceMatch) throws org.apache.thrift.TException;
+    public boolean checkClass(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String className, java.lang.String interfaceMatch) throws ThriftSecurityException, org.apache.thrift.TException;
 
     public boolean checkTableClass(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String tableId, java.lang.String className, java.lang.String interfaceMatch) throws ThriftSecurityException, ThriftTableOperationException, org.apache.thrift.TException;
 
@@ -1161,7 +1161,7 @@ public class ClientService {
     }
 
     @Override
-    public boolean checkClass(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String className, java.lang.String interfaceMatch) throws org.apache.thrift.TException
+    public boolean checkClass(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String className, java.lang.String interfaceMatch) throws ThriftSecurityException, org.apache.thrift.TException
     {
       send_checkClass(tinfo, credentials, className, interfaceMatch);
       return recv_checkClass();
@@ -1177,12 +1177,15 @@ public class ClientService {
       sendBase("checkClass", args);
     }
 
-    public boolean recv_checkClass() throws org.apache.thrift.TException
+    public boolean recv_checkClass() throws ThriftSecurityException, org.apache.thrift.TException
     {
       checkClass_result result = new checkClass_result();
       receiveBase(result, "checkClass");
       if (result.isSetSuccess()) {
         return result.success;
+      }
+      if (result.sec != null) {
+        throw result.sec;
       }
       throw new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.MISSING_RESULT, "checkClass failed: unknown result");
     }
@@ -2687,7 +2690,7 @@ public class ClientService {
       }
 
       @Override
-      public java.lang.Boolean getResult() throws org.apache.thrift.TException {
+      public java.lang.Boolean getResult() throws ThriftSecurityException, org.apache.thrift.TException {
         if (getState() != org.apache.thrift.async.TAsyncMethodCall.State.RESPONSE_READ) {
           throw new java.lang.IllegalStateException("Method call not finished!");
         }
@@ -3940,8 +3943,12 @@ public class ClientService {
       @Override
       public checkClass_result getResult(I iface, checkClass_args args) throws org.apache.thrift.TException {
         checkClass_result result = new checkClass_result();
-        result.success = iface.checkClass(args.tinfo, args.credentials, args.className, args.interfaceMatch);
-        result.setSuccessIsSet(true);
+        try {
+          result.success = iface.checkClass(args.tinfo, args.credentials, args.className, args.interfaceMatch);
+          result.setSuccessIsSet(true);
+        } catch (ThriftSecurityException sec) {
+          result.sec = sec;
+        }
         return result;
       }
     }
@@ -6480,7 +6487,11 @@ public class ClientService {
             byte msgType = org.apache.thrift.protocol.TMessageType.REPLY;
             org.apache.thrift.TSerializable msg;
             checkClass_result result = new checkClass_result();
-            if (e instanceof org.apache.thrift.transport.TTransportException) {
+            if (e instanceof ThriftSecurityException) {
+              result.sec = (ThriftSecurityException) e;
+              result.setSecIsSet(true);
+              msg = result;
+            } else if (e instanceof org.apache.thrift.transport.TTransportException) {
               _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
@@ -44167,15 +44178,18 @@ public class ClientService {
     private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("checkClass_result");
 
     private static final org.apache.thrift.protocol.TField SUCCESS_FIELD_DESC = new org.apache.thrift.protocol.TField("success", org.apache.thrift.protocol.TType.BOOL, (short)0);
+    private static final org.apache.thrift.protocol.TField SEC_FIELD_DESC = new org.apache.thrift.protocol.TField("sec", org.apache.thrift.protocol.TType.STRUCT, (short)1);
 
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new checkClass_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new checkClass_resultTupleSchemeFactory();
 
     public boolean success; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
-      SUCCESS((short)0, "success");
+      SUCCESS((short)0, "success"),
+      SEC((short)1, "sec");
 
       private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -44193,6 +44207,8 @@ public class ClientService {
         switch(fieldId) {
           case 0: // SUCCESS
             return SUCCESS;
+          case 1: // SEC
+            return SEC;
           default:
             return null;
         }
@@ -44243,6 +44259,8 @@ public class ClientService {
       java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
       tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT, 
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BOOL)));
+      tmpMap.put(_Fields.SEC, new org.apache.thrift.meta_data.FieldMetaData("sec", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, ThriftSecurityException.class)));
       metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(checkClass_result.class, metaDataMap);
     }
@@ -44251,11 +44269,13 @@ public class ClientService {
     }
 
     public checkClass_result(
-      boolean success)
+      boolean success,
+      ThriftSecurityException sec)
     {
       this();
       this.success = success;
       setSuccessIsSet(true);
+      this.sec = sec;
     }
 
     /**
@@ -44264,6 +44284,9 @@ public class ClientService {
     public checkClass_result(checkClass_result other) {
       __isset_bitfield = other.__isset_bitfield;
       this.success = other.success;
+      if (other.isSetSec()) {
+        this.sec = new ThriftSecurityException(other.sec);
+      }
     }
 
     @Override
@@ -44275,6 +44298,7 @@ public class ClientService {
     public void clear() {
       setSuccessIsSet(false);
       this.success = false;
+      this.sec = null;
     }
 
     public boolean isSuccess() {
@@ -44300,6 +44324,31 @@ public class ClientService {
       __isset_bitfield = org.apache.thrift.EncodingUtils.setBit(__isset_bitfield, __SUCCESS_ISSET_ID, value);
     }
 
+    @org.apache.thrift.annotation.Nullable
+    public ThriftSecurityException getSec() {
+      return this.sec;
+    }
+
+    public checkClass_result setSec(@org.apache.thrift.annotation.Nullable ThriftSecurityException sec) {
+      this.sec = sec;
+      return this;
+    }
+
+    public void unsetSec() {
+      this.sec = null;
+    }
+
+    /** Returns true if field sec is set (has been assigned a value) and false otherwise */
+    public boolean isSetSec() {
+      return this.sec != null;
+    }
+
+    public void setSecIsSet(boolean value) {
+      if (!value) {
+        this.sec = null;
+      }
+    }
+
     @Override
     public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
       switch (field) {
@@ -44308,6 +44357,14 @@ public class ClientService {
           unsetSuccess();
         } else {
           setSuccess((java.lang.Boolean)value);
+        }
+        break;
+
+      case SEC:
+        if (value == null) {
+          unsetSec();
+        } else {
+          setSec((ThriftSecurityException)value);
         }
         break;
 
@@ -44320,6 +44377,9 @@ public class ClientService {
       switch (field) {
       case SUCCESS:
         return isSuccess();
+
+      case SEC:
+        return getSec();
 
       }
       throw new java.lang.IllegalStateException();
@@ -44335,6 +44395,8 @@ public class ClientService {
       switch (field) {
       case SUCCESS:
         return isSetSuccess();
+      case SEC:
+        return isSetSec();
       }
       throw new java.lang.IllegalStateException();
     }
@@ -44361,6 +44423,15 @@ public class ClientService {
           return false;
       }
 
+      boolean this_present_sec = true && this.isSetSec();
+      boolean that_present_sec = true && that.isSetSec();
+      if (this_present_sec || that_present_sec) {
+        if (!(this_present_sec && that_present_sec))
+          return false;
+        if (!this.sec.equals(that.sec))
+          return false;
+      }
+
       return true;
     }
 
@@ -44369,6 +44440,10 @@ public class ClientService {
       int hashCode = 1;
 
       hashCode = hashCode * 8191 + ((success) ? 131071 : 524287);
+
+      hashCode = hashCode * 8191 + ((isSetSec()) ? 131071 : 524287);
+      if (isSetSec())
+        hashCode = hashCode * 8191 + sec.hashCode();
 
       return hashCode;
     }
@@ -44387,6 +44462,16 @@ public class ClientService {
       }
       if (isSetSuccess()) {
         lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.success, other.success);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
+      lastComparison = java.lang.Boolean.compare(isSetSec(), other.isSetSec());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (isSetSec()) {
+        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.sec, other.sec);
         if (lastComparison != 0) {
           return lastComparison;
         }
@@ -44416,6 +44501,14 @@ public class ClientService {
 
       sb.append("success:");
       sb.append(this.success);
+      first = false;
+      if (!first) sb.append(", ");
+      sb.append("sec:");
+      if (this.sec == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.sec);
+      }
       first = false;
       sb.append(")");
       return sb.toString();
@@ -44472,6 +44565,15 @@ public class ClientService {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
+            case 1: // SEC
+              if (schemeField.type == org.apache.thrift.protocol.TType.STRUCT) {
+                struct.sec = new ThriftSecurityException();
+                struct.sec.read(iprot);
+                struct.setSecIsSet(true);
+              } else { 
+                org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+              }
+              break;
             default:
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
           }
@@ -44491,6 +44593,11 @@ public class ClientService {
         if (struct.isSetSuccess()) {
           oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
           oprot.writeBool(struct.success);
+          oprot.writeFieldEnd();
+        }
+        if (struct.sec != null) {
+          oprot.writeFieldBegin(SEC_FIELD_DESC);
+          struct.sec.write(oprot);
           oprot.writeFieldEnd();
         }
         oprot.writeFieldStop();
@@ -44515,19 +44622,30 @@ public class ClientService {
         if (struct.isSetSuccess()) {
           optionals.set(0);
         }
-        oprot.writeBitSet(optionals, 1);
+        if (struct.isSetSec()) {
+          optionals.set(1);
+        }
+        oprot.writeBitSet(optionals, 2);
         if (struct.isSetSuccess()) {
           oprot.writeBool(struct.success);
+        }
+        if (struct.isSetSec()) {
+          struct.sec.write(oprot);
         }
       }
 
       @Override
       public void read(org.apache.thrift.protocol.TProtocol prot, checkClass_result struct) throws org.apache.thrift.TException {
         org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
-        java.util.BitSet incoming = iprot.readBitSet(1);
+        java.util.BitSet incoming = iprot.readBitSet(2);
         if (incoming.get(0)) {
           struct.success = iprot.readBool();
           struct.setSuccessIsSet(true);
+        }
+        if (incoming.get(1)) {
+          struct.sec = new ThriftSecurityException();
+          struct.sec.read(iprot);
+          struct.setSecIsSet(true);
         }
       }
     }

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/compaction/thrift/CompactionCoordinatorService.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/compaction/thrift/CompactionCoordinatorService.java
@@ -29,19 +29,19 @@ public class CompactionCoordinatorService {
 
   public interface Iface {
 
-    public void compactionCompleted(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String externalCompactionId, org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent, org.apache.accumulo.core.tabletserver.thrift.TCompactionStats stats) throws org.apache.thrift.TException;
+    public void compactionCompleted(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String externalCompactionId, org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent, org.apache.accumulo.core.tabletserver.thrift.TCompactionStats stats) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException;
 
-    public TNextCompactionJob getCompactionJob(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String queueName, java.lang.String compactor, java.lang.String externalCompactionId) throws org.apache.thrift.TException;
+    public TNextCompactionJob getCompactionJob(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String queueName, java.lang.String compactor, java.lang.String externalCompactionId) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException;
 
-    public void updateCompactionStatus(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String externalCompactionId, TCompactionStatusUpdate status, long timestamp) throws org.apache.thrift.TException;
+    public void updateCompactionStatus(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String externalCompactionId, TCompactionStatusUpdate status, long timestamp) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException;
 
-    public void compactionFailed(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String externalCompactionId, org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent, java.lang.String exceptionClassName) throws org.apache.thrift.TException;
+    public void compactionFailed(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String externalCompactionId, org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent, java.lang.String exceptionClassName) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException;
 
-    public TExternalCompactionList getRunningCompactions(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials) throws org.apache.thrift.TException;
+    public TExternalCompactionList getRunningCompactions(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException;
 
-    public TExternalCompactionList getCompletedCompactions(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials) throws org.apache.thrift.TException;
+    public TExternalCompactionList getCompletedCompactions(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException;
 
-    public void cancel(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String externalCompactionId) throws org.apache.thrift.TException;
+    public void cancel(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String externalCompactionId) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException;
 
   }
 
@@ -86,7 +86,7 @@ public class CompactionCoordinatorService {
     }
 
     @Override
-    public void compactionCompleted(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String externalCompactionId, org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent, org.apache.accumulo.core.tabletserver.thrift.TCompactionStats stats) throws org.apache.thrift.TException
+    public void compactionCompleted(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String externalCompactionId, org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent, org.apache.accumulo.core.tabletserver.thrift.TCompactionStats stats) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException
     {
       send_compactionCompleted(tinfo, credentials, externalCompactionId, extent, stats);
       recv_compactionCompleted();
@@ -103,15 +103,18 @@ public class CompactionCoordinatorService {
       sendBase("compactionCompleted", args);
     }
 
-    public void recv_compactionCompleted() throws org.apache.thrift.TException
+    public void recv_compactionCompleted() throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException
     {
       compactionCompleted_result result = new compactionCompleted_result();
       receiveBase(result, "compactionCompleted");
+      if (result.sec != null) {
+        throw result.sec;
+      }
       return;
     }
 
     @Override
-    public TNextCompactionJob getCompactionJob(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String queueName, java.lang.String compactor, java.lang.String externalCompactionId) throws org.apache.thrift.TException
+    public TNextCompactionJob getCompactionJob(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String queueName, java.lang.String compactor, java.lang.String externalCompactionId) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException
     {
       send_getCompactionJob(tinfo, credentials, queueName, compactor, externalCompactionId);
       return recv_getCompactionJob();
@@ -128,18 +131,21 @@ public class CompactionCoordinatorService {
       sendBase("getCompactionJob", args);
     }
 
-    public TNextCompactionJob recv_getCompactionJob() throws org.apache.thrift.TException
+    public TNextCompactionJob recv_getCompactionJob() throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException
     {
       getCompactionJob_result result = new getCompactionJob_result();
       receiveBase(result, "getCompactionJob");
       if (result.isSetSuccess()) {
         return result.success;
       }
+      if (result.sec != null) {
+        throw result.sec;
+      }
       throw new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.MISSING_RESULT, "getCompactionJob failed: unknown result");
     }
 
     @Override
-    public void updateCompactionStatus(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String externalCompactionId, TCompactionStatusUpdate status, long timestamp) throws org.apache.thrift.TException
+    public void updateCompactionStatus(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String externalCompactionId, TCompactionStatusUpdate status, long timestamp) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException
     {
       send_updateCompactionStatus(tinfo, credentials, externalCompactionId, status, timestamp);
       recv_updateCompactionStatus();
@@ -156,15 +162,18 @@ public class CompactionCoordinatorService {
       sendBase("updateCompactionStatus", args);
     }
 
-    public void recv_updateCompactionStatus() throws org.apache.thrift.TException
+    public void recv_updateCompactionStatus() throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException
     {
       updateCompactionStatus_result result = new updateCompactionStatus_result();
       receiveBase(result, "updateCompactionStatus");
+      if (result.sec != null) {
+        throw result.sec;
+      }
       return;
     }
 
     @Override
-    public void compactionFailed(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String externalCompactionId, org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent, java.lang.String exceptionClassName) throws org.apache.thrift.TException
+    public void compactionFailed(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String externalCompactionId, org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent, java.lang.String exceptionClassName) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException
     {
       send_compactionFailed(tinfo, credentials, externalCompactionId, extent, exceptionClassName);
       recv_compactionFailed();
@@ -181,15 +190,18 @@ public class CompactionCoordinatorService {
       sendBase("compactionFailed", args);
     }
 
-    public void recv_compactionFailed() throws org.apache.thrift.TException
+    public void recv_compactionFailed() throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException
     {
       compactionFailed_result result = new compactionFailed_result();
       receiveBase(result, "compactionFailed");
+      if (result.sec != null) {
+        throw result.sec;
+      }
       return;
     }
 
     @Override
-    public TExternalCompactionList getRunningCompactions(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials) throws org.apache.thrift.TException
+    public TExternalCompactionList getRunningCompactions(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException
     {
       send_getRunningCompactions(tinfo, credentials);
       return recv_getRunningCompactions();
@@ -203,18 +215,21 @@ public class CompactionCoordinatorService {
       sendBase("getRunningCompactions", args);
     }
 
-    public TExternalCompactionList recv_getRunningCompactions() throws org.apache.thrift.TException
+    public TExternalCompactionList recv_getRunningCompactions() throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException
     {
       getRunningCompactions_result result = new getRunningCompactions_result();
       receiveBase(result, "getRunningCompactions");
       if (result.isSetSuccess()) {
         return result.success;
       }
+      if (result.sec != null) {
+        throw result.sec;
+      }
       throw new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.MISSING_RESULT, "getRunningCompactions failed: unknown result");
     }
 
     @Override
-    public TExternalCompactionList getCompletedCompactions(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials) throws org.apache.thrift.TException
+    public TExternalCompactionList getCompletedCompactions(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException
     {
       send_getCompletedCompactions(tinfo, credentials);
       return recv_getCompletedCompactions();
@@ -228,18 +243,21 @@ public class CompactionCoordinatorService {
       sendBase("getCompletedCompactions", args);
     }
 
-    public TExternalCompactionList recv_getCompletedCompactions() throws org.apache.thrift.TException
+    public TExternalCompactionList recv_getCompletedCompactions() throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException
     {
       getCompletedCompactions_result result = new getCompletedCompactions_result();
       receiveBase(result, "getCompletedCompactions");
       if (result.isSetSuccess()) {
         return result.success;
       }
+      if (result.sec != null) {
+        throw result.sec;
+      }
       throw new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.MISSING_RESULT, "getCompletedCompactions failed: unknown result");
     }
 
     @Override
-    public void cancel(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String externalCompactionId) throws org.apache.thrift.TException
+    public void cancel(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String externalCompactionId) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException
     {
       send_cancel(tinfo, credentials, externalCompactionId);
       recv_cancel();
@@ -254,10 +272,13 @@ public class CompactionCoordinatorService {
       sendBase("cancel", args);
     }
 
-    public void recv_cancel() throws org.apache.thrift.TException
+    public void recv_cancel() throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException
     {
       cancel_result result = new cancel_result();
       receiveBase(result, "cancel");
+      if (result.sec != null) {
+        throw result.sec;
+      }
       return;
     }
 
@@ -317,7 +338,7 @@ public class CompactionCoordinatorService {
       }
 
       @Override
-      public Void getResult() throws org.apache.thrift.TException {
+      public Void getResult() throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException {
         if (getState() != org.apache.thrift.async.TAsyncMethodCall.State.RESPONSE_READ) {
           throw new java.lang.IllegalStateException("Method call not finished!");
         }
@@ -365,7 +386,7 @@ public class CompactionCoordinatorService {
       }
 
       @Override
-      public TNextCompactionJob getResult() throws org.apache.thrift.TException {
+      public TNextCompactionJob getResult() throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException {
         if (getState() != org.apache.thrift.async.TAsyncMethodCall.State.RESPONSE_READ) {
           throw new java.lang.IllegalStateException("Method call not finished!");
         }
@@ -412,7 +433,7 @@ public class CompactionCoordinatorService {
       }
 
       @Override
-      public Void getResult() throws org.apache.thrift.TException {
+      public Void getResult() throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException {
         if (getState() != org.apache.thrift.async.TAsyncMethodCall.State.RESPONSE_READ) {
           throw new java.lang.IllegalStateException("Method call not finished!");
         }
@@ -460,7 +481,7 @@ public class CompactionCoordinatorService {
       }
 
       @Override
-      public Void getResult() throws org.apache.thrift.TException {
+      public Void getResult() throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException {
         if (getState() != org.apache.thrift.async.TAsyncMethodCall.State.RESPONSE_READ) {
           throw new java.lang.IllegalStateException("Method call not finished!");
         }
@@ -499,7 +520,7 @@ public class CompactionCoordinatorService {
       }
 
       @Override
-      public TExternalCompactionList getResult() throws org.apache.thrift.TException {
+      public TExternalCompactionList getResult() throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException {
         if (getState() != org.apache.thrift.async.TAsyncMethodCall.State.RESPONSE_READ) {
           throw new java.lang.IllegalStateException("Method call not finished!");
         }
@@ -537,7 +558,7 @@ public class CompactionCoordinatorService {
       }
 
       @Override
-      public TExternalCompactionList getResult() throws org.apache.thrift.TException {
+      public TExternalCompactionList getResult() throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException {
         if (getState() != org.apache.thrift.async.TAsyncMethodCall.State.RESPONSE_READ) {
           throw new java.lang.IllegalStateException("Method call not finished!");
         }
@@ -578,7 +599,7 @@ public class CompactionCoordinatorService {
       }
 
       @Override
-      public Void getResult() throws org.apache.thrift.TException {
+      public Void getResult() throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException {
         if (getState() != org.apache.thrift.async.TAsyncMethodCall.State.RESPONSE_READ) {
           throw new java.lang.IllegalStateException("Method call not finished!");
         }
@@ -635,7 +656,11 @@ public class CompactionCoordinatorService {
       @Override
       public compactionCompleted_result getResult(I iface, compactionCompleted_args args) throws org.apache.thrift.TException {
         compactionCompleted_result result = new compactionCompleted_result();
-        iface.compactionCompleted(args.tinfo, args.credentials, args.externalCompactionId, args.extent, args.stats);
+        try {
+          iface.compactionCompleted(args.tinfo, args.credentials, args.externalCompactionId, args.extent, args.stats);
+        } catch (org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec) {
+          result.sec = sec;
+        }
         return result;
       }
     }
@@ -663,7 +688,11 @@ public class CompactionCoordinatorService {
       @Override
       public getCompactionJob_result getResult(I iface, getCompactionJob_args args) throws org.apache.thrift.TException {
         getCompactionJob_result result = new getCompactionJob_result();
-        result.success = iface.getCompactionJob(args.tinfo, args.credentials, args.queueName, args.compactor, args.externalCompactionId);
+        try {
+          result.success = iface.getCompactionJob(args.tinfo, args.credentials, args.queueName, args.compactor, args.externalCompactionId);
+        } catch (org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec) {
+          result.sec = sec;
+        }
         return result;
       }
     }
@@ -691,7 +720,11 @@ public class CompactionCoordinatorService {
       @Override
       public updateCompactionStatus_result getResult(I iface, updateCompactionStatus_args args) throws org.apache.thrift.TException {
         updateCompactionStatus_result result = new updateCompactionStatus_result();
-        iface.updateCompactionStatus(args.tinfo, args.credentials, args.externalCompactionId, args.status, args.timestamp);
+        try {
+          iface.updateCompactionStatus(args.tinfo, args.credentials, args.externalCompactionId, args.status, args.timestamp);
+        } catch (org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec) {
+          result.sec = sec;
+        }
         return result;
       }
     }
@@ -719,7 +752,11 @@ public class CompactionCoordinatorService {
       @Override
       public compactionFailed_result getResult(I iface, compactionFailed_args args) throws org.apache.thrift.TException {
         compactionFailed_result result = new compactionFailed_result();
-        iface.compactionFailed(args.tinfo, args.credentials, args.externalCompactionId, args.extent, args.exceptionClassName);
+        try {
+          iface.compactionFailed(args.tinfo, args.credentials, args.externalCompactionId, args.extent, args.exceptionClassName);
+        } catch (org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec) {
+          result.sec = sec;
+        }
         return result;
       }
     }
@@ -747,7 +784,11 @@ public class CompactionCoordinatorService {
       @Override
       public getRunningCompactions_result getResult(I iface, getRunningCompactions_args args) throws org.apache.thrift.TException {
         getRunningCompactions_result result = new getRunningCompactions_result();
-        result.success = iface.getRunningCompactions(args.tinfo, args.credentials);
+        try {
+          result.success = iface.getRunningCompactions(args.tinfo, args.credentials);
+        } catch (org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec) {
+          result.sec = sec;
+        }
         return result;
       }
     }
@@ -775,7 +816,11 @@ public class CompactionCoordinatorService {
       @Override
       public getCompletedCompactions_result getResult(I iface, getCompletedCompactions_args args) throws org.apache.thrift.TException {
         getCompletedCompactions_result result = new getCompletedCompactions_result();
-        result.success = iface.getCompletedCompactions(args.tinfo, args.credentials);
+        try {
+          result.success = iface.getCompletedCompactions(args.tinfo, args.credentials);
+        } catch (org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec) {
+          result.sec = sec;
+        }
         return result;
       }
     }
@@ -803,7 +848,11 @@ public class CompactionCoordinatorService {
       @Override
       public cancel_result getResult(I iface, cancel_args args) throws org.apache.thrift.TException {
         cancel_result result = new cancel_result();
-        iface.cancel(args.tinfo, args.credentials, args.externalCompactionId);
+        try {
+          iface.cancel(args.tinfo, args.credentials, args.externalCompactionId);
+        } catch (org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec) {
+          result.sec = sec;
+        }
         return result;
       }
     }
@@ -863,7 +912,11 @@ public class CompactionCoordinatorService {
             byte msgType = org.apache.thrift.protocol.TMessageType.REPLY;
             org.apache.thrift.TSerializable msg;
             compactionCompleted_result result = new compactionCompleted_result();
-            if (e instanceof org.apache.thrift.transport.TTransportException) {
+            if (e instanceof org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException) {
+              result.sec = (org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException) e;
+              result.setSecIsSet(true);
+              msg = result;
+            } else if (e instanceof org.apache.thrift.transport.TTransportException) {
               _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
@@ -930,7 +983,11 @@ public class CompactionCoordinatorService {
             byte msgType = org.apache.thrift.protocol.TMessageType.REPLY;
             org.apache.thrift.TSerializable msg;
             getCompactionJob_result result = new getCompactionJob_result();
-            if (e instanceof org.apache.thrift.transport.TTransportException) {
+            if (e instanceof org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException) {
+              result.sec = (org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException) e;
+              result.setSecIsSet(true);
+              msg = result;
+            } else if (e instanceof org.apache.thrift.transport.TTransportException) {
               _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
@@ -996,7 +1053,11 @@ public class CompactionCoordinatorService {
             byte msgType = org.apache.thrift.protocol.TMessageType.REPLY;
             org.apache.thrift.TSerializable msg;
             updateCompactionStatus_result result = new updateCompactionStatus_result();
-            if (e instanceof org.apache.thrift.transport.TTransportException) {
+            if (e instanceof org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException) {
+              result.sec = (org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException) e;
+              result.setSecIsSet(true);
+              msg = result;
+            } else if (e instanceof org.apache.thrift.transport.TTransportException) {
               _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
@@ -1062,7 +1123,11 @@ public class CompactionCoordinatorService {
             byte msgType = org.apache.thrift.protocol.TMessageType.REPLY;
             org.apache.thrift.TSerializable msg;
             compactionFailed_result result = new compactionFailed_result();
-            if (e instanceof org.apache.thrift.transport.TTransportException) {
+            if (e instanceof org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException) {
+              result.sec = (org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException) e;
+              result.setSecIsSet(true);
+              msg = result;
+            } else if (e instanceof org.apache.thrift.transport.TTransportException) {
               _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
@@ -1129,7 +1194,11 @@ public class CompactionCoordinatorService {
             byte msgType = org.apache.thrift.protocol.TMessageType.REPLY;
             org.apache.thrift.TSerializable msg;
             getRunningCompactions_result result = new getRunningCompactions_result();
-            if (e instanceof org.apache.thrift.transport.TTransportException) {
+            if (e instanceof org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException) {
+              result.sec = (org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException) e;
+              result.setSecIsSet(true);
+              msg = result;
+            } else if (e instanceof org.apache.thrift.transport.TTransportException) {
               _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
@@ -1196,7 +1265,11 @@ public class CompactionCoordinatorService {
             byte msgType = org.apache.thrift.protocol.TMessageType.REPLY;
             org.apache.thrift.TSerializable msg;
             getCompletedCompactions_result result = new getCompletedCompactions_result();
-            if (e instanceof org.apache.thrift.transport.TTransportException) {
+            if (e instanceof org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException) {
+              result.sec = (org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException) e;
+              result.setSecIsSet(true);
+              msg = result;
+            } else if (e instanceof org.apache.thrift.transport.TTransportException) {
               _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
@@ -1262,7 +1335,11 @@ public class CompactionCoordinatorService {
             byte msgType = org.apache.thrift.protocol.TMessageType.REPLY;
             org.apache.thrift.TSerializable msg;
             cancel_result result = new cancel_result();
-            if (e instanceof org.apache.thrift.transport.TTransportException) {
+            if (e instanceof org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException) {
+              result.sec = (org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException) e;
+              result.setSecIsSet(true);
+              msg = result;
+            } else if (e instanceof org.apache.thrift.transport.TTransportException) {
               _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
@@ -2121,14 +2198,16 @@ public class CompactionCoordinatorService {
   public static class compactionCompleted_result implements org.apache.thrift.TBase<compactionCompleted_result, compactionCompleted_result._Fields>, java.io.Serializable, Cloneable, Comparable<compactionCompleted_result>   {
     private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("compactionCompleted_result");
 
+    private static final org.apache.thrift.protocol.TField SEC_FIELD_DESC = new org.apache.thrift.protocol.TField("sec", org.apache.thrift.protocol.TType.STRUCT, (short)1);
 
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new compactionCompleted_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new compactionCompleted_resultTupleSchemeFactory();
 
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
-;
+      SEC((short)1, "sec");
 
       private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -2144,6 +2223,8 @@ public class CompactionCoordinatorService {
       @org.apache.thrift.annotation.Nullable
       public static _Fields findByThriftId(int fieldId) {
         switch(fieldId) {
+          case 1: // SEC
+            return SEC;
           default:
             return null;
         }
@@ -2185,9 +2266,13 @@ public class CompactionCoordinatorService {
         return _fieldName;
       }
     }
+
+    // isset id assignments
     public static final java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
     static {
       java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+      tmpMap.put(_Fields.SEC, new org.apache.thrift.meta_data.FieldMetaData("sec", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException.class)));
       metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(compactionCompleted_result.class, metaDataMap);
     }
@@ -2195,10 +2280,20 @@ public class CompactionCoordinatorService {
     public compactionCompleted_result() {
     }
 
+    public compactionCompleted_result(
+      org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec)
+    {
+      this();
+      this.sec = sec;
+    }
+
     /**
      * Performs a deep copy on <i>other</i>.
      */
     public compactionCompleted_result(compactionCompleted_result other) {
+      if (other.isSetSec()) {
+        this.sec = new org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException(other.sec);
+      }
     }
 
     @Override
@@ -2208,11 +2303,45 @@ public class CompactionCoordinatorService {
 
     @Override
     public void clear() {
+      this.sec = null;
+    }
+
+    @org.apache.thrift.annotation.Nullable
+    public org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException getSec() {
+      return this.sec;
+    }
+
+    public compactionCompleted_result setSec(@org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec) {
+      this.sec = sec;
+      return this;
+    }
+
+    public void unsetSec() {
+      this.sec = null;
+    }
+
+    /** Returns true if field sec is set (has been assigned a value) and false otherwise */
+    public boolean isSetSec() {
+      return this.sec != null;
+    }
+
+    public void setSecIsSet(boolean value) {
+      if (!value) {
+        this.sec = null;
+      }
     }
 
     @Override
     public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
       switch (field) {
+      case SEC:
+        if (value == null) {
+          unsetSec();
+        } else {
+          setSec((org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException)value);
+        }
+        break;
+
       }
     }
 
@@ -2220,6 +2349,9 @@ public class CompactionCoordinatorService {
     @Override
     public java.lang.Object getFieldValue(_Fields field) {
       switch (field) {
+      case SEC:
+        return getSec();
+
       }
       throw new java.lang.IllegalStateException();
     }
@@ -2232,6 +2364,8 @@ public class CompactionCoordinatorService {
       }
 
       switch (field) {
+      case SEC:
+        return isSetSec();
       }
       throw new java.lang.IllegalStateException();
     }
@@ -2249,12 +2383,25 @@ public class CompactionCoordinatorService {
       if (this == that)
         return true;
 
+      boolean this_present_sec = true && this.isSetSec();
+      boolean that_present_sec = true && that.isSetSec();
+      if (this_present_sec || that_present_sec) {
+        if (!(this_present_sec && that_present_sec))
+          return false;
+        if (!this.sec.equals(that.sec))
+          return false;
+      }
+
       return true;
     }
 
     @Override
     public int hashCode() {
       int hashCode = 1;
+
+      hashCode = hashCode * 8191 + ((isSetSec()) ? 131071 : 524287);
+      if (isSetSec())
+        hashCode = hashCode * 8191 + sec.hashCode();
 
       return hashCode;
     }
@@ -2267,6 +2414,16 @@ public class CompactionCoordinatorService {
 
       int lastComparison = 0;
 
+      lastComparison = java.lang.Boolean.compare(isSetSec(), other.isSetSec());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (isSetSec()) {
+        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.sec, other.sec);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
       return 0;
     }
 
@@ -2290,6 +2447,13 @@ public class CompactionCoordinatorService {
       java.lang.StringBuilder sb = new java.lang.StringBuilder("compactionCompleted_result(");
       boolean first = true;
 
+      sb.append("sec:");
+      if (this.sec == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.sec);
+      }
+      first = false;
       sb.append(")");
       return sb.toString();
     }
@@ -2335,6 +2499,15 @@ public class CompactionCoordinatorService {
             break;
           }
           switch (schemeField.id) {
+            case 1: // SEC
+              if (schemeField.type == org.apache.thrift.protocol.TType.STRUCT) {
+                struct.sec = new org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException();
+                struct.sec.read(iprot);
+                struct.setSecIsSet(true);
+              } else { 
+                org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+              }
+              break;
             default:
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
           }
@@ -2351,6 +2524,11 @@ public class CompactionCoordinatorService {
         struct.validate();
 
         oprot.writeStructBegin(STRUCT_DESC);
+        if (struct.sec != null) {
+          oprot.writeFieldBegin(SEC_FIELD_DESC);
+          struct.sec.write(oprot);
+          oprot.writeFieldEnd();
+        }
         oprot.writeFieldStop();
         oprot.writeStructEnd();
       }
@@ -2369,11 +2547,25 @@ public class CompactionCoordinatorService {
       @Override
       public void write(org.apache.thrift.protocol.TProtocol prot, compactionCompleted_result struct) throws org.apache.thrift.TException {
         org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
+        java.util.BitSet optionals = new java.util.BitSet();
+        if (struct.isSetSec()) {
+          optionals.set(0);
+        }
+        oprot.writeBitSet(optionals, 1);
+        if (struct.isSetSec()) {
+          struct.sec.write(oprot);
+        }
       }
 
       @Override
       public void read(org.apache.thrift.protocol.TProtocol prot, compactionCompleted_result struct) throws org.apache.thrift.TException {
         org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
+        java.util.BitSet incoming = iprot.readBitSet(1);
+        if (incoming.get(0)) {
+          struct.sec = new org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException();
+          struct.sec.read(iprot);
+          struct.setSecIsSet(true);
+        }
       }
     }
 
@@ -3196,15 +3388,18 @@ public class CompactionCoordinatorService {
     private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("getCompactionJob_result");
 
     private static final org.apache.thrift.protocol.TField SUCCESS_FIELD_DESC = new org.apache.thrift.protocol.TField("success", org.apache.thrift.protocol.TType.STRUCT, (short)0);
+    private static final org.apache.thrift.protocol.TField SEC_FIELD_DESC = new org.apache.thrift.protocol.TField("sec", org.apache.thrift.protocol.TType.STRUCT, (short)1);
 
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getCompactionJob_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getCompactionJob_resultTupleSchemeFactory();
 
     public @org.apache.thrift.annotation.Nullable TNextCompactionJob success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
-      SUCCESS((short)0, "success");
+      SUCCESS((short)0, "success"),
+      SEC((short)1, "sec");
 
       private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -3222,6 +3417,8 @@ public class CompactionCoordinatorService {
         switch(fieldId) {
           case 0: // SUCCESS
             return SUCCESS;
+          case 1: // SEC
+            return SEC;
           default:
             return null;
         }
@@ -3270,6 +3467,8 @@ public class CompactionCoordinatorService {
       java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
       tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT, 
           new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, TNextCompactionJob.class)));
+      tmpMap.put(_Fields.SEC, new org.apache.thrift.meta_data.FieldMetaData("sec", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException.class)));
       metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(getCompactionJob_result.class, metaDataMap);
     }
@@ -3278,10 +3477,12 @@ public class CompactionCoordinatorService {
     }
 
     public getCompactionJob_result(
-      TNextCompactionJob success)
+      TNextCompactionJob success,
+      org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec)
     {
       this();
       this.success = success;
+      this.sec = sec;
     }
 
     /**
@@ -3290,6 +3491,9 @@ public class CompactionCoordinatorService {
     public getCompactionJob_result(getCompactionJob_result other) {
       if (other.isSetSuccess()) {
         this.success = new TNextCompactionJob(other.success);
+      }
+      if (other.isSetSec()) {
+        this.sec = new org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException(other.sec);
       }
     }
 
@@ -3301,6 +3505,7 @@ public class CompactionCoordinatorService {
     @Override
     public void clear() {
       this.success = null;
+      this.sec = null;
     }
 
     @org.apache.thrift.annotation.Nullable
@@ -3328,6 +3533,31 @@ public class CompactionCoordinatorService {
       }
     }
 
+    @org.apache.thrift.annotation.Nullable
+    public org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException getSec() {
+      return this.sec;
+    }
+
+    public getCompactionJob_result setSec(@org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec) {
+      this.sec = sec;
+      return this;
+    }
+
+    public void unsetSec() {
+      this.sec = null;
+    }
+
+    /** Returns true if field sec is set (has been assigned a value) and false otherwise */
+    public boolean isSetSec() {
+      return this.sec != null;
+    }
+
+    public void setSecIsSet(boolean value) {
+      if (!value) {
+        this.sec = null;
+      }
+    }
+
     @Override
     public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
       switch (field) {
@@ -3336,6 +3566,14 @@ public class CompactionCoordinatorService {
           unsetSuccess();
         } else {
           setSuccess((TNextCompactionJob)value);
+        }
+        break;
+
+      case SEC:
+        if (value == null) {
+          unsetSec();
+        } else {
+          setSec((org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException)value);
         }
         break;
 
@@ -3348,6 +3586,9 @@ public class CompactionCoordinatorService {
       switch (field) {
       case SUCCESS:
         return getSuccess();
+
+      case SEC:
+        return getSec();
 
       }
       throw new java.lang.IllegalStateException();
@@ -3363,6 +3604,8 @@ public class CompactionCoordinatorService {
       switch (field) {
       case SUCCESS:
         return isSetSuccess();
+      case SEC:
+        return isSetSec();
       }
       throw new java.lang.IllegalStateException();
     }
@@ -3389,6 +3632,15 @@ public class CompactionCoordinatorService {
           return false;
       }
 
+      boolean this_present_sec = true && this.isSetSec();
+      boolean that_present_sec = true && that.isSetSec();
+      if (this_present_sec || that_present_sec) {
+        if (!(this_present_sec && that_present_sec))
+          return false;
+        if (!this.sec.equals(that.sec))
+          return false;
+      }
+
       return true;
     }
 
@@ -3399,6 +3651,10 @@ public class CompactionCoordinatorService {
       hashCode = hashCode * 8191 + ((isSetSuccess()) ? 131071 : 524287);
       if (isSetSuccess())
         hashCode = hashCode * 8191 + success.hashCode();
+
+      hashCode = hashCode * 8191 + ((isSetSec()) ? 131071 : 524287);
+      if (isSetSec())
+        hashCode = hashCode * 8191 + sec.hashCode();
 
       return hashCode;
     }
@@ -3417,6 +3673,16 @@ public class CompactionCoordinatorService {
       }
       if (isSetSuccess()) {
         lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.success, other.success);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
+      lastComparison = java.lang.Boolean.compare(isSetSec(), other.isSetSec());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (isSetSec()) {
+        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.sec, other.sec);
         if (lastComparison != 0) {
           return lastComparison;
         }
@@ -3449,6 +3715,14 @@ public class CompactionCoordinatorService {
         sb.append("null");
       } else {
         sb.append(this.success);
+      }
+      first = false;
+      if (!first) sb.append(", ");
+      sb.append("sec:");
+      if (this.sec == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.sec);
       }
       first = false;
       sb.append(")");
@@ -3508,6 +3782,15 @@ public class CompactionCoordinatorService {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
+            case 1: // SEC
+              if (schemeField.type == org.apache.thrift.protocol.TType.STRUCT) {
+                struct.sec = new org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException();
+                struct.sec.read(iprot);
+                struct.setSecIsSet(true);
+              } else { 
+                org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+              }
+              break;
             default:
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
           }
@@ -3527,6 +3810,11 @@ public class CompactionCoordinatorService {
         if (struct.success != null) {
           oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
           struct.success.write(oprot);
+          oprot.writeFieldEnd();
+        }
+        if (struct.sec != null) {
+          oprot.writeFieldBegin(SEC_FIELD_DESC);
+          struct.sec.write(oprot);
           oprot.writeFieldEnd();
         }
         oprot.writeFieldStop();
@@ -3551,20 +3839,31 @@ public class CompactionCoordinatorService {
         if (struct.isSetSuccess()) {
           optionals.set(0);
         }
-        oprot.writeBitSet(optionals, 1);
+        if (struct.isSetSec()) {
+          optionals.set(1);
+        }
+        oprot.writeBitSet(optionals, 2);
         if (struct.isSetSuccess()) {
           struct.success.write(oprot);
+        }
+        if (struct.isSetSec()) {
+          struct.sec.write(oprot);
         }
       }
 
       @Override
       public void read(org.apache.thrift.protocol.TProtocol prot, getCompactionJob_result struct) throws org.apache.thrift.TException {
         org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
-        java.util.BitSet incoming = iprot.readBitSet(1);
+        java.util.BitSet incoming = iprot.readBitSet(2);
         if (incoming.get(0)) {
           struct.success = new TNextCompactionJob();
           struct.success.read(iprot);
           struct.setSuccessIsSet(true);
+        }
+        if (incoming.get(1)) {
+          struct.sec = new org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException();
+          struct.sec.read(iprot);
+          struct.setSecIsSet(true);
         }
       }
     }
@@ -4387,14 +4686,16 @@ public class CompactionCoordinatorService {
   public static class updateCompactionStatus_result implements org.apache.thrift.TBase<updateCompactionStatus_result, updateCompactionStatus_result._Fields>, java.io.Serializable, Cloneable, Comparable<updateCompactionStatus_result>   {
     private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("updateCompactionStatus_result");
 
+    private static final org.apache.thrift.protocol.TField SEC_FIELD_DESC = new org.apache.thrift.protocol.TField("sec", org.apache.thrift.protocol.TType.STRUCT, (short)1);
 
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new updateCompactionStatus_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new updateCompactionStatus_resultTupleSchemeFactory();
 
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
-;
+      SEC((short)1, "sec");
 
       private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -4410,6 +4711,8 @@ public class CompactionCoordinatorService {
       @org.apache.thrift.annotation.Nullable
       public static _Fields findByThriftId(int fieldId) {
         switch(fieldId) {
+          case 1: // SEC
+            return SEC;
           default:
             return null;
         }
@@ -4451,9 +4754,13 @@ public class CompactionCoordinatorService {
         return _fieldName;
       }
     }
+
+    // isset id assignments
     public static final java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
     static {
       java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+      tmpMap.put(_Fields.SEC, new org.apache.thrift.meta_data.FieldMetaData("sec", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException.class)));
       metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(updateCompactionStatus_result.class, metaDataMap);
     }
@@ -4461,10 +4768,20 @@ public class CompactionCoordinatorService {
     public updateCompactionStatus_result() {
     }
 
+    public updateCompactionStatus_result(
+      org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec)
+    {
+      this();
+      this.sec = sec;
+    }
+
     /**
      * Performs a deep copy on <i>other</i>.
      */
     public updateCompactionStatus_result(updateCompactionStatus_result other) {
+      if (other.isSetSec()) {
+        this.sec = new org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException(other.sec);
+      }
     }
 
     @Override
@@ -4474,11 +4791,45 @@ public class CompactionCoordinatorService {
 
     @Override
     public void clear() {
+      this.sec = null;
+    }
+
+    @org.apache.thrift.annotation.Nullable
+    public org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException getSec() {
+      return this.sec;
+    }
+
+    public updateCompactionStatus_result setSec(@org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec) {
+      this.sec = sec;
+      return this;
+    }
+
+    public void unsetSec() {
+      this.sec = null;
+    }
+
+    /** Returns true if field sec is set (has been assigned a value) and false otherwise */
+    public boolean isSetSec() {
+      return this.sec != null;
+    }
+
+    public void setSecIsSet(boolean value) {
+      if (!value) {
+        this.sec = null;
+      }
     }
 
     @Override
     public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
       switch (field) {
+      case SEC:
+        if (value == null) {
+          unsetSec();
+        } else {
+          setSec((org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException)value);
+        }
+        break;
+
       }
     }
 
@@ -4486,6 +4837,9 @@ public class CompactionCoordinatorService {
     @Override
     public java.lang.Object getFieldValue(_Fields field) {
       switch (field) {
+      case SEC:
+        return getSec();
+
       }
       throw new java.lang.IllegalStateException();
     }
@@ -4498,6 +4852,8 @@ public class CompactionCoordinatorService {
       }
 
       switch (field) {
+      case SEC:
+        return isSetSec();
       }
       throw new java.lang.IllegalStateException();
     }
@@ -4515,12 +4871,25 @@ public class CompactionCoordinatorService {
       if (this == that)
         return true;
 
+      boolean this_present_sec = true && this.isSetSec();
+      boolean that_present_sec = true && that.isSetSec();
+      if (this_present_sec || that_present_sec) {
+        if (!(this_present_sec && that_present_sec))
+          return false;
+        if (!this.sec.equals(that.sec))
+          return false;
+      }
+
       return true;
     }
 
     @Override
     public int hashCode() {
       int hashCode = 1;
+
+      hashCode = hashCode * 8191 + ((isSetSec()) ? 131071 : 524287);
+      if (isSetSec())
+        hashCode = hashCode * 8191 + sec.hashCode();
 
       return hashCode;
     }
@@ -4533,6 +4902,16 @@ public class CompactionCoordinatorService {
 
       int lastComparison = 0;
 
+      lastComparison = java.lang.Boolean.compare(isSetSec(), other.isSetSec());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (isSetSec()) {
+        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.sec, other.sec);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
       return 0;
     }
 
@@ -4556,6 +4935,13 @@ public class CompactionCoordinatorService {
       java.lang.StringBuilder sb = new java.lang.StringBuilder("updateCompactionStatus_result(");
       boolean first = true;
 
+      sb.append("sec:");
+      if (this.sec == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.sec);
+      }
+      first = false;
       sb.append(")");
       return sb.toString();
     }
@@ -4601,6 +4987,15 @@ public class CompactionCoordinatorService {
             break;
           }
           switch (schemeField.id) {
+            case 1: // SEC
+              if (schemeField.type == org.apache.thrift.protocol.TType.STRUCT) {
+                struct.sec = new org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException();
+                struct.sec.read(iprot);
+                struct.setSecIsSet(true);
+              } else { 
+                org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+              }
+              break;
             default:
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
           }
@@ -4617,6 +5012,11 @@ public class CompactionCoordinatorService {
         struct.validate();
 
         oprot.writeStructBegin(STRUCT_DESC);
+        if (struct.sec != null) {
+          oprot.writeFieldBegin(SEC_FIELD_DESC);
+          struct.sec.write(oprot);
+          oprot.writeFieldEnd();
+        }
         oprot.writeFieldStop();
         oprot.writeStructEnd();
       }
@@ -4635,11 +5035,25 @@ public class CompactionCoordinatorService {
       @Override
       public void write(org.apache.thrift.protocol.TProtocol prot, updateCompactionStatus_result struct) throws org.apache.thrift.TException {
         org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
+        java.util.BitSet optionals = new java.util.BitSet();
+        if (struct.isSetSec()) {
+          optionals.set(0);
+        }
+        oprot.writeBitSet(optionals, 1);
+        if (struct.isSetSec()) {
+          struct.sec.write(oprot);
+        }
       }
 
       @Override
       public void read(org.apache.thrift.protocol.TProtocol prot, updateCompactionStatus_result struct) throws org.apache.thrift.TException {
         org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
+        java.util.BitSet incoming = iprot.readBitSet(1);
+        if (incoming.get(0)) {
+          struct.sec = new org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException();
+          struct.sec.read(iprot);
+          struct.setSecIsSet(true);
+        }
       }
     }
 
@@ -5466,14 +5880,16 @@ public class CompactionCoordinatorService {
   public static class compactionFailed_result implements org.apache.thrift.TBase<compactionFailed_result, compactionFailed_result._Fields>, java.io.Serializable, Cloneable, Comparable<compactionFailed_result>   {
     private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("compactionFailed_result");
 
+    private static final org.apache.thrift.protocol.TField SEC_FIELD_DESC = new org.apache.thrift.protocol.TField("sec", org.apache.thrift.protocol.TType.STRUCT, (short)1);
 
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new compactionFailed_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new compactionFailed_resultTupleSchemeFactory();
 
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
-;
+      SEC((short)1, "sec");
 
       private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -5489,6 +5905,8 @@ public class CompactionCoordinatorService {
       @org.apache.thrift.annotation.Nullable
       public static _Fields findByThriftId(int fieldId) {
         switch(fieldId) {
+          case 1: // SEC
+            return SEC;
           default:
             return null;
         }
@@ -5530,9 +5948,13 @@ public class CompactionCoordinatorService {
         return _fieldName;
       }
     }
+
+    // isset id assignments
     public static final java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
     static {
       java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+      tmpMap.put(_Fields.SEC, new org.apache.thrift.meta_data.FieldMetaData("sec", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException.class)));
       metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(compactionFailed_result.class, metaDataMap);
     }
@@ -5540,10 +5962,20 @@ public class CompactionCoordinatorService {
     public compactionFailed_result() {
     }
 
+    public compactionFailed_result(
+      org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec)
+    {
+      this();
+      this.sec = sec;
+    }
+
     /**
      * Performs a deep copy on <i>other</i>.
      */
     public compactionFailed_result(compactionFailed_result other) {
+      if (other.isSetSec()) {
+        this.sec = new org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException(other.sec);
+      }
     }
 
     @Override
@@ -5553,11 +5985,45 @@ public class CompactionCoordinatorService {
 
     @Override
     public void clear() {
+      this.sec = null;
+    }
+
+    @org.apache.thrift.annotation.Nullable
+    public org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException getSec() {
+      return this.sec;
+    }
+
+    public compactionFailed_result setSec(@org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec) {
+      this.sec = sec;
+      return this;
+    }
+
+    public void unsetSec() {
+      this.sec = null;
+    }
+
+    /** Returns true if field sec is set (has been assigned a value) and false otherwise */
+    public boolean isSetSec() {
+      return this.sec != null;
+    }
+
+    public void setSecIsSet(boolean value) {
+      if (!value) {
+        this.sec = null;
+      }
     }
 
     @Override
     public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
       switch (field) {
+      case SEC:
+        if (value == null) {
+          unsetSec();
+        } else {
+          setSec((org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException)value);
+        }
+        break;
+
       }
     }
 
@@ -5565,6 +6031,9 @@ public class CompactionCoordinatorService {
     @Override
     public java.lang.Object getFieldValue(_Fields field) {
       switch (field) {
+      case SEC:
+        return getSec();
+
       }
       throw new java.lang.IllegalStateException();
     }
@@ -5577,6 +6046,8 @@ public class CompactionCoordinatorService {
       }
 
       switch (field) {
+      case SEC:
+        return isSetSec();
       }
       throw new java.lang.IllegalStateException();
     }
@@ -5594,12 +6065,25 @@ public class CompactionCoordinatorService {
       if (this == that)
         return true;
 
+      boolean this_present_sec = true && this.isSetSec();
+      boolean that_present_sec = true && that.isSetSec();
+      if (this_present_sec || that_present_sec) {
+        if (!(this_present_sec && that_present_sec))
+          return false;
+        if (!this.sec.equals(that.sec))
+          return false;
+      }
+
       return true;
     }
 
     @Override
     public int hashCode() {
       int hashCode = 1;
+
+      hashCode = hashCode * 8191 + ((isSetSec()) ? 131071 : 524287);
+      if (isSetSec())
+        hashCode = hashCode * 8191 + sec.hashCode();
 
       return hashCode;
     }
@@ -5612,6 +6096,16 @@ public class CompactionCoordinatorService {
 
       int lastComparison = 0;
 
+      lastComparison = java.lang.Boolean.compare(isSetSec(), other.isSetSec());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (isSetSec()) {
+        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.sec, other.sec);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
       return 0;
     }
 
@@ -5635,6 +6129,13 @@ public class CompactionCoordinatorService {
       java.lang.StringBuilder sb = new java.lang.StringBuilder("compactionFailed_result(");
       boolean first = true;
 
+      sb.append("sec:");
+      if (this.sec == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.sec);
+      }
+      first = false;
       sb.append(")");
       return sb.toString();
     }
@@ -5680,6 +6181,15 @@ public class CompactionCoordinatorService {
             break;
           }
           switch (schemeField.id) {
+            case 1: // SEC
+              if (schemeField.type == org.apache.thrift.protocol.TType.STRUCT) {
+                struct.sec = new org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException();
+                struct.sec.read(iprot);
+                struct.setSecIsSet(true);
+              } else { 
+                org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+              }
+              break;
             default:
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
           }
@@ -5696,6 +6206,11 @@ public class CompactionCoordinatorService {
         struct.validate();
 
         oprot.writeStructBegin(STRUCT_DESC);
+        if (struct.sec != null) {
+          oprot.writeFieldBegin(SEC_FIELD_DESC);
+          struct.sec.write(oprot);
+          oprot.writeFieldEnd();
+        }
         oprot.writeFieldStop();
         oprot.writeStructEnd();
       }
@@ -5714,11 +6229,25 @@ public class CompactionCoordinatorService {
       @Override
       public void write(org.apache.thrift.protocol.TProtocol prot, compactionFailed_result struct) throws org.apache.thrift.TException {
         org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
+        java.util.BitSet optionals = new java.util.BitSet();
+        if (struct.isSetSec()) {
+          optionals.set(0);
+        }
+        oprot.writeBitSet(optionals, 1);
+        if (struct.isSetSec()) {
+          struct.sec.write(oprot);
+        }
       }
 
       @Override
       public void read(org.apache.thrift.protocol.TProtocol prot, compactionFailed_result struct) throws org.apache.thrift.TException {
         org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
+        java.util.BitSet incoming = iprot.readBitSet(1);
+        if (incoming.get(0)) {
+          struct.sec = new org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException();
+          struct.sec.read(iprot);
+          struct.setSecIsSet(true);
+        }
       }
     }
 
@@ -6226,15 +6755,18 @@ public class CompactionCoordinatorService {
     private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("getRunningCompactions_result");
 
     private static final org.apache.thrift.protocol.TField SUCCESS_FIELD_DESC = new org.apache.thrift.protocol.TField("success", org.apache.thrift.protocol.TType.STRUCT, (short)0);
+    private static final org.apache.thrift.protocol.TField SEC_FIELD_DESC = new org.apache.thrift.protocol.TField("sec", org.apache.thrift.protocol.TType.STRUCT, (short)1);
 
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getRunningCompactions_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getRunningCompactions_resultTupleSchemeFactory();
 
     public @org.apache.thrift.annotation.Nullable TExternalCompactionList success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
-      SUCCESS((short)0, "success");
+      SUCCESS((short)0, "success"),
+      SEC((short)1, "sec");
 
       private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -6252,6 +6784,8 @@ public class CompactionCoordinatorService {
         switch(fieldId) {
           case 0: // SUCCESS
             return SUCCESS;
+          case 1: // SEC
+            return SEC;
           default:
             return null;
         }
@@ -6300,6 +6834,8 @@ public class CompactionCoordinatorService {
       java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
       tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT, 
           new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, TExternalCompactionList.class)));
+      tmpMap.put(_Fields.SEC, new org.apache.thrift.meta_data.FieldMetaData("sec", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException.class)));
       metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(getRunningCompactions_result.class, metaDataMap);
     }
@@ -6308,10 +6844,12 @@ public class CompactionCoordinatorService {
     }
 
     public getRunningCompactions_result(
-      TExternalCompactionList success)
+      TExternalCompactionList success,
+      org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec)
     {
       this();
       this.success = success;
+      this.sec = sec;
     }
 
     /**
@@ -6320,6 +6858,9 @@ public class CompactionCoordinatorService {
     public getRunningCompactions_result(getRunningCompactions_result other) {
       if (other.isSetSuccess()) {
         this.success = new TExternalCompactionList(other.success);
+      }
+      if (other.isSetSec()) {
+        this.sec = new org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException(other.sec);
       }
     }
 
@@ -6331,6 +6872,7 @@ public class CompactionCoordinatorService {
     @Override
     public void clear() {
       this.success = null;
+      this.sec = null;
     }
 
     @org.apache.thrift.annotation.Nullable
@@ -6358,6 +6900,31 @@ public class CompactionCoordinatorService {
       }
     }
 
+    @org.apache.thrift.annotation.Nullable
+    public org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException getSec() {
+      return this.sec;
+    }
+
+    public getRunningCompactions_result setSec(@org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec) {
+      this.sec = sec;
+      return this;
+    }
+
+    public void unsetSec() {
+      this.sec = null;
+    }
+
+    /** Returns true if field sec is set (has been assigned a value) and false otherwise */
+    public boolean isSetSec() {
+      return this.sec != null;
+    }
+
+    public void setSecIsSet(boolean value) {
+      if (!value) {
+        this.sec = null;
+      }
+    }
+
     @Override
     public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
       switch (field) {
@@ -6366,6 +6933,14 @@ public class CompactionCoordinatorService {
           unsetSuccess();
         } else {
           setSuccess((TExternalCompactionList)value);
+        }
+        break;
+
+      case SEC:
+        if (value == null) {
+          unsetSec();
+        } else {
+          setSec((org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException)value);
         }
         break;
 
@@ -6378,6 +6953,9 @@ public class CompactionCoordinatorService {
       switch (field) {
       case SUCCESS:
         return getSuccess();
+
+      case SEC:
+        return getSec();
 
       }
       throw new java.lang.IllegalStateException();
@@ -6393,6 +6971,8 @@ public class CompactionCoordinatorService {
       switch (field) {
       case SUCCESS:
         return isSetSuccess();
+      case SEC:
+        return isSetSec();
       }
       throw new java.lang.IllegalStateException();
     }
@@ -6419,6 +6999,15 @@ public class CompactionCoordinatorService {
           return false;
       }
 
+      boolean this_present_sec = true && this.isSetSec();
+      boolean that_present_sec = true && that.isSetSec();
+      if (this_present_sec || that_present_sec) {
+        if (!(this_present_sec && that_present_sec))
+          return false;
+        if (!this.sec.equals(that.sec))
+          return false;
+      }
+
       return true;
     }
 
@@ -6429,6 +7018,10 @@ public class CompactionCoordinatorService {
       hashCode = hashCode * 8191 + ((isSetSuccess()) ? 131071 : 524287);
       if (isSetSuccess())
         hashCode = hashCode * 8191 + success.hashCode();
+
+      hashCode = hashCode * 8191 + ((isSetSec()) ? 131071 : 524287);
+      if (isSetSec())
+        hashCode = hashCode * 8191 + sec.hashCode();
 
       return hashCode;
     }
@@ -6447,6 +7040,16 @@ public class CompactionCoordinatorService {
       }
       if (isSetSuccess()) {
         lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.success, other.success);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
+      lastComparison = java.lang.Boolean.compare(isSetSec(), other.isSetSec());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (isSetSec()) {
+        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.sec, other.sec);
         if (lastComparison != 0) {
           return lastComparison;
         }
@@ -6479,6 +7082,14 @@ public class CompactionCoordinatorService {
         sb.append("null");
       } else {
         sb.append(this.success);
+      }
+      first = false;
+      if (!first) sb.append(", ");
+      sb.append("sec:");
+      if (this.sec == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.sec);
       }
       first = false;
       sb.append(")");
@@ -6538,6 +7149,15 @@ public class CompactionCoordinatorService {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
+            case 1: // SEC
+              if (schemeField.type == org.apache.thrift.protocol.TType.STRUCT) {
+                struct.sec = new org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException();
+                struct.sec.read(iprot);
+                struct.setSecIsSet(true);
+              } else { 
+                org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+              }
+              break;
             default:
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
           }
@@ -6557,6 +7177,11 @@ public class CompactionCoordinatorService {
         if (struct.success != null) {
           oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
           struct.success.write(oprot);
+          oprot.writeFieldEnd();
+        }
+        if (struct.sec != null) {
+          oprot.writeFieldBegin(SEC_FIELD_DESC);
+          struct.sec.write(oprot);
           oprot.writeFieldEnd();
         }
         oprot.writeFieldStop();
@@ -6581,20 +7206,31 @@ public class CompactionCoordinatorService {
         if (struct.isSetSuccess()) {
           optionals.set(0);
         }
-        oprot.writeBitSet(optionals, 1);
+        if (struct.isSetSec()) {
+          optionals.set(1);
+        }
+        oprot.writeBitSet(optionals, 2);
         if (struct.isSetSuccess()) {
           struct.success.write(oprot);
+        }
+        if (struct.isSetSec()) {
+          struct.sec.write(oprot);
         }
       }
 
       @Override
       public void read(org.apache.thrift.protocol.TProtocol prot, getRunningCompactions_result struct) throws org.apache.thrift.TException {
         org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
-        java.util.BitSet incoming = iprot.readBitSet(1);
+        java.util.BitSet incoming = iprot.readBitSet(2);
         if (incoming.get(0)) {
           struct.success = new TExternalCompactionList();
           struct.success.read(iprot);
           struct.setSuccessIsSet(true);
+        }
+        if (incoming.get(1)) {
+          struct.sec = new org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException();
+          struct.sec.read(iprot);
+          struct.setSecIsSet(true);
         }
       }
     }
@@ -7103,15 +7739,18 @@ public class CompactionCoordinatorService {
     private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("getCompletedCompactions_result");
 
     private static final org.apache.thrift.protocol.TField SUCCESS_FIELD_DESC = new org.apache.thrift.protocol.TField("success", org.apache.thrift.protocol.TType.STRUCT, (short)0);
+    private static final org.apache.thrift.protocol.TField SEC_FIELD_DESC = new org.apache.thrift.protocol.TField("sec", org.apache.thrift.protocol.TType.STRUCT, (short)1);
 
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getCompletedCompactions_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getCompletedCompactions_resultTupleSchemeFactory();
 
     public @org.apache.thrift.annotation.Nullable TExternalCompactionList success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
-      SUCCESS((short)0, "success");
+      SUCCESS((short)0, "success"),
+      SEC((short)1, "sec");
 
       private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -7129,6 +7768,8 @@ public class CompactionCoordinatorService {
         switch(fieldId) {
           case 0: // SUCCESS
             return SUCCESS;
+          case 1: // SEC
+            return SEC;
           default:
             return null;
         }
@@ -7177,6 +7818,8 @@ public class CompactionCoordinatorService {
       java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
       tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT, 
           new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, TExternalCompactionList.class)));
+      tmpMap.put(_Fields.SEC, new org.apache.thrift.meta_data.FieldMetaData("sec", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException.class)));
       metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(getCompletedCompactions_result.class, metaDataMap);
     }
@@ -7185,10 +7828,12 @@ public class CompactionCoordinatorService {
     }
 
     public getCompletedCompactions_result(
-      TExternalCompactionList success)
+      TExternalCompactionList success,
+      org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec)
     {
       this();
       this.success = success;
+      this.sec = sec;
     }
 
     /**
@@ -7197,6 +7842,9 @@ public class CompactionCoordinatorService {
     public getCompletedCompactions_result(getCompletedCompactions_result other) {
       if (other.isSetSuccess()) {
         this.success = new TExternalCompactionList(other.success);
+      }
+      if (other.isSetSec()) {
+        this.sec = new org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException(other.sec);
       }
     }
 
@@ -7208,6 +7856,7 @@ public class CompactionCoordinatorService {
     @Override
     public void clear() {
       this.success = null;
+      this.sec = null;
     }
 
     @org.apache.thrift.annotation.Nullable
@@ -7235,6 +7884,31 @@ public class CompactionCoordinatorService {
       }
     }
 
+    @org.apache.thrift.annotation.Nullable
+    public org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException getSec() {
+      return this.sec;
+    }
+
+    public getCompletedCompactions_result setSec(@org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec) {
+      this.sec = sec;
+      return this;
+    }
+
+    public void unsetSec() {
+      this.sec = null;
+    }
+
+    /** Returns true if field sec is set (has been assigned a value) and false otherwise */
+    public boolean isSetSec() {
+      return this.sec != null;
+    }
+
+    public void setSecIsSet(boolean value) {
+      if (!value) {
+        this.sec = null;
+      }
+    }
+
     @Override
     public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
       switch (field) {
@@ -7243,6 +7917,14 @@ public class CompactionCoordinatorService {
           unsetSuccess();
         } else {
           setSuccess((TExternalCompactionList)value);
+        }
+        break;
+
+      case SEC:
+        if (value == null) {
+          unsetSec();
+        } else {
+          setSec((org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException)value);
         }
         break;
 
@@ -7255,6 +7937,9 @@ public class CompactionCoordinatorService {
       switch (field) {
       case SUCCESS:
         return getSuccess();
+
+      case SEC:
+        return getSec();
 
       }
       throw new java.lang.IllegalStateException();
@@ -7270,6 +7955,8 @@ public class CompactionCoordinatorService {
       switch (field) {
       case SUCCESS:
         return isSetSuccess();
+      case SEC:
+        return isSetSec();
       }
       throw new java.lang.IllegalStateException();
     }
@@ -7296,6 +7983,15 @@ public class CompactionCoordinatorService {
           return false;
       }
 
+      boolean this_present_sec = true && this.isSetSec();
+      boolean that_present_sec = true && that.isSetSec();
+      if (this_present_sec || that_present_sec) {
+        if (!(this_present_sec && that_present_sec))
+          return false;
+        if (!this.sec.equals(that.sec))
+          return false;
+      }
+
       return true;
     }
 
@@ -7306,6 +8002,10 @@ public class CompactionCoordinatorService {
       hashCode = hashCode * 8191 + ((isSetSuccess()) ? 131071 : 524287);
       if (isSetSuccess())
         hashCode = hashCode * 8191 + success.hashCode();
+
+      hashCode = hashCode * 8191 + ((isSetSec()) ? 131071 : 524287);
+      if (isSetSec())
+        hashCode = hashCode * 8191 + sec.hashCode();
 
       return hashCode;
     }
@@ -7324,6 +8024,16 @@ public class CompactionCoordinatorService {
       }
       if (isSetSuccess()) {
         lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.success, other.success);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
+      lastComparison = java.lang.Boolean.compare(isSetSec(), other.isSetSec());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (isSetSec()) {
+        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.sec, other.sec);
         if (lastComparison != 0) {
           return lastComparison;
         }
@@ -7356,6 +8066,14 @@ public class CompactionCoordinatorService {
         sb.append("null");
       } else {
         sb.append(this.success);
+      }
+      first = false;
+      if (!first) sb.append(", ");
+      sb.append("sec:");
+      if (this.sec == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.sec);
       }
       first = false;
       sb.append(")");
@@ -7415,6 +8133,15 @@ public class CompactionCoordinatorService {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
+            case 1: // SEC
+              if (schemeField.type == org.apache.thrift.protocol.TType.STRUCT) {
+                struct.sec = new org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException();
+                struct.sec.read(iprot);
+                struct.setSecIsSet(true);
+              } else { 
+                org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+              }
+              break;
             default:
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
           }
@@ -7434,6 +8161,11 @@ public class CompactionCoordinatorService {
         if (struct.success != null) {
           oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
           struct.success.write(oprot);
+          oprot.writeFieldEnd();
+        }
+        if (struct.sec != null) {
+          oprot.writeFieldBegin(SEC_FIELD_DESC);
+          struct.sec.write(oprot);
           oprot.writeFieldEnd();
         }
         oprot.writeFieldStop();
@@ -7458,20 +8190,31 @@ public class CompactionCoordinatorService {
         if (struct.isSetSuccess()) {
           optionals.set(0);
         }
-        oprot.writeBitSet(optionals, 1);
+        if (struct.isSetSec()) {
+          optionals.set(1);
+        }
+        oprot.writeBitSet(optionals, 2);
         if (struct.isSetSuccess()) {
           struct.success.write(oprot);
+        }
+        if (struct.isSetSec()) {
+          struct.sec.write(oprot);
         }
       }
 
       @Override
       public void read(org.apache.thrift.protocol.TProtocol prot, getCompletedCompactions_result struct) throws org.apache.thrift.TException {
         org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
-        java.util.BitSet incoming = iprot.readBitSet(1);
+        java.util.BitSet incoming = iprot.readBitSet(2);
         if (incoming.get(0)) {
           struct.success = new TExternalCompactionList();
           struct.success.read(iprot);
           struct.setSuccessIsSet(true);
+        }
+        if (incoming.get(1)) {
+          struct.sec = new org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException();
+          struct.sec.read(iprot);
+          struct.setSecIsSet(true);
         }
       }
     }
@@ -8084,14 +8827,16 @@ public class CompactionCoordinatorService {
   public static class cancel_result implements org.apache.thrift.TBase<cancel_result, cancel_result._Fields>, java.io.Serializable, Cloneable, Comparable<cancel_result>   {
     private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("cancel_result");
 
+    private static final org.apache.thrift.protocol.TField SEC_FIELD_DESC = new org.apache.thrift.protocol.TField("sec", org.apache.thrift.protocol.TType.STRUCT, (short)1);
 
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new cancel_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new cancel_resultTupleSchemeFactory();
 
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
-;
+      SEC((short)1, "sec");
 
       private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -8107,6 +8852,8 @@ public class CompactionCoordinatorService {
       @org.apache.thrift.annotation.Nullable
       public static _Fields findByThriftId(int fieldId) {
         switch(fieldId) {
+          case 1: // SEC
+            return SEC;
           default:
             return null;
         }
@@ -8148,9 +8895,13 @@ public class CompactionCoordinatorService {
         return _fieldName;
       }
     }
+
+    // isset id assignments
     public static final java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
     static {
       java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+      tmpMap.put(_Fields.SEC, new org.apache.thrift.meta_data.FieldMetaData("sec", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException.class)));
       metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(cancel_result.class, metaDataMap);
     }
@@ -8158,10 +8909,20 @@ public class CompactionCoordinatorService {
     public cancel_result() {
     }
 
+    public cancel_result(
+      org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec)
+    {
+      this();
+      this.sec = sec;
+    }
+
     /**
      * Performs a deep copy on <i>other</i>.
      */
     public cancel_result(cancel_result other) {
+      if (other.isSetSec()) {
+        this.sec = new org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException(other.sec);
+      }
     }
 
     @Override
@@ -8171,11 +8932,45 @@ public class CompactionCoordinatorService {
 
     @Override
     public void clear() {
+      this.sec = null;
+    }
+
+    @org.apache.thrift.annotation.Nullable
+    public org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException getSec() {
+      return this.sec;
+    }
+
+    public cancel_result setSec(@org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec) {
+      this.sec = sec;
+      return this;
+    }
+
+    public void unsetSec() {
+      this.sec = null;
+    }
+
+    /** Returns true if field sec is set (has been assigned a value) and false otherwise */
+    public boolean isSetSec() {
+      return this.sec != null;
+    }
+
+    public void setSecIsSet(boolean value) {
+      if (!value) {
+        this.sec = null;
+      }
     }
 
     @Override
     public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
       switch (field) {
+      case SEC:
+        if (value == null) {
+          unsetSec();
+        } else {
+          setSec((org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException)value);
+        }
+        break;
+
       }
     }
 
@@ -8183,6 +8978,9 @@ public class CompactionCoordinatorService {
     @Override
     public java.lang.Object getFieldValue(_Fields field) {
       switch (field) {
+      case SEC:
+        return getSec();
+
       }
       throw new java.lang.IllegalStateException();
     }
@@ -8195,6 +8993,8 @@ public class CompactionCoordinatorService {
       }
 
       switch (field) {
+      case SEC:
+        return isSetSec();
       }
       throw new java.lang.IllegalStateException();
     }
@@ -8212,12 +9012,25 @@ public class CompactionCoordinatorService {
       if (this == that)
         return true;
 
+      boolean this_present_sec = true && this.isSetSec();
+      boolean that_present_sec = true && that.isSetSec();
+      if (this_present_sec || that_present_sec) {
+        if (!(this_present_sec && that_present_sec))
+          return false;
+        if (!this.sec.equals(that.sec))
+          return false;
+      }
+
       return true;
     }
 
     @Override
     public int hashCode() {
       int hashCode = 1;
+
+      hashCode = hashCode * 8191 + ((isSetSec()) ? 131071 : 524287);
+      if (isSetSec())
+        hashCode = hashCode * 8191 + sec.hashCode();
 
       return hashCode;
     }
@@ -8230,6 +9043,16 @@ public class CompactionCoordinatorService {
 
       int lastComparison = 0;
 
+      lastComparison = java.lang.Boolean.compare(isSetSec(), other.isSetSec());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (isSetSec()) {
+        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.sec, other.sec);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
       return 0;
     }
 
@@ -8253,6 +9076,13 @@ public class CompactionCoordinatorService {
       java.lang.StringBuilder sb = new java.lang.StringBuilder("cancel_result(");
       boolean first = true;
 
+      sb.append("sec:");
+      if (this.sec == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.sec);
+      }
+      first = false;
       sb.append(")");
       return sb.toString();
     }
@@ -8298,6 +9128,15 @@ public class CompactionCoordinatorService {
             break;
           }
           switch (schemeField.id) {
+            case 1: // SEC
+              if (schemeField.type == org.apache.thrift.protocol.TType.STRUCT) {
+                struct.sec = new org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException();
+                struct.sec.read(iprot);
+                struct.setSecIsSet(true);
+              } else { 
+                org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+              }
+              break;
             default:
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
           }
@@ -8314,6 +9153,11 @@ public class CompactionCoordinatorService {
         struct.validate();
 
         oprot.writeStructBegin(STRUCT_DESC);
+        if (struct.sec != null) {
+          oprot.writeFieldBegin(SEC_FIELD_DESC);
+          struct.sec.write(oprot);
+          oprot.writeFieldEnd();
+        }
         oprot.writeFieldStop();
         oprot.writeStructEnd();
       }
@@ -8332,11 +9176,25 @@ public class CompactionCoordinatorService {
       @Override
       public void write(org.apache.thrift.protocol.TProtocol prot, cancel_result struct) throws org.apache.thrift.TException {
         org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
+        java.util.BitSet optionals = new java.util.BitSet();
+        if (struct.isSetSec()) {
+          optionals.set(0);
+        }
+        oprot.writeBitSet(optionals, 1);
+        if (struct.isSetSec()) {
+          struct.sec.write(oprot);
+        }
       }
 
       @Override
       public void read(org.apache.thrift.protocol.TProtocol prot, cancel_result struct) throws org.apache.thrift.TException {
         org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
+        java.util.BitSet incoming = iprot.readBitSet(1);
+        if (incoming.get(0)) {
+          struct.sec = new org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException();
+          struct.sec.read(iprot);
+          struct.setSecIsSet(true);
+        }
       }
     }
 

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/compaction/thrift/CompactorService.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/compaction/thrift/CompactorService.java
@@ -35,7 +35,7 @@ public class CompactorService {
 
     public java.util.List<org.apache.accumulo.core.tabletserver.thrift.ActiveCompaction> getActiveCompactions(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException;
 
-    public void cancel(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String externalCompactionId) throws org.apache.thrift.TException;
+    public void cancel(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String externalCompactionId) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, UnknownCompactionIdException, org.apache.thrift.TException;
 
   }
 
@@ -158,7 +158,7 @@ public class CompactorService {
     }
 
     @Override
-    public void cancel(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String externalCompactionId) throws org.apache.thrift.TException
+    public void cancel(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String externalCompactionId) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, UnknownCompactionIdException, org.apache.thrift.TException
     {
       send_cancel(tinfo, credentials, externalCompactionId);
       recv_cancel();
@@ -173,10 +173,16 @@ public class CompactorService {
       sendBase("cancel", args);
     }
 
-    public void recv_cancel() throws org.apache.thrift.TException
+    public void recv_cancel() throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, UnknownCompactionIdException, org.apache.thrift.TException
     {
       cancel_result result = new cancel_result();
       receiveBase(result, "cancel");
+      if (result.sec != null) {
+        throw result.sec;
+      }
+      if (result.unk != null) {
+        throw result.unk;
+      }
       return;
     }
 
@@ -344,7 +350,7 @@ public class CompactorService {
       }
 
       @Override
-      public Void getResult() throws org.apache.thrift.TException {
+      public Void getResult() throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, UnknownCompactionIdException, org.apache.thrift.TException {
         if (getState() != org.apache.thrift.async.TAsyncMethodCall.State.RESPONSE_READ) {
           throw new java.lang.IllegalStateException("Method call not finished!");
         }
@@ -494,7 +500,13 @@ public class CompactorService {
       @Override
       public cancel_result getResult(I iface, cancel_args args) throws org.apache.thrift.TException {
         cancel_result result = new cancel_result();
-        iface.cancel(args.tinfo, args.credentials, args.externalCompactionId);
+        try {
+          iface.cancel(args.tinfo, args.credentials, args.externalCompactionId);
+        } catch (org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec) {
+          result.sec = sec;
+        } catch (UnknownCompactionIdException unk) {
+          result.unk = unk;
+        }
         return result;
       }
     }
@@ -764,7 +776,15 @@ public class CompactorService {
             byte msgType = org.apache.thrift.protocol.TMessageType.REPLY;
             org.apache.thrift.TSerializable msg;
             cancel_result result = new cancel_result();
-            if (e instanceof org.apache.thrift.transport.TTransportException) {
+            if (e instanceof org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException) {
+              result.sec = (org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException) e;
+              result.setSecIsSet(true);
+              msg = result;
+            } else if (e instanceof UnknownCompactionIdException) {
+              result.unk = (UnknownCompactionIdException) e;
+              result.setUnkIsSet(true);
+              msg = result;
+            } else if (e instanceof org.apache.thrift.transport.TTransportException) {
               _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
@@ -4400,14 +4420,19 @@ public class CompactorService {
   public static class cancel_result implements org.apache.thrift.TBase<cancel_result, cancel_result._Fields>, java.io.Serializable, Cloneable, Comparable<cancel_result>   {
     private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("cancel_result");
 
+    private static final org.apache.thrift.protocol.TField SEC_FIELD_DESC = new org.apache.thrift.protocol.TField("sec", org.apache.thrift.protocol.TType.STRUCT, (short)1);
+    private static final org.apache.thrift.protocol.TField UNK_FIELD_DESC = new org.apache.thrift.protocol.TField("unk", org.apache.thrift.protocol.TType.STRUCT, (short)2);
 
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new cancel_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new cancel_resultTupleSchemeFactory();
 
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable UnknownCompactionIdException unk; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
-;
+      SEC((short)1, "sec"),
+      UNK((short)2, "unk");
 
       private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -4423,6 +4448,10 @@ public class CompactorService {
       @org.apache.thrift.annotation.Nullable
       public static _Fields findByThriftId(int fieldId) {
         switch(fieldId) {
+          case 1: // SEC
+            return SEC;
+          case 2: // UNK
+            return UNK;
           default:
             return null;
         }
@@ -4464,9 +4493,15 @@ public class CompactorService {
         return _fieldName;
       }
     }
+
+    // isset id assignments
     public static final java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
     static {
       java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+      tmpMap.put(_Fields.SEC, new org.apache.thrift.meta_data.FieldMetaData("sec", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException.class)));
+      tmpMap.put(_Fields.UNK, new org.apache.thrift.meta_data.FieldMetaData("unk", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, UnknownCompactionIdException.class)));
       metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(cancel_result.class, metaDataMap);
     }
@@ -4474,10 +4509,25 @@ public class CompactorService {
     public cancel_result() {
     }
 
+    public cancel_result(
+      org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec,
+      UnknownCompactionIdException unk)
+    {
+      this();
+      this.sec = sec;
+      this.unk = unk;
+    }
+
     /**
      * Performs a deep copy on <i>other</i>.
      */
     public cancel_result(cancel_result other) {
+      if (other.isSetSec()) {
+        this.sec = new org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException(other.sec);
+      }
+      if (other.isSetUnk()) {
+        this.unk = new UnknownCompactionIdException(other.unk);
+      }
     }
 
     @Override
@@ -4487,11 +4537,79 @@ public class CompactorService {
 
     @Override
     public void clear() {
+      this.sec = null;
+      this.unk = null;
+    }
+
+    @org.apache.thrift.annotation.Nullable
+    public org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException getSec() {
+      return this.sec;
+    }
+
+    public cancel_result setSec(@org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec) {
+      this.sec = sec;
+      return this;
+    }
+
+    public void unsetSec() {
+      this.sec = null;
+    }
+
+    /** Returns true if field sec is set (has been assigned a value) and false otherwise */
+    public boolean isSetSec() {
+      return this.sec != null;
+    }
+
+    public void setSecIsSet(boolean value) {
+      if (!value) {
+        this.sec = null;
+      }
+    }
+
+    @org.apache.thrift.annotation.Nullable
+    public UnknownCompactionIdException getUnk() {
+      return this.unk;
+    }
+
+    public cancel_result setUnk(@org.apache.thrift.annotation.Nullable UnknownCompactionIdException unk) {
+      this.unk = unk;
+      return this;
+    }
+
+    public void unsetUnk() {
+      this.unk = null;
+    }
+
+    /** Returns true if field unk is set (has been assigned a value) and false otherwise */
+    public boolean isSetUnk() {
+      return this.unk != null;
+    }
+
+    public void setUnkIsSet(boolean value) {
+      if (!value) {
+        this.unk = null;
+      }
     }
 
     @Override
     public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
       switch (field) {
+      case SEC:
+        if (value == null) {
+          unsetSec();
+        } else {
+          setSec((org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException)value);
+        }
+        break;
+
+      case UNK:
+        if (value == null) {
+          unsetUnk();
+        } else {
+          setUnk((UnknownCompactionIdException)value);
+        }
+        break;
+
       }
     }
 
@@ -4499,6 +4617,12 @@ public class CompactorService {
     @Override
     public java.lang.Object getFieldValue(_Fields field) {
       switch (field) {
+      case SEC:
+        return getSec();
+
+      case UNK:
+        return getUnk();
+
       }
       throw new java.lang.IllegalStateException();
     }
@@ -4511,6 +4635,10 @@ public class CompactorService {
       }
 
       switch (field) {
+      case SEC:
+        return isSetSec();
+      case UNK:
+        return isSetUnk();
       }
       throw new java.lang.IllegalStateException();
     }
@@ -4528,12 +4656,38 @@ public class CompactorService {
       if (this == that)
         return true;
 
+      boolean this_present_sec = true && this.isSetSec();
+      boolean that_present_sec = true && that.isSetSec();
+      if (this_present_sec || that_present_sec) {
+        if (!(this_present_sec && that_present_sec))
+          return false;
+        if (!this.sec.equals(that.sec))
+          return false;
+      }
+
+      boolean this_present_unk = true && this.isSetUnk();
+      boolean that_present_unk = true && that.isSetUnk();
+      if (this_present_unk || that_present_unk) {
+        if (!(this_present_unk && that_present_unk))
+          return false;
+        if (!this.unk.equals(that.unk))
+          return false;
+      }
+
       return true;
     }
 
     @Override
     public int hashCode() {
       int hashCode = 1;
+
+      hashCode = hashCode * 8191 + ((isSetSec()) ? 131071 : 524287);
+      if (isSetSec())
+        hashCode = hashCode * 8191 + sec.hashCode();
+
+      hashCode = hashCode * 8191 + ((isSetUnk()) ? 131071 : 524287);
+      if (isSetUnk())
+        hashCode = hashCode * 8191 + unk.hashCode();
 
       return hashCode;
     }
@@ -4546,6 +4700,26 @@ public class CompactorService {
 
       int lastComparison = 0;
 
+      lastComparison = java.lang.Boolean.compare(isSetSec(), other.isSetSec());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (isSetSec()) {
+        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.sec, other.sec);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
+      lastComparison = java.lang.Boolean.compare(isSetUnk(), other.isSetUnk());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (isSetUnk()) {
+        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.unk, other.unk);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
       return 0;
     }
 
@@ -4569,6 +4743,21 @@ public class CompactorService {
       java.lang.StringBuilder sb = new java.lang.StringBuilder("cancel_result(");
       boolean first = true;
 
+      sb.append("sec:");
+      if (this.sec == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.sec);
+      }
+      first = false;
+      if (!first) sb.append(", ");
+      sb.append("unk:");
+      if (this.unk == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.unk);
+      }
+      first = false;
       sb.append(")");
       return sb.toString();
     }
@@ -4614,6 +4803,24 @@ public class CompactorService {
             break;
           }
           switch (schemeField.id) {
+            case 1: // SEC
+              if (schemeField.type == org.apache.thrift.protocol.TType.STRUCT) {
+                struct.sec = new org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException();
+                struct.sec.read(iprot);
+                struct.setSecIsSet(true);
+              } else { 
+                org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+              }
+              break;
+            case 2: // UNK
+              if (schemeField.type == org.apache.thrift.protocol.TType.STRUCT) {
+                struct.unk = new UnknownCompactionIdException();
+                struct.unk.read(iprot);
+                struct.setUnkIsSet(true);
+              } else { 
+                org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+              }
+              break;
             default:
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
           }
@@ -4630,6 +4837,16 @@ public class CompactorService {
         struct.validate();
 
         oprot.writeStructBegin(STRUCT_DESC);
+        if (struct.sec != null) {
+          oprot.writeFieldBegin(SEC_FIELD_DESC);
+          struct.sec.write(oprot);
+          oprot.writeFieldEnd();
+        }
+        if (struct.unk != null) {
+          oprot.writeFieldBegin(UNK_FIELD_DESC);
+          struct.unk.write(oprot);
+          oprot.writeFieldEnd();
+        }
         oprot.writeFieldStop();
         oprot.writeStructEnd();
       }
@@ -4648,11 +4865,36 @@ public class CompactorService {
       @Override
       public void write(org.apache.thrift.protocol.TProtocol prot, cancel_result struct) throws org.apache.thrift.TException {
         org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
+        java.util.BitSet optionals = new java.util.BitSet();
+        if (struct.isSetSec()) {
+          optionals.set(0);
+        }
+        if (struct.isSetUnk()) {
+          optionals.set(1);
+        }
+        oprot.writeBitSet(optionals, 2);
+        if (struct.isSetSec()) {
+          struct.sec.write(oprot);
+        }
+        if (struct.isSetUnk()) {
+          struct.unk.write(oprot);
+        }
       }
 
       @Override
       public void read(org.apache.thrift.protocol.TProtocol prot, cancel_result struct) throws org.apache.thrift.TException {
         org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
+        java.util.BitSet incoming = iprot.readBitSet(2);
+        if (incoming.get(0)) {
+          struct.sec = new org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException();
+          struct.sec.read(iprot);
+          struct.setSecIsSet(true);
+        }
+        if (incoming.get(1)) {
+          struct.unk = new UnknownCompactionIdException();
+          struct.unk.read(iprot);
+          struct.setUnkIsSet(true);
+        }
       }
     }
 

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/ManagerClientService.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/ManagerClientService.java
@@ -37,13 +37,13 @@ public class ManagerClientService {
 
     public void modifyTableProperties(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String tableName, org.apache.accumulo.core.clientImpl.thrift.TVersionedProperties vProperties) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException, org.apache.accumulo.core.clientImpl.thrift.ThriftConcurrentModificationException, ThriftPropertyException, org.apache.thrift.TException;
 
-    public void removeTableProperty(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String tableName, java.lang.String property) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException, org.apache.thrift.TException;
+    public void removeTableProperty(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String tableName, java.lang.String property) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException, ThriftPropertyException, org.apache.thrift.TException;
 
     public void setNamespaceProperty(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String ns, java.lang.String property, java.lang.String value) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException, ThriftPropertyException, org.apache.thrift.TException;
 
     public void modifyNamespaceProperties(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String ns, org.apache.accumulo.core.clientImpl.thrift.TVersionedProperties vProperties) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException, org.apache.accumulo.core.clientImpl.thrift.ThriftConcurrentModificationException, org.apache.thrift.TException;
 
-    public void removeNamespaceProperty(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String ns, java.lang.String property) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException, org.apache.thrift.TException;
+    public void removeNamespaceProperty(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String ns, java.lang.String property) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException, ThriftPropertyException, org.apache.thrift.TException;
 
     public void setManagerGoalState(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, ManagerGoalState state) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException, org.apache.thrift.TException;
 
@@ -293,7 +293,7 @@ public class ManagerClientService {
     }
 
     @Override
-    public void removeTableProperty(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String tableName, java.lang.String property) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException, org.apache.thrift.TException
+    public void removeTableProperty(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String tableName, java.lang.String property) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException, ThriftPropertyException, org.apache.thrift.TException
     {
       send_removeTableProperty(tinfo, credentials, tableName, property);
       recv_removeTableProperty();
@@ -309,7 +309,7 @@ public class ManagerClientService {
       sendBase("removeTableProperty", args);
     }
 
-    public void recv_removeTableProperty() throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException, org.apache.thrift.TException
+    public void recv_removeTableProperty() throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException, ThriftPropertyException, org.apache.thrift.TException
     {
       removeTableProperty_result result = new removeTableProperty_result();
       receiveBase(result, "removeTableProperty");
@@ -321,6 +321,9 @@ public class ManagerClientService {
       }
       if (result.tnase != null) {
         throw result.tnase;
+      }
+      if (result.tpe != null) {
+        throw result.tpe;
       }
       return;
     }
@@ -399,7 +402,7 @@ public class ManagerClientService {
     }
 
     @Override
-    public void removeNamespaceProperty(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String ns, java.lang.String property) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException, org.apache.thrift.TException
+    public void removeNamespaceProperty(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, java.lang.String ns, java.lang.String property) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException, ThriftPropertyException, org.apache.thrift.TException
     {
       send_removeNamespaceProperty(tinfo, credentials, ns, property);
       recv_removeNamespaceProperty();
@@ -415,7 +418,7 @@ public class ManagerClientService {
       sendBase("removeNamespaceProperty", args);
     }
 
-    public void recv_removeNamespaceProperty() throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException, org.apache.thrift.TException
+    public void recv_removeNamespaceProperty() throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException, ThriftPropertyException, org.apache.thrift.TException
     {
       removeNamespaceProperty_result result = new removeNamespaceProperty_result();
       receiveBase(result, "removeNamespaceProperty");
@@ -427,6 +430,9 @@ public class ManagerClientService {
       }
       if (result.tnase != null) {
         throw result.tnase;
+      }
+      if (result.tpe != null) {
+        throw result.tpe;
       }
       return;
     }
@@ -1067,7 +1073,7 @@ public class ManagerClientService {
       }
 
       @Override
-      public Void getResult() throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException, org.apache.thrift.TException {
+      public Void getResult() throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException, ThriftPropertyException, org.apache.thrift.TException {
         if (getState() != org.apache.thrift.async.TAsyncMethodCall.State.RESPONSE_READ) {
           throw new java.lang.IllegalStateException("Method call not finished!");
         }
@@ -1205,7 +1211,7 @@ public class ManagerClientService {
       }
 
       @Override
-      public Void getResult() throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException, org.apache.thrift.TException {
+      public Void getResult() throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException, ThriftPropertyException, org.apache.thrift.TException {
         if (getState() != org.apache.thrift.async.TAsyncMethodCall.State.RESPONSE_READ) {
           throw new java.lang.IllegalStateException("Method call not finished!");
         }
@@ -2024,6 +2030,8 @@ public class ManagerClientService {
           result.tope = tope;
         } catch (org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase) {
           result.tnase = tnase;
+        } catch (ThriftPropertyException tpe) {
+          result.tpe = tpe;
         }
         return result;
       }
@@ -2136,6 +2144,8 @@ public class ManagerClientService {
           result.tope = tope;
         } catch (org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase) {
           result.tnase = tnase;
+        } catch (ThriftPropertyException tpe) {
+          result.tpe = tpe;
         }
         return result;
       }
@@ -3014,6 +3024,10 @@ public class ManagerClientService {
               result.tnase = (org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException) e;
               result.setTnaseIsSet(true);
               msg = result;
+            } else if (e instanceof ThriftPropertyException) {
+              result.tpe = (ThriftPropertyException) e;
+              result.setTpeIsSet(true);
+              msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
               _LOGGER.error("TTransportException inside handler", e);
               fb.close();
@@ -3255,6 +3269,10 @@ public class ManagerClientService {
             } else if (e instanceof org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException) {
               result.tnase = (org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException) e;
               result.setTnaseIsSet(true);
+              msg = result;
+            } else if (e instanceof ThriftPropertyException) {
+              result.tpe = (ThriftPropertyException) e;
+              result.setTpeIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
               _LOGGER.error("TTransportException inside handler", e);
@@ -10927,6 +10945,7 @@ public class ManagerClientService {
     private static final org.apache.thrift.protocol.TField SEC_FIELD_DESC = new org.apache.thrift.protocol.TField("sec", org.apache.thrift.protocol.TType.STRUCT, (short)1);
     private static final org.apache.thrift.protocol.TField TOPE_FIELD_DESC = new org.apache.thrift.protocol.TField("tope", org.apache.thrift.protocol.TType.STRUCT, (short)2);
     private static final org.apache.thrift.protocol.TField TNASE_FIELD_DESC = new org.apache.thrift.protocol.TField("tnase", org.apache.thrift.protocol.TType.STRUCT, (short)3);
+    private static final org.apache.thrift.protocol.TField TPE_FIELD_DESC = new org.apache.thrift.protocol.TField("tpe", org.apache.thrift.protocol.TType.STRUCT, (short)4);
 
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new removeTableProperty_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new removeTableProperty_resultTupleSchemeFactory();
@@ -10934,12 +10953,14 @@ public class ManagerClientService {
     public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
     public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException tope; // required
     public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable ThriftPropertyException tpe; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
       SEC((short)1, "sec"),
       TOPE((short)2, "tope"),
-      TNASE((short)3, "tnase");
+      TNASE((short)3, "tnase"),
+      TPE((short)4, "tpe");
 
       private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -10961,6 +10982,8 @@ public class ManagerClientService {
             return TOPE;
           case 3: // TNASE
             return TNASE;
+          case 4: // TPE
+            return TPE;
           default:
             return null;
         }
@@ -11013,6 +11036,8 @@ public class ManagerClientService {
           new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException.class)));
       tmpMap.put(_Fields.TNASE, new org.apache.thrift.meta_data.FieldMetaData("tnase", org.apache.thrift.TFieldRequirementType.DEFAULT, 
           new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException.class)));
+      tmpMap.put(_Fields.TPE, new org.apache.thrift.meta_data.FieldMetaData("tpe", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, ThriftPropertyException.class)));
       metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(removeTableProperty_result.class, metaDataMap);
     }
@@ -11023,12 +11048,14 @@ public class ManagerClientService {
     public removeTableProperty_result(
       org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec,
       org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException tope,
-      org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase)
+      org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase,
+      ThriftPropertyException tpe)
     {
       this();
       this.sec = sec;
       this.tope = tope;
       this.tnase = tnase;
+      this.tpe = tpe;
     }
 
     /**
@@ -11044,6 +11071,9 @@ public class ManagerClientService {
       if (other.isSetTnase()) {
         this.tnase = new org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException(other.tnase);
       }
+      if (other.isSetTpe()) {
+        this.tpe = new ThriftPropertyException(other.tpe);
+      }
     }
 
     @Override
@@ -11056,6 +11086,7 @@ public class ManagerClientService {
       this.sec = null;
       this.tope = null;
       this.tnase = null;
+      this.tpe = null;
     }
 
     @org.apache.thrift.annotation.Nullable
@@ -11133,6 +11164,31 @@ public class ManagerClientService {
       }
     }
 
+    @org.apache.thrift.annotation.Nullable
+    public ThriftPropertyException getTpe() {
+      return this.tpe;
+    }
+
+    public removeTableProperty_result setTpe(@org.apache.thrift.annotation.Nullable ThriftPropertyException tpe) {
+      this.tpe = tpe;
+      return this;
+    }
+
+    public void unsetTpe() {
+      this.tpe = null;
+    }
+
+    /** Returns true if field tpe is set (has been assigned a value) and false otherwise */
+    public boolean isSetTpe() {
+      return this.tpe != null;
+    }
+
+    public void setTpeIsSet(boolean value) {
+      if (!value) {
+        this.tpe = null;
+      }
+    }
+
     @Override
     public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
       switch (field) {
@@ -11160,6 +11216,14 @@ public class ManagerClientService {
         }
         break;
 
+      case TPE:
+        if (value == null) {
+          unsetTpe();
+        } else {
+          setTpe((ThriftPropertyException)value);
+        }
+        break;
+
       }
     }
 
@@ -11175,6 +11239,9 @@ public class ManagerClientService {
 
       case TNASE:
         return getTnase();
+
+      case TPE:
+        return getTpe();
 
       }
       throw new java.lang.IllegalStateException();
@@ -11194,6 +11261,8 @@ public class ManagerClientService {
         return isSetTope();
       case TNASE:
         return isSetTnase();
+      case TPE:
+        return isSetTpe();
       }
       throw new java.lang.IllegalStateException();
     }
@@ -11238,6 +11307,15 @@ public class ManagerClientService {
           return false;
       }
 
+      boolean this_present_tpe = true && this.isSetTpe();
+      boolean that_present_tpe = true && that.isSetTpe();
+      if (this_present_tpe || that_present_tpe) {
+        if (!(this_present_tpe && that_present_tpe))
+          return false;
+        if (!this.tpe.equals(that.tpe))
+          return false;
+      }
+
       return true;
     }
 
@@ -11256,6 +11334,10 @@ public class ManagerClientService {
       hashCode = hashCode * 8191 + ((isSetTnase()) ? 131071 : 524287);
       if (isSetTnase())
         hashCode = hashCode * 8191 + tnase.hashCode();
+
+      hashCode = hashCode * 8191 + ((isSetTpe()) ? 131071 : 524287);
+      if (isSetTpe())
+        hashCode = hashCode * 8191 + tpe.hashCode();
 
       return hashCode;
     }
@@ -11294,6 +11376,16 @@ public class ManagerClientService {
       }
       if (isSetTnase()) {
         lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.tnase, other.tnase);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
+      lastComparison = java.lang.Boolean.compare(isSetTpe(), other.isSetTpe());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (isSetTpe()) {
+        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.tpe, other.tpe);
         if (lastComparison != 0) {
           return lastComparison;
         }
@@ -11342,6 +11434,14 @@ public class ManagerClientService {
         sb.append("null");
       } else {
         sb.append(this.tnase);
+      }
+      first = false;
+      if (!first) sb.append(", ");
+      sb.append("tpe:");
+      if (this.tpe == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.tpe);
       }
       first = false;
       sb.append(")");
@@ -11416,6 +11516,15 @@ public class ManagerClientService {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
+            case 4: // TPE
+              if (schemeField.type == org.apache.thrift.protocol.TType.STRUCT) {
+                struct.tpe = new ThriftPropertyException();
+                struct.tpe.read(iprot);
+                struct.setTpeIsSet(true);
+              } else { 
+                org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+              }
+              break;
             default:
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
           }
@@ -11447,6 +11556,11 @@ public class ManagerClientService {
           struct.tnase.write(oprot);
           oprot.writeFieldEnd();
         }
+        if (struct.tpe != null) {
+          oprot.writeFieldBegin(TPE_FIELD_DESC);
+          struct.tpe.write(oprot);
+          oprot.writeFieldEnd();
+        }
         oprot.writeFieldStop();
         oprot.writeStructEnd();
       }
@@ -11475,7 +11589,10 @@ public class ManagerClientService {
         if (struct.isSetTnase()) {
           optionals.set(2);
         }
-        oprot.writeBitSet(optionals, 3);
+        if (struct.isSetTpe()) {
+          optionals.set(3);
+        }
+        oprot.writeBitSet(optionals, 4);
         if (struct.isSetSec()) {
           struct.sec.write(oprot);
         }
@@ -11485,12 +11602,15 @@ public class ManagerClientService {
         if (struct.isSetTnase()) {
           struct.tnase.write(oprot);
         }
+        if (struct.isSetTpe()) {
+          struct.tpe.write(oprot);
+        }
       }
 
       @Override
       public void read(org.apache.thrift.protocol.TProtocol prot, removeTableProperty_result struct) throws org.apache.thrift.TException {
         org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
-        java.util.BitSet incoming = iprot.readBitSet(3);
+        java.util.BitSet incoming = iprot.readBitSet(4);
         if (incoming.get(0)) {
           struct.sec = new org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException();
           struct.sec.read(iprot);
@@ -11505,6 +11625,11 @@ public class ManagerClientService {
           struct.tnase = new org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException();
           struct.tnase.read(iprot);
           struct.setTnaseIsSet(true);
+        }
+        if (incoming.get(3)) {
+          struct.tpe = new ThriftPropertyException();
+          struct.tpe.read(iprot);
+          struct.setTpeIsSet(true);
         }
       }
     }
@@ -15145,6 +15270,7 @@ public class ManagerClientService {
     private static final org.apache.thrift.protocol.TField SEC_FIELD_DESC = new org.apache.thrift.protocol.TField("sec", org.apache.thrift.protocol.TType.STRUCT, (short)1);
     private static final org.apache.thrift.protocol.TField TOPE_FIELD_DESC = new org.apache.thrift.protocol.TField("tope", org.apache.thrift.protocol.TType.STRUCT, (short)2);
     private static final org.apache.thrift.protocol.TField TNASE_FIELD_DESC = new org.apache.thrift.protocol.TField("tnase", org.apache.thrift.protocol.TType.STRUCT, (short)3);
+    private static final org.apache.thrift.protocol.TField TPE_FIELD_DESC = new org.apache.thrift.protocol.TField("tpe", org.apache.thrift.protocol.TType.STRUCT, (short)4);
 
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new removeNamespaceProperty_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new removeNamespaceProperty_resultTupleSchemeFactory();
@@ -15152,12 +15278,14 @@ public class ManagerClientService {
     public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
     public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException tope; // required
     public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable ThriftPropertyException tpe; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
       SEC((short)1, "sec"),
       TOPE((short)2, "tope"),
-      TNASE((short)3, "tnase");
+      TNASE((short)3, "tnase"),
+      TPE((short)4, "tpe");
 
       private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -15179,6 +15307,8 @@ public class ManagerClientService {
             return TOPE;
           case 3: // TNASE
             return TNASE;
+          case 4: // TPE
+            return TPE;
           default:
             return null;
         }
@@ -15231,6 +15361,8 @@ public class ManagerClientService {
           new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException.class)));
       tmpMap.put(_Fields.TNASE, new org.apache.thrift.meta_data.FieldMetaData("tnase", org.apache.thrift.TFieldRequirementType.DEFAULT, 
           new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException.class)));
+      tmpMap.put(_Fields.TPE, new org.apache.thrift.meta_data.FieldMetaData("tpe", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, ThriftPropertyException.class)));
       metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(removeNamespaceProperty_result.class, metaDataMap);
     }
@@ -15241,12 +15373,14 @@ public class ManagerClientService {
     public removeNamespaceProperty_result(
       org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec,
       org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException tope,
-      org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase)
+      org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase,
+      ThriftPropertyException tpe)
     {
       this();
       this.sec = sec;
       this.tope = tope;
       this.tnase = tnase;
+      this.tpe = tpe;
     }
 
     /**
@@ -15262,6 +15396,9 @@ public class ManagerClientService {
       if (other.isSetTnase()) {
         this.tnase = new org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException(other.tnase);
       }
+      if (other.isSetTpe()) {
+        this.tpe = new ThriftPropertyException(other.tpe);
+      }
     }
 
     @Override
@@ -15274,6 +15411,7 @@ public class ManagerClientService {
       this.sec = null;
       this.tope = null;
       this.tnase = null;
+      this.tpe = null;
     }
 
     @org.apache.thrift.annotation.Nullable
@@ -15351,6 +15489,31 @@ public class ManagerClientService {
       }
     }
 
+    @org.apache.thrift.annotation.Nullable
+    public ThriftPropertyException getTpe() {
+      return this.tpe;
+    }
+
+    public removeNamespaceProperty_result setTpe(@org.apache.thrift.annotation.Nullable ThriftPropertyException tpe) {
+      this.tpe = tpe;
+      return this;
+    }
+
+    public void unsetTpe() {
+      this.tpe = null;
+    }
+
+    /** Returns true if field tpe is set (has been assigned a value) and false otherwise */
+    public boolean isSetTpe() {
+      return this.tpe != null;
+    }
+
+    public void setTpeIsSet(boolean value) {
+      if (!value) {
+        this.tpe = null;
+      }
+    }
+
     @Override
     public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
       switch (field) {
@@ -15378,6 +15541,14 @@ public class ManagerClientService {
         }
         break;
 
+      case TPE:
+        if (value == null) {
+          unsetTpe();
+        } else {
+          setTpe((ThriftPropertyException)value);
+        }
+        break;
+
       }
     }
 
@@ -15393,6 +15564,9 @@ public class ManagerClientService {
 
       case TNASE:
         return getTnase();
+
+      case TPE:
+        return getTpe();
 
       }
       throw new java.lang.IllegalStateException();
@@ -15412,6 +15586,8 @@ public class ManagerClientService {
         return isSetTope();
       case TNASE:
         return isSetTnase();
+      case TPE:
+        return isSetTpe();
       }
       throw new java.lang.IllegalStateException();
     }
@@ -15456,6 +15632,15 @@ public class ManagerClientService {
           return false;
       }
 
+      boolean this_present_tpe = true && this.isSetTpe();
+      boolean that_present_tpe = true && that.isSetTpe();
+      if (this_present_tpe || that_present_tpe) {
+        if (!(this_present_tpe && that_present_tpe))
+          return false;
+        if (!this.tpe.equals(that.tpe))
+          return false;
+      }
+
       return true;
     }
 
@@ -15474,6 +15659,10 @@ public class ManagerClientService {
       hashCode = hashCode * 8191 + ((isSetTnase()) ? 131071 : 524287);
       if (isSetTnase())
         hashCode = hashCode * 8191 + tnase.hashCode();
+
+      hashCode = hashCode * 8191 + ((isSetTpe()) ? 131071 : 524287);
+      if (isSetTpe())
+        hashCode = hashCode * 8191 + tpe.hashCode();
 
       return hashCode;
     }
@@ -15512,6 +15701,16 @@ public class ManagerClientService {
       }
       if (isSetTnase()) {
         lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.tnase, other.tnase);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
+      lastComparison = java.lang.Boolean.compare(isSetTpe(), other.isSetTpe());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (isSetTpe()) {
+        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.tpe, other.tpe);
         if (lastComparison != 0) {
           return lastComparison;
         }
@@ -15560,6 +15759,14 @@ public class ManagerClientService {
         sb.append("null");
       } else {
         sb.append(this.tnase);
+      }
+      first = false;
+      if (!first) sb.append(", ");
+      sb.append("tpe:");
+      if (this.tpe == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.tpe);
       }
       first = false;
       sb.append(")");
@@ -15634,6 +15841,15 @@ public class ManagerClientService {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
+            case 4: // TPE
+              if (schemeField.type == org.apache.thrift.protocol.TType.STRUCT) {
+                struct.tpe = new ThriftPropertyException();
+                struct.tpe.read(iprot);
+                struct.setTpeIsSet(true);
+              } else { 
+                org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+              }
+              break;
             default:
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
           }
@@ -15665,6 +15881,11 @@ public class ManagerClientService {
           struct.tnase.write(oprot);
           oprot.writeFieldEnd();
         }
+        if (struct.tpe != null) {
+          oprot.writeFieldBegin(TPE_FIELD_DESC);
+          struct.tpe.write(oprot);
+          oprot.writeFieldEnd();
+        }
         oprot.writeFieldStop();
         oprot.writeStructEnd();
       }
@@ -15693,7 +15914,10 @@ public class ManagerClientService {
         if (struct.isSetTnase()) {
           optionals.set(2);
         }
-        oprot.writeBitSet(optionals, 3);
+        if (struct.isSetTpe()) {
+          optionals.set(3);
+        }
+        oprot.writeBitSet(optionals, 4);
         if (struct.isSetSec()) {
           struct.sec.write(oprot);
         }
@@ -15703,12 +15927,15 @@ public class ManagerClientService {
         if (struct.isSetTnase()) {
           struct.tnase.write(oprot);
         }
+        if (struct.isSetTpe()) {
+          struct.tpe.write(oprot);
+        }
       }
 
       @Override
       public void read(org.apache.thrift.protocol.TProtocol prot, removeNamespaceProperty_result struct) throws org.apache.thrift.TException {
         org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
-        java.util.BitSet incoming = iprot.readBitSet(3);
+        java.util.BitSet incoming = iprot.readBitSet(4);
         if (incoming.get(0)) {
           struct.sec = new org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException();
           struct.sec.read(iprot);
@@ -15723,6 +15950,11 @@ public class ManagerClientService {
           struct.tnase = new org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException();
           struct.tnase.read(iprot);
           struct.setTnaseIsSet(true);
+        }
+        if (incoming.get(3)) {
+          struct.tpe = new ThriftPropertyException();
+          struct.tpe.read(iprot);
+          struct.setTpeIsSet(true);
         }
       }
     }

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletserver/thrift/TabletClientService.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletserver/thrift/TabletClientService.java
@@ -51,7 +51,7 @@ public class TabletClientService {
 
     public void loadFiles(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, long tid, java.lang.String dir, java.util.Map<org.apache.accumulo.core.dataImpl.thrift.TKeyExtent,java.util.Map<java.lang.String,org.apache.accumulo.core.dataImpl.thrift.MapFileInfo>> files, boolean setTime) throws org.apache.thrift.TException;
 
-    public void loadFilesV2(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, long tid, java.lang.String dir, java.util.Map<org.apache.accumulo.core.dataImpl.thrift.TKeyExtent,java.util.Map<java.lang.String,org.apache.accumulo.core.dataImpl.thrift.MapFileInfo>> files, boolean setTime) throws org.apache.thrift.TException;
+    public void loadFilesV2(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, long tid, java.lang.String dir, java.util.Map<org.apache.accumulo.core.dataImpl.thrift.TKeyExtent,java.util.Map<java.lang.String,org.apache.accumulo.core.dataImpl.thrift.MapFileInfo>> files, boolean setTime) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException;
 
     public void splitTablet(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent, java.nio.ByteBuffer splitPoint) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, NotServingTabletException, org.apache.thrift.TException;
 
@@ -477,7 +477,7 @@ public class TabletClientService {
     }
 
     @Override
-    public void loadFilesV2(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, long tid, java.lang.String dir, java.util.Map<org.apache.accumulo.core.dataImpl.thrift.TKeyExtent,java.util.Map<java.lang.String,org.apache.accumulo.core.dataImpl.thrift.MapFileInfo>> files, boolean setTime) throws org.apache.thrift.TException
+    public void loadFilesV2(org.apache.accumulo.core.trace.thrift.TInfo tinfo, org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials, long tid, java.lang.String dir, java.util.Map<org.apache.accumulo.core.dataImpl.thrift.TKeyExtent,java.util.Map<java.lang.String,org.apache.accumulo.core.dataImpl.thrift.MapFileInfo>> files, boolean setTime) throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException
     {
       send_loadFilesV2(tinfo, credentials, tid, dir, files, setTime);
       recv_loadFilesV2();
@@ -495,10 +495,13 @@ public class TabletClientService {
       sendBase("loadFilesV2", args);
     }
 
-    public void recv_loadFilesV2() throws org.apache.thrift.TException
+    public void recv_loadFilesV2() throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException
     {
       loadFilesV2_result result = new loadFilesV2_result();
       receiveBase(result, "loadFilesV2");
+      if (result.sec != null) {
+        throw result.sec;
+      }
       return;
     }
 
@@ -1579,7 +1582,7 @@ public class TabletClientService {
       }
 
       @Override
-      public Void getResult() throws org.apache.thrift.TException {
+      public Void getResult() throws org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException, org.apache.thrift.TException {
         if (getState() != org.apache.thrift.async.TAsyncMethodCall.State.RESPONSE_READ) {
           throw new java.lang.IllegalStateException("Method call not finished!");
         }
@@ -2995,7 +2998,11 @@ public class TabletClientService {
       @Override
       public loadFilesV2_result getResult(I iface, loadFilesV2_args args) throws org.apache.thrift.TException {
         loadFilesV2_result result = new loadFilesV2_result();
-        iface.loadFilesV2(args.tinfo, args.credentials, args.tid, args.dir, args.files, args.setTime);
+        try {
+          iface.loadFilesV2(args.tinfo, args.credentials, args.tid, args.dir, args.files, args.setTime);
+        } catch (org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec) {
+          result.sec = sec;
+        }
         return result;
       }
     }
@@ -4457,7 +4464,11 @@ public class TabletClientService {
             byte msgType = org.apache.thrift.protocol.TMessageType.REPLY;
             org.apache.thrift.TSerializable msg;
             loadFilesV2_result result = new loadFilesV2_result();
-            if (e instanceof org.apache.thrift.transport.TTransportException) {
+            if (e instanceof org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException) {
+              result.sec = (org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException) e;
+              result.setSecIsSet(true);
+              msg = result;
+            } else if (e instanceof org.apache.thrift.transport.TTransportException) {
               _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
@@ -18507,14 +18518,16 @@ public class TabletClientService {
   public static class loadFilesV2_result implements org.apache.thrift.TBase<loadFilesV2_result, loadFilesV2_result._Fields>, java.io.Serializable, Cloneable, Comparable<loadFilesV2_result>   {
     private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("loadFilesV2_result");
 
+    private static final org.apache.thrift.protocol.TField SEC_FIELD_DESC = new org.apache.thrift.protocol.TField("sec", org.apache.thrift.protocol.TType.STRUCT, (short)1);
 
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new loadFilesV2_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new loadFilesV2_resultTupleSchemeFactory();
 
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
-;
+      SEC((short)1, "sec");
 
       private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -18530,6 +18543,8 @@ public class TabletClientService {
       @org.apache.thrift.annotation.Nullable
       public static _Fields findByThriftId(int fieldId) {
         switch(fieldId) {
+          case 1: // SEC
+            return SEC;
           default:
             return null;
         }
@@ -18571,9 +18586,13 @@ public class TabletClientService {
         return _fieldName;
       }
     }
+
+    // isset id assignments
     public static final java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
     static {
       java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+      tmpMap.put(_Fields.SEC, new org.apache.thrift.meta_data.FieldMetaData("sec", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException.class)));
       metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(loadFilesV2_result.class, metaDataMap);
     }
@@ -18581,10 +18600,20 @@ public class TabletClientService {
     public loadFilesV2_result() {
     }
 
+    public loadFilesV2_result(
+      org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec)
+    {
+      this();
+      this.sec = sec;
+    }
+
     /**
      * Performs a deep copy on <i>other</i>.
      */
     public loadFilesV2_result(loadFilesV2_result other) {
+      if (other.isSetSec()) {
+        this.sec = new org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException(other.sec);
+      }
     }
 
     @Override
@@ -18594,11 +18623,45 @@ public class TabletClientService {
 
     @Override
     public void clear() {
+      this.sec = null;
+    }
+
+    @org.apache.thrift.annotation.Nullable
+    public org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException getSec() {
+      return this.sec;
+    }
+
+    public loadFilesV2_result setSec(@org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec) {
+      this.sec = sec;
+      return this;
+    }
+
+    public void unsetSec() {
+      this.sec = null;
+    }
+
+    /** Returns true if field sec is set (has been assigned a value) and false otherwise */
+    public boolean isSetSec() {
+      return this.sec != null;
+    }
+
+    public void setSecIsSet(boolean value) {
+      if (!value) {
+        this.sec = null;
+      }
     }
 
     @Override
     public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
       switch (field) {
+      case SEC:
+        if (value == null) {
+          unsetSec();
+        } else {
+          setSec((org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException)value);
+        }
+        break;
+
       }
     }
 
@@ -18606,6 +18669,9 @@ public class TabletClientService {
     @Override
     public java.lang.Object getFieldValue(_Fields field) {
       switch (field) {
+      case SEC:
+        return getSec();
+
       }
       throw new java.lang.IllegalStateException();
     }
@@ -18618,6 +18684,8 @@ public class TabletClientService {
       }
 
       switch (field) {
+      case SEC:
+        return isSetSec();
       }
       throw new java.lang.IllegalStateException();
     }
@@ -18635,12 +18703,25 @@ public class TabletClientService {
       if (this == that)
         return true;
 
+      boolean this_present_sec = true && this.isSetSec();
+      boolean that_present_sec = true && that.isSetSec();
+      if (this_present_sec || that_present_sec) {
+        if (!(this_present_sec && that_present_sec))
+          return false;
+        if (!this.sec.equals(that.sec))
+          return false;
+      }
+
       return true;
     }
 
     @Override
     public int hashCode() {
       int hashCode = 1;
+
+      hashCode = hashCode * 8191 + ((isSetSec()) ? 131071 : 524287);
+      if (isSetSec())
+        hashCode = hashCode * 8191 + sec.hashCode();
 
       return hashCode;
     }
@@ -18653,6 +18734,16 @@ public class TabletClientService {
 
       int lastComparison = 0;
 
+      lastComparison = java.lang.Boolean.compare(isSetSec(), other.isSetSec());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (isSetSec()) {
+        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.sec, other.sec);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
       return 0;
     }
 
@@ -18676,6 +18767,13 @@ public class TabletClientService {
       java.lang.StringBuilder sb = new java.lang.StringBuilder("loadFilesV2_result(");
       boolean first = true;
 
+      sb.append("sec:");
+      if (this.sec == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.sec);
+      }
+      first = false;
       sb.append(")");
       return sb.toString();
     }
@@ -18721,6 +18819,15 @@ public class TabletClientService {
             break;
           }
           switch (schemeField.id) {
+            case 1: // SEC
+              if (schemeField.type == org.apache.thrift.protocol.TType.STRUCT) {
+                struct.sec = new org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException();
+                struct.sec.read(iprot);
+                struct.setSecIsSet(true);
+              } else { 
+                org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+              }
+              break;
             default:
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
           }
@@ -18737,6 +18844,11 @@ public class TabletClientService {
         struct.validate();
 
         oprot.writeStructBegin(STRUCT_DESC);
+        if (struct.sec != null) {
+          oprot.writeFieldBegin(SEC_FIELD_DESC);
+          struct.sec.write(oprot);
+          oprot.writeFieldEnd();
+        }
         oprot.writeFieldStop();
         oprot.writeStructEnd();
       }
@@ -18755,11 +18867,25 @@ public class TabletClientService {
       @Override
       public void write(org.apache.thrift.protocol.TProtocol prot, loadFilesV2_result struct) throws org.apache.thrift.TException {
         org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
+        java.util.BitSet optionals = new java.util.BitSet();
+        if (struct.isSetSec()) {
+          optionals.set(0);
+        }
+        oprot.writeBitSet(optionals, 1);
+        if (struct.isSetSec()) {
+          struct.sec.write(oprot);
+        }
       }
 
       @Override
       public void read(org.apache.thrift.protocol.TProtocol prot, loadFilesV2_result struct) throws org.apache.thrift.TException {
         org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
+        java.util.BitSet incoming = iprot.readBitSet(1);
+        if (incoming.get(0)) {
+          struct.sec = new org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException();
+          struct.sec.read(iprot);
+          struct.setSecIsSet(true);
+        }
       }
     }
 

--- a/core/src/main/thrift/client.thrift
+++ b/core/src/main/thrift/client.thrift
@@ -402,6 +402,8 @@ service ClientService {
     4:security.TCredentials credentials
     2:string className
     3:string interfaceMatch
+  ) throws (
+    1:ThriftSecurityException sec
   )
 
   bool checkTableClass(

--- a/core/src/main/thrift/compaction-coordinator.thrift
+++ b/core/src/main/thrift/compaction-coordinator.thrift
@@ -80,6 +80,8 @@ service CompactionCoordinatorService {
     3:string externalCompactionId
     4:data.TKeyExtent extent
     5:tabletserver.TCompactionStats stats
+  ) throws (
+    1:client.ThriftSecurityException sec
   )
   
   /*
@@ -91,6 +93,8 @@ service CompactionCoordinatorService {
     3:string queueName
     4:string compactor
     5:string externalCompactionId
+  ) throws (
+    1:client.ThriftSecurityException sec
   )
   
   /*
@@ -102,6 +106,8 @@ service CompactionCoordinatorService {
     3:string externalCompactionId
     4:TCompactionStatusUpdate status
     5:i64 timestamp
+  ) throws (
+    1:client.ThriftSecurityException sec
   )
   
   /*
@@ -113,6 +119,8 @@ service CompactionCoordinatorService {
     3:string externalCompactionId
     4:data.TKeyExtent extent
     5:string exceptionClassName
+  ) throws (
+    1:client.ThriftSecurityException sec
   )
 
   /*
@@ -121,6 +129,8 @@ service CompactionCoordinatorService {
   TExternalCompactionList getRunningCompactions(
     1:trace.TInfo tinfo
     2:security.TCredentials credentials
+  ) throws (
+    1:client.ThriftSecurityException sec
   )
 
   /*
@@ -129,12 +139,16 @@ service CompactionCoordinatorService {
   TExternalCompactionList getCompletedCompactions(
     1:trace.TInfo tinfo
     2:security.TCredentials credentials
+  ) throws (
+    1:client.ThriftSecurityException sec
   )
 
   void cancel(
     1:trace.TInfo tinfo
     2:security.TCredentials credentials
     3:string externalCompactionId
+  ) throws (
+    1:client.ThriftSecurityException sec
   )
 
 }
@@ -166,5 +180,8 @@ service CompactorService {
     1:trace.TInfo tinfo
     2:security.TCredentials credentials
     3:string externalCompactionId
+  ) throws (
+    1:client.ThriftSecurityException sec
+    2:UnknownCompactionIdException unk
   )
 }

--- a/core/src/main/thrift/manager.thrift
+++ b/core/src/main/thrift/manager.thrift
@@ -224,6 +224,7 @@ service ManagerClientService {
     1:client.ThriftSecurityException sec
     2:client.ThriftTableOperationException tope
     3:client.ThriftNotActiveServiceException tnase
+    4:ThriftPropertyException tpe
   )
 
   void setNamespaceProperty(
@@ -260,6 +261,7 @@ service ManagerClientService {
     1:client.ThriftSecurityException sec
     2:client.ThriftTableOperationException tope
     3:client.ThriftNotActiveServiceException tnase
+    4:ThriftPropertyException tpe
   )
 
   // system management methods

--- a/core/src/main/thrift/tabletserver.thrift
+++ b/core/src/main/thrift/tabletserver.thrift
@@ -393,6 +393,8 @@ service TabletClientService {
     4:string dir
     5:map<data.TKeyExtent, map<string, data.MapFileInfo>> files
     6:bool setTime
+  ) throws (
+    1:client.ThriftSecurityException sec
   )
 
   void splitTablet(

--- a/core/src/test/java/org/apache/accumulo/core/client/TestThrift1474.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/TestThrift1474.java
@@ -24,11 +24,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
-
 import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.clientImpl.thrift.ThriftTest;
-import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.server.TServer;
@@ -43,24 +40,24 @@ public class TestThrift1474 {
   static class TestServer implements ThriftTest.Iface {
 
     @Override
-    public boolean success() throws TException {
+    public boolean success() {
       return true;
     }
 
     @Override
-    public boolean fails() throws TException {
+    public boolean fails() {
       return false;
     }
 
     @Override
-    public boolean throwsError() throws ThriftSecurityException, TException {
+    public boolean throwsError() throws ThriftSecurityException {
       throw new ThriftSecurityException();
     }
 
   }
 
   @Test
-  public void test() throws IOException, TException, InterruptedException {
+  public void test() throws Exception {
     TServerSocket serverTransport = new TServerSocket(0);
     serverTransport.listen();
     int port = serverTransport.getServerSocket().getLocalPort();

--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@ under the License.
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>5.12.1</version>
+        <version>5.14.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -607,7 +607,7 @@ under the License.
       <dependency>
         <groupId>org.easymock</groupId>
         <artifactId>easymock</artifactId>
-        <version>5.5.0</version>
+        <version>5.6.0</version>
       </dependency>
       <dependency>
         <groupId>org.freemarker</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,7 @@ under the License.
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>5.12.1</version>
+        <version>5.14.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -613,7 +613,7 @@ under the License.
       <dependency>
         <groupId>org.easymock</groupId>
         <artifactId>easymock</artifactId>
-        <version>5.5.0</version>
+        <version>5.6.0</version>
       </dependency>
       <dependency>
         <groupId>org.freemarker</groupId>

--- a/server/base/src/main/java/org/apache/accumulo/server/client/ClientServiceHandler.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/client/ClientServiceHandler.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.server.client;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -31,7 +32,6 @@ import java.util.Set;
 import java.util.SortedSet;
 
 import org.apache.accumulo.core.classloader.ClassLoaderUtil;
-import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.NamespaceNotFoundException;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
@@ -69,7 +69,6 @@ import org.apache.accumulo.server.security.AuditedSecurityOperation;
 import org.apache.accumulo.server.util.ServerBulkImportStatus;
 import org.apache.accumulo.server.util.TableDiskUsage;
 import org.apache.accumulo.server.zookeeper.TransactionWatcher;
-import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,15 +87,15 @@ public class ClientServiceHandler implements ClientService.Iface {
 
   public static TableId checkTableId(ClientContext context, String tableName,
       TableOperation operation) throws ThriftTableOperationException {
-    TableOperationExceptionType reason = null;
     try {
       return context._getTableIdDetectNamespaceNotFound(tableName);
     } catch (NamespaceNotFoundException e) {
-      reason = TableOperationExceptionType.NAMESPACE_NOTFOUND;
+      throw new ThriftTableOperationException(null, tableName, operation,
+          TableOperationExceptionType.NAMESPACE_NOTFOUND, e.getMessage());
     } catch (TableNotFoundException e) {
-      reason = TableOperationExceptionType.NOTFOUND;
+      throw new ThriftTableOperationException(null, tableName, operation,
+          TableOperationExceptionType.NOTFOUND, e.getMessage());
     }
-    throw new ThriftTableOperationException(null, tableName, operation, reason, null);
   }
 
   public static NamespaceId checkNamespaceId(ClientContext context, String namespaceName,
@@ -109,7 +108,7 @@ public class ClientServiceHandler implements ClientService.Iface {
       namespaceId = Namespaces.lookupNamespaceId(context, namespaceName);
       if (namespaceId == null) {
         throw new ThriftTableOperationException(null, namespaceName, operation,
-            TableOperationExceptionType.NAMESPACE_NOTFOUND, null);
+            TableOperationExceptionType.NAMESPACE_NOTFOUND, "Namespace does not exist");
       }
     }
     return namespaceId;
@@ -211,7 +210,8 @@ public class ClientServiceHandler implements ClientService.Iface {
 
   @Override
   public void grantTablePermission(TInfo tinfo, TCredentials credentials, String user,
-      String tableName, byte permission) throws TException {
+      String tableName, byte permission)
+      throws ThriftSecurityException, ThriftTableOperationException {
     TableId tableId = checkTableId(context, tableName, TableOperation.PERMISSION);
     NamespaceId namespaceId;
     try {
@@ -219,7 +219,8 @@ public class ClientServiceHandler implements ClientService.Iface {
       security.grantTablePermission(credentials, user, tableId, tableName,
           TablePermission.getPermissionById(permission), namespaceId);
     } catch (TableNotFoundException e) {
-      throw new TException(e);
+      throw new ThriftTableOperationException(tableId.canonical(), tableName,
+          TableOperation.PERMISSION, TableOperationExceptionType.NOTFOUND, e.getMessage());
     }
   }
 
@@ -240,13 +241,15 @@ public class ClientServiceHandler implements ClientService.Iface {
 
   @Override
   public void revokeTablePermission(TInfo tinfo, TCredentials credentials, String user,
-      String tableName, byte permission) throws TException {
+      String tableName, byte permission)
+      throws ThriftSecurityException, ThriftTableOperationException {
     TableId tableId = checkTableId(context, tableName, TableOperation.PERMISSION);
     NamespaceId namespaceId;
     try {
       namespaceId = context.getNamespaceId(tableId);
     } catch (TableNotFoundException e) {
-      throw new TException(e);
+      throw new ThriftTableOperationException(tableId.canonical(), tableName,
+          TableOperation.PERMISSION, TableOperationExceptionType.NOTFOUND, e.getMessage());
     }
 
     security.revokeTablePermission(credentials, user, tableId,
@@ -291,8 +294,7 @@ public class ClientServiceHandler implements ClientService.Iface {
     return security.listUsers(credentials);
   }
 
-  private Map<String,String> conf(TCredentials credentials, AccumuloConfiguration conf)
-      throws TException {
+  private Map<String,String> conf(TCredentials credentials, AccumuloConfiguration conf) {
     conf.invalidateCache();
 
     Map<String,String> result = new HashMap<>();
@@ -345,7 +347,7 @@ public class ClientServiceHandler implements ClientService.Iface {
 
   @Override
   public Map<String,String> getConfiguration(TInfo tinfo, TCredentials credentials,
-      ConfigurationType type) throws TException {
+      ConfigurationType type) throws ThriftSecurityException {
     checkSystemPermission(credentials);
     switch (type) {
       case CURRENT:
@@ -377,7 +379,7 @@ public class ClientServiceHandler implements ClientService.Iface {
 
   @Override
   public Map<String,String> getTableConfiguration(TInfo tinfo, TCredentials credentials,
-      String tableName) throws TException, ThriftTableOperationException {
+      String tableName) throws ThriftTableOperationException, ThriftSecurityException {
     TableId tableId = checkTableId(context, tableName, null);
     checkTablePermission(credentials, tableId, TablePermission.ALTER_TABLE);
     context.getPropStore().getCache().remove(TablePropKey.of(context, tableId));
@@ -387,7 +389,7 @@ public class ClientServiceHandler implements ClientService.Iface {
 
   @Override
   public Map<String,String> getTableProperties(TInfo tinfo, TCredentials credentials,
-      String tableName) throws TException {
+      String tableName) throws ThriftTableOperationException, ThriftSecurityException {
     final TableId tableId = checkTableId(context, tableName, null);
     checkTablePermission(credentials, tableId, TablePermission.ALTER_TABLE);
     return context.getPropStore().get(TablePropKey.of(context, tableId)).asMap();
@@ -395,7 +397,7 @@ public class ClientServiceHandler implements ClientService.Iface {
 
   @Override
   public TVersionedProperties getVersionedTableProperties(TInfo tinfo, TCredentials credentials,
-      String tableName) throws TException {
+      String tableName) throws ThriftTableOperationException, ThriftSecurityException {
     final TableId tableId = checkTableId(context, tableName, null);
     checkTablePermission(credentials, tableId, TablePermission.ALTER_TABLE);
     return Optional.of(context.getPropStore().get(TablePropKey.of(context, tableId)))
@@ -406,25 +408,21 @@ public class ClientServiceHandler implements ClientService.Iface {
   @Override
   public List<String> bulkImportFiles(TInfo tinfo, final TCredentials credentials, final long tid,
       final String tableId, final List<String> files, final String errorDir, final boolean setTime)
-      throws ThriftSecurityException, ThriftTableOperationException, TException {
-    try {
-      if (!security.canPerformSystemActions(credentials)) {
-        throw new AccumuloSecurityException(credentials.getPrincipal(),
-            SecurityErrorCode.PERMISSION_DENIED);
-      }
-      bulkImportStatus.updateBulkImportStatus(files, BulkImportState.INITIAL);
-      log.debug("Got request to bulk import files to table({}): {}", tableId, files);
+      throws ThriftSecurityException, ThriftTableOperationException {
+    if (!security.canPerformSystemActions(credentials)) {
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
+    }
+    bulkImportStatus.updateBulkImportStatus(files, BulkImportState.INITIAL);
+    log.debug("Got request to bulk import files to table({}): {}", tableId, files);
 
-      bulkImportStatus.updateBulkImportStatus(files, BulkImportState.PROCESSING);
-      try {
-        return BulkImporter.bulkLoad(context, tid, tableId, files, setTime);
-      } finally {
-        bulkImportStatus.removeBulkImportStatus(files);
-      }
-    } catch (AccumuloSecurityException e) {
-      throw e.asThriftException();
-    } catch (Exception ex) {
-      throw new TException(ex);
+    bulkImportStatus.updateBulkImportStatus(files, BulkImportState.PROCESSING);
+    try {
+      return BulkImporter.bulkLoad(context, tid, tableId, files, setTime);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    } finally {
+      bulkImportStatus.removeBulkImportStatus(files);
     }
   }
 
@@ -435,7 +433,7 @@ public class ClientServiceHandler implements ClientService.Iface {
 
   @Override
   public boolean checkClass(TInfo tinfo, TCredentials credentials, String className,
-      String interfaceMatch) throws TException {
+      String interfaceMatch) throws ThriftSecurityException {
     security.authenticateUser(credentials, credentials);
 
     ClassLoader loader = getClass().getClassLoader();
@@ -454,7 +452,7 @@ public class ClientServiceHandler implements ClientService.Iface {
   @Override
   public boolean checkTableClass(TInfo tinfo, TCredentials credentials, String tableName,
       String className, String interfaceMatch)
-      throws TException, ThriftTableOperationException, ThriftSecurityException {
+      throws ThriftTableOperationException, ThriftSecurityException {
 
     security.authenticateUser(credentials, credentials);
 
@@ -478,7 +476,7 @@ public class ClientServiceHandler implements ClientService.Iface {
   @Override
   public boolean checkNamespaceClass(TInfo tinfo, TCredentials credentials, String ns,
       String className, String interfaceMatch)
-      throws TException, ThriftTableOperationException, ThriftSecurityException {
+      throws ThriftTableOperationException, ThriftSecurityException {
 
     security.authenticateUser(credentials, credentials);
 
@@ -501,7 +499,7 @@ public class ClientServiceHandler implements ClientService.Iface {
 
   @Override
   public List<TDiskUsage> getDiskUsage(Set<String> tables, TCredentials credentials)
-      throws ThriftTableOperationException, ThriftSecurityException, TException {
+      throws ThriftTableOperationException, ThriftSecurityException {
     try {
       HashSet<TableId> tableIds = new HashSet<>();
 
@@ -525,18 +523,19 @@ public class ClientServiceHandler implements ClientService.Iface {
       return retUsages;
 
     } catch (TableNotFoundException e) {
-      throw new TException(e);
+      throw new ThriftTableOperationException(null, e.getTableName(), null,
+          TableOperationExceptionType.NOTFOUND, e.getMessage());
     }
   }
 
   @Override
   public Map<String,String> getNamespaceConfiguration(TInfo tinfo, TCredentials credentials,
-      String ns) throws ThriftTableOperationException, TException {
+      String ns) throws ThriftTableOperationException, ThriftSecurityException {
     NamespaceId namespaceId;
     try {
       namespaceId = Namespaces.getNamespaceId(context, ns);
     } catch (NamespaceNotFoundException e) {
-      String why = "Could not find namespace while getting configuration.";
+      String why = "Could not find namespace while getting configuration: " + e.getMessage();
       throw new ThriftTableOperationException(null, ns, null,
           TableOperationExceptionType.NAMESPACE_NOTFOUND, why);
     }
@@ -549,7 +548,7 @@ public class ClientServiceHandler implements ClientService.Iface {
 
   @Override
   public Map<String,String> getNamespaceProperties(TInfo tinfo, TCredentials credentials, String ns)
-      throws TException {
+      throws ThriftTableOperationException, ThriftSecurityException {
     NamespaceId namespaceId;
     try {
       namespaceId = Namespaces.getNamespaceId(context, ns);
@@ -557,7 +556,7 @@ public class ClientServiceHandler implements ClientService.Iface {
       return context.getPropStore().get(NamespacePropKey.of(context, namespaceId)).asMap();
 
     } catch (NamespaceNotFoundException e) {
-      String why = "Could not find namespace while getting configuration.";
+      String why = "Could not find namespace while getting configuration: " + e.getMessage();
       throw new ThriftTableOperationException(null, ns, null,
           TableOperationExceptionType.NAMESPACE_NOTFOUND, why);
     }
@@ -565,7 +564,7 @@ public class ClientServiceHandler implements ClientService.Iface {
 
   @Override
   public TVersionedProperties getVersionedNamespaceProperties(TInfo tinfo, TCredentials credentials,
-      String ns) throws TException {
+      String ns) throws ThriftTableOperationException, ThriftSecurityException {
     NamespaceId namespaceId;
     try {
       namespaceId = Namespaces.getNamespaceId(context, ns);
@@ -574,7 +573,7 @@ public class ClientServiceHandler implements ClientService.Iface {
           .map(vProps -> new TVersionedProperties(vProps.getDataVersion(), vProps.asMap()))
           .orElseThrow();
     } catch (NamespaceNotFoundException e) {
-      String why = "Could not find namespace while getting configuration.";
+      String why = "Could not find namespace while getting configuration: " + e.getMessage();
       throw new ThriftTableOperationException(null, ns, null,
           TableOperationExceptionType.NAMESPACE_NOTFOUND, why);
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/VerifyTabletAssignments.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/VerifyTabletAssignments.java
@@ -57,7 +57,6 @@ import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.hadoop.io.Text;
 import org.apache.thrift.TException;
-import org.apache.thrift.TServiceClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -155,7 +154,7 @@ public class VerifyTabletAssignments {
 
   private static void checkTabletServer(ClientContext context,
       Entry<HostAndPort,List<KeyExtent>> entry, HashSet<KeyExtent> failures) throws TException {
-    TabletScanClientService.Iface client =
+    TabletScanClientService.Client client =
         ThriftUtil.getClient(ThriftClientTypes.TABLET_SCAN, entry.getKey(), context);
 
     Map<TKeyExtent,List<TRange>> batch = new TreeMap<>();
@@ -205,6 +204,6 @@ public class VerifyTabletAssignments {
 
     client.closeMultiScan(tinfo, is.scanID);
 
-    ThriftUtil.returnClient((TServiceClient) client, context);
+    ThriftUtil.returnClient(client, context);
   }
 }

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
@@ -39,13 +39,9 @@ import java.util.stream.Collectors;
 
 import org.apache.accumulo.coordinator.QueueSummaries.PrioTserver;
 import org.apache.accumulo.core.Constants;
-import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.clientImpl.thrift.SecurityErrorCode;
-import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
-import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
 import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
-import org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException;
 import org.apache.accumulo.core.compaction.thrift.CompactionCoordinatorService;
 import org.apache.accumulo.core.compaction.thrift.TCompactionState;
 import org.apache.accumulo.core.compaction.thrift.TCompactionStatusUpdate;
@@ -542,8 +538,8 @@ public class CompactionCoordinator extends AbstractServer implements
 
     // do not expect users to call this directly, expect compactors to call this method
     if (!security.canPerformSystemActions(credentials)) {
-      throw new AccumuloSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
     }
     final String queue = queueName.intern();
     LOG.trace("getCompactionJob called for queue {} by compactor {}", queue, compactorAddress);
@@ -648,8 +644,8 @@ public class CompactionCoordinator extends AbstractServer implements
       throws ThriftSecurityException {
     // do not expect users to call this directly, expect other tservers to call this method
     if (!security.canPerformSystemActions(credentials)) {
-      throw new AccumuloSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
     }
 
     var extent = KeyExtent.fromThrift(textent);
@@ -669,8 +665,8 @@ public class CompactionCoordinator extends AbstractServer implements
       TKeyExtent extent, String exceptionClassName) throws ThriftSecurityException {
     // do not expect users to call this directly, expect other tservers to call this method
     if (!security.canPerformSystemActions(credentials)) {
-      throw new AccumuloSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
     }
     KeyExtent fromThriftExtent = KeyExtent.fromThrift(extent);
     LOG.info("Compaction failed: id: {}, extent: {}, compactor exception:{}", externalCompactionId,
@@ -773,8 +769,8 @@ public class CompactionCoordinator extends AbstractServer implements
       throws ThriftSecurityException {
     // do not expect users to call this directly, expect other tservers to call this method
     if (!security.canPerformSystemActions(credentials)) {
-      throw new AccumuloSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
     }
     STATUS_LOG.trace("Compaction status update, id: {}, timestamp: {}, update: {}",
         externalCompactionId, timestamp, update);
@@ -839,8 +835,8 @@ public class CompactionCoordinator extends AbstractServer implements
       throws ThriftSecurityException {
     // do not expect users to call this directly, expect other tservers to call this method
     if (!security.canPerformSystemActions(credentials)) {
-      throw new AccumuloSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
     }
 
     final TExternalCompactionList result = new TExternalCompactionList();
@@ -868,8 +864,8 @@ public class CompactionCoordinator extends AbstractServer implements
       throws ThriftSecurityException {
     // do not expect users to call this directly, expect other tservers to call this method
     if (!security.canPerformSystemActions(credentials)) {
-      throw new AccumuloSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
     }
     final TExternalCompactionList result = new TExternalCompactionList();
     COMPLETED.asMap().forEach((ecid, rc) -> {
@@ -885,18 +881,18 @@ public class CompactionCoordinator extends AbstractServer implements
 
   @Override
   public void cancel(TInfo tinfo, TCredentials credentials, String externalCompactionId)
-      throws TException {
+      throws ThriftSecurityException {
     var runningCompaction = RUNNING_CACHE.get(ExternalCompactionId.of(externalCompactionId));
     var extent = KeyExtent.fromThrift(runningCompaction.getJob().getExtent());
+    NamespaceId nsId;
     try {
-      NamespaceId nsId = getContext().getNamespaceId(extent.tableId());
-      if (!security.canCompact(credentials, extent.tableId(), nsId)) {
-        throw new AccumuloSecurityException(credentials.getPrincipal(),
-            SecurityErrorCode.PERMISSION_DENIED).asThriftException();
-      }
+      nsId = getContext().getNamespaceId(extent.tableId());
     } catch (TableNotFoundException e) {
-      throw new ThriftTableOperationException(extent.tableId().canonical(), null,
-          TableOperation.COMPACT_CANCEL, TableOperationExceptionType.NOTFOUND, e.getMessage());
+      throw new IllegalStateException("Table " + extent.tableId() + " no longer exists");
+    }
+    if (!security.canCompact(credentials, extent.tableId(), nsId)) {
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
     }
 
     HostAndPort address = HostAndPort.fromString(runningCompaction.getCompactorAddress());

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
@@ -39,13 +39,9 @@ import java.util.stream.Collectors;
 
 import org.apache.accumulo.coordinator.QueueSummaries.PrioTserver;
 import org.apache.accumulo.core.Constants;
-import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.clientImpl.thrift.SecurityErrorCode;
-import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
-import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
 import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
-import org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException;
 import org.apache.accumulo.core.compaction.thrift.CompactionCoordinatorService;
 import org.apache.accumulo.core.compaction.thrift.TCompactionState;
 import org.apache.accumulo.core.compaction.thrift.TCompactionStatusUpdate;
@@ -537,8 +533,8 @@ public class CompactionCoordinator extends AbstractServer implements
 
     // do not expect users to call this directly, expect compactors to call this method
     if (!security.canPerformSystemActions(credentials)) {
-      throw new AccumuloSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
     }
     final String queue = queueName.intern();
     LOG.trace("getCompactionJob called for queue {} by compactor {}", queue, compactorAddress);
@@ -643,8 +639,8 @@ public class CompactionCoordinator extends AbstractServer implements
       throws ThriftSecurityException {
     // do not expect users to call this directly, expect other tservers to call this method
     if (!security.canPerformSystemActions(credentials)) {
-      throw new AccumuloSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
     }
 
     var extent = KeyExtent.fromThrift(textent);
@@ -664,8 +660,8 @@ public class CompactionCoordinator extends AbstractServer implements
       TKeyExtent extent, String exceptionClassName) throws ThriftSecurityException {
     // do not expect users to call this directly, expect other tservers to call this method
     if (!security.canPerformSystemActions(credentials)) {
-      throw new AccumuloSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
     }
     KeyExtent fromThriftExtent = KeyExtent.fromThrift(extent);
     LOG.info("Compaction failed: id: {}, extent: {}, compactor exception:{}", externalCompactionId,
@@ -768,8 +764,8 @@ public class CompactionCoordinator extends AbstractServer implements
       throws ThriftSecurityException {
     // do not expect users to call this directly, expect other tservers to call this method
     if (!security.canPerformSystemActions(credentials)) {
-      throw new AccumuloSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
     }
     STATUS_LOG.trace("Compaction status update, id: {}, timestamp: {}, update: {}",
         externalCompactionId, timestamp, update);
@@ -834,8 +830,8 @@ public class CompactionCoordinator extends AbstractServer implements
       throws ThriftSecurityException {
     // do not expect users to call this directly, expect other tservers to call this method
     if (!security.canPerformSystemActions(credentials)) {
-      throw new AccumuloSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
     }
 
     final TExternalCompactionList result = new TExternalCompactionList();
@@ -863,8 +859,8 @@ public class CompactionCoordinator extends AbstractServer implements
       throws ThriftSecurityException {
     // do not expect users to call this directly, expect other tservers to call this method
     if (!security.canPerformSystemActions(credentials)) {
-      throw new AccumuloSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
     }
     final TExternalCompactionList result = new TExternalCompactionList();
     COMPLETED.asMap().forEach((ecid, rc) -> {
@@ -880,18 +876,20 @@ public class CompactionCoordinator extends AbstractServer implements
 
   @Override
   public void cancel(TInfo tinfo, TCredentials credentials, String externalCompactionId)
-      throws TException {
+      throws ThriftSecurityException {
     var runningCompaction = RUNNING_CACHE.get(ExternalCompactionId.of(externalCompactionId));
     var extent = KeyExtent.fromThrift(runningCompaction.getJob().getExtent());
     try {
       NamespaceId nsId = getContext().getNamespaceId(extent.tableId());
       if (!security.canCompact(credentials, extent.tableId(), nsId)) {
-        throw new AccumuloSecurityException(credentials.getPrincipal(),
-            SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+        throw new ThriftSecurityException(credentials.getPrincipal(),
+            SecurityErrorCode.PERMISSION_DENIED);
       }
     } catch (TableNotFoundException e) {
-      throw new ThriftTableOperationException(extent.tableId().canonical(), null,
-          TableOperation.COMPACT_CANCEL, TableOperationExceptionType.NOTFOUND, e.getMessage());
+      // if the table is deleted, there is no way to check user permissions to cancel
+      // the system should handle this automatically
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
     }
 
     HostAndPort address = HostAndPort.fromString(runningCompaction.getCompactorAddress());

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
@@ -879,15 +879,13 @@ public class CompactionCoordinator extends AbstractServer implements
       throws ThriftSecurityException {
     var runningCompaction = RUNNING_CACHE.get(ExternalCompactionId.of(externalCompactionId));
     var extent = KeyExtent.fromThrift(runningCompaction.getJob().getExtent());
+    NamespaceId nsId;
     try {
-      NamespaceId nsId = getContext().getNamespaceId(extent.tableId());
-      if (!security.canCompact(credentials, extent.tableId(), nsId)) {
-        throw new ThriftSecurityException(credentials.getPrincipal(),
-            SecurityErrorCode.PERMISSION_DENIED);
-      }
+      nsId = getContext().getNamespaceId(extent.tableId());
     } catch (TableNotFoundException e) {
-      // if the table is deleted, there is no way to check user permissions to cancel
-      // the system should handle this automatically
+      throw new IllegalStateException("Table " + extent.tableId() + " no longer exists");
+    }
+    if (!security.canCompact(credentials, extent.tableId(), nsId)) {
       throw new ThriftSecurityException(credentials.getPrincipal(),
           SecurityErrorCode.PERMISSION_DENIED);
     }

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -45,14 +45,10 @@ import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Supplier;
 
 import org.apache.accumulo.core.Constants;
-import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.clientImpl.thrift.SecurityErrorCode;
-import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
-import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
 import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
-import org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException;
 import org.apache.accumulo.core.compaction.thrift.CompactionCoordinatorService;
 import org.apache.accumulo.core.compaction.thrift.CompactionCoordinatorService.Client;
 import org.apache.accumulo.core.compaction.thrift.CompactorService;
@@ -116,7 +112,6 @@ import org.apache.accumulo.server.rpc.TServerUtils;
 import org.apache.accumulo.server.rpc.ThriftProcessorTypes;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.thrift.TException;
 import org.apache.thrift.transport.TTransportException;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
@@ -427,9 +422,8 @@ public class Compactor extends AbstractServer
    * @param externalCompactionId compaction id
    * @throws UnknownCompactionIdException if the externalCompactionId does not match the currently
    *         executing compaction
-   * @throws TException thrift error
    */
-  private void cancel(String externalCompactionId) throws TException {
+  private void cancel(String externalCompactionId) throws UnknownCompactionIdException {
     if (JOB_HOLDER.cancel(externalCompactionId)) {
       LOG.info("Cancel requested for compaction job {}", externalCompactionId);
     } else {
@@ -439,17 +433,17 @@ public class Compactor extends AbstractServer
 
   @Override
   public void cancel(TInfo tinfo, TCredentials credentials, String externalCompactionId)
-      throws TException {
+      throws ThriftSecurityException, UnknownCompactionIdException {
     TableId tableId = JOB_HOLDER.getTableId();
+    NamespaceId nsId;
     try {
-      NamespaceId nsId = getContext().getNamespaceId(tableId);
-      if (!getContext().getSecurityOperation().canCompact(credentials, tableId, nsId)) {
-        throw new AccumuloSecurityException(credentials.getPrincipal(),
-            SecurityErrorCode.PERMISSION_DENIED).asThriftException();
-      }
+      nsId = getContext().getNamespaceId(tableId);
     } catch (TableNotFoundException e) {
-      throw new ThriftTableOperationException(tableId.canonical(), null,
-          TableOperation.COMPACT_CANCEL, TableOperationExceptionType.NOTFOUND, e.getMessage());
+      throw new IllegalStateException("Table " + tableId + " no longer exists");
+    }
+    if (!getContext().getSecurityOperation().canCompact(credentials, tableId, nsId)) {
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
     }
 
     cancel(externalCompactionId);
@@ -984,7 +978,7 @@ public class Compactor extends AbstractServer
                     e);
                 try {
                   cancel(job.getExternalCompactionId());
-                } catch (TException e1) {
+                } catch (UnknownCompactionIdException e1) {
                   LOG.error("Error cancelling compaction.", e1);
                 }
               } finally {
@@ -997,7 +991,7 @@ public class Compactor extends AbstractServer
                 e1);
             try {
               cancel(job.getExternalCompactionId());
-            } catch (TException e2) {
+            } catch (UnknownCompactionIdException e2) {
               LOG.error("Error cancelling compaction.", e2);
             }
           } finally {
@@ -1062,10 +1056,10 @@ public class Compactor extends AbstractServer
 
   @Override
   public List<ActiveCompaction> getActiveCompactions(TInfo tinfo, TCredentials credentials)
-      throws ThriftSecurityException, TException {
+      throws ThriftSecurityException {
     if (!getContext().getSecurityOperation().canPerformSystemActions(credentials)) {
-      throw new AccumuloSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
     }
 
     List<CompactionInfo> compactions =
@@ -1088,11 +1082,11 @@ public class Compactor extends AbstractServer
    */
   @Override
   public TExternalCompactionJob getRunningCompaction(TInfo tinfo, TCredentials credentials)
-      throws ThriftSecurityException, TException {
+      throws ThriftSecurityException {
     // do not expect users to call this directly, expect other tservers to call this method
     if (!getContext().getSecurityOperation().canPerformSystemActions(credentials)) {
-      throw new AccumuloSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
     }
 
     // Return what is currently running, does not wait for jobs in the process of reserving. This
@@ -1113,11 +1107,11 @@ public class Compactor extends AbstractServer
 
   @Override
   public String getRunningCompactionId(TInfo tinfo, TCredentials credentials)
-      throws ThriftSecurityException, TException {
+      throws ThriftSecurityException {
     // do not expect users to call this directly, expect other tservers to call this method
     if (!getContext().getSecurityOperation().canPerformSystemActions(credentials)) {
-      throw new AccumuloSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
     }
 
     // Any returned id must cover the time period from before a job is reserved until after it

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -45,14 +45,10 @@ import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Supplier;
 
 import org.apache.accumulo.core.Constants;
-import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.clientImpl.thrift.SecurityErrorCode;
-import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
-import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
 import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
-import org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException;
 import org.apache.accumulo.core.compaction.thrift.CompactionCoordinatorService;
 import org.apache.accumulo.core.compaction.thrift.CompactionCoordinatorService.Client;
 import org.apache.accumulo.core.compaction.thrift.CompactorService;
@@ -116,7 +112,6 @@ import org.apache.accumulo.server.rpc.TServerUtils;
 import org.apache.accumulo.server.rpc.ThriftProcessorTypes;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.thrift.TException;
 import org.apache.thrift.transport.TTransportException;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
@@ -427,9 +422,8 @@ public class Compactor extends AbstractServer
    * @param externalCompactionId compaction id
    * @throws UnknownCompactionIdException if the externalCompactionId does not match the currently
    *         executing compaction
-   * @throws TException thrift error
    */
-  private void cancel(String externalCompactionId) throws TException {
+  private void cancel(String externalCompactionId) throws UnknownCompactionIdException {
     if (JOB_HOLDER.cancel(externalCompactionId)) {
       LOG.info("Cancel requested for compaction job {}", externalCompactionId);
     } else {
@@ -439,17 +433,19 @@ public class Compactor extends AbstractServer
 
   @Override
   public void cancel(TInfo tinfo, TCredentials credentials, String externalCompactionId)
-      throws TException {
+      throws ThriftSecurityException, UnknownCompactionIdException {
     TableId tableId = JOB_HOLDER.getTableId();
     try {
       NamespaceId nsId = getContext().getNamespaceId(tableId);
       if (!getContext().getSecurityOperation().canCompact(credentials, tableId, nsId)) {
-        throw new AccumuloSecurityException(credentials.getPrincipal(),
-            SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+        throw new ThriftSecurityException(credentials.getPrincipal(),
+            SecurityErrorCode.PERMISSION_DENIED);
       }
     } catch (TableNotFoundException e) {
-      throw new ThriftTableOperationException(tableId.canonical(), null,
-          TableOperation.COMPACT_CANCEL, TableOperationExceptionType.NOTFOUND, e.getMessage());
+      // if the table is deleted, there is no way to check user permissions to cancel
+      // the system should handle this automatically
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
     }
 
     cancel(externalCompactionId);
@@ -981,7 +977,7 @@ public class Compactor extends AbstractServer
                     e);
                 try {
                   cancel(job.getExternalCompactionId());
-                } catch (TException e1) {
+                } catch (UnknownCompactionIdException e1) {
                   LOG.error("Error cancelling compaction.", e1);
                 }
               } finally {
@@ -994,7 +990,7 @@ public class Compactor extends AbstractServer
                 e1);
             try {
               cancel(job.getExternalCompactionId());
-            } catch (TException e2) {
+            } catch (UnknownCompactionIdException e2) {
               LOG.error("Error cancelling compaction.", e2);
             }
           } finally {
@@ -1058,10 +1054,10 @@ public class Compactor extends AbstractServer
 
   @Override
   public List<ActiveCompaction> getActiveCompactions(TInfo tinfo, TCredentials credentials)
-      throws ThriftSecurityException, TException {
+      throws ThriftSecurityException {
     if (!getContext().getSecurityOperation().canPerformSystemActions(credentials)) {
-      throw new AccumuloSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
     }
 
     List<CompactionInfo> compactions =
@@ -1084,11 +1080,11 @@ public class Compactor extends AbstractServer
    */
   @Override
   public TExternalCompactionJob getRunningCompaction(TInfo tinfo, TCredentials credentials)
-      throws ThriftSecurityException, TException {
+      throws ThriftSecurityException {
     // do not expect users to call this directly, expect other tservers to call this method
     if (!getContext().getSecurityOperation().canPerformSystemActions(credentials)) {
-      throw new AccumuloSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
     }
 
     // Return what is currently running, does not wait for jobs in the process of reserving. This
@@ -1109,11 +1105,11 @@ public class Compactor extends AbstractServer
 
   @Override
   public String getRunningCompactionId(TInfo tinfo, TCredentials credentials)
-      throws ThriftSecurityException, TException {
+      throws ThriftSecurityException {
     // do not expect users to call this directly, expect other tservers to call this method
     if (!getContext().getSecurityOperation().canPerformSystemActions(credentials)) {
-      throw new AccumuloSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
     }
 
     // Any returned id must cover the time period from before a job is reserved until after it

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -435,15 +435,13 @@ public class Compactor extends AbstractServer
   public void cancel(TInfo tinfo, TCredentials credentials, String externalCompactionId)
       throws ThriftSecurityException, UnknownCompactionIdException {
     TableId tableId = JOB_HOLDER.getTableId();
+    NamespaceId nsId;
     try {
-      NamespaceId nsId = getContext().getNamespaceId(tableId);
-      if (!getContext().getSecurityOperation().canCompact(credentials, tableId, nsId)) {
-        throw new ThriftSecurityException(credentials.getPrincipal(),
-            SecurityErrorCode.PERMISSION_DENIED);
-      }
+      nsId = getContext().getNamespaceId(tableId);
     } catch (TableNotFoundException e) {
-      // if the table is deleted, there is no way to check user permissions to cancel
-      // the system should handle this automatically
+      throw new IllegalStateException("Table " + tableId + " no longer exists");
+    }
+    if (!getContext().getSecurityOperation().canCompact(credentials, tableId, nsId)) {
       throw new ThriftSecurityException(credentials.getPrincipal(),
           SecurityErrorCode.PERMISSION_DENIED);
     }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
@@ -201,7 +201,7 @@ class FateServiceHandler implements FateService.Iface {
           } catch (IOException e) {
             throw new ThriftTableOperationException(null, tableName, tableOp,
                 TableOperationExceptionType.OTHER,
-                "Exception thrown while writing splits to file system");
+                "Exception thrown while writing splits to file system: " + e.getMessage());
           }
         }
         NamespaceId namespaceId;
@@ -211,7 +211,7 @@ class FateServiceHandler implements FateService.Iface {
               TableNameUtil.qualify(tableName).getFirst());
         } catch (NamespaceNotFoundException e) {
           throw new ThriftTableOperationException(null, tableName, tableOp,
-              TableOperationExceptionType.NAMESPACE_NOTFOUND, "");
+              TableOperationExceptionType.NAMESPACE_NOTFOUND, e.getMessage());
         }
 
         if (!manager.security.canCreateTable(c, tableName, namespaceId)) {
@@ -269,7 +269,7 @@ class FateServiceHandler implements FateService.Iface {
               autoCleanup, goalMessage);
         } catch (NamespaceNotFoundException e) {
           throw new ThriftTableOperationException(null, oldTableName, tableOp,
-              TableOperationExceptionType.NAMESPACE_NOTFOUND, "");
+              TableOperationExceptionType.NAMESPACE_NOTFOUND, e.getMessage());
         }
 
         break;
@@ -291,7 +291,7 @@ class FateServiceHandler implements FateService.Iface {
         } catch (TableNotFoundException e) {
           // could happen if the table was deleted while processing this request
           throw new ThriftTableOperationException(srcTableId.canonical(), null, tableOp,
-              TableOperationExceptionType.NOTFOUND, "");
+              TableOperationExceptionType.NOTFOUND, e.getMessage());
         }
 
         NamespaceId namespaceId;
@@ -301,7 +301,7 @@ class FateServiceHandler implements FateService.Iface {
         } catch (NamespaceNotFoundException e) {
           // dest namespace does not exist yet, needs to be created
           throw new ThriftTableOperationException(null, tableName, tableOp,
-              TableOperationExceptionType.NAMESPACE_NOTFOUND, "");
+              TableOperationExceptionType.NAMESPACE_NOTFOUND, e.getMessage());
         }
 
         final boolean canCloneTable;
@@ -614,7 +614,7 @@ class FateServiceHandler implements FateService.Iface {
               TableNameUtil.qualify(tableName).getFirst());
         } catch (NamespaceNotFoundException e) {
           throw new ThriftTableOperationException(null, tableName, tableOp,
-              TableOperationExceptionType.NAMESPACE_NOTFOUND, "");
+              TableOperationExceptionType.NAMESPACE_NOTFOUND, e.getMessage());
         }
 
         final boolean canImport;
@@ -686,8 +686,7 @@ class FateServiceHandler implements FateService.Iface {
           throw e;
         } catch (TableNotFoundException e) {
           throw new ThriftTableOperationException(tableId.canonical(), null,
-              TableOperation.BULK_IMPORT, TableOperationExceptionType.NOTFOUND,
-              "Table no longer exists");
+              TableOperation.BULK_IMPORT, TableOperationExceptionType.NOTFOUND, e.getMessage());
         }
 
         if (!canBulkImport) {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/ManagerClientServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/ManagerClientServiceHandler.java
@@ -39,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.BatchScanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.admin.DelegationTokenConfig;
@@ -135,11 +136,11 @@ public class ManagerClientServiceHandler implements ManagerClientService.Iface {
       });
     } catch (NoNodeException nne) {
       throw new ThriftTableOperationException(tableId.canonical(), null, TableOperation.FLUSH,
-          TableOperationExceptionType.NOTFOUND, null);
+          TableOperationExceptionType.NOTFOUND, nne.getMessage());
     } catch (Exception e) {
       Manager.log.warn("{}", e.getMessage(), e);
       throw new ThriftTableOperationException(tableId.canonical(), null, TableOperation.FLUSH,
-          TableOperationExceptionType.OTHER, null);
+          TableOperationExceptionType.OTHER, e.getMessage());
     }
     return Long.parseLong(new String(fid, UTF_8));
   }
@@ -290,7 +291,7 @@ public class ManagerClientServiceHandler implements ManagerClientService.Iface {
           TableOperation.SET_PROPERTY);
       throw new ThriftTableOperationException(tableId.canonical(), tableName,
           TableOperation.SET_PROPERTY, TableOperationExceptionType.OTHER,
-          "Error modifying table properties: tableId: " + tableId.canonical());
+          "Error modifying table properties: " + ex.getMessage());
     } catch (IllegalArgumentException iae) {
       throw new ThriftPropertyException("Modify properties", "failed", iae.getMessage());
     }
@@ -348,7 +349,7 @@ public class ManagerClientServiceHandler implements ManagerClientService.Iface {
 
   @Override
   public void tabletServerStopping(TInfo tinfo, TCredentials credentials, String tabletServer)
-      throws ThriftSecurityException, ThriftNotActiveServiceException, TException {
+      throws ThriftSecurityException, ThriftNotActiveServiceException {
     if (!manager.security.canPerformSystemActions(credentials)) {
       throw new ThriftSecurityException(credentials.getPrincipal(),
           SecurityErrorCode.PERMISSION_DENIED);
@@ -368,10 +369,17 @@ public class ManagerClientServiceHandler implements ManagerClientService.Iface {
 
   @Override
   public void reportSplitExtent(TInfo info, TCredentials credentials, String serverName,
-      TabletSplit split) throws ThriftSecurityException {
-    if (!manager.security.canPerformSystemActions(credentials)) {
-      throw new ThriftSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED);
+      TabletSplit split) {
+    try {
+      if (!manager.security.canPerformSystemActions(credentials)) {
+        throw new ThriftSecurityException(credentials.getPrincipal(),
+            SecurityErrorCode.PERMISSION_DENIED);
+      }
+    } catch (ThriftSecurityException e) {
+      // this oneway method can't throw a ThriftSecurityException
+      // convert it to a runtime exception, so at least it gets logged on the server
+      Manager.log.warn("Got a split from a server with bad credentials: {}", serverName);
+      return;
     }
 
     KeyExtent oldTablet = KeyExtent.fromThrift(split.oldTablet);
@@ -391,10 +399,18 @@ public class ManagerClientServiceHandler implements ManagerClientService.Iface {
 
   @Override
   public void reportTabletStatus(TInfo info, TCredentials credentials, String serverName,
-      TabletLoadState status, TKeyExtent ttablet) throws ThriftSecurityException {
-    if (!manager.security.canPerformSystemActions(credentials)) {
-      throw new ThriftSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED);
+      TabletLoadState status, TKeyExtent ttablet) {
+    try {
+      if (!manager.security.canPerformSystemActions(credentials)) {
+        throw new ThriftSecurityException(credentials.getPrincipal(),
+            SecurityErrorCode.PERMISSION_DENIED);
+      }
+    } catch (ThriftSecurityException e) {
+      // this oneway method can't throw a ThriftSecurityException
+      // convert it to a runtime exception, so at least it gets logged on the server
+      Manager.log.warn("Got a tablet status report from a server with bad credentials: {}",
+          serverName);
+      return;
     }
 
     KeyExtent tablet = KeyExtent.fromThrift(ttablet);
@@ -451,7 +467,7 @@ public class ManagerClientServiceHandler implements ManagerClientService.Iface {
 
   @Override
   public void setSystemProperty(TInfo info, TCredentials c, String property, String value)
-      throws TException {
+      throws ThriftSecurityException, ThriftPropertyException {
     if (!manager.security.canPerformSystemActions(c)) {
       throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
     }
@@ -462,15 +478,13 @@ public class ManagerClientServiceHandler implements ManagerClientService.Iface {
       Manager.log.error("Problem setting invalid property", iae);
       throw new ThriftPropertyException(property, value,
           "Property is invalid. message: " + iae.getMessage());
-    } catch (Exception e) {
-      Manager.log.error("Problem setting config property in zookeeper", e);
-      throw new TException(e.getMessage());
     }
   }
 
   @Override
   public void modifySystemProperties(TInfo info, TCredentials c, TVersionedProperties properties)
-      throws TException {
+      throws ThriftSecurityException, ThriftConcurrentModificationException,
+      ThriftPropertyException {
     if (!manager.security.canPerformSystemActions(c)) {
       throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
     }
@@ -484,9 +498,6 @@ public class ManagerClientServiceHandler implements ManagerClientService.Iface {
     } catch (ConcurrentModificationException cme) {
       log.warn("Error modifying system properties, properties have changed", cme);
       throw new ThriftConcurrentModificationException(cme.getMessage());
-    } catch (Exception e) {
-      Manager.log.error("Problem setting config property in zookeeper", e);
-      throw new TException(e.getMessage());
     }
   }
 
@@ -499,7 +510,8 @@ public class ManagerClientServiceHandler implements ManagerClientService.Iface {
 
   @Override
   public void modifyNamespaceProperties(TInfo tinfo, TCredentials credentials, String ns,
-      TVersionedProperties properties) throws TException {
+      TVersionedProperties properties) throws ThriftSecurityException,
+      ThriftTableOperationException, ThriftConcurrentModificationException {
     final NamespaceId namespaceId = ClientServiceHandler.checkNamespaceId(manager.getContext(), ns,
         TableOperation.SET_PROPERTY);
     if (!manager.security.canAlterNamespace(credentials, namespaceId)) {
@@ -524,9 +536,7 @@ public class ManagerClientServiceHandler implements ManagerClientService.Iface {
       log.warn("Error modifying namespace properties", ex);
       throw new ThriftTableOperationException(namespaceId.canonical(), ns,
           TableOperation.SET_PROPERTY, TableOperationExceptionType.OTHER,
-          "Error modifying namespace properties");
-    } catch (IllegalArgumentException iae) {
-      throw new ThriftPropertyException("Modify properties", "failed", iae.getMessage());
+          "Error modifying namespace properties: " + ex.getMessage());
     }
   }
 
@@ -566,7 +576,8 @@ public class ManagerClientServiceHandler implements ManagerClientService.Iface {
       ClientServiceHandler.checkNamespaceId(manager.getContext(), namespace, op);
       log.info("Error altering namespace property", ex);
       throw new ThriftTableOperationException(namespaceId.canonical(), namespace, op,
-          TableOperationExceptionType.OTHER, "Problem altering namespace property");
+          TableOperationExceptionType.OTHER,
+          "Problem altering namespace property: " + ex.getMessage());
     } catch (IllegalArgumentException iae) {
       throw new ThriftPropertyException(property, value, iae.getMessage());
     }
@@ -606,7 +617,7 @@ public class ManagerClientServiceHandler implements ManagerClientService.Iface {
       ClientServiceHandler.checkTableId(manager.getContext(), tableName, op);
       throw new ThriftTableOperationException(tableId.canonical(), tableName, op,
           TableOperationExceptionType.OTHER, "Invalid table property, tried to set: tableId: "
-              + tableId.canonical() + " to: " + property + "=" + value);
+              + tableId.canonical() + " to: " + property + "=" + value + " : " + ex.getMessage());
     } catch (IllegalArgumentException iae) {
       throw new ThriftPropertyException(property, value, iae.getMessage());
     }
@@ -636,7 +647,7 @@ public class ManagerClientServiceHandler implements ManagerClientService.Iface {
 
   @Override
   public TDelegationToken getDelegationToken(TInfo tinfo, TCredentials credentials,
-      TDelegationTokenConfig tConfig) throws ThriftSecurityException, TException {
+      TDelegationTokenConfig tConfig) throws ThriftSecurityException {
     if (!manager.security.canObtainDelegationToken(credentials)) {
       throw new ThriftSecurityException(credentials.getPrincipal(),
           SecurityErrorCode.PERMISSION_DENIED);
@@ -645,7 +656,7 @@ public class ManagerClientServiceHandler implements ManagerClientService.Iface {
     // Make sure we're actually generating the secrets to make delegation tokens
     // Round-about way to verify that SASL is also enabled.
     if (!manager.delegationTokensAvailable()) {
-      throw new TException("Delegation tokens are not available for use");
+      throw new IllegalStateException("Delegation tokens are not available for use");
     }
 
     final DelegationTokenConfig config = DelegationTokenConfigSerializer.deserialize(tConfig);
@@ -656,18 +667,24 @@ public class ManagerClientServiceHandler implements ManagerClientService.Iface {
 
       return new TDelegationToken(ByteBuffer.wrap(pair.getKey().getPassword()),
           pair.getValue().getThriftIdentifier());
-    } catch (Exception e) {
-      throw new TException(e.getMessage());
+    } catch (AccumuloException e) {
+      throw new IllegalStateException(e);
     }
   }
 
   @SuppressWarnings("deprecation")
   @Override
   public boolean drainReplicationTable(TInfo tfino, TCredentials credentials, String tableName,
-      Set<String> logsToWatch) throws TException {
+      Set<String> logsToWatch) {
     AccumuloClient client = manager.getContext();
 
-    final Text tableId = new Text(getTableId(manager.getContext(), tableName).canonical());
+    Text tableId;
+    try {
+      tableId = new Text(getTableId(manager.getContext(), tableName).canonical());
+    } catch (ThriftTableOperationException e) {
+      // table or namespace not found from getTableId
+      throw new IllegalStateException(e);
+    }
 
     drainLog.trace("Waiting for {} to be replicated for {}", logsToWatch, tableId);
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/ManagerClientServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/ManagerClientServiceHandler.java
@@ -672,7 +672,7 @@ public class ManagerClientServiceHandler implements ManagerClientService.Iface {
     }
   }
 
-  @SuppressWarnings("deprecation")
+  @Deprecated
   @Override
   public boolean drainReplicationTable(TInfo tfino, TCredentials credentials, String tableName,
       Set<String> logsToWatch) {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/replication/ManagerReplicationCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/replication/ManagerReplicationCoordinator.java
@@ -35,7 +35,6 @@ import org.apache.accumulo.core.replication.thrift.ReplicationCoordinatorExcepti
 import org.apache.accumulo.core.securityImpl.thrift.TCredentials;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.server.security.AuditedSecurityOperation;
-import org.apache.thrift.TException;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,19 +51,22 @@ public class ManagerReplicationCoordinator implements ReplicationCoordinator.Ifa
   private final ZooReader reader;
   private final AuditedSecurityOperation security;
 
+  @Deprecated
   public ManagerReplicationCoordinator(Manager manager) {
     this(manager, manager.getContext().getZooReader());
   }
 
+  @Deprecated
   protected ManagerReplicationCoordinator(Manager manager, ZooReader reader) {
     this.manager = manager;
     this.reader = reader;
     this.security = manager.getContext().getSecurityOperation();
   }
 
+  @Deprecated
   @Override
   public String getServicerAddress(String remoteTableId, TCredentials creds)
-      throws ReplicationCoordinatorException, TException {
+      throws ReplicationCoordinatorException {
     try {
       security.authenticateUser(manager.getContext().rpcCreds(), creds);
     } catch (ThriftSecurityException e) {
@@ -99,6 +101,7 @@ public class ManagerReplicationCoordinator implements ReplicationCoordinator.Ifa
     return replServiceAddr;
   }
 
+  @Deprecated
   protected TServerInstance getRandomTServer(Set<TServerInstance> tservers, int offset) {
     checkArgument(tservers.size() > offset, "Must provide an offset less than the size of the set");
     Iterator<TServerInstance> iter = tservers.iterator();

--- a/server/manager/src/main/java/org/apache/accumulo/manager/replication/ManagerReplicationCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/replication/ManagerReplicationCoordinator.java
@@ -35,7 +35,6 @@ import org.apache.accumulo.core.replication.thrift.ReplicationCoordinatorExcepti
 import org.apache.accumulo.core.securityImpl.thrift.TCredentials;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.server.security.AuditedSecurityOperation;
-import org.apache.thrift.TException;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,19 +51,22 @@ public class ManagerReplicationCoordinator implements ReplicationCoordinator.Ifa
   private final ZooReader reader;
   private final AuditedSecurityOperation security;
 
+  @Deprecated
   public ManagerReplicationCoordinator(Manager manager) {
     this(manager, manager.getContext().getZooReader());
   }
 
+  @Deprecated
   protected ManagerReplicationCoordinator(Manager manager, ZooReader reader) {
     this.manager = manager;
     this.reader = reader;
     this.security = manager.getContext().getSecurityOperation();
   }
 
+  @Deprecated
   @Override
   public String getServicerAddress(String remoteTableId, TCredentials creds)
-      throws ReplicationCoordinatorException, TException {
+      throws ReplicationCoordinatorException {
     try {
       security.authenticateUser(manager.getContext().rpcCreds(), creds);
     } catch (ThriftSecurityException e) {
@@ -96,6 +98,7 @@ public class ManagerReplicationCoordinator implements ReplicationCoordinator.Ifa
     return replServiceAddr;
   }
 
+  @Deprecated
   protected TServerInstance getRandomTServer(Set<TServerInstance> tservers, int offset) {
     checkArgument(tservers.size() > offset, "Must provide an offset less than the size of the set");
     Iterator<TServerInstance> iter = tservers.iterator();

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/PopulateZookeeper.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/PopulateZookeeper.java
@@ -65,7 +65,7 @@ class PopulateZookeeper extends ManagerRepo {
         throw new ThriftTableOperationException(null, tableInfo.getTableName(),
             TableOperation.CREATE, TableOperationExceptionType.OTHER,
             "Property or value not valid for create " + tableInfo.getTableName() + " in "
-                + tableInfo.props);
+                + tableInfo.props + " : " + ex.getMessage());
       }
 
       manager.getContext().clearTableListCache();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -117,7 +117,6 @@ import org.apache.accumulo.tserver.session.SingleScanSession;
 import org.apache.accumulo.tserver.tablet.SnapshotTablet;
 import org.apache.accumulo.tserver.tablet.Tablet;
 import org.apache.accumulo.tserver.tablet.TabletBase;
-import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TException;
 import org.apache.thrift.TProcessor;
 import org.apache.zookeeper.KeeperException;
@@ -1066,7 +1065,7 @@ public class ScanServer extends AbstractServer
       boolean isolated, long readaheadThreshold, TSamplerConfiguration samplerConfig,
       long batchTimeOut, String classLoaderContext, Map<String,String> executionHints,
       long busyTimeout) throws ThriftSecurityException, NotServingTabletException,
-      TooManyFilesException, TSampleNotPresentException, TException {
+      TooManyFilesException, TSampleNotPresentException, ScanServerBusyException {
 
     if (isShutdownRequested()) {
       // Prevent scans from starting if shutting down
@@ -1076,7 +1075,7 @@ public class ScanServer extends AbstractServer
     KeyExtent extent = getKeyExtent(textent);
 
     if (!isAllowed(credentials, extent.tableId())) {
-      throw new TApplicationException(TApplicationException.INTERNAL_ERROR,
+      throw new IllegalArgumentException(
           "Scan of table " + extent.tableId() + " disallowed by property: "
               + Property.SSERV_SCAN_ALLOWED_TABLES.getKey() + this.groupName);
     }
@@ -1108,7 +1107,7 @@ public class ScanServer extends AbstractServer
   @Override
   public ScanResult continueScan(TInfo tinfo, long scanID, long busyTimeout)
       throws NoSuchScanIDException, NotServingTabletException, TooManyFilesException,
-      TSampleNotPresentException, TException {
+      TSampleNotPresentException, ScanServerBusyException {
     LOG.trace("continue scan: {}", scanID);
 
     try (ScanReservation reservation = reserveFilesInstrumented(scanID)) {
@@ -1121,7 +1120,7 @@ public class ScanServer extends AbstractServer
   }
 
   @Override
-  public void closeScan(TInfo tinfo, long scanID) throws TException {
+  public void closeScan(TInfo tinfo, long scanID) {
     LOG.trace("close scan: {}", scanID);
     delegate.closeScan(tinfo, scanID);
   }
@@ -1132,7 +1131,7 @@ public class ScanServer extends AbstractServer
       Map<String,Map<String,String>> ssio, List<ByteBuffer> authorizations, boolean waitForWrites,
       TSamplerConfiguration tSamplerConfig, long batchTimeOut, String contextArg,
       Map<String,String> executionHints, long busyTimeout)
-      throws ThriftSecurityException, TSampleNotPresentException, TException {
+      throws ThriftSecurityException, TSampleNotPresentException, ScanServerBusyException {
 
     if (isShutdownRequested()) {
       // Prevent scans from starting if shutting down
@@ -1140,7 +1139,7 @@ public class ScanServer extends AbstractServer
     }
 
     if (tbatch.size() == 0) {
-      throw new TException("Scan Server batch must include at least one extent");
+      throw new IllegalArgumentException("Scan Server batch must include at least one extent");
     }
 
     final Map<KeyExtent,List<TRange>> batch = new HashMap<>();
@@ -1149,7 +1148,7 @@ public class ScanServer extends AbstractServer
       KeyExtent extent = getKeyExtent(entry.getKey());
 
       if (!isAllowed(credentials, extent.tableId())) {
-        throw new TApplicationException(TApplicationException.INTERNAL_ERROR,
+        throw new IllegalArgumentException(
             "Scan of table " + extent.tableId() + " disallowed by property: "
                 + Property.SSERV_SCAN_ALLOWED_TABLES.getKey() + this.groupName);
       }
@@ -1188,7 +1187,7 @@ public class ScanServer extends AbstractServer
 
   @Override
   public MultiScanResult continueMultiScan(TInfo tinfo, long scanID, long busyTimeout)
-      throws NoSuchScanIDException, TSampleNotPresentException, TException {
+      throws NoSuchScanIDException, TSampleNotPresentException, ScanServerBusyException {
     LOG.trace("continue multi scan: {}", scanID);
 
     try (ScanReservation reservation = reserveFilesInstrumented(scanID)) {
@@ -1201,14 +1200,14 @@ public class ScanServer extends AbstractServer
   }
 
   @Override
-  public void closeMultiScan(TInfo tinfo, long scanID) throws NoSuchScanIDException, TException {
+  public void closeMultiScan(TInfo tinfo, long scanID) throws NoSuchScanIDException {
     LOG.trace("close multi scan: {}", scanID);
     delegate.closeMultiScan(tinfo, scanID);
   }
 
   @Override
   public List<ActiveScan> getActiveScans(TInfo tinfo, TCredentials credentials)
-      throws ThriftSecurityException, TException {
+      throws ThriftSecurityException {
     return delegate.getActiveScans(tinfo, credentials);
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -117,7 +117,6 @@ import org.apache.accumulo.tserver.session.SingleScanSession;
 import org.apache.accumulo.tserver.tablet.SnapshotTablet;
 import org.apache.accumulo.tserver.tablet.Tablet;
 import org.apache.accumulo.tserver.tablet.TabletBase;
-import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TException;
 import org.apache.thrift.TProcessor;
 import org.apache.zookeeper.KeeperException;
@@ -1069,7 +1068,7 @@ public class ScanServer extends AbstractServer
       boolean isolated, long readaheadThreshold, TSamplerConfiguration samplerConfig,
       long batchTimeOut, String classLoaderContext, Map<String,String> executionHints,
       long busyTimeout) throws ThriftSecurityException, NotServingTabletException,
-      TooManyFilesException, TSampleNotPresentException, TException {
+      TooManyFilesException, TSampleNotPresentException, ScanServerBusyException {
 
     if (isShutdownRequested()) {
       // Prevent scans from starting if shutting down
@@ -1079,7 +1078,7 @@ public class ScanServer extends AbstractServer
     KeyExtent extent = getKeyExtent(textent);
 
     if (!isAllowed(credentials, extent.tableId())) {
-      throw new TApplicationException(TApplicationException.INTERNAL_ERROR,
+      throw new IllegalArgumentException(
           "Scan of table " + extent.tableId() + " disallowed by property: "
               + Property.SSERV_SCAN_ALLOWED_TABLES.getKey() + this.groupName);
     }
@@ -1111,7 +1110,7 @@ public class ScanServer extends AbstractServer
   @Override
   public ScanResult continueScan(TInfo tinfo, long scanID, long busyTimeout)
       throws NoSuchScanIDException, NotServingTabletException, TooManyFilesException,
-      TSampleNotPresentException, TException {
+      TSampleNotPresentException, ScanServerBusyException {
     LOG.trace("continue scan: {}", scanID);
 
     try (ScanReservation reservation = reserveFilesInstrumented(scanID)) {
@@ -1124,7 +1123,7 @@ public class ScanServer extends AbstractServer
   }
 
   @Override
-  public void closeScan(TInfo tinfo, long scanID) throws TException {
+  public void closeScan(TInfo tinfo, long scanID) {
     LOG.trace("close scan: {}", scanID);
     delegate.closeScan(tinfo, scanID);
   }
@@ -1135,7 +1134,7 @@ public class ScanServer extends AbstractServer
       Map<String,Map<String,String>> ssio, List<ByteBuffer> authorizations, boolean waitForWrites,
       TSamplerConfiguration tSamplerConfig, long batchTimeOut, String contextArg,
       Map<String,String> executionHints, long busyTimeout)
-      throws ThriftSecurityException, TSampleNotPresentException, TException {
+      throws ThriftSecurityException, TSampleNotPresentException, ScanServerBusyException {
 
     if (isShutdownRequested()) {
       // Prevent scans from starting if shutting down
@@ -1143,7 +1142,7 @@ public class ScanServer extends AbstractServer
     }
 
     if (tbatch.size() == 0) {
-      throw new TException("Scan Server batch must include at least one extent");
+      throw new IllegalArgumentException("Scan Server batch must include at least one extent");
     }
 
     final Map<KeyExtent,List<TRange>> batch = new HashMap<>();
@@ -1152,7 +1151,7 @@ public class ScanServer extends AbstractServer
       KeyExtent extent = getKeyExtent(entry.getKey());
 
       if (!isAllowed(credentials, extent.tableId())) {
-        throw new TApplicationException(TApplicationException.INTERNAL_ERROR,
+        throw new IllegalArgumentException(
             "Scan of table " + extent.tableId() + " disallowed by property: "
                 + Property.SSERV_SCAN_ALLOWED_TABLES.getKey() + this.groupName);
       }
@@ -1191,7 +1190,7 @@ public class ScanServer extends AbstractServer
 
   @Override
   public MultiScanResult continueMultiScan(TInfo tinfo, long scanID, long busyTimeout)
-      throws NoSuchScanIDException, TSampleNotPresentException, TException {
+      throws NoSuchScanIDException, TSampleNotPresentException, ScanServerBusyException {
     LOG.trace("continue multi scan: {}", scanID);
 
     try (ScanReservation reservation = reserveFilesInstrumented(scanID)) {
@@ -1204,14 +1203,14 @@ public class ScanServer extends AbstractServer
   }
 
   @Override
-  public void closeMultiScan(TInfo tinfo, long scanID) throws NoSuchScanIDException, TException {
+  public void closeMultiScan(TInfo tinfo, long scanID) throws NoSuchScanIDException {
     LOG.trace("close multi scan: {}", scanID);
     delegate.closeMultiScan(tinfo, scanID);
   }
 
   @Override
   public List<ActiveScan> getActiveScans(TInfo tinfo, TCredentials credentials)
-      throws ThriftSecurityException, TException {
+      throws ThriftSecurityException {
     return delegate.getActiveScans(tinfo, credentials);
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
@@ -23,6 +23,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.stream.Collectors.toList;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -42,7 +43,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.Constants;
-import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.Durability;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.admin.CompactionConfig;
@@ -126,7 +126,6 @@ import org.apache.hadoop.fs.FSError;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
-import org.apache.thrift.TException;
 import org.apache.zookeeper.KeeperException.NoNodeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -210,6 +209,17 @@ public class TabletClientHandler implements TabletClientService.Iface {
 
   @Override
   public void loadFiles(TInfo tinfo, TCredentials credentials, long tid, String dir,
+      Map<TKeyExtent,Map<String,MapFileInfo>> tabletImports, boolean setTime) {
+    try {
+      loadFilesV2(tinfo, credentials, tid, dir, tabletImports, setTime);
+    } catch (ThriftSecurityException e) {
+      log.warn("Received oneway load files message (dir: {}) from user ({}) with bad credentials",
+          dir, credentials.getPrincipal());
+    }
+  }
+
+  @Override
+  public void loadFilesV2(TInfo tinfo, TCredentials credentials, long tid, String dir,
       Map<TKeyExtent,Map<String,MapFileInfo>> tabletImports, boolean setTime)
       throws ThriftSecurityException {
     if (!security.canPerformSystemActions(credentials)) {
@@ -245,14 +255,6 @@ public class TabletClientHandler implements TabletClientService.Iface {
         }
       });
     });
-
-  }
-
-  @Override
-  public void loadFilesV2(TInfo tinfo, TCredentials credentials, long tid, String dir,
-      Map<TKeyExtent,Map<String,MapFileInfo>> tabletImports, boolean setTime)
-      throws ThriftSecurityException {
-    loadFiles(tinfo, credentials, tid, dir, tabletImports, setTime);
   }
 
   @Override
@@ -645,7 +647,7 @@ public class TabletClientHandler implements TabletClientService.Iface {
   }
 
   @Override
-  public boolean cancelUpdate(TInfo tinfo, long updateID) throws TException {
+  public boolean cancelUpdate(TInfo tinfo, long updateID) {
     return server.sessionManager.removeIfNotReserved(updateID);
   }
 
@@ -949,7 +951,7 @@ public class TabletClientHandler implements TabletClientService.Iface {
   @Override
   public TConditionalSession startConditionalUpdate(TInfo tinfo, TCredentials credentials,
       List<ByteBuffer> authorizations, String tableIdStr, TDurability tdurabilty,
-      String classLoaderContext) throws ThriftSecurityException, TException {
+      String classLoaderContext) throws ThriftSecurityException {
 
     TableId tableId = TableId.of(tableIdStr);
     Authorizations userauths = null;
@@ -977,7 +979,7 @@ public class TabletClientHandler implements TabletClientService.Iface {
   @Override
   public List<TCMResult> conditionalUpdate(TInfo tinfo, long sessID,
       Map<TKeyExtent,List<TConditionalMutation>> mutations, List<String> symbols)
-      throws NoSuchScanIDException, TException {
+      throws NoSuchScanIDException {
 
     ConditionalSession cs = null;
     Long opid = null;
@@ -1024,9 +1026,13 @@ public class TabletClientHandler implements TabletClientService.Iface {
       }
 
       return results;
-    } catch (IOException | ReflectiveOperationException ioe) {
-      throw new TException(ioe);
-    } catch (Exception e) {
+    } catch (IOException e) {
+      log.warn("Exception returned for conditionalUpdate {}", e);
+      throw new UncheckedIOException(e);
+    } catch (ReflectiveOperationException e) {
+      log.warn("Exception returned for conditionalUpdate {}", e);
+      throw new IllegalStateException(e);
+    } catch (RuntimeException e) {
       log.warn("Exception returned for conditionalUpdate {}", e);
       throw e;
     } finally {
@@ -1416,7 +1422,7 @@ public class TabletClientHandler implements TabletClientService.Iface {
 
   @Override
   public List<ActiveCompaction> getActiveCompactions(TInfo tinfo, TCredentials credentials)
-      throws ThriftSecurityException, TException {
+      throws ThriftSecurityException {
     try {
       checkPermission(context, server, credentials, null, "getActiveCompactions");
     } catch (ThriftSecurityException e) {
@@ -1436,11 +1442,11 @@ public class TabletClientHandler implements TabletClientService.Iface {
 
   @Override
   public List<TCompactionQueueSummary> getCompactionQueueInfo(TInfo tinfo, TCredentials credentials)
-      throws ThriftSecurityException, TException {
+      throws ThriftSecurityException {
 
     if (!security.canPerformSystemActions(credentials)) {
-      throw new AccumuloSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
     }
 
     return server.getCompactionManager().getCompactionQueueSummaries();
@@ -1449,11 +1455,11 @@ public class TabletClientHandler implements TabletClientService.Iface {
   @Override
   public TExternalCompactionJob reserveCompactionJob(TInfo tinfo, TCredentials credentials,
       String queueName, long priority, String compactor, String externalCompactionId)
-      throws ThriftSecurityException, TException {
+      throws ThriftSecurityException {
 
     if (!security.canPerformSystemActions(credentials)) {
-      throw new AccumuloSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
     }
 
     ExternalCompactionId eci = ExternalCompactionId.of(externalCompactionId);
@@ -1470,12 +1476,17 @@ public class TabletClientHandler implements TabletClientService.Iface {
 
   @Override
   public void compactionJobFinished(TInfo tinfo, TCredentials credentials,
-      String externalCompactionId, TKeyExtent extent, long fileSize, long entries)
-      throws ThriftSecurityException, TException {
+      String externalCompactionId, TKeyExtent extent, long fileSize, long entries) {
 
-    if (!security.canPerformSystemActions(credentials)) {
-      throw new AccumuloSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+    try {
+      if (!security.canPerformSystemActions(credentials)) {
+        throw new ThriftSecurityException(credentials.getPrincipal(),
+            SecurityErrorCode.PERMISSION_DENIED);
+      }
+    } catch (ThriftSecurityException e) {
+      log.warn(
+          "Received compaction job finished message (id: {}) from user ({}) with bad credentials",
+          externalCompactionId, credentials.getPrincipal());
     }
 
     server.getCompactionManager().commitExternalCompaction(
@@ -1485,10 +1496,16 @@ public class TabletClientHandler implements TabletClientService.Iface {
 
   @Override
   public void compactionJobFailed(TInfo tinfo, TCredentials credentials,
-      String externalCompactionId, TKeyExtent extent) throws TException {
-    if (!security.canPerformSystemActions(credentials)) {
-      throw new AccumuloSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+      String externalCompactionId, TKeyExtent extent) {
+    try {
+      if (!security.canPerformSystemActions(credentials)) {
+        throw new ThriftSecurityException(credentials.getPrincipal(),
+            SecurityErrorCode.PERMISSION_DENIED);
+      }
+    } catch (ThriftSecurityException e) {
+      log.warn(
+          "Received compaction job failed message (id: {}) from user ({}) with bad credentials",
+          externalCompactionId, credentials.getPrincipal());
     }
 
     server.getCompactionManager().externalCompactionFailed(
@@ -1550,20 +1567,19 @@ public class TabletClientHandler implements TabletClientService.Iface {
 
   @Override
   public TSummaries startGetSummaries(TInfo tinfo, TCredentials credentials,
-      TSummaryRequest request)
-      throws ThriftSecurityException, ThriftTableOperationException, TException {
+      TSummaryRequest request) throws ThriftSecurityException, ThriftTableOperationException {
     NamespaceId namespaceId;
     TableId tableId = TableId.of(request.getTableId());
     try {
       namespaceId = server.getContext().getNamespaceId(tableId);
     } catch (TableNotFoundException e1) {
       throw new ThriftTableOperationException(tableId.canonical(), null, null,
-          TableOperationExceptionType.NOTFOUND, null);
+          TableOperationExceptionType.NOTFOUND, e1.getMessage());
     }
 
     if (!security.canGetSummaries(credentials, tableId, namespaceId)) {
-      throw new AccumuloSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
     }
 
     ExecutorService es = server.resourceManager.getSummaryPartitionExecutor();
@@ -1577,12 +1593,11 @@ public class TabletClientHandler implements TabletClientService.Iface {
 
   @Override
   public TSummaries startGetSummariesForPartition(TInfo tinfo, TCredentials credentials,
-      TSummaryRequest request, int modulus, int remainder)
-      throws ThriftSecurityException, TException {
+      TSummaryRequest request, int modulus, int remainder) throws ThriftSecurityException {
     // do not expect users to call this directly, expect other tservers to call this method
     if (!security.canPerformSystemActions(credentials)) {
-      throw new AccumuloSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
     }
 
     ExecutorService spe = server.resourceManager.getSummaryRemoteExecutor();
@@ -1597,12 +1612,11 @@ public class TabletClientHandler implements TabletClientService.Iface {
 
   @Override
   public TSummaries startGetSummariesFromFiles(TInfo tinfo, TCredentials credentials,
-      TSummaryRequest request, Map<String,List<TRowRange>> files)
-      throws ThriftSecurityException, TException {
+      TSummaryRequest request, Map<String,List<TRowRange>> files) throws ThriftSecurityException {
     // do not expect users to call this directly, expect other tservers to call this method
     if (!security.canPerformSystemActions(credentials)) {
-      throw new AccumuloSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
     }
 
     ExecutorService srp = server.resourceManager.getSummaryRetrievalExecutor();
@@ -1620,8 +1634,7 @@ public class TabletClientHandler implements TabletClientService.Iface {
   }
 
   @Override
-  public TSummaries contiuneGetSummaries(TInfo tinfo, long sessionId)
-      throws NoSuchScanIDException, TException {
+  public TSummaries contiuneGetSummaries(TInfo tinfo, long sessionId) throws NoSuchScanIDException {
     SummarySession session = (SummarySession) server.sessionManager.getSession(sessionId);
     if (session == null) {
       throw new NoSuchScanIDException();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
@@ -1479,48 +1479,42 @@ public class TabletClientHandler implements TabletClientService.Iface {
       String externalCompactionId, TKeyExtent extent, long fileSize, long entries) {
 
     try {
-      if (!security.canPerformSystemActions(credentials)) {
-        throw new ThriftSecurityException(credentials.getPrincipal(),
-            SecurityErrorCode.PERMISSION_DENIED);
+      if (security.canPerformSystemActions(credentials)) {
+        server.getCompactionManager().commitExternalCompaction(
+            ExternalCompactionId.of(externalCompactionId), KeyExtent.fromThrift(extent),
+            server.getOnlineTablets(), fileSize, entries);
+        return;
       }
     } catch (ThriftSecurityException e) {
-      log.warn(
-          "Received compaction job finished message (id: {}) from user ({}) with bad credentials",
-          externalCompactionId, credentials.getPrincipal());
+      // logged below
     }
-
-    server.getCompactionManager().commitExternalCompaction(
-        ExternalCompactionId.of(externalCompactionId), KeyExtent.fromThrift(extent),
-        server.getOnlineTablets(), fileSize, entries);
+    log.warn(
+        "Received compaction job finished message (id: {}) from user ({}) with bad credentials",
+        externalCompactionId, credentials.getPrincipal());
   }
 
   @Override
   public void compactionJobFailed(TInfo tinfo, TCredentials credentials,
       String externalCompactionId, TKeyExtent extent) {
     try {
-      if (!security.canPerformSystemActions(credentials)) {
-        throw new ThriftSecurityException(credentials.getPrincipal(),
-            SecurityErrorCode.PERMISSION_DENIED);
+      if (security.canPerformSystemActions(credentials)) {
+        server.getCompactionManager().externalCompactionFailed(
+            ExternalCompactionId.of(externalCompactionId), KeyExtent.fromThrift(extent),
+            server.getOnlineTablets());
+        return;
       }
     } catch (ThriftSecurityException e) {
-      log.warn(
-          "Received compaction job failed message (id: {}) from user ({}) with bad credentials",
-          externalCompactionId, credentials.getPrincipal());
+      // logged below
     }
-
-    server.getCompactionManager().externalCompactionFailed(
-        ExternalCompactionId.of(externalCompactionId), KeyExtent.fromThrift(extent),
-        server.getOnlineTablets());
+    log.warn("Received compaction job failed message (id: {}) from user ({}) with bad credentials",
+        externalCompactionId, credentials.getPrincipal());
   }
 
   @Override
   public List<String> getActiveLogs(TInfo tinfo, TCredentials credentials) {
     String log = server.logger.getLogFile();
     // Might be null if there no active logger
-    if (log == null) {
-      return Collections.emptyList();
-    }
-    return Collections.singletonList(log);
+    return log == null ? Collections.emptyList() : Collections.singletonList(log);
   }
 
   @Override

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
@@ -23,6 +23,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.stream.Collectors.toList;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -42,7 +43,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.Constants;
-import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.Durability;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.admin.CompactionConfig;
@@ -126,7 +126,6 @@ import org.apache.hadoop.fs.FSError;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
-import org.apache.thrift.TException;
 import org.apache.zookeeper.KeeperException.NoNodeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -210,6 +209,17 @@ public class TabletClientHandler implements TabletClientService.Iface {
 
   @Override
   public void loadFiles(TInfo tinfo, TCredentials credentials, long tid, String dir,
+      Map<TKeyExtent,Map<String,MapFileInfo>> tabletImports, boolean setTime) {
+    try {
+      loadFilesV2(tinfo, credentials, tid, dir, tabletImports, setTime);
+    } catch (ThriftSecurityException e) {
+      log.warn("Received oneway load files message (dir: {}) from user ({}) with bad credentials",
+          dir, credentials.getPrincipal());
+    }
+  }
+
+  @Override
+  public void loadFilesV2(TInfo tinfo, TCredentials credentials, long tid, String dir,
       Map<TKeyExtent,Map<String,MapFileInfo>> tabletImports, boolean setTime)
       throws ThriftSecurityException {
     if (!security.canPerformSystemActions(credentials)) {
@@ -245,14 +255,6 @@ public class TabletClientHandler implements TabletClientService.Iface {
         }
       });
     });
-
-  }
-
-  @Override
-  public void loadFilesV2(TInfo tinfo, TCredentials credentials, long tid, String dir,
-      Map<TKeyExtent,Map<String,MapFileInfo>> tabletImports, boolean setTime)
-      throws ThriftSecurityException {
-    loadFiles(tinfo, credentials, tid, dir, tabletImports, setTime);
   }
 
   @Override
@@ -645,7 +647,7 @@ public class TabletClientHandler implements TabletClientService.Iface {
   }
 
   @Override
-  public boolean cancelUpdate(TInfo tinfo, long updateID) throws TException {
+  public boolean cancelUpdate(TInfo tinfo, long updateID) {
     return server.sessionManager.removeIfNotReserved(updateID);
   }
 
@@ -949,7 +951,7 @@ public class TabletClientHandler implements TabletClientService.Iface {
   @Override
   public TConditionalSession startConditionalUpdate(TInfo tinfo, TCredentials credentials,
       List<ByteBuffer> authorizations, String tableIdStr, TDurability tdurabilty,
-      String classLoaderContext) throws ThriftSecurityException, TException {
+      String classLoaderContext) throws ThriftSecurityException {
 
     TableId tableId = TableId.of(tableIdStr);
     Authorizations userauths = null;
@@ -977,7 +979,7 @@ public class TabletClientHandler implements TabletClientService.Iface {
   @Override
   public List<TCMResult> conditionalUpdate(TInfo tinfo, long sessID,
       Map<TKeyExtent,List<TConditionalMutation>> mutations, List<String> symbols)
-      throws NoSuchScanIDException, TException {
+      throws NoSuchScanIDException {
 
     ConditionalSession cs = null;
     Long opid = null;
@@ -1024,9 +1026,13 @@ public class TabletClientHandler implements TabletClientService.Iface {
       }
 
       return results;
-    } catch (IOException | ReflectiveOperationException ioe) {
-      throw new TException(ioe);
-    } catch (Exception e) {
+    } catch (IOException e) {
+      log.warn("Exception returned for conditionalUpdate {}", e);
+      throw new UncheckedIOException(e);
+    } catch (ReflectiveOperationException e) {
+      log.warn("Exception returned for conditionalUpdate {}", e);
+      throw new IllegalStateException(e);
+    } catch (RuntimeException e) {
       log.warn("Exception returned for conditionalUpdate {}", e);
       throw e;
     } finally {
@@ -1418,7 +1424,7 @@ public class TabletClientHandler implements TabletClientService.Iface {
 
   @Override
   public List<ActiveCompaction> getActiveCompactions(TInfo tinfo, TCredentials credentials)
-      throws ThriftSecurityException, TException {
+      throws ThriftSecurityException {
     try {
       checkPermission(context, server, credentials, null, "getActiveCompactions");
     } catch (ThriftSecurityException e) {
@@ -1438,11 +1444,11 @@ public class TabletClientHandler implements TabletClientService.Iface {
 
   @Override
   public List<TCompactionQueueSummary> getCompactionQueueInfo(TInfo tinfo, TCredentials credentials)
-      throws ThriftSecurityException, TException {
+      throws ThriftSecurityException {
 
     if (!security.canPerformSystemActions(credentials)) {
-      throw new AccumuloSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
     }
 
     return server.getCompactionManager().getCompactionQueueSummaries();
@@ -1451,11 +1457,11 @@ public class TabletClientHandler implements TabletClientService.Iface {
   @Override
   public TExternalCompactionJob reserveCompactionJob(TInfo tinfo, TCredentials credentials,
       String queueName, long priority, String compactor, String externalCompactionId)
-      throws ThriftSecurityException, TException {
+      throws ThriftSecurityException {
 
     if (!security.canPerformSystemActions(credentials)) {
-      throw new AccumuloSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
     }
 
     ExternalCompactionId eci = ExternalCompactionId.of(externalCompactionId);
@@ -1472,40 +1478,45 @@ public class TabletClientHandler implements TabletClientService.Iface {
 
   @Override
   public void compactionJobFinished(TInfo tinfo, TCredentials credentials,
-      String externalCompactionId, TKeyExtent extent, long fileSize, long entries)
-      throws ThriftSecurityException, TException {
+      String externalCompactionId, TKeyExtent extent, long fileSize, long entries) {
 
-    if (!security.canPerformSystemActions(credentials)) {
-      throw new AccumuloSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+    try {
+      if (security.canPerformSystemActions(credentials)) {
+        server.getCompactionManager().commitExternalCompaction(
+            ExternalCompactionId.of(externalCompactionId), KeyExtent.fromThrift(extent),
+            server.getOnlineTablets(), fileSize, entries);
+        return;
+      }
+    } catch (ThriftSecurityException e) {
+      // logged below
     }
-
-    server.getCompactionManager().commitExternalCompaction(
-        ExternalCompactionId.of(externalCompactionId), KeyExtent.fromThrift(extent),
-        server.getOnlineTablets(), fileSize, entries);
+    log.warn(
+        "Received compaction job finished message (id: {}) from user ({}) with bad credentials",
+        externalCompactionId, credentials.getPrincipal());
   }
 
   @Override
   public void compactionJobFailed(TInfo tinfo, TCredentials credentials,
-      String externalCompactionId, TKeyExtent extent) throws TException {
-    if (!security.canPerformSystemActions(credentials)) {
-      throw new AccumuloSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+      String externalCompactionId, TKeyExtent extent) {
+    try {
+      if (security.canPerformSystemActions(credentials)) {
+        server.getCompactionManager().externalCompactionFailed(
+            ExternalCompactionId.of(externalCompactionId), KeyExtent.fromThrift(extent),
+            server.getOnlineTablets());
+        return;
+      }
+    } catch (ThriftSecurityException e) {
+      // logged below
     }
-
-    server.getCompactionManager().externalCompactionFailed(
-        ExternalCompactionId.of(externalCompactionId), KeyExtent.fromThrift(extent),
-        server.getOnlineTablets());
+    log.warn("Received compaction job failed message (id: {}) from user ({}) with bad credentials",
+        externalCompactionId, credentials.getPrincipal());
   }
 
   @Override
   public List<String> getActiveLogs(TInfo tinfo, TCredentials credentials) {
     String log = server.logger.getLogFile();
     // Might be null if there no active logger
-    if (log == null) {
-      return Collections.emptyList();
-    }
-    return Collections.singletonList(log);
+    return log == null ? Collections.emptyList() : Collections.singletonList(log);
   }
 
   @Override
@@ -1552,20 +1563,19 @@ public class TabletClientHandler implements TabletClientService.Iface {
 
   @Override
   public TSummaries startGetSummaries(TInfo tinfo, TCredentials credentials,
-      TSummaryRequest request)
-      throws ThriftSecurityException, ThriftTableOperationException, TException {
+      TSummaryRequest request) throws ThriftSecurityException, ThriftTableOperationException {
     NamespaceId namespaceId;
     TableId tableId = TableId.of(request.getTableId());
     try {
       namespaceId = server.getContext().getNamespaceId(tableId);
     } catch (TableNotFoundException e1) {
       throw new ThriftTableOperationException(tableId.canonical(), null, null,
-          TableOperationExceptionType.NOTFOUND, null);
+          TableOperationExceptionType.NOTFOUND, e1.getMessage());
     }
 
     if (!security.canGetSummaries(credentials, tableId, namespaceId)) {
-      throw new AccumuloSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
     }
 
     ExecutorService es = server.resourceManager.getSummaryPartitionExecutor();
@@ -1579,12 +1589,11 @@ public class TabletClientHandler implements TabletClientService.Iface {
 
   @Override
   public TSummaries startGetSummariesForPartition(TInfo tinfo, TCredentials credentials,
-      TSummaryRequest request, int modulus, int remainder)
-      throws ThriftSecurityException, TException {
+      TSummaryRequest request, int modulus, int remainder) throws ThriftSecurityException {
     // do not expect users to call this directly, expect other tservers to call this method
     if (!security.canPerformSystemActions(credentials)) {
-      throw new AccumuloSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
     }
 
     ExecutorService spe = server.resourceManager.getSummaryRemoteExecutor();
@@ -1599,12 +1608,11 @@ public class TabletClientHandler implements TabletClientService.Iface {
 
   @Override
   public TSummaries startGetSummariesFromFiles(TInfo tinfo, TCredentials credentials,
-      TSummaryRequest request, Map<String,List<TRowRange>> files)
-      throws ThriftSecurityException, TException {
+      TSummaryRequest request, Map<String,List<TRowRange>> files) throws ThriftSecurityException {
     // do not expect users to call this directly, expect other tservers to call this method
     if (!security.canPerformSystemActions(credentials)) {
-      throw new AccumuloSecurityException(credentials.getPrincipal(),
-          SecurityErrorCode.PERMISSION_DENIED).asThriftException();
+      throw new ThriftSecurityException(credentials.getPrincipal(),
+          SecurityErrorCode.PERMISSION_DENIED);
     }
 
     ExecutorService srp = server.resourceManager.getSummaryRetrievalExecutor();
@@ -1622,8 +1630,7 @@ public class TabletClientHandler implements TabletClientService.Iface {
   }
 
   @Override
-  public TSummaries contiuneGetSummaries(TInfo tinfo, long sessionId)
-      throws NoSuchScanIDException, TException {
+  public TSummaries contiuneGetSummaries(TInfo tinfo, long sessionId) throws NoSuchScanIDException {
     SummarySession session = (SummarySession) server.sessionManager.getSession(sessionId);
     if (session == null) {
       throw new NoSuchScanIDException();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -160,7 +160,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 import org.apache.thrift.TException;
 import org.apache.thrift.TProcessor;
-import org.apache.thrift.TServiceClient;
 import org.apache.thrift.server.TServer;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
@@ -899,7 +898,7 @@ public class TabletServer extends AbstractServer
       // send all of the pending messages
       try {
         ManagerMessage mm = null;
-        ManagerClientService.Client iface = null;
+        ManagerClientService.Client client = null;
 
         try {
           // wait until a message is ready to send, or a server stop
@@ -912,8 +911,7 @@ public class TabletServer extends AbstractServer
           // have a message to send to the manager, so grab a
           // connection
           managerHost = getManagerAddress();
-          iface = managerConnection(managerHost);
-          TServiceClient client = iface;
+          client = managerConnection(managerHost);
 
           // if while loop does not execute at all and mm != null,
           // then finally block should place mm back on queue
@@ -922,7 +920,7 @@ public class TabletServer extends AbstractServer
               && client.getOutputProtocol().getTransport() != null
               && client.getOutputProtocol().getTransport().isOpen()) {
             try {
-              mm.send(getContext().rpcCreds(), getClientAddressString(), iface);
+              mm.send(getContext().rpcCreds(), getClientAddressString(), client);
               mm = null;
             } catch (TException ex) {
               log.warn("Error sending message: queuing message again");
@@ -942,7 +940,7 @@ public class TabletServer extends AbstractServer
           if (mm != null) {
             managerMessages.putFirst(mm);
           }
-          returnManagerConnection(iface);
+          returnManagerConnection(client);
 
           sleepUninterruptibly(1, TimeUnit.SECONDS);
         }
@@ -958,13 +956,13 @@ public class TabletServer extends AbstractServer
       }
     }
 
-    ManagerClientService.Client iface = managerConnection(getManagerAddress());
+    ManagerClientService.Client client = managerConnection(getManagerAddress());
     try {
       // Ask the manager to unload our tablets and stop loading new tablets
-      if (iface == null) {
+      if (client == null) {
         Halt.halt(-1, "Error informing Manager that we are shutting down, exiting!");
       } else {
-        iface.tabletServerStopping(TraceUtil.traceInfo(), getContext().rpcCreds(),
+        client.tabletServerStopping(TraceUtil.traceInfo(), getContext().rpcCreds(),
             getTabletSession().getHostPortSession());
       }
 
@@ -973,17 +971,17 @@ public class TabletServer extends AbstractServer
         log.info("Shutdown requested, waiting for manager to unload {} tablets",
             getOnlineTablets().size());
 
-        managerDown = sendManagerMessages(managerDown, iface);
+        managerDown = sendManagerMessages(managerDown, client);
 
         UtilWaitThread.sleep(1000);
       }
 
-      sendManagerMessages(managerDown, iface);
+      sendManagerMessages(managerDown, client);
 
     } catch (TException | RuntimeException e) {
       Halt.halt(-1, "Error informing Manager that we are shutting down, exiting!", e);
     } finally {
-      returnManagerConnection(iface);
+      returnManagerConnection(client);
     }
 
     log.debug("Stopping Replication Server");
@@ -1014,11 +1012,11 @@ public class TabletServer extends AbstractServer
     }
   }
 
-  private boolean sendManagerMessages(boolean managerDown, ManagerClientService.Client iface) {
+  private boolean sendManagerMessages(boolean managerDown, ManagerClientService.Client client) {
     ManagerMessage mm = managerMessages.poll();
     while (mm != null && !managerDown) {
       try {
-        mm.send(getContext().rpcCreds(), getClientAddressString(), iface);
+        mm.send(getContext().rpcCreds(), getClientAddressString(), client);
         mm = managerMessages.poll();
       } catch (TException e) {
         managerDown = true;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -160,7 +160,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 import org.apache.thrift.TException;
 import org.apache.thrift.TProcessor;
-import org.apache.thrift.TServiceClient;
 import org.apache.thrift.server.TServer;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
@@ -893,7 +892,7 @@ public class TabletServer extends AbstractServer
       // send all of the pending messages
       try {
         ManagerMessage mm = null;
-        ManagerClientService.Client iface = null;
+        ManagerClientService.Client client = null;
 
         try {
           // wait until a message is ready to send, or a server stop
@@ -906,8 +905,7 @@ public class TabletServer extends AbstractServer
           // have a message to send to the manager, so grab a
           // connection
           managerHost = getManagerAddress();
-          iface = managerConnection(managerHost);
-          TServiceClient client = iface;
+          client = managerConnection(managerHost);
 
           // if while loop does not execute at all and mm != null,
           // then finally block should place mm back on queue
@@ -916,7 +914,7 @@ public class TabletServer extends AbstractServer
               && client.getOutputProtocol().getTransport() != null
               && client.getOutputProtocol().getTransport().isOpen()) {
             try {
-              mm.send(getContext().rpcCreds(), getClientAddressString(), iface);
+              mm.send(getContext().rpcCreds(), getClientAddressString(), client);
               mm = null;
             } catch (TException ex) {
               log.warn("Error sending message: queuing message again");
@@ -936,7 +934,7 @@ public class TabletServer extends AbstractServer
           if (mm != null) {
             managerMessages.putFirst(mm);
           }
-          returnManagerConnection(iface);
+          returnManagerConnection(client);
 
           sleepUninterruptibly(1, TimeUnit.SECONDS);
         }
@@ -951,13 +949,13 @@ public class TabletServer extends AbstractServer
       }
     }
 
-    ManagerClientService.Client iface = managerConnection(getManagerAddress());
+    ManagerClientService.Client client = managerConnection(getManagerAddress());
     try {
       // Ask the manager to unload our tablets and stop loading new tablets
-      if (iface == null) {
+      if (client == null) {
         Halt.halt(-1, "Error informing Manager that we are shutting down, exiting!");
       } else {
-        iface.tabletServerStopping(TraceUtil.traceInfo(), getContext().rpcCreds(),
+        client.tabletServerStopping(TraceUtil.traceInfo(), getContext().rpcCreds(),
             getTabletSession().getHostPortSession());
       }
 
@@ -966,17 +964,17 @@ public class TabletServer extends AbstractServer
         log.info("Shutdown requested, waiting for manager to unload {} tablets",
             getOnlineTablets().size());
 
-        managerDown = sendManagerMessages(managerDown, iface);
+        managerDown = sendManagerMessages(managerDown, client);
 
         UtilWaitThread.sleep(1000);
       }
 
-      sendManagerMessages(managerDown, iface);
+      sendManagerMessages(managerDown, client);
 
     } catch (TException | RuntimeException e) {
       Halt.halt(-1, "Error informing Manager that we are shutting down, exiting!", e);
     } finally {
-      returnManagerConnection(iface);
+      returnManagerConnection(client);
     }
 
     log.debug("Stopping Replication Server");
@@ -1007,11 +1005,11 @@ public class TabletServer extends AbstractServer
     }
   }
 
-  private boolean sendManagerMessages(boolean managerDown, ManagerClientService.Client iface) {
+  private boolean sendManagerMessages(boolean managerDown, ManagerClientService.Client client) {
     ManagerMessage mm = managerMessages.poll();
     while (mm != null && !managerDown) {
       try {
-        mm.send(getContext().rpcCreds(), getClientAddressString(), iface);
+        mm.send(getContext().rpcCreds(), getClientAddressString(), client);
         mm = managerMessages.poll();
       } catch (TException e) {
         managerDown = true;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ThriftScanClientHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ThriftScanClientHandler.java
@@ -84,7 +84,6 @@ import org.apache.accumulo.tserver.tablet.KVEntry;
 import org.apache.accumulo.tserver.tablet.ScanBatch;
 import org.apache.accumulo.tserver.tablet.Tablet;
 import org.apache.accumulo.tserver.tablet.TabletBase;
-import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -540,7 +539,7 @@ public class ThriftScanClientHandler implements TabletScanClientService.Iface {
 
   @Override
   public List<ActiveScan> getActiveScans(TInfo tinfo, TCredentials credentials)
-      throws ThriftSecurityException, TException {
+      throws ThriftSecurityException {
     TabletClientHandler.checkPermission(context, server, credentials, null, "getScans");
     return server.getSessionManager().getActiveScans();
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/managermessage/ManagerMessage.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/managermessage/ManagerMessage.java
@@ -25,7 +25,7 @@ import org.apache.thrift.TException;
 
 public interface ManagerMessage {
 
-  void send(TCredentials info, String serverName, ManagerClientService.Iface client)
+  void send(TCredentials info, String serverName, ManagerClientService.Client client)
       throws TException, ThriftSecurityException;
 
 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/managermessage/SplitReportMessage.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/managermessage/SplitReportMessage.java
@@ -44,7 +44,7 @@ public class SplitReportMessage implements ManagerMessage {
   }
 
   @Override
-  public void send(TCredentials credentials, String serverName, ManagerClientService.Iface client)
+  public void send(TCredentials credentials, String serverName, ManagerClientService.Client client)
       throws TException, ThriftSecurityException {
     TabletSplit split = new TabletSplit();
     split.oldTablet = old_extent.toThrift();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/managermessage/TabletStatusMessage.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/managermessage/TabletStatusMessage.java
@@ -20,7 +20,7 @@ package org.apache.accumulo.tserver.managermessage;
 
 import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.manager.thrift.ManagerClientService.Iface;
+import org.apache.accumulo.core.manager.thrift.ManagerClientService;
 import org.apache.accumulo.core.manager.thrift.TabletLoadState;
 import org.apache.accumulo.core.securityImpl.thrift.TCredentials;
 import org.apache.accumulo.core.trace.TraceUtil;
@@ -37,7 +37,7 @@ public class TabletStatusMessage implements ManagerMessage {
   }
 
   @Override
-  public void send(TCredentials auth, String serverName, Iface client)
+  public void send(TCredentials auth, String serverName, ManagerClientService.Client client)
       throws TException, ThriftSecurityException {
     client.reportTabletStatus(TraceUtil.traceInfo(), auth, serverName, status, extent.toThrift());
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/ReplicationServicerHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/ReplicationServicerHandler.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.TableId;
@@ -34,7 +35,6 @@ import org.apache.accumulo.core.replication.thrift.ReplicationServicer.Iface;
 import org.apache.accumulo.core.replication.thrift.WalEdits;
 import org.apache.accumulo.core.securityImpl.thrift.TCredentials;
 import org.apache.accumulo.tserver.TabletServer;
-import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,17 +44,23 @@ public class ReplicationServicerHandler implements Iface {
 
   private TabletServer tabletServer;
 
+  @Deprecated
   public ReplicationServicerHandler(TabletServer tabletServer) {
     this.tabletServer = tabletServer;
   }
 
+  @Deprecated
   @Override
   public long replicateLog(String tableIdStr, WalEdits data, TCredentials tcreds)
-      throws TException {
+      throws RemoteReplicationException {
     TableId tableId = TableId.of(tableIdStr);
     log.debug("Got replication request to tableID {} with {} edits", tableId, data.getEditsSize());
-    tabletServer.getContext().getSecurityOperation()
-        .authenticateUser(tabletServer.getContext().rpcCreds(), tcreds);
+    try {
+      tabletServer.getContext().getSecurityOperation()
+          .authenticateUser(tabletServer.getContext().rpcCreds(), tcreds);
+    } catch (ThriftSecurityException e) {
+      throw new IllegalStateException(e);
+    }
 
     String tableName;
 
@@ -117,6 +123,7 @@ public class ReplicationServicerHandler implements Iface {
     return entriesReplicated;
   }
 
+  @Deprecated
   @Override
   public long replicateKeyValues(String tableId, KeyValues data, TCredentials creds) {
     throw new UnsupportedOperationException();

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/ScanServerTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/ScanServerTest.java
@@ -61,8 +61,6 @@ import org.apache.accumulo.tserver.session.ScanSession.TabletResolver;
 import org.apache.accumulo.tserver.tablet.SnapshotTablet;
 import org.apache.accumulo.tserver.tablet.Tablet;
 import org.apache.accumulo.tserver.tablet.TabletBase;
-import org.apache.thrift.TApplicationException;
-import org.apache.thrift.TException;
 import org.junit.jupiter.api.Test;
 
 public class ScanServerTest {
@@ -223,10 +221,9 @@ public class ScanServerTest {
     ss.delegate = handler;
     ss.reservation = reservation;
 
-    assertThrows(NotServingTabletException.class, () -> {
-      ss.startScan(tinfo, tcreds, textent, trange, tcols, 10, titer, ssio, auths, false, false, 10,
-          tsc, 30L, classLoaderContext, execHints, 0L);
-    });
+    assertThrows(NotServingTabletException.class,
+        () -> ss.startScan(tinfo, tcreds, textent, trange, tcols, 10, titer, ssio, auths, false,
+            false, 10, tsc, 30L, classLoaderContext, execHints, 0L));
 
     verify(extent, reservation);
   }
@@ -391,10 +388,9 @@ public class ScanServerTest {
     ss.resolver = resolver;
     ss.clientAddress = HostAndPort.fromParts("127.0.0.1", 1234);
 
-    assertThrows(TException.class, () -> {
-      ss.startMultiScan(tinfo, tcreds, extents, tcols, titer, ssio, auths, false, tsc, 30L,
-          classLoaderContext, execHints, 0L);
-    });
+    var e = assertThrows(IllegalArgumentException.class, () -> ss.startMultiScan(tinfo, tcreds,
+        extents, tcols, titer, ssio, auths, false, tsc, 30L, classLoaderContext, execHints, 0L));
+    assertEquals(e.getMessage(), "Scan Server batch must include at least one extent");
     verify(handler);
   }
 
@@ -482,14 +478,10 @@ public class ScanServerTest {
     ss.clientAddress = HostAndPort.fromParts("127.0.0.1", 1234);
 
     TKeyExtent textent = createMock(TKeyExtent.class);
-    TException te = assertThrows(TException.class, () -> {
-      ss.startScan(tinfo, tcreds, textent, trange, tcols, 10, titer, ssio, auths, false, false, 10,
-          tsc, 30L, classLoaderContext, execHints, 0L);
-    });
-    assertTrue(te instanceof TApplicationException);
-    TApplicationException tae = (TApplicationException) te;
-    assertEquals(TApplicationException.INTERNAL_ERROR, tae.getType());
-    assertTrue(tae.getMessage().contains("disallowed by property"));
+    var e = assertThrows(IllegalArgumentException.class,
+        () -> ss.startScan(tinfo, tcreds, textent, trange, tcols, 10, titer, ssio, auths, false,
+            false, 10, tsc, 30L, classLoaderContext, execHints, 0L));
+    assertTrue(e.getMessage().contains("disallowed by property"));
     verify(sextent, reservation, handler);
 
   }

--- a/test/src/main/java/org/apache/accumulo/test/ScanServerAllowedTablesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ScanServerAllowedTablesIT.java
@@ -212,7 +212,6 @@ public class ScanServerAllowedTablesIT extends SharedMiniClusterBase {
         assertTrue(root instanceof TApplicationException);
         TApplicationException tae = (TApplicationException) root;
         assertEquals(TApplicationException.INTERNAL_ERROR, tae.getType());
-        assertTrue(tae.getMessage().contains("disallowed by property"));
       }
 
       // Using GROUP1 ScanServer should fail, only allowed to test tables
@@ -224,7 +223,6 @@ public class ScanServerAllowedTablesIT extends SharedMiniClusterBase {
         assertTrue(root instanceof TApplicationException);
         TApplicationException tae = (TApplicationException) root;
         assertEquals(TApplicationException.INTERNAL_ERROR, tae.getType());
-        assertTrue(tae.getMessage().contains("disallowed by property"));
       }
 
       // Using GROUP1 ScanServer should succeed
@@ -247,7 +245,6 @@ public class ScanServerAllowedTablesIT extends SharedMiniClusterBase {
         assertTrue(root instanceof TApplicationException);
         TApplicationException tae = (TApplicationException) root;
         assertEquals(TApplicationException.INTERNAL_ERROR, tae.getType());
-        assertTrue(tae.getMessage().contains("disallowed by property"));
       }
 
       // Using GROUP1 ScanServer should fail as the property was changed

--- a/test/src/main/java/org/apache/accumulo/test/ScanServerOfflineTableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ScanServerOfflineTableIT.java
@@ -53,6 +53,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 
 import com.google.common.collect.Iterables;
 
@@ -121,9 +122,9 @@ public class ScanServerOfflineTableIT extends SharedMiniClusterBase {
   }
 
   public static class ArgProvider implements ArgumentsProvider {
-
     @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+    public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters,
+        ExtensionContext context) throws Exception {
       List<Arguments> args = new ArrayList<>();
       args.add(Arguments.of(ScannerType.BATCH_SCANNER, 0));
       args.add(Arguments.of(ScannerType.SCANNER, 0));
@@ -131,7 +132,6 @@ public class ScanServerOfflineTableIT extends SharedMiniClusterBase {
       args.add(Arguments.of(ScannerType.SCANNER, 100));
       return args.stream();
     }
-
   }
 
   @ParameterizedTest

--- a/test/src/main/java/org/apache/accumulo/test/SelfStoppingScanServer.java
+++ b/test/src/main/java/org/apache/accumulo/test/SelfStoppingScanServer.java
@@ -26,7 +26,6 @@ import org.apache.accumulo.core.tabletserver.thrift.TabletScanClientService;
 import org.apache.accumulo.core.trace.thrift.TInfo;
 import org.apache.accumulo.tserver.ScanServer;
 import org.apache.accumulo.tserver.TabletHostingServer;
-import org.apache.thrift.TException;
 
 /**
  * ScanServer implementation that will stop itself after the the 3rd scan batch scan
@@ -42,7 +41,7 @@ public class SelfStoppingScanServer extends ScanServer
   }
 
   @Override
-  public void closeMultiScan(TInfo tinfo, long scanID) throws NoSuchScanIDException, TException {
+  public void closeMultiScan(TInfo tinfo, long scanID) throws NoSuchScanIDException {
     scanCount.incrementAndGet();
     super.closeMultiScan(tinfo, scanID);
     if (scanCount.get() == 3) {

--- a/test/src/main/java/org/apache/accumulo/test/compaction/NonCommittingExternalCompactionTabletClientHandler.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/NonCommittingExternalCompactionTabletClientHandler.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.test.compaction;
 
-import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.dataImpl.thrift.TKeyExtent;
 import org.apache.accumulo.core.securityImpl.thrift.TCredentials;
 import org.apache.accumulo.core.tabletserver.thrift.TabletClientService;
@@ -27,7 +26,6 @@ import org.apache.accumulo.server.zookeeper.TransactionWatcher;
 import org.apache.accumulo.tserver.TabletClientHandler;
 import org.apache.accumulo.tserver.TabletServer;
 import org.apache.accumulo.tserver.WriteTracker;
-import org.apache.thrift.TException;
 
 public class NonCommittingExternalCompactionTabletClientHandler extends TabletClientHandler
     implements TabletClientService.Iface {
@@ -39,14 +37,13 @@ public class NonCommittingExternalCompactionTabletClientHandler extends TabletCl
 
   @Override
   public void compactionJobFinished(TInfo tinfo, TCredentials credentials,
-      String externalCompactionId, TKeyExtent extent, long fileSize, long entries)
-      throws ThriftSecurityException, TException {
+      String externalCompactionId, TKeyExtent extent, long fileSize, long entries) {
     // do nothing
   }
 
   @Override
   public void compactionJobFailed(TInfo tinfo, TCredentials credentials,
-      String externalCompactionId, TKeyExtent extent) throws TException {
+      String externalCompactionId, TKeyExtent extent) {
     // do nothing
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/performance/NullTserver.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/NullTserver.java
@@ -30,7 +30,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.cli.Help;
 import org.apache.accumulo.core.clientImpl.thrift.ClientService;
-import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.conf.SiteConfiguration;
@@ -83,7 +82,6 @@ import org.apache.accumulo.server.rpc.TServerUtils;
 import org.apache.accumulo.server.rpc.ThriftProcessorTypes;
 import org.apache.accumulo.server.rpc.ThriftServerType;
 import org.apache.accumulo.server.zookeeper.TransactionWatcher;
-import org.apache.thrift.TException;
 import org.apache.thrift.TMultiplexedProcessor;
 
 import com.beust.jcommander.Parameter;
@@ -115,7 +113,7 @@ public class NullTserver {
     }
 
     @Override
-    public boolean cancelUpdate(TInfo tinfo, long updateID) throws TException {
+    public boolean cancelUpdate(TInfo tinfo, long updateID) {
       return true;
     }
 
@@ -289,25 +287,23 @@ public class NullTserver {
 
     @Override
     public List<TCompactionQueueSummary> getCompactionQueueInfo(TInfo tinfo,
-        TCredentials credentials) throws ThriftSecurityException, TException {
+        TCredentials credentials) {
       return null;
     }
 
     @Override
     public TExternalCompactionJob reserveCompactionJob(TInfo tinfo, TCredentials credentials,
-        String queueName, long priority, String compactor, String externalCompactionId)
-        throws ThriftSecurityException, TException {
+        String queueName, long priority, String compactor, String externalCompactionId) {
       return null;
     }
 
     @Override
     public void compactionJobFinished(TInfo tinfo, TCredentials credentials,
-        String externalCompactionId, TKeyExtent extent, long fileSize, long entries)
-        throws ThriftSecurityException, TException {}
+        String externalCompactionId, TKeyExtent extent, long fileSize, long entries) {}
 
     @Override
     public void compactionJobFailed(TInfo tinfo, TCredentials credentials,
-        String externalCompactionId, TKeyExtent extent) throws TException {}
+        String externalCompactionId, TKeyExtent extent) {}
 
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/replication/ReplicationOperationsImplIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/ReplicationOperationsImplIT.java
@@ -53,7 +53,6 @@ import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.replication.proto.Replication.Status;
 import org.apache.accumulo.test.functional.ConfigurableMacBase;
 import org.apache.hadoop.io.Text;
-import org.apache.thrift.TException;
 import org.easymock.EasyMock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -69,6 +68,7 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
   private AccumuloClient client;
   private ServerContext context;
 
+  @Deprecated
   @BeforeEach
   public void configureInstance() throws Exception {
     client = Accumulo.newClient().from(getClientProperties()).build();
@@ -106,15 +106,12 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
       @Override
       protected boolean getManagerDrain(final TInfo tinfo, final TCredentials rpcCreds,
           final String tableName, final Set<String> wals) {
-        try {
-          return mcsh.drainReplicationTable(tinfo, rpcCreds, tableName, wals);
-        } catch (TException e) {
-          throw new RuntimeException(e);
-        }
+        return mcsh.drainReplicationTable(tinfo, rpcCreds, tableName, wals);
       }
     };
   }
 
+  @Deprecated
   @Test
   public void waitsUntilEntriesAreReplicated() throws Exception {
     client.tableOperations().create("foo");
@@ -208,6 +205,7 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
     assertFalse(exception.get(), "Saw unexpected exception");
   }
 
+  @Deprecated
   @Test
   public void unrelatedReplicationRecordsDontBlockDrain() throws Exception {
     client.tableOperations().create("foo");
@@ -292,6 +290,7 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
     assertFalse(exception.get(), "Saw unexpected exception");
   }
 
+  @Deprecated
   @Test
   public void inprogressReplicationRecordsBlockExecution() throws Exception {
     client.tableOperations().create("foo");
@@ -370,6 +369,7 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
     assertFalse(exception.get(), "Saw unexpected exception");
   }
 
+  @Deprecated
   @Test
   public void laterCreatedLogsDontBlockExecution() throws Exception {
     client.tableOperations().create("foo");

--- a/test/src/main/java/org/apache/accumulo/test/replication/ReplicationOperationsImplIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/ReplicationOperationsImplIT.java
@@ -53,7 +53,6 @@ import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.replication.proto.Replication.Status;
 import org.apache.accumulo.test.functional.ConfigurableMacBase;
 import org.apache.hadoop.io.Text;
-import org.apache.thrift.TException;
 import org.easymock.EasyMock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -69,6 +68,7 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
   private AccumuloClient client;
   private ServerContext context;
 
+  @Deprecated
   @BeforeEach
   public void configureInstance() throws Exception {
     client = Accumulo.newClient().from(getClientProperties()).build();
@@ -106,15 +106,12 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
       @Override
       protected boolean getManagerDrain(final TInfo tinfo, final TCredentials rpcCreds,
           final String tableName, final Set<String> wals) {
-        try {
-          return mcsh.drainReplicationTable(tinfo, rpcCreds, tableName, wals);
-        } catch (TException e) {
-          throw new RuntimeException(e);
-        }
+        return mcsh.drainReplicationTable(tinfo, rpcCreds, tableName, wals);
       }
     };
   }
 
+  @Deprecated
   @Test
   public void waitsUntilEntriesAreReplicated() throws Exception {
     client.tableOperations().create("foo");
@@ -209,6 +206,7 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
     assertFalse(exception.get(), "Saw unexpected exception");
   }
 
+  @Deprecated
   @Test
   public void unrelatedReplicationRecordsDontBlockDrain() throws Exception {
     client.tableOperations().create("foo");
@@ -294,6 +292,7 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
     assertFalse(exception.get(), "Saw unexpected exception");
   }
 
+  @Deprecated
   @Test
   public void inprogressReplicationRecordsBlockExecution() throws Exception {
     client.tableOperations().create("foo");
@@ -373,6 +372,7 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
     assertFalse(exception.get(), "Saw unexpected exception");
   }
 
+  @Deprecated
   @Test
   public void laterCreatedLogsDontBlockExecution() throws Exception {
     client.tableOperations().create("foo");

--- a/test/src/main/java/org/apache/accumulo/test/rpc/SimpleThriftServiceHandler.java
+++ b/test/src/main/java/org/apache/accumulo/test/rpc/SimpleThriftServiceHandler.java
@@ -46,7 +46,7 @@ public class SimpleThriftServiceHandler implements SimpleThriftService.Iface {
   }
 
   @Override
-  public void echoPassVoid(String value) throws TException {
+  public void echoPassVoid(String value) {
     setProp("echoPassVoid", value);
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/rpc/ThriftExceptionsCheckIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/rpc/ThriftExceptionsCheckIT.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test.rpc;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.accumulo.harness.AccumuloITBase.SUNNY_DAY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.reflect.ClassPath;
+import com.google.common.reflect.ClassPath.ClassInfo;
+
+/**
+ * This IT is intended to verify that our Thrift RPC handler implementation methods only declare the
+ * exact exceptions defined in the Thrift IDL files, minus the generic TException, which should
+ * never be declared directly. Unexpected exception handling behavior can occur if throwing
+ * TExceptions that are not declared in a Thrift IDL, and the generic TException is thrown on every
+ * RPC interface method, but it has special handling and is intended only for things like libthrift
+ * handling of network issues or runtime exceptions thrown from an application.
+ */
+@Tag(SUNNY_DAY)
+@Timeout(value = 15, unit = SECONDS)
+public class ThriftExceptionsCheckIT {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ThriftExceptionsCheckIT.class);
+
+  private static class RpcServiceAndInterface {
+    private final ClassInfo info;
+    private final Class<?> loadedClass;
+    private final Class<?> matchingInterface;
+
+    private RpcServiceAndInterface(ClassInfo info, Class<?> loadedClass,
+        Class<?> matchingInterface) {
+      this.info = info;
+      this.loadedClass = loadedClass;
+      this.matchingInterface = matchingInterface;
+    }
+  }
+
+  @Test
+  public void checkThriftServices() throws IOException, ClassNotFoundException {
+    var allClasses = ClassPath.from(ClassLoader.getSystemClassLoader()).getAllClasses();
+    var rpcInterfaces = new HashSet<String>();
+    var rpcServiceImplCandidates = new ArrayList<ClassInfo>();
+
+    allClasses.forEach(info -> {
+      String name = info.getName();
+      if (name.startsWith("org.apache.accumulo.") && name.contains(".thrift.")
+          && (name.endsWith("$Iface") || name.endsWith("$AsyncIface"))) {
+        rpcInterfaces.add(name);
+      } else {
+        rpcServiceImplCandidates.add(info);
+      }
+    });
+    assertFalse(allClasses.isEmpty());
+    assertFalse(rpcInterfaces.isEmpty());
+    assertFalse(rpcServiceImplCandidates.isEmpty());
+    assertEquals(allClasses.size(), rpcInterfaces.size() + rpcServiceImplCandidates.size());
+
+    // remove stuff we don't care about
+    rpcServiceImplCandidates.removeIf(c -> c.getSimpleName().equals("module-info"));
+    rpcServiceImplCandidates.removeIf(c -> !c.getName().startsWith("org.apache.accumulo."));
+    rpcServiceImplCandidates.removeIf(c -> c.getName().contains(".thrift.")
+        && (c.getName().endsWith("$Client") || c.getName().endsWith("$AsyncClient")));
+    rpcServiceImplCandidates
+        .removeIf(c -> c.getName().equals(SimpleThriftServiceHandler.class.getName()));
+
+    // identify all the RPC handler classes (those implementing a Thrift Iface)
+    var rpcServiceImpls = new ArrayList<RpcServiceAndInterface>();
+    for (var c : rpcServiceImplCandidates) {
+      Class<?> loaded = c.load();
+      for (var i : loaded.getInterfaces()) {
+        String iName = i.getName();
+        if (rpcInterfaces.contains(iName)) {
+          rpcServiceImpls.add(new RpcServiceAndInterface(c, loaded, i));
+          LOG.trace("{} implements {}", c.getName(), iName);
+        }
+      }
+    }
+
+    assertFalse(rpcServiceImpls.isEmpty());
+
+    // check each method
+    rpcServiceImpls.forEach(ThriftExceptionsCheckIT::checkClass);
+  }
+
+  private static void checkClass(RpcServiceAndInterface tuple) {
+    for (var method : tuple.loadedClass.getDeclaredMethods()) {
+      try {
+        var interfaceMethod =
+            tuple.matchingInterface.getDeclaredMethod(method.getName(), method.getParameterTypes());
+        Set<String> interfaceExceptions =
+            Stream.of(interfaceMethod.getExceptionTypes()).map(Class::getName)
+                .filter(n -> !n.equals("org.apache.thrift.TException")).collect(Collectors.toSet());
+        Set<String> implExceptions =
+            Stream.of(method.getExceptionTypes()).map(Class::getName).collect(Collectors.toSet());
+        implExceptions.removeAll(interfaceExceptions);
+        assertTrue(implExceptions.isEmpty(),
+            () -> String.format("%s#%s throws exceptions not defined in the Thrift IDL (%s)",
+                tuple.info.getSimpleName(), method.getName(), implExceptions.toString()));
+      } catch (NoSuchMethodException e) {
+        // method does not exist in the interface, so skip it
+      }
+    }
+  }
+
+}

--- a/test/src/main/java/org/apache/accumulo/test/rpc/ThriftExceptionsCheckIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/rpc/ThriftExceptionsCheckIT.java
@@ -25,12 +25,20 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
+import org.apache.accumulo.core.securityImpl.thrift.TCredentials;
+import org.apache.accumulo.manager.ManagerClientServiceHandler;
+import org.apache.accumulo.manager.replication.ManagerReplicationCoordinator;
+import org.apache.accumulo.tserver.replication.ReplicationServicerHandler;
+import org.apache.thrift.TException;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -104,6 +112,7 @@ public class ThriftExceptionsCheckIT {
         if (rpcInterfaces.contains(iName)) {
           rpcServiceImpls.add(new RpcServiceAndInterface(c, loaded, i));
           LOG.trace("{} implements {}", c.getName(), iName);
+          assertTrue(i.getName().endsWith("$Iface"));
         }
       }
     }
@@ -117,11 +126,47 @@ public class ThriftExceptionsCheckIT {
   private static void checkClass(RpcServiceAndInterface tuple) {
     for (var method : tuple.loadedClass.getDeclaredMethods()) {
       try {
+        // get the exceptions declared on the interface, exclude TException, which is always present
         var interfaceMethod =
             tuple.matchingInterface.getDeclaredMethod(method.getName(), method.getParameterTypes());
         Set<String> interfaceExceptions =
             Stream.of(interfaceMethod.getExceptionTypes()).map(Class::getName)
-                .filter(n -> !n.equals("org.apache.thrift.TException")).collect(Collectors.toSet());
+                .filter(n -> !n.equals(TException.class.getName())).collect(Collectors.toSet());
+
+        // no user-declared exceptions should exist on oneway interface methods, since they won't go
+        // back to the client
+        if (isOnewayMethod(tuple, interfaceMethod)) {
+          assertTrue(interfaceExceptions.isEmpty());
+          return;
+        }
+
+        // if one of the parameters was TCredentials, we expect to throw ThriftSecurityException
+        // if the credentials fail to authenticate or the user is unauthorized
+        var hasTCredentials = new AtomicBoolean();
+        for (var t : method.getParameterTypes()) {
+          if (t.getName().equals(TCredentials.class.getName())) {
+            hasTCredentials.set(true);
+            break;
+          }
+        }
+        var throwsSecurityException = new AtomicBoolean(
+            interfaceExceptions.contains(ThriftSecurityException.class.getName()));
+        @SuppressWarnings("deprecation")
+        boolean isDeprecatedException = Set
+            .of(ManagerReplicationCoordinator.class.getName(),
+                ReplicationServicerHandler.class.getName())
+            .contains(tuple.loadedClass.getName())
+            || (tuple.loadedClass.getName().equals(ManagerClientServiceHandler.class.getName())
+                && method.getName().equals("drainReplicationTable"));
+        if (!isDeprecatedException) {
+          assertEquals(hasTCredentials.get(), throwsSecurityException.get(), () -> String.format(
+              "%s#%s should throw ThriftSecurityException if and only if it accepts a TCredentials parameter (accepts TCredentials: %s; throws ThriftSecurityException: %s",
+              tuple.info.getSimpleName(), method.getName(), hasTCredentials.get(),
+              throwsSecurityException.get()));
+        }
+
+        // check the provided implementation class for any exceptions not declared on the interface
+        // including TException, which should only exist on the interface, not implementing classes
         Set<String> implExceptions =
             Stream.of(method.getExceptionTypes()).map(Class::getName).collect(Collectors.toSet());
         implExceptions.removeAll(interfaceExceptions);
@@ -131,6 +176,22 @@ public class ThriftExceptionsCheckIT {
       } catch (NoSuchMethodException e) {
         // method does not exist in the interface, so skip it
       }
+    }
+  }
+
+  // helper to check if a method is a oneway
+  private static boolean isOnewayMethod(RpcServiceAndInterface tuple, Method method) {
+    try {
+      // get the parent class of the interface and use it to find the static inner class that
+      // represents the ProcessFunction for the RPC method, to check if that RPC method is a oneway
+      var processFunction = Class.forName(tuple.matchingInterface.getName().replaceFirst("\\$Iface",
+          "\\$Processor\\$" + method.getName()));
+      var isOnewayMethod = processFunction.getDeclaredMethod("isOneway");
+      isOnewayMethod.setAccessible(true);
+      return (boolean) isOnewayMethod
+          .invoke(processFunction.getDeclaredConstructor().newInstance());
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException(e);
     }
   }
 


### PR DESCRIPTION
* Use Client instead of Iface where it makes sense
* Remove improperly thrown exceptions from RPC implementation methods (TException when specified directly, and any others that are not declared in the IDL for that method)
* Add some essential exceptions to Thrift IDL where they were previously missed (and assumed to work)
* Create an integration test that inspects our thrift service implementations and verifies we haven't introduced additional mistakes
* Update JUnit and EasyMock to work better with Eclipse IDE on newer Java versions
* Add some missing descriptions to some ThriftTableOperationException instances
* Remove improper constructions of TApplicationException (should only be constructed internally inside libthrift, never by us, as it is an exception that signals to a client that a server-side exception occurred, most often by a runtime exception being thrown on the server side)
* Construct ThriftSecurityOperation directly in RPC handler code, instead of constructing as AccumuloSecurityException and then calling .asThriftException(); that method is provided to make it easy to serialize public API exceptions for RPC requests, and is not needed in RPC code itself
* Remove some attempts to convert RuntimeExceptions to TException in RPC handling code

This fixes #6061