### PR TITLE
Adding/Updating Wait Blocks in Unit Tests

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/ListCompactionsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ListCompactionsIT.java
@@ -107,14 +107,16 @@ public class ListCompactionsIT extends SharedMiniClusterBase {
       }
 
       final List<RunningCompactionSummary> running =
-          new ListCompactionsWrapper().getRunningCompactions(getCluster().getServerContext(), true);
+              new ListCompactionsWrapper().getRunningCompactions(getCluster().getServerContext(), true);
       final Map<String,RunningCompactionSummary> compactionsByEcid = new HashMap<>();
       running.forEach(rcs -> compactionsByEcid.put(rcs.getEcid(), rcs));
       final Map<String, org.apache.accumulo.core.compaction.thrift.TExternalCompaction> finalExpected = expected;
 
       Wait.waitFor(() -> {
+        final List<RunningCompactionSummary> finalRunning =
+                new ListCompactionsWrapper().getRunningCompactions(getCluster().getServerContext(), true);
         final Map<String,RunningCompactionSummary> finalCompactionsByEcid = new HashMap<>();
-        running.forEach(rcs -> finalCompactionsByEcid.put(rcs.getEcid(), rcs));
+        finalRunning.forEach(rcs -> finalCompactionsByEcid.put(rcs.getEcid(), rcs));
         return finalExpected.size() == finalCompactionsByEcid.size();
       }, 1000);
 

--- a/test/src/main/java/org/apache/accumulo/test/ListCompactionsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ListCompactionsIT.java
@@ -44,6 +44,7 @@ import org.apache.accumulo.server.util.ListCompactions;
 import org.apache.accumulo.server.util.ListCompactions.RunningCompactionSummary;
 import org.apache.accumulo.test.compaction.ExternalCompactionTestUtils;
 import org.apache.accumulo.test.functional.SlowIterator;
