### PR TITLE
Fix/improve a few ITs

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/VerifySerialRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/VerifySerialRecoveryIT.java
@@ -126,25 +126,31 @@ public class VerifySerialRecoveryIT extends ConfigurableMacBase {
       // time
       boolean ongoingRecovery = false;
       int recoveries = 0;
+      String recoveryStartLine = null;
       var pattern =
           Pattern.compile(".*recovered \\d+ mutations creating \\d+ entries from \\d+ walogs.*");
       for (String line : result.split("\n")) {
-        // ignore metadata and root tables
-        if (line.contains(SystemTables.METADATA.tableId().canonical())
-            || line.contains(SystemTables.ROOT.tableId().canonical())) {
+        // ignore system tables
+        if (SystemTables.tableIds().stream()
+            .anyMatch(tableId -> line.contains(tableId.canonical()))) {
           continue;
         }
         if (line.contains("recovering data from walogs")) {
-          assertFalse(ongoingRecovery, "Saw recovery start before previous recovery finished");
+          assertFalse(ongoingRecovery,
+              "Saw recovery start before previous recovery finished. Previous start: "
+                  + recoveryStartLine + ", new start: " + line);
           ongoingRecovery = true;
+          recoveryStartLine = line;
           recoveries++;
         }
         if (pattern.matcher(line).matches()) {
-          assertTrue(ongoingRecovery, "Saw recovery end without recovery start");
+          assertTrue(ongoingRecovery, "Saw recovery end without recovery start: " + line);
           ongoingRecovery = false;
+          recoveryStartLine = null;
         }
       }
-      assertFalse(ongoingRecovery, "Expected no ongoing recovery at end of test");
+      assertFalse(ongoingRecovery,
+          "Expected no ongoing recovery at end of test. Last start: " + recoveryStartLine);
       assertTrue(recoveries > 0, "Expected at least one recovery to have occurred");
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/fate/FateStoreITBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/FateStoreITBase.java
@@ -396,8 +396,8 @@ public abstract class FateStoreITBase extends SharedMiniClusterBase
       // After deletion, make sure we can create again with the same key
       var fateId2 =
           seedTransaction(store, TEST_FATE_OP, fateKey, new TestRepo(), true).orElseThrow();
-      txStore = store.reserve(fateId);
       assertEquals(fateId, fateId2);
+      txStore = store.reserve(fateId2);
       assertTrue(txStore.timeCreated() > 0);
       assertEquals(TStatus.SUBMITTED, txStore.getStatus());
     } finally {

--- a/test/src/main/java/org/apache/accumulo/test/functional/DeleteAndVerifyFileRemovalsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/DeleteAndVerifyFileRemovalsIT.java
@@ -256,10 +256,6 @@ public class DeleteAndVerifyFileRemovalsIT extends ConfigurableMacBase {
         assertEquals(4, ample.stream().count());
       }
 
-      // A GcCandidate for each tablet directory should exist until the shared references are
-      // compacted.
-      Wait.waitFor(() -> countGcCandidates(sourceTableId, 4), GC_MAX_WAIT, POLLING_WAIT);
-
       client.tableOperations().compact(cloneTable, new CompactionConfig().setWait(true));
 
       Wait.waitFor(() -> !fs.exists(sourceDir), GC_MAX_WAIT, POLLING_WAIT,

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitMillionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitMillionIT.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.test.functional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -75,6 +76,11 @@ public class SplitMillionIT extends ConfigurableMacBase {
   public void configure(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
     cfg.setMemory(ServerType.MANAGER, 1, MemoryUnit.GIGABYTE);
     cfg.setMemory(ServerType.TABLET_SERVER, 1, MemoryUnit.GIGABYTE);
+  }
+
+  @Override
+  protected Duration defaultTimeout() {
+    return Duration.ofMinutes(20);
   }
 
   @SuppressFBWarnings(value = {"PREDICTABLE_RANDOM", "DMI_RANDOM_USED_ONLY_ONCE"},


### PR DESCRIPTION
Fixes several ITs that I saw failing from a recent build. 

* `VerifySerialRecoveryIT` - fixes a failing assertion by ignoring all system tables. Improved error logging to print more details if it fails again
* `DeleteAndVerifyFileRemovalsIT` was timing out due to a flaky wait. I removed that since the condition its checking for could have already happened before the wait loop runs. Verified the other existing checks in the test cover things properly still
* `SplitMillionIT` was timing out. Increased the timeout to double the default timeout
* `FateStoreITBase` - fixed a bug by reserving the correct fate ID