### PR TITLE
Increase timeout and cache size for flaky ITs

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/functional/SessionBlockVerifyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SessionBlockVerifyIT.java
@@ -60,7 +60,7 @@ public class SessionBlockVerifyIT extends ScanSessionTimeOutIT {
 
   @Override
   protected Duration defaultTimeout() {
-    return Duration.ofMinutes(1);
+    return Duration.ofMinutes(2);
   }
 
   @Override

--- a/test/src/main/java/org/apache/accumulo/test/tracing/ScanTracingIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/tracing/ScanTracingIT.java
@@ -76,7 +76,7 @@ class ScanTracingIT extends ConfigurableMacBase {
   protected void configure(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
     cfg.getJvmOptions().addAll(getJvmArgs());
     // sized such that full table scans will not fit in the cache
-    cfg.setProperty(Property.TSERV_DATACACHE_SIZE.getKey(), "8M");
+    cfg.setProperty(Property.TSERV_DATACACHE_SIZE.getKey(), "10M");
     cfg.setProperty(Property.TSERV_SCAN_EXECUTORS_PREFIX.getKey() + "pool1.threads", "8");
   }
 


### PR DESCRIPTION
This commit bumps the timeout and cache size for a couple of ITs that are intermittently failing.