+import org.apache.accumulo.test.util.Wait;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -109,8 +110,10 @@ public class ListCompactionsIT extends SharedMiniClusterBase {
           new ListCompactionsWrapper().getRunningCompactions(getCluster().getServerContext(), true);
       final Map<String,RunningCompactionSummary> compactionsByEcid = new HashMap<>();
       running.forEach(rcs -> compactionsByEcid.put(rcs.getEcid(), rcs));
+      final Map<String, org.apache.accumulo.core.compaction.thrift.TExternalCompaction> finalExpected = expected;
 
-      assertEquals(expected.size(), compactionsByEcid.size());
+      Wait.waitFor(() -> finalExpected.size() == compactionsByEcid.size());
+
       expected.values().forEach(tec -> {
         RunningCompactionSummary rcs = compactionsByEcid.get(tec.job.getExternalCompactionId());
         assertNotNull(rcs);

--- a/test/src/main/java/org/apache/accumulo/test/ListCompactionsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ListCompactionsIT.java
@@ -112,7 +112,11 @@ public class ListCompactionsIT extends SharedMiniClusterBase {
       running.forEach(rcs -> compactionsByEcid.put(rcs.getEcid(), rcs));
       final Map<String, org.apache.accumulo.core.compaction.thrift.TExternalCompaction> finalExpected = expected;
 
-      Wait.waitFor(() -> finalExpected.size() == compactionsByEcid.size());
+      Wait.waitFor(() -> {
+        final Map<String,RunningCompactionSummary> finalCompactionsByEcid = new HashMap<>();
+        running.forEach(rcs -> finalCompactionsByEcid.put(rcs.getEcid(), rcs));
+        return finalExpected.size() == finalCompactionsByEcid.size();
+      }, 1000);
 
       expected.values().forEach(tec -> {
         RunningCompactionSummary rcs = compactionsByEcid.get(tec.job.getExternalCompactionId());

--- a/test/src/main/java/org/apache/accumulo/test/ListCompactionsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ListCompactionsIT.java
@@ -114,13 +114,15 @@ public class ListCompactionsIT extends SharedMiniClusterBase {
         running.clear();
         compactionsByEcid.clear();
 
-        running.addAll(new ListCompactionsWrapper().getRunningCompactions(getCluster().getServerContext(), true));
+        running.addAll(new ListCompactionsWrapper()
+            .getRunningCompactions(getCluster().getServerContext(), true));
         running.forEach(rcs -> compactionsByEcid.put(rcs.getEcid(), rcs));
 
-        return expectedCompactions.size() == compactionsByEcid.size();
+        return expectedCompactions.size() == compactionsByEcid.size()
+            && expectedCompactions.keySet().stream().allMatch(compactionsByEcid::containsKey);
       }, 10000);
 
-      expected.values().forEach(tec -> {
+      expectedCompactions.values().forEach(tec -> {
         RunningCompactionSummary rcs = compactionsByEcid.get(tec.job.getExternalCompactionId());
         assertNotNull(rcs);
         assertEquals(tec.getJob().getExternalCompactionId(), rcs.getEcid());

--- a/test/src/main/java/org/apache/accumulo/test/ListCompactionsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ListCompactionsIT.java
@@ -106,19 +106,19 @@ public class ListCompactionsIT extends SharedMiniClusterBase {
             ExternalCompactionTestUtils.getRunningCompactions(getCluster().getServerContext());
       }
 
-      final List<RunningCompactionSummary> running =
-              new ListCompactionsWrapper().getRunningCompactions(getCluster().getServerContext(), true);
+      final List<RunningCompactionSummary> running = new ArrayList<>();
       final Map<String,RunningCompactionSummary> compactionsByEcid = new HashMap<>();
-      running.forEach(rcs -> compactionsByEcid.put(rcs.getEcid(), rcs));
-      final Map<String, org.apache.accumulo.core.compaction.thrift.TExternalCompaction> finalExpected = expected;
+      final var expectedCompactions = expected;
 
       Wait.waitFor(() -> {
-        final List<RunningCompactionSummary> finalRunning =
-                new ListCompactionsWrapper().getRunningCompactions(getCluster().getServerContext(), true);
-        final Map<String,RunningCompactionSummary> finalCompactionsByEcid = new HashMap<>();
-        finalRunning.forEach(rcs -> finalCompactionsByEcid.put(rcs.getEcid(), rcs));
-        return finalExpected.size() == finalCompactionsByEcid.size();
-      }, 1000);
+        running.clear();
+        compactionsByEcid.clear();
+
+        running.addAll(new ListCompactionsWrapper().getRunningCompactions(getCluster().getServerContext(), true));
+        running.forEach(rcs -> compactionsByEcid.put(rcs.getEcid(), rcs));
+
+        return expectedCompactions.size() == compactionsByEcid.size();
+      }, 10000);
 
       expected.values().forEach(tec -> {
         RunningCompactionSummary rcs = compactionsByEcid.get(tec.job.getExternalCompactionId());

--- a/test/src/main/java/org/apache/accumulo/test/LocatorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/LocatorIT.java
@@ -215,8 +215,9 @@ public class LocatorIT extends AccumuloClusterHarness {
         // Accessing table3 in the cache should cause table1 and table4 to eventually be cleared
         // because they no longer exist. This also test that online and offline tables a properly
         // cleared from the cache.
-        assertNotNull(ctx.getTabletLocationCache(tableId3));
-        return !ctx.isTabletLocationCachePresent(tableId1)
+        var t3 = ctx.getTabletLocationCache(tableId3);
+        return t3 != null
+            && !ctx.isTabletLocationCachePresent(tableId1)
             && !ctx.isTabletLocationCachePresent(tableId4);
       });
 

--- a/test/src/main/java/org/apache/accumulo/test/LocatorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/LocatorIT.java
@@ -216,8 +216,7 @@ public class LocatorIT extends AccumuloClusterHarness {
         // because they no longer exist. This also test that online and offline tables a properly
         // cleared from the cache.
         var t3 = ctx.getTabletLocationCache(tableId3);
-        return t3 != null
-            && !ctx.isTabletLocationCachePresent(tableId1)
+        return t3 != null && !ctx.isTabletLocationCachePresent(tableId1)
             && !ctx.isTabletLocationCachePresent(tableId4);
       });
 

--- a/test/src/main/java/org/apache/accumulo/test/conf/ResourceGroupConfigIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/conf/ResourceGroupConfigIT.java
@@ -274,10 +274,11 @@ public class ResourceGroupConfigIT extends SharedMiniClusterBase {
       assertEquals(rgid, rgs2.iterator().next());
       client.resourceGroupOperations().create(rgid); // creating again succeeds doing nothing
       client.resourceGroupOperations().remove(rgid);
-      rgs = client.resourceGroupOperations().list();
-      final Set<ResourceGroupId> finalRgs = rgs;
 
-      Wait.waitFor(() -> finalRgs.size() == 1);
+      Wait.waitFor(() -> {
+        final Set<ResourceGroupId> finalrgs = client.resourceGroupOperations().list();
+        return finalrgs.size() == 1;
+      });
       assertEquals(ResourceGroupId.DEFAULT, rgs.iterator().next());
       assertThrows(ResourceGroupNotFoundException.class,
           () -> client.resourceGroupOperations().remove(rgid));

--- a/test/src/main/java/org/apache/accumulo/test/conf/ResourceGroupConfigIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/conf/ResourceGroupConfigIT.java
@@ -277,7 +277,7 @@ public class ResourceGroupConfigIT extends SharedMiniClusterBase {
 
       Wait.waitFor(() -> {
         final Set<ResourceGroupId> finalrgs = client.resourceGroupOperations().list();
-        return finalrgs.size() == 1;
+        return finalrgs.size() == 1 && finalrgs.contains(ResourceGroupId.DEFAULT);
       });
       assertEquals(ResourceGroupId.DEFAULT, rgs.iterator().next());
       assertThrows(ResourceGroupNotFoundException.class,

--- a/test/src/main/java/org/apache/accumulo/test/conf/ResourceGroupConfigIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/conf/ResourceGroupConfigIT.java
@@ -275,7 +275,9 @@ public class ResourceGroupConfigIT extends SharedMiniClusterBase {
       client.resourceGroupOperations().create(rgid); // creating again succeeds doing nothing
       client.resourceGroupOperations().remove(rgid);
       rgs = client.resourceGroupOperations().list();
-      assertEquals(1, rgs.size());
+      final Set<ResourceGroupId> finalRgs = rgs;
+
+      Wait.waitFor(() -> finalRgs.size() == 1);
       assertEquals(ResourceGroupId.DEFAULT, rgs.iterator().next());
       assertThrows(ResourceGroupNotFoundException.class,
           () -> client.resourceGroupOperations().remove(rgid));

--- a/test/src/main/java/org/apache/accumulo/test/conf/ResourceGroupConfigIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/conf/ResourceGroupConfigIT.java
@@ -279,7 +279,6 @@ public class ResourceGroupConfigIT extends SharedMiniClusterBase {
         final Set<ResourceGroupId> finalrgs = client.resourceGroupOperations().list();
         return finalrgs.size() == 1 && finalrgs.contains(ResourceGroupId.DEFAULT);
       });
-      assertEquals(ResourceGroupId.DEFAULT, rgs.iterator().next());
       assertThrows(ResourceGroupNotFoundException.class,
           () -> client.resourceGroupOperations().remove(rgid));
     }


### PR DESCRIPTION
ListCompactionsIT.java and ResourceGroupConfigIT.java each had 1 assert that was flaky, failure found from jenkins. Updated the asserts to use a wait block instead.

LocatorIT.java had a wait block with an assert, updated to use wait block only, found during fixing original issue.