### PR TITLE
Reset Thread interrupted state after catching InterruptedException

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
@@ -155,6 +155,7 @@ public class ConditionalWriterImpl implements ConditionalWriter {
         count--;
         return result;
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         throw new RuntimeException(e);
       }
     }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
@@ -154,6 +154,7 @@ public class InstanceOperationsImpl implements InstanceOperations {
               "Unable to modify instance properties for because of concurrent modification");
           retry.waitForNextAttempt(log, "Modify instance properties");
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           throw new RuntimeException(e);
         }
       } finally {
@@ -349,6 +350,9 @@ public class InstanceOperationsImpl implements InstanceOperations {
         try {
           ret.addAll(future.get());
         } catch (InterruptedException | ExecutionException e) {
+          if (e instanceof InterruptedException) {
+            Thread.currentThread().interrupt();
+          }
           if (e.getCause() instanceof ThriftSecurityException) {
             ThriftSecurityException tse = (ThriftSecurityException) e.getCause();
             throw new AccumuloSecurityException(tse.user, tse.code, e);

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/NamespaceOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/NamespaceOperationsImpl.java
@@ -257,6 +257,7 @@ public class NamespaceOperationsImpl extends NamespaceOperationsHelper {
               + " because of concurrent modification");
           retry.waitForNextAttempt(log, "Modify namespace properties for " + namespace);
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           throw new RuntimeException(e);
         }
       } finally {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -530,6 +530,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
         }
       }
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       throw new RuntimeException(e);
     } finally {
       executor.shutdown();
@@ -1065,6 +1066,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
               + " because of concurrent modification");
           retry.waitForNextAttempt(log, "modify table properties for " + tableName);
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           throw new RuntimeException(e);
         }
       } finally {
@@ -1956,6 +1958,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
             String.format("locating tablets in table %s(%s) for %d ranges", tableName, tableId,
                 rangeList.size()));
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         throw new RuntimeException(e);
       }
       locator.invalidateCache();

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java
@@ -156,6 +156,7 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
       try {
         resultsQueue.put(entries);
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         if (TabletServerBatchReaderIterator.this.queryThreadPool.isShutdown()) {
           log.debug("Failed to add Batch Scan result", e);
         } else {
@@ -215,6 +216,7 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
         batchIterator = batch.iterator();
         return batch != LAST_BATCH;
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         throw new RuntimeException(e);
       }
     }
@@ -288,6 +290,7 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
         try {
           retry.waitForNextAttempt(log, "binRanges retry failures");
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           throw new RuntimeException(e);
         }
 
@@ -491,6 +494,7 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
               try {
                 resultsQueue.put(LAST_BATCH);
               } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 fatalException = e;
                 if (!resultsQueue.offer(LAST_BATCH)) {
                   log.debug("Could not add to result queue after seeing fatalException",

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchWriter.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchWriter.java
@@ -507,6 +507,7 @@ public class TabletServerBatchWriter implements AutoCloseable {
         wait();
       }
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       throw new RuntimeException(e);
     }
   }
@@ -1074,6 +1075,7 @@ public class TabletServerBatchWriter implements AutoCloseable {
           try {
             cancelSession();
           } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new IllegalStateException(e);
           }
         }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftScanner.java
@@ -298,6 +298,7 @@ public class ThriftScanner {
         retry.waitForNextAttempt(log, String.format(
             "For tableId %s scan server selector is waiting for '%s'", tableId, description));
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         throw new RuntimeException(e);
       }
 
@@ -550,6 +551,7 @@ public class ThriftScanner {
 
       return results;
     } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
       TraceUtil.setException(parent, ex, true);
       throw new AccumuloException(ex);
     } finally {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportPool.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportPool.java
@@ -258,6 +258,7 @@ public class ThriftTransportPool {
     try {
       checkThread.join();
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       throw new RuntimeException(e);
     }
   }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/BulkImport.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/BulkImport.java
@@ -182,6 +182,7 @@ public class BulkImport implements ImportDestinationArguments, ImportMappingOpti
         try {
           retry.waitForNextAttempt(log, String.format("bulk import to %s(%s)", tableName, tableId));
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           throw new RuntimeException(e);
         }
         log.info(ae.getMessage() + ". Retrying bulk import to " + tableName);

--- a/core/src/main/java/org/apache/accumulo/core/fate/AdminUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/AdminUtil.java
@@ -564,6 +564,7 @@ public class AdminUtil<T> {
         return false;
       }
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       System.err.println("ERROR: Could not read manager lock, not running" + e.getMessage());
       if (this.exitOnError) {
         System.exit(1);

--- a/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
@@ -483,6 +483,7 @@ public class Fate<T> {
         try {
           executor.awaitTermination(1, SECONDS);
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           throw new IllegalStateException(e);
         }
       }

--- a/core/src/main/java/org/apache/accumulo/core/fate/ZooStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/ZooStore.java
@@ -238,6 +238,9 @@ public class ZooStore<T> implements TStore<T> {
         }
       }
     } catch (InterruptedException | KeeperException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new RuntimeException(e);
     }
   }
@@ -251,6 +254,7 @@ public class ZooStore<T> implements TStore<T> {
           try {
             this.wait(1000);
           } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
           }
         }
@@ -451,6 +455,7 @@ public class ZooStore<T> implements TStore<T> {
           try {
             this.wait(5000);
           } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
           }
         }
@@ -567,6 +572,9 @@ public class ZooStore<T> implements TStore<T> {
       } catch (KeeperException.NoNodeException e) {
         return Collections.emptyList();
       } catch (KeeperException | InterruptedException e1) {
+        if (e1 instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
         throw new RuntimeException(e1);
       }
 
@@ -587,6 +595,9 @@ public class ZooStore<T> implements TStore<T> {
             // children changed so start over
             continue outer;
           } catch (KeeperException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+              Thread.currentThread().interrupt();
+            }
             throw new RuntimeException(e);
           }
         }

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ServiceLock.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ServiceLock.java
@@ -414,6 +414,9 @@ public class ServiceLock implements Watcher {
                     LOG.debug("[{}] Renewed watch on prior node {}", vmLockPrefix, nodeToWatch);
                   }
                 } catch (KeeperException | InterruptedException e) {
+                  if (e instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                  }
                   lw.failedToAcquireLock(
                       new Exception("Failed to renew watch on prior node: " + nodeToWatch, e));
                 }
@@ -575,6 +578,9 @@ public class ServiceLock implements Watcher {
       determineLockOwnership(lw);
 
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       lw.failedToAcquireLock(e);
     }
   }
@@ -915,6 +921,9 @@ public class ServiceLock implements Watcher {
     try {
       return null != this.zooKeeper.exists(lockPath, false);
     } catch (KeeperException | InterruptedException | RuntimeException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       LOG.error("Error verfiying lock at {}", lockPath, e);
       return false;
     }

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ServiceLockSupport.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ServiceLockSupport.java
@@ -103,7 +103,7 @@ public class ServiceLockSupport {
           LOG.info("{} lock held by someone else, waiting for a change in state", serviceName);
           wait();
         } catch (InterruptedException e) {
-          // empty
+          Thread.currentThread().interrupt();
         }
       }
     }

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooCache.java
@@ -263,6 +263,7 @@ public class ZooCache {
             log.warn("Zookeeper error, will retry", e);
           }
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           log.info("Zookeeper error, will retry", e);
         } catch (ConcurrentModificationException e) {
           log.debug("Zookeeper was modified, will retry");
@@ -272,6 +273,7 @@ public class ZooCache {
           // do not hold lock while sleeping
           Thread.sleep(sleepTime);
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           log.debug("Wait in retry() was interrupted.", e);
         }
         LockSupport.parkNanos(sleepTime);

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooSession.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooSession.java
@@ -148,6 +148,7 @@ public class ZooSession {
             zooKeeper.close();
             zooKeeper = null;
           } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             log.warn("interrupted", e);
           }
         }

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/lru/LruBlockCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/lru/LruBlockCache.java
@@ -154,6 +154,7 @@ public class LruBlockCache extends SynchronousLoadingBlockCache implements Block
         try {
           Thread.sleep(10);
         } catch (InterruptedException ex) {
+          Thread.currentThread().interrupt();
           throw new RuntimeException(ex);
         }
       }
@@ -533,7 +534,7 @@ public class LruBlockCache extends SynchronousLoadingBlockCache implements Block
           try {
             this.wait();
           } catch (InterruptedException e) {
-            // empty
+            Thread.currentThread().interrupt();
           }
         }
         LruBlockCache cache = this.cache.get();

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
@@ -557,6 +557,9 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
           byte[] bytes = zooReader.getData(path);
           return new RootTabletMetadata(new String(bytes, UTF_8)).toTabletMetadata();
         } catch (InterruptedException | KeeperException e) {
+          if (e instanceof InterruptedException) {
+            Thread.currentThread().interrupt();
+          }
           throw new RuntimeException(e);
         }
       default:

--- a/core/src/main/java/org/apache/accumulo/core/rpc/UGIAssumingTransport.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/UGIAssumingTransport.java
@@ -57,6 +57,9 @@ public class UGIAssumingTransport extends FilterTransport {
         return null;
       });
     } catch (IOException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new RuntimeException(e);
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/rpc/clients/ReplicationCoordinatorThriftClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/clients/ReplicationCoordinatorThriftClient.java
@@ -75,6 +75,9 @@ public class ReplicationCoordinatorThriftClient extends ThriftClientTypes<Client
       ZooReader reader = context.getZooReader();
       replCoordinatorAddr = new String(reader.getData(zkPath), UTF_8);
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       LOG.error("Could not fetch remote coordinator port", e);
       return null;
     }
@@ -109,6 +112,7 @@ public class ReplicationCoordinatorThriftClient extends ThriftClientTypes<Client
       try {
         Thread.sleep(attempts * 250L);
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         throw new RuntimeException(e);
       }
     }
@@ -130,6 +134,7 @@ public class ReplicationCoordinatorThriftClient extends ThriftClientTypes<Client
         try {
           Thread.sleep(100);
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           throw new AccumuloException(e);
         }
       } catch (ThriftSecurityException e) {

--- a/core/src/main/java/org/apache/accumulo/core/util/CleanUp.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/CleanUp.java
@@ -77,6 +77,7 @@ public class CleanUp {
           try {
             Thread.sleep(100);
           } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             log.error("{}", e.getMessage(), e);
           }
         }

--- a/core/src/main/java/org/apache/accumulo/core/util/UtilWaitThread.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/UtilWaitThread.java
@@ -32,6 +32,7 @@ public class UtilWaitThread {
     try {
       Thread.sleep(millis);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       log.error("{}", e.getMessage(), e);
     }
   }
@@ -57,6 +58,7 @@ public class UtilWaitThread {
           NANOSECONDS.sleep(remainingNanos);
           return;
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           interrupted = true;
           remainingNanos = end - System.nanoTime();
         }

--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/ExternalCompactionUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/ExternalCompactionUtil.java
@@ -244,6 +244,9 @@ public class ExternalCompactionUtil {
           results.add(new RunningCompaction(job, compactorAddress, rcf.getQueue()));
         }
       } catch (InterruptedException | ExecutionException e) {
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
         throw new RuntimeException(e);
       }
     });
@@ -272,6 +275,9 @@ public class ExternalCompactionUtil {
           runningIds.add(ceid);
         }
       } catch (InterruptedException | ExecutionException e) {
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
         throw new RuntimeException(e);
       }
     });

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
@@ -181,6 +181,7 @@ public class ThreadPools {
         // the list of critical tasks
         return true;
       } catch (InterruptedException ie) {
+        Thread.currentThread().interrupt();
         // current thread was interrupted waiting for get to return, which in theory,
         // shouldn't happen since the task is done.
         LOG.info("Interrupted while waiting to check on scheduled background task.");

--- a/core/src/test/java/org/apache/accumulo/core/data/TableIdTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/TableIdTest.java
@@ -116,6 +116,7 @@ public class TableIdTest extends WithTestNames {
     try {
       Thread.sleep(100);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       fail("Thread interrupted while waiting for GC");
     }
   }

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
@@ -257,6 +257,7 @@ public class MultiThreadedRFileTest {
         try {
           pool.awaitTermination(Long.MAX_VALUE, MILLISECONDS);
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           e.printStackTrace();
         }
       }

--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/MiniAccumuloRunner.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/MiniAccumuloRunner.java
@@ -239,6 +239,7 @@ public class MiniAccumuloRunner {
         log.error("IOException attempting to stop Accumulo.", e);
         return;
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         log.error("InterruptedException attempting to stop Accumulo.", e);
         return;
       }

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
@@ -542,6 +542,7 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
           } catch (IOException e) {
             log.error("IOException while attempting to stop the MiniAccumuloCluster.", e);
           } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             log.error("The stopping of MiniAccumuloCluster was interrupted.", e);
           }
         }));
@@ -719,6 +720,9 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
                   (rc, path, ctx, name) -> log.warn("{}", path));
               log.warn("******* END ZK DUMP ************");
             } catch (KeeperException | InterruptedException e) {
+              if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+              }
               log.error("Error dumping zk", e);
             }
           }

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterStartStopTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterStartStopTest.java
@@ -55,6 +55,9 @@ public class MiniAccumuloClusterStartStopTest extends WithTestNames {
       try {
         accumulo.stop();
       } catch (IOException | InterruptedException e) {
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
         log.warn("Failure during tear down", e);
       }
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/AbstractServer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/AbstractServer.java
@@ -113,6 +113,9 @@ public abstract class AbstractServer
                 + upgradePrepNode);
       }
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new IllegalStateException(
           "Error checking for upgrade preparation node (" + upgradePrepNode + ") in zookeeper", e);
     }
@@ -312,6 +315,7 @@ public abstract class AbstractServer
                     interval);
                 Thread.sleep(interval);
               } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 if (serverThread.isAlive()) {
                   // throw an Error, which will cause this process to be terminated
                   throw new Error("Sleep interrupted in ServiceLock verification thread");

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
@@ -316,6 +316,9 @@ public class ServerContext extends ClientContext {
         getZooReaderWriter().getChildren(Constants.ZROOT);
         break;
       } catch (InterruptedException | KeeperException ex) {
+        if (ex instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
         log.info("Waiting for accumulo to be initialized");
         sleepUninterruptibly(1, SECONDS);
       }

--- a/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
@@ -165,6 +165,7 @@ public class BulkImporter {
         try {
           threadPool.awaitTermination(60, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           throw new RuntimeException(e);
         }
       }
@@ -420,6 +421,7 @@ public class BulkImporter {
       try {
         threadPool.awaitTermination(60, TimeUnit.SECONDS);
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         log.error("Encountered InterruptedException while waiting for the threadPool to terminate.",
             e);
         throw new RuntimeException(e);
@@ -568,6 +570,7 @@ public class BulkImporter {
       try {
         threadPool.awaitTermination(60, TimeUnit.SECONDS);
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         log.error(
             "Encountered InterruptedException while waiting for the thread pool to terminate.", e);
         throw new RuntimeException(e);

--- a/server/base/src/main/java/org/apache/accumulo/server/compaction/RetryableThriftCall.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/compaction/RetryableThriftCall.java
@@ -114,6 +114,7 @@ public class RetryableThriftCall<T> {
           try {
             this.retry.waitForNextAttempt(LOG, "making a thrift RPC");
           } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             LOG.error("Error waiting for next attempt: {}, retrying now.", e.getMessage(), e);
           }
         } else {

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/store/impl/ZooPropLoader.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/store/impl/ZooPropLoader.java
@@ -132,6 +132,9 @@ public class ZooPropLoader implements CacheLoader<PropStoreKey<?>,VersionedPrope
       log.trace("Updated value {}", updatedValue == null ? "null" : updatedValue.print(true));
       return updatedValue;
     } catch (RuntimeException | KeeperException | InterruptedException ex) {
+      if (ex instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       log.warn("async exception occurred reading properties from ZooKeeper for: {} returning null",
           propCacheId, ex);
       propStoreWatcher.signalZkChangeEvent(propCacheId);

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/store/impl/ZooPropStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/store/impl/ZooPropStore.java
@@ -144,6 +144,9 @@ public class ZooPropStore implements PropStore, PropChangeListener {
       String path = propStoreKey.getPath();
       zrw.putPrivatePersistentData(path, codec.toBytes(vProps), ZooUtil.NodeExistsPolicy.FAIL);
     } catch (IOException | KeeperException | InterruptedException ex) {
+      if (ex instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new IllegalStateException("Failed to serialize properties for " + propStoreKey, ex);
     }
   }
@@ -254,6 +257,9 @@ public class ZooPropStore implements PropStore, PropChangeListener {
       zrw.delete(path);
       cache.remove(propStoreKey);
     } catch (KeeperException | InterruptedException ex) {
+      if (ex instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new IllegalStateException("Failed to delete properties for propCacheId " + propStoreKey,
           ex);
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/util/ConfigPropertyUpgrader.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/util/ConfigPropertyUpgrader.java
@@ -115,6 +115,7 @@ public class ConfigPropertyUpgrader implements KeywordExecutable {
       throw new IllegalStateException(
           "Failed to read namespaces from ZooKeeper for path: " + zkPathNamespaceBase, ex);
     } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
       throw new IllegalStateException(
           "Interrupted reading namespaces from ZooKeeper for path: " + zkPathNamespaceBase, ex);
     }
@@ -136,6 +137,7 @@ public class ConfigPropertyUpgrader implements KeywordExecutable {
       throw new IllegalStateException(
           "Failed to read tables from ZooKeeper for path: " + zkPathTableBase, ex);
     } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
       throw new IllegalStateException(
           "Interrupted reading tables from ZooKeeper for path: " + zkPathTableBase, ex);
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/util/ZooPropEditor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/util/ZooPropEditor.java
@@ -205,6 +205,9 @@ public class ZooPropEditor implements KeywordExecutable {
     try {
       return ZooPropStore.readFromZk(propKey, nullWatcher, zooReader);
     } catch (IOException | KeeperException | InterruptedException ex) {
+      if (ex instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new IllegalStateException(ex);
     }
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManagerImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManagerImpl.java
@@ -355,6 +355,9 @@ public class VolumeManagerImpl implements VolumeManager {
         future.get();
       }
     } catch (InterruptedException | ExecutionException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new IOException(e);
     }
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
@@ -246,6 +246,9 @@ public class Initialize implements KeywordExecutable {
     try {
       return zoo.exists("/");
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       return false;
     }
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/init/ZooKeeperInitializer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/ZooKeeperInitializer.java
@@ -84,6 +84,9 @@ public class ZooKeeperInitializer {
             "Failed to create default system props during initialization at: {}" + sysPropPath);
       }
     } catch (IOException | KeeperException | InterruptedException ex) {
+      if (ex instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new IllegalStateException("Failed to initialize configuration for prop store", ex);
     }
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/log/WalStateManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/log/WalStateManager.java
@@ -110,6 +110,9 @@ public class WalStateManager {
 
       checkedExistance = true;
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new WalMarkerException(e);
     }
 
@@ -123,6 +126,9 @@ public class WalStateManager {
     try {
       zoo.putPersistentData(root() + "/" + tsi, data, NodeExistsPolicy.FAIL);
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new WalMarkerException(e);
     }
   }
@@ -143,6 +149,9 @@ public class WalStateManager {
       log.debug("Setting {} to {}", path.getName(), state);
       zoo.putPersistentData(root() + "/" + tsi + "/" + path.getName(), data, policy);
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new WalMarkerException(e);
     }
   }
@@ -185,6 +194,9 @@ public class WalStateManager {
     } catch (KeeperException.NoNodeException e) {
       log.debug("{} has no wal entry in zookeeper, assuming no logs", tsi);
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new WalMarkerException(e);
     }
     return result;
@@ -206,6 +218,9 @@ public class WalStateManager {
         }
       }
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new WalMarkerException(e);
     }
     return result;
@@ -217,6 +232,9 @@ public class WalStateManager {
       String path = root() + "/" + instance + "/" + uuid;
       return parse(zoo.getData(path));
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new WalMarkerException(e);
     }
   }
@@ -242,6 +260,9 @@ public class WalStateManager {
       String path = root() + "/" + instance + "/" + uuid;
       zoo.delete(path);
     } catch (InterruptedException | KeeperException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new WalMarkerException(e);
     }
   }
@@ -252,6 +273,9 @@ public class WalStateManager {
     try {
       zoo.recursiveDelete(path, NodeMissingPolicy.FAIL);
     } catch (InterruptedException | KeeperException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new WalMarkerException(e);
     }
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
@@ -257,6 +257,9 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
         jsonBytes =
             zooReader.getData(context.getZooKeeperRoot() + RootTable.ZROOT_TABLET_GC_CANDIDATES);
       } catch (KeeperException | InterruptedException e) {
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
         throw new RuntimeException(e);
       }
       return new RootGcCandidates(new String(jsonBytes, UTF_8)).sortedStream().iterator();

--- a/server/base/src/main/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenKeyManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenKeyManager.java
@@ -87,6 +87,7 @@ public class AuthenticationTokenKeyManager implements Runnable {
       try {
         Thread.sleep(5000);
       } catch (InterruptedException ie) {
+        Thread.currentThread().interrupt();
         log.debug("Interrupted waiting for next update", ie);
       }
     }
@@ -119,6 +120,9 @@ public class AuthenticationTokenKeyManager implements Runnable {
         }
       }
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       log.warn("Failed to fetch existing AuthenticationKeys from ZooKeeper");
     }
   }
@@ -161,6 +165,9 @@ public class AuthenticationTokenKeyManager implements Runnable {
       try {
         keyDistributor.advertise(newKey);
       } catch (KeeperException | InterruptedException e) {
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
         log.error("Failed to advertise AuthenticationKey in ZooKeeper. Exiting.", e);
         throw new RuntimeException(e);
       }

--- a/server/base/src/main/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenSecretManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenSecretManager.java
@@ -257,6 +257,9 @@ public class AuthenticationTokenSecretManager extends SecretManager<Authenticati
         try {
           keyDistributor.remove(key);
         } catch (KeeperException | InterruptedException e) {
+          if (e instanceof InterruptedException) {
+            Thread.currentThread().interrupt();
+          }
           log.error("Failed to remove AuthenticationKey from ZooKeeper. Exiting", e);
           throw new RuntimeException(e);
         }

--- a/server/base/src/main/java/org/apache/accumulo/server/security/delegation/ZooAuthenticationKeyWatcher.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/delegation/ZooAuthenticationKeyWatcher.java
@@ -67,6 +67,9 @@ public class ZooAuthenticationKeyWatcher implements Watcher {
           try {
             updateAuthKeys();
           } catch (KeeperException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+              Thread.currentThread().interrupt();
+            }
             log.error("Failed to update secret manager after ZooKeeper reconnect; {}", event, e);
           }
           break;
@@ -95,6 +98,9 @@ public class ZooAuthenticationKeyWatcher implements Watcher {
         processChildNode(event);
       }
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       log.error("Failed to communicate with ZooKeeper processing {}", event, e);
     }
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/KerberosAuthenticator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/KerberosAuthenticator.java
@@ -102,6 +102,9 @@ public class KerberosAuthenticator implements Authenticator {
         createUserNodeInZk(Base64.getEncoder().encodeToString(principalData));
       }
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       log.error("Failed to initialize security", e);
       throw new RuntimeException(e);
     }
@@ -158,6 +161,7 @@ public class KerberosAuthenticator implements Authenticator {
       log.error("Failed to create user in ZooKeeper", e);
       throw new AccumuloSecurityException(principal, SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       log.error("Interrupted trying to create node for user", e);
       throw new RuntimeException(e);
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKAuthenticator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKAuthenticator.java
@@ -101,6 +101,9 @@ public final class ZKAuthenticator implements Authenticator {
         constructUser(principal, ZKSecurityTool.createPass(token));
       }
     } catch (KeeperException | AccumuloException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     }
@@ -139,6 +142,7 @@ public final class ZKAuthenticator implements Authenticator {
       }
       throw new AccumuloSecurityException(principal, SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     } catch (AccumuloException e) {
@@ -156,6 +160,7 @@ public final class ZKAuthenticator implements Authenticator {
             NodeMissingPolicy.FAIL);
       }
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     } catch (KeeperException e) {
@@ -185,6 +190,7 @@ public final class ZKAuthenticator implements Authenticator {
         log.error("{}", e.getMessage(), e);
         throw new AccumuloSecurityException(principal, SecurityErrorCode.CONNECTION_ERROR, e);
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         log.error("{}", e.getMessage(), e);
         throw new RuntimeException(e);
       } catch (AccumuloException e) {

--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKAuthorizor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKAuthorizor.java
@@ -83,6 +83,9 @@ public class ZKAuthorizor implements Authorizor {
       zoo.putPersistentData(ZKUserPath + "/" + rootuser + ZKUserAuths,
           ZKSecurityTool.convertAuthorizations(Authorizations.EMPTY), NodeExistsPolicy.FAIL);
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     }
@@ -97,6 +100,7 @@ public class ZKAuthorizor implements Authorizor {
       log.error("{}", e.getMessage(), e);
       throw new AccumuloSecurityException(user, SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     }
@@ -111,6 +115,7 @@ public class ZKAuthorizor implements Authorizor {
         zooCache.clear(ZKUserPath + "/" + user);
       }
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     } catch (KeeperException e) {
@@ -136,6 +141,7 @@ public class ZKAuthorizor implements Authorizor {
       log.error("{}", e.getMessage(), e);
       throw new AccumuloSecurityException(user, SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKPermHandler.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKPermHandler.java
@@ -90,6 +90,7 @@ public class ZKPermHandler implements PermissionHandler {
           // it's there, you don't have permission
           return false;
         } catch (InterruptedException ex) {
+          Thread.currentThread().interrupt();
           log.warn("Unhandled InterruptedException, failing closed for table permission check", e);
           return false;
         } catch (KeeperException ex) {
@@ -104,6 +105,7 @@ public class ZKPermHandler implements PermissionHandler {
       log.warn("Unhandled KeeperException, failing closed for table permission check", e);
       return false;
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       log.warn("Unhandled InterruptedException, failing closed for table permission check", e);
       return false;
     }
@@ -139,6 +141,7 @@ public class ZKPermHandler implements PermissionHandler {
           // it's there, you don't have permission
           return false;
         } catch (InterruptedException ex) {
+          Thread.currentThread().interrupt();
           log.warn("Unhandled InterruptedException, failing closed for namespace permission check",
               e);
           return false;
@@ -154,6 +157,7 @@ public class ZKPermHandler implements PermissionHandler {
       log.warn("Unhandled KeeperException, failing closed for table permission check", e);
       return false;
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       log.warn("Unhandled InterruptedException, failing closed for table permission check", e);
       return false;
     }
@@ -197,6 +201,7 @@ public class ZKPermHandler implements PermissionHandler {
       log.error("{}", e.getMessage(), e);
       throw new AccumuloSecurityException(user, SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     }
@@ -225,6 +230,7 @@ public class ZKPermHandler implements PermissionHandler {
       log.error("{}", e.getMessage(), e);
       throw new AccumuloSecurityException(user, SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     }
@@ -255,6 +261,7 @@ public class ZKPermHandler implements PermissionHandler {
       log.error("{}", e.getMessage(), e);
       throw new AccumuloSecurityException(user, SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     }
@@ -284,6 +291,7 @@ public class ZKPermHandler implements PermissionHandler {
       log.error("{}", e.getMessage(), e);
       throw new AccumuloSecurityException(user, SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     }
@@ -315,6 +323,7 @@ public class ZKPermHandler implements PermissionHandler {
       log.error("{}", e.getMessage(), e);
       throw new AccumuloSecurityException(user, SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     }
@@ -349,6 +358,7 @@ public class ZKPermHandler implements PermissionHandler {
       log.error("{}", e.getMessage(), e);
       throw new AccumuloSecurityException(user, SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     }
@@ -368,6 +378,7 @@ public class ZKPermHandler implements PermissionHandler {
       log.error("{}", e.getMessage(), e);
       throw new AccumuloSecurityException("unknownUser", SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     }
@@ -387,6 +398,7 @@ public class ZKPermHandler implements PermissionHandler {
       log.error("{}", e.getMessage(), e);
       throw new AccumuloSecurityException("unknownUser", SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     }
@@ -427,6 +439,9 @@ public class ZKPermHandler implements PermissionHandler {
         createNamespacePerm(rootuser, entry.getKey(), entry.getValue());
       }
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     }
@@ -444,6 +459,7 @@ public class ZKPermHandler implements PermissionHandler {
       log.error("{}", e.getMessage(), e);
       throw new AccumuloSecurityException(user, SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     }
@@ -485,6 +501,7 @@ public class ZKPermHandler implements PermissionHandler {
         zooCache.clear(ZKUserPath + "/" + user);
       }
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     } catch (KeeperException e) {
@@ -511,6 +528,7 @@ public class ZKPermHandler implements PermissionHandler {
       log.warn("Unhandled KeeperException, failing closed for table permission check", e);
       return false;
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       log.warn("Unhandled InterruptedException, failing closed for table permission check", e);
       return false;
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/AccumuloStatus.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/AccumuloStatus.java
@@ -49,6 +49,9 @@ public class AccumuloStatus {
         return false;
       }
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new IOException("Issues contacting ZooKeeper to get Accumulo status.", e);
     }
     return true;

--- a/server/base/src/main/java/org/apache/accumulo/server/util/UpgradeUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/UpgradeUtil.java
@@ -146,6 +146,9 @@ public class UpgradeUtil implements KeywordExecutable {
           zoo.delete(zUpgradepath);
         }
       } catch (KeeperException | InterruptedException e) {
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
         throw new IllegalStateException("Error creating or checking for " + zUpgradepath
             + " node in zookeeper: " + e.getMessage(), e);
       }
@@ -159,6 +162,9 @@ public class UpgradeUtil implements KeywordExecutable {
               "Manager is running, shut it down and retry this operation");
         }
       } catch (KeeperException | InterruptedException e) {
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
         throw new IllegalStateException("Error trying to determine if Manager lock is held", e);
       }
 
@@ -174,6 +180,9 @@ public class UpgradeUtil implements KeywordExecutable {
               + " retry this operation.");
         }
       } catch (KeeperException | InterruptedException e) {
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
         throw new IllegalStateException("Error checking for existing FATE transactions", e);
       }
 
@@ -182,6 +191,9 @@ public class UpgradeUtil implements KeywordExecutable {
       try {
         zoo.putPersistentData(zUpgradepath, new byte[0], NodeExistsPolicy.SKIP);
       } catch (KeeperException | InterruptedException e) {
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
         throw new IllegalStateException("Error creating " + zUpgradepath
             + " node in zookeeper. Check for any issues and retry.", e);
       }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
@@ -172,6 +172,9 @@ public class ZooZap implements KeywordExecutable {
       try {
         removeSingletonLock(zoo, managerLockPath, hostPortPredicate, opts);
       } catch (KeeperException | InterruptedException e) {
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
         log.error("Error deleting manager lock", e);
       }
     }
@@ -182,6 +185,9 @@ public class ZooZap implements KeywordExecutable {
         ServiceLock.deleteLock(zoo, gcLockPath, ServerServices.Service.GC_CLIENT, hostPortPredicate,
             m -> message(m, opts), opts.dryRun);
       } catch (KeeperException | InterruptedException e) {
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
         log.error("Error deleting gc lock", e);
       }
     }
@@ -191,6 +197,9 @@ public class ZooZap implements KeywordExecutable {
       try {
         removeSingletonLock(zoo, monitorLockPath, hostPortPredicate, opts);
       } catch (KeeperException | InterruptedException e) {
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
         log.error("Error deleting monitor lock", e);
       }
     }
@@ -212,6 +221,9 @@ public class ZooZap implements KeywordExecutable {
               opts.dryRun);
         }
       } catch (KeeperException | InterruptedException e) {
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
         log.error("Error deleting tserver locks", e);
       }
     }
@@ -230,6 +242,9 @@ public class ZooZap implements KeywordExecutable {
       try {
         removeSingletonLock(zoo, coordinatorPath, hostPortPredicate, opts);
       } catch (KeeperException | InterruptedException e) {
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
         log.error("Error deleting coordinator from zookeeper", e);
       }
     }
@@ -240,6 +255,9 @@ public class ZooZap implements KeywordExecutable {
         removeCompactorGroupedLocks(zoo, compactorsBasepath, groupPredicate, hostPortPredicate,
             opts);
       } catch (KeeperException | InterruptedException e) {
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
         log.error("Error deleting compactors from zookeeper", e);
       }
 
@@ -254,6 +272,9 @@ public class ZooZap implements KeywordExecutable {
           removeScanServerGroupLocks(zoo, sserversPath, hostPortPredicate, groupPredicate, opts);
         }
       } catch (KeeperException | InterruptedException e) {
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
         log.error("Error deleting scan server locks", e);
       }
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/zookeeper/DistributedWorkQueue.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/zookeeper/DistributedWorkQueue.java
@@ -157,6 +157,7 @@ public class DistributedWorkQueue {
             } catch (KeeperException e) {
               log.error("Failed to look for work", e);
             } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
               log.info("Interrupted looking for work", e);
             }
           }
@@ -219,6 +220,7 @@ public class DistributedWorkQueue {
               } catch (KeeperException e) {
                 log.error("Failed to look for work at path {}; {}", path, event, e);
               } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 log.info("Interrupted looking for work at path {}; {}", path, event, e);
               }
             } else {
@@ -246,6 +248,7 @@ public class DistributedWorkQueue {
             } catch (KeeperException e) {
               log.error("Failed to look for work", e);
             } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
               log.info("Interrupted looking for work", e);
             }
           }

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/store/impl/ReadyMonitorTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/store/impl/ReadyMonitorTest.java
@@ -71,6 +71,7 @@ public class ReadyMonitorTest {
       boolean terminated = workerPool.awaitTermination(2000, MILLISECONDS);
       log.trace("Worked pool successfully terminated: {}", terminated);
     } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
       // don't care.
       workerPool.shutdownNow();
     }
@@ -145,6 +146,9 @@ public class ReadyMonitorTest {
         log.debug("waiting: {}", NANOSECONDS.toSeconds(timeWaiting));
         assertTrue(timeWaiting < MILLISECONDS.toNanos(readyTestTimeout));
       } catch (ExecutionException | InterruptedException ex) {
+        if (ex instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
         log.warn("Task failed", ex);
         fail("Task failed with exception - " + ex.getMessage());
       }

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
@@ -303,6 +303,7 @@ public class CompactionCoordinator extends AbstractServer implements
     try {
       waitForUpgrade();
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       LOG.error("Interrupted while waiting for upgrade to complete, exiting...");
       System.exit(1);
     }
@@ -319,6 +320,9 @@ public class CompactionCoordinator extends AbstractServer implements
     try {
       getCoordinatorLock(clientAddress);
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new IllegalStateException("Exception getting Coordinator lock", e);
     }
 
@@ -380,6 +384,7 @@ public class CompactionCoordinator extends AbstractServer implements
           Thread.sleep(checkInterval - duration);
         }
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         LOG.info("Interrupt Exception received, shutting down");
         gracefulShutdown(getContext().rpcCreds());
       }

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -812,6 +812,9 @@ public class Compactor extends AbstractServer
     try {
       announceExistence(clientAddress);
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new RuntimeException("Error registering compactor in ZooKeeper", e);
     }
 
@@ -1012,6 +1015,7 @@ public class Compactor extends AbstractServer
             }
           }
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           LOG.info("Interrupt Exception received, shutting down");
           gracefulShutdown(getContext().rpcCreds());
         }

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
@@ -392,6 +392,7 @@ public class GCRun implements GarbageCollectionEnvironment {
         }
       }
     } catch (InterruptedException e1) {
+      Thread.currentThread().interrupt();
       log.error("{}", e1.getMessage(), e1);
     }
 

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
@@ -314,6 +314,9 @@ public class GarbageCollectWriteAheadLogs {
               iter.remove();
               f.getValue().get();
             } catch (InterruptedException | ExecutionException e) {
+              if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+              }
               throw new RuntimeException("Uncaught exception deleting wal file" + f.getKey(), e);
             }
           }
@@ -354,6 +357,9 @@ public class GarbageCollectWriteAheadLogs {
               iter.remove();
               f.getValue().get();
             } catch (InterruptedException | ExecutionException e) {
+              if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+              }
               throw new RuntimeException(
                   "Uncaught exception deleting recovery log file" + f.getKey(), e);
             }

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -156,6 +156,7 @@ public class SimpleGarbageCollector extends AbstractServer
     try {
       waitForUpgrade();
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       LOG.error("Interrupted while waiting for upgrade to complete, exiting...");
       System.exit(1);
     }
@@ -186,6 +187,7 @@ public class SimpleGarbageCollector extends AbstractServer
       log.debug("Sleeping for {} milliseconds before beginning garbage collection cycles", delay);
       Thread.sleep(delay);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       log.warn("{}", e.getMessage(), e);
       return;
     }
@@ -336,10 +338,12 @@ public class SimpleGarbageCollector extends AbstractServer
           log.debug("Sleeping for {} milliseconds", gcDelay);
           Thread.sleep(gcDelay);
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           log.warn("{}", e.getMessage(), e);
           throw e;
         }
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         log.info("Interrupt Exception received, shutting down");
         gracefulShutdown(getContext().rpcCreds());
       }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/EventCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/EventCoordinator.java
@@ -36,6 +36,7 @@ public class EventCoordinator {
       try {
         wait(millis);
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         log.debug("ignoring InterruptedException", e);
       }
     }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -810,7 +810,6 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener, 
         } catch (KeeperException e) {
           log.error("Exception trying to delete empty scan server ZNodes, will retry", e);
         } catch (InterruptedException e) {
-          Thread.interrupted();
           log.error("Interrupted trying to delete empty scan server ZNodes, will retry", e);
         } finally {
           // sleep for 5 mins
@@ -1250,6 +1249,9 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener, 
                   tserverHaltRpcAttempts.remove(server);
                   badServers.remove(server);
                 } catch (KeeperException | InterruptedException e) {
+                  if (e instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                  }
                   log.error("Failed to delete zlock for server {}", server, e);
                 }
               } else {
@@ -1280,6 +1282,7 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener, 
     try {
       tp.awaitTermination(Math.max(10000, rpcTimeout / 3), MILLISECONDS);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       log.debug("Interrupted while fetching status");
     }
 
@@ -1344,6 +1347,9 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener, 
     try {
       getManagerLock(ServiceLock.path(zroot + Constants.ZMANAGER_LOCK), clientAddress);
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new IllegalStateException("Exception getting manager lock", e);
     }
 
@@ -1390,6 +1396,9 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener, 
         }
       });
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new IllegalStateException("Unable to read " + zroot + Constants.ZRECOVERY, e);
     }
 
@@ -1433,6 +1442,9 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener, 
         upgradeMetadataFuture.get();
       }
     } catch (ExecutionException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new IllegalStateException("Metadata upgrade failed", e);
     }
 
@@ -1454,6 +1466,9 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener, 
       ThreadPools.watchCriticalScheduledTask(context.getScheduledExecutor()
           .scheduleWithFixedDelay(store::ageOff, 63000, 63000, MILLISECONDS));
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new IllegalStateException("Exception setting up FaTE cleanup thread", e);
     }
 
@@ -1470,6 +1485,9 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener, 
       try {
         keyDistributor.initialize();
       } catch (KeeperException | InterruptedException e) {
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
         throw new IllegalStateException("Exception setting up delegation-token key manager", e);
       }
       authenticationTokenKeyManagerThread = Threads
@@ -1493,6 +1511,9 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener, 
     try {
       managerLock.replaceLockData(address.getBytes(UTF_8));
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new IllegalStateException("Exception updating manager lock", e);
     }
 
@@ -1511,6 +1532,9 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener, 
           replServer.set(setupReplication());
         }
       } catch (UnknownHostException | KeeperException | InterruptedException e) {
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
         log.error("Error occurred starting replication services. ", e);
       }
     }, 0, 5000, MILLISECONDS);
@@ -1530,6 +1554,7 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener, 
       try {
         Thread.sleep(500);
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         log.info("Interrupt Exception received, shutting down");
         gracefulShutdown(context.rpcCreds());
       }
@@ -1551,6 +1576,7 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener, 
         replicationWorkThread.join(remaining(deadline));
       }
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       throw new IllegalStateException("Exception stopping replication workers", e);
     }
     var nullableReplServer = replServer.get();
@@ -1566,6 +1592,7 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener, 
           authenticationTokenKeyManagerThread.join(remaining(deadline));
         }
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         throw new IllegalStateException("Exception waiting on delegation-token key manager", e);
       }
     }
@@ -1576,6 +1603,7 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener, 
       try {
         watcher.join(remaining(deadline));
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         throw new IllegalStateException("Exception waiting on watcher", e);
       }
     }
@@ -1595,6 +1623,9 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener, 
       org.apache.accumulo.server.replication.ZooKeeperInitialization
           .ensureZooKeeperInitialized(zReaderWriter, zroot);
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new IllegalStateException("Exception while ensuring ZooKeeper is initialized", e);
     }
   }
@@ -1921,6 +1952,7 @@ public class Manager extends AbstractServer implements LiveTServerSet.Listener, 
         try {
           balancedNotifier.wait();
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           log.debug(e.toString(), e);
         }
       } while (displayUnassigned() > 0 || !migrations.isEmpty()

--- a/server/manager/src/main/java/org/apache/accumulo/manager/replication/ManagerReplicationCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/replication/ManagerReplicationCoordinator.java
@@ -87,6 +87,9 @@ public class ManagerReplicationCoordinator implements ReplicationCoordinator.Ifa
       replServiceAddr = new String(reader.getData(manager.getZooKeeperRoot()
           + ReplicationConstants.ZOO_TSERVERS + "/" + tserver.getHostPort()), UTF_8);
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       log.error("Could not fetch replication service port for tserver", e);
       throw new ReplicationCoordinatorException(
           ReplicationCoordinatorErrorCode.SERVICE_CONFIGURATION_UNAVAILABLE,

--- a/server/manager/src/main/java/org/apache/accumulo/manager/replication/ReplicationDriver.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/replication/ReplicationDriver.java
@@ -123,6 +123,7 @@ public class ReplicationDriver implements Runnable {
       try {
         Thread.sleep(sleepMillis);
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         log.error("Interrupted while sleeping", e);
       }
     }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/replication/SequentialWorkAssigner.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/replication/SequentialWorkAssigner.java
@@ -91,6 +91,9 @@ public class SequentialWorkAssigner extends DistributedWorkQueueWorkAssigner {
     try {
       existingWork = workQueue.getWorkQueued();
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new RuntimeException("Error reading existing queued replication work", e);
     }
 
@@ -178,6 +181,9 @@ public class SequentialWorkAssigner extends DistributedWorkQueueWorkAssigner {
         workQueue.addWork(queueKey, path.toString());
         workForPeer.put(target.getSourceTableId(), queueKey);
       } catch (KeeperException | InterruptedException e) {
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
         log.warn("Could not queue work for {} to {}", path, target, e);
         return false;
       }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/replication/UnorderedWorkAssigner.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/replication/UnorderedWorkAssigner.java
@@ -100,6 +100,7 @@ public class UnorderedWorkAssigner extends DistributedWorkQueueWorkAssigner {
         throw new RuntimeException("Error reading existing queued replication work from ZooKeeper",
             e);
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         log.error("Error reading existing queued replication work from ZooKeeper", e);
         throw new RuntimeException("Error reading existing queued replication work from ZooKeeper",
             e);
@@ -126,6 +127,9 @@ public class UnorderedWorkAssigner extends DistributedWorkQueueWorkAssigner {
       workQueue.addWork(queueKey, path.toString());
       queuedWork.add(queueKey);
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       log.warn("Could not queue work for {}", path, e);
       return false;
     }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
@@ -92,6 +92,9 @@ public class Utils {
         }
       }
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       log.error("Error checking to see if tableId {} exists in ZooKeeper", tableId, e);
       throw new AcceptableThriftTableOperationException(null, tableName, TableOperation.CREATE,
           TableOperationExceptionType.OTHER, e.getMessage());

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/RenameMasterDirInZK.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/RenameMasterDirInZK.java
@@ -65,6 +65,9 @@ public class RenameMasterDirInZK {
       }
       return mastersDirExists;
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new RuntimeException("Unable to rename " + mastersZooDir + " in ZooKeeper", e);
     }
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader9to10.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader9to10.java
@@ -176,6 +176,9 @@ public class Upgrader9to10 implements Upgrader {
             aclErrorOccurred.set(true);
           }
         } catch (KeeperException | InterruptedException e) {
+          if (e instanceof InterruptedException) {
+            Thread.currentThread().interrupt();
+          }
           log.error("Error getting ACL for path: {}", path, e);
           aclErrorOccurred.set(true);
         }
@@ -187,6 +190,9 @@ public class Upgrader9to10 implements Upgrader {
                 + "for instructions on how to fix.");
       }
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new RuntimeException("Upgrade Failed! Error validating nodes under " + rootPath, e);
     }
   }
@@ -245,6 +251,9 @@ public class Upgrader9to10 implements Upgrader {
           context.getZooKeeperRoot() + Constants.ZSSERVERS, EMPTY_BYTE_ARRAY,
           NodeExistsPolicy.SKIP);
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new RuntimeException("Unable to create scan server paths", e);
     }
   }
@@ -263,6 +272,9 @@ public class Upgrader9to10 implements Upgrader {
           context.getZooKeeperRoot() + Constants.ZCOMPACTORS, EMPTY_BYTE_ARRAY,
           NodeExistsPolicy.SKIP);
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new RuntimeException("Unable to create external compaction paths", e);
     }
   }
@@ -315,6 +327,9 @@ public class Upgrader9to10 implements Upgrader {
           context.getZooKeeperRoot() + ZROOT_TABLET_GC_CANDIDATES,
           new RootGcCandidates().toJson().getBytes(UTF_8), NodeExistsPolicy.SKIP);
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new RuntimeException(e);
     }
 
@@ -410,6 +425,9 @@ public class Upgrader9to10 implements Upgrader {
 
       return result;
     } catch (KeeperException | InterruptedException | IOException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new RuntimeException(e);
     }
   }
@@ -425,6 +443,9 @@ public class Upgrader9to10 implements Upgrader {
     } catch (NoNodeException e) {
       return null;
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new RuntimeException(e);
     }
   }
@@ -434,6 +455,9 @@ public class Upgrader9to10 implements Upgrader {
       context.getZooReaderWriter().recursiveDelete(context.getZooKeeperRoot() + relpath,
           NodeMissingPolicy.SKIP);
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new RuntimeException(e);
     }
   }

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -512,6 +512,9 @@ public class Monitor extends AbstractServer implements HighlyAvailableService {
     try {
       monitorLock.replaceLockData(monitorHostAndPort.toString().getBytes(UTF_8));
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new IllegalStateException("Exception updating monitor lock with host and port", e);
     }
 
@@ -558,6 +561,7 @@ public class Monitor extends AbstractServer implements HighlyAvailableService {
       try {
         Thread.sleep(1000);
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         LOG.info("Interrupt Exception received, shutting down");
         gracefulShutdown(context.rpcCreds());
       }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -395,6 +395,7 @@ public class ScanServer extends AbstractServer
     try {
       waitForUpgrade();
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       LOG.error("Interrupted while waiting for upgrade to complete, exiting...");
       System.exit(1);
     }
@@ -438,6 +439,7 @@ public class ScanServer extends AbstractServer
               && tabletMetadataCache.estimatedSize() == 0);
           updateAllowedTables(false);
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           LOG.info("Interrupt Exception received, shutting down");
           gracefulShutdown(getContext().rpcCreds());
         }
@@ -742,6 +744,7 @@ public class ScanServer extends AbstractServer
       // file from the metadata table or the reservedFiles map
       influxFiles.addAll(allFiles.keySet());
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       throw new RuntimeException(e);
     } finally {
       reservationsWriteLock.unlock();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -728,6 +728,9 @@ public class TabletServer extends AbstractServer
       org.apache.accumulo.server.replication.ZooKeeperInitialization.ensureZooKeeperInitialized(
           getContext().getZooReaderWriter(), getContext().getZooKeeperRoot());
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new IllegalStateException("Exception while ensuring ZooKeeper is initialized", e);
     }
   }
@@ -746,6 +749,9 @@ public class TabletServer extends AbstractServer
       try {
         authKeyWatcher.updateAuthKeys();
       } catch (KeeperException | InterruptedException e) {
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
         // TODO Does there need to be a better check? What are the error conditions that we'd fall
         // out here? AUTH_FAILURE?
         // If we get the error, do we just put it on a timer and retry the exists(String, Watcher)
@@ -941,6 +947,7 @@ public class TabletServer extends AbstractServer
           sleepUninterruptibly(1, TimeUnit.SECONDS);
         }
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         log.info("Interrupt Exception received, shutting down");
         gracefulShutdown(getContext().rpcCreds());
       } catch (Exception e) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
@@ -525,6 +525,7 @@ public class TabletServerResourceManager {
           }
 
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           log.warn("Interrupted processing tablet memory statistics", e);
         }
       }
@@ -632,7 +633,9 @@ public class TabletServerResourceManager {
               throw new HoldTimeoutException("Commits are held");
             }
             commitHold.wait(1000);
-          } catch (InterruptedException e) {}
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          }
         }
       }
     }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/UnloadTabletHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/UnloadTabletHandler.java
@@ -67,7 +67,9 @@ class UnloadTabletHandler implements Runnable {
         try {
           log.info("Waiting for tablet {} to finish opening before unloading.", extent);
           server.openingTablets.wait();
-        } catch (InterruptedException e) {}
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
       }
     }
     synchronized (server.onlineTablets) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/WriteTracker.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/WriteTracker.java
@@ -83,6 +83,7 @@ public class WriteTracker {
       try {
         this.wait();
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         log.error("{}", e.getMessage(), e);
       }
     }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionManager.java
@@ -171,6 +171,7 @@ public class CompactionManager {
         try {
           retry.waitForNextAttempt(log, "compaction initiation loop");
         } catch (InterruptedException e1) {
+          Thread.currentThread().interrupt();
           log.debug("Retry interrupted", e1);
         }
       }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
@@ -145,6 +145,7 @@ public class DfsLogger implements Comparable<DfsLogger> {
         try {
           work.add(workQueue.take());
         } catch (InterruptedException ex) {
+          Thread.currentThread().interrupt();
           continue;
         }
         workQueue.drainTo(work);
@@ -251,6 +252,7 @@ public class DfsLogger implements Comparable<DfsLogger> {
       try {
         work.latch.await();
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         throw new RuntimeException(e);
       }
 
@@ -539,6 +541,7 @@ public class DfsLogger implements Comparable<DfsLogger> {
       try {
         syncThread.join();
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         throw new RuntimeException(e);
       }
     }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/TabletServerLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/TabletServerLogger.java
@@ -300,6 +300,7 @@ public class TabletServerLogger {
             try {
               nextLog.offer(t, 12, TimeUnit.HOURS);
             } catch (InterruptedException ex) {
+              Thread.currentThread().interrupt();
               // Throw an Error, not an Exception, so the AccumuloUncaughtExceptionHandler
               // will log this then halt the VM.
               throw new Error("Next log maker thread interrupted", ex);
@@ -338,6 +339,7 @@ public class TabletServerLogger {
             try {
               nextLog.offer(t, 12, TimeUnit.HOURS);
             } catch (InterruptedException ex) {
+              Thread.currentThread().interrupt();
               // Throw an Error, not an Exception, so the AccumuloUncaughtExceptionHandler
               // will log this then halt the VM.
               throw new Error("Next log maker thread interrupted", ex);
@@ -351,6 +353,7 @@ public class TabletServerLogger {
               log.info("Our WAL was not used for 12 hours: {}", fileName);
             }
           } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             // Throw an Error, not an Exception, so the AccumuloUncaughtExceptionHandler
             // will log this then halt the VM.
             throw new Error("Next log maker thread interrupted", e);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/ReplicationWorker.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/ReplicationWorker.java
@@ -73,6 +73,9 @@ public class ReplicationWorker implements Runnable {
 
       workQueue.startProcessing(new ReplicationProcessor(server.getContext()), executor);
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new RuntimeException(e);
     }
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SessionManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SessionManager.java
@@ -139,6 +139,7 @@ public class SessionManager {
           try {
             session.wait(1000);
           } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException();
           }
         }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CommitSession.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CommitSession.java
@@ -73,6 +73,7 @@ public class CommitSession {
       try {
         committer.wait(50);
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         log.warn("InterruptedException", e);
       }
     }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
@@ -209,6 +209,7 @@ class DatafileManager {
             try {
               tablet.wait(100);
             } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
               log.warn("{}", e.getMessage(), e);
             }
           }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
@@ -138,6 +138,9 @@ public class MinorCompactor extends FileCompactor {
           reportedProblem = true;
           retryCounter++;
         } catch (CompactionCanceledException | InterruptedException e) {
+          if (e instanceof InterruptedException) {
+            Thread.currentThread().interrupt();
+          }
           throw new IllegalStateException(e);
         }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Scanner.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Scanner.java
@@ -103,6 +103,7 @@ public class Scanner {
         // would not handle that well.
         readInProgress = true;
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         sawException = true;
       }
 
@@ -232,6 +233,7 @@ public class Scanner {
         isolatedDataSource.close(false);
       }
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       return false;
     } finally {
       if (obtainedLock) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -719,6 +719,9 @@ public class Tablet extends TabletBase {
       String id = new String(context.getZooReaderWriter().getData(zTablePath), UTF_8);
       return Long.parseLong(id);
     } catch (InterruptedException | NumberFormatException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new RuntimeException("Exception on " + extent + " getting flush ID", e);
     } catch (KeeperException ke) {
       if (ke instanceof NoNodeException) {
@@ -769,6 +772,9 @@ public class Tablet extends TabletBase {
 
       return new Pair<>(compactID, overlappingConfig);
     } catch (InterruptedException | DecoderException | NumberFormatException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new RuntimeException("Exception on " + extent + " getting compaction ID", e);
     } catch (KeeperException ke) {
       if (ke instanceof NoNodeException) {
@@ -1024,6 +1030,7 @@ public class Tablet extends TabletBase {
         try {
           this.wait(50);
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           log.error(e.toString());
         }
       }
@@ -1093,6 +1100,7 @@ public class Tablet extends TabletBase {
             runningScans.size());
         this.wait(50);
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         log.error("Interrupted waiting to completeClose for extent {}", extent, e);
       }
     }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletMemory.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletMemory.java
@@ -136,6 +136,7 @@ class TabletMemory implements Closeable {
       try {
         tablet.wait(50);
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         log.warn("{}", e.getMessage(), e);
       }
     }

--- a/start/src/main/java/org/apache/accumulo/start/classloader/vfs/AccumuloReloadingVFSClassLoader.java
+++ b/start/src/main/java/org/apache/accumulo/start/classloader/vfs/AccumuloReloadingVFSClassLoader.java
@@ -102,6 +102,7 @@ public class AccumuloReloadingVFSClassLoader implements FileListener, ReloadingC
                 currentSleepMillis = Math.min(maxWaitInterval, currentSleepMillis + sleepInterval);
 
               } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 log.error("VFS Retry Interrupted", e);
                 throw new RuntimeException(e);
               }
@@ -135,6 +136,7 @@ public class AccumuloReloadingVFSClassLoader implements FileListener, ReloadingC
           try {
             Thread.sleep(DEFAULT_TIMEOUT);
           } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
             log.error("{}", ie.getMessage(), ie);
           }
         }

--- a/test/src/main/java/org/apache/accumulo/test/BatchWriterIterator.java
+++ b/test/src/main/java/org/apache/accumulo/test/BatchWriterIterator.java
@@ -227,7 +227,9 @@ public class BatchWriterIterator extends WrappingIterator {
           if (sleepAfterFirstWrite > 0) {
             try {
               Thread.sleep(sleepAfterFirstWrite);
-            } catch (InterruptedException ignored) {}
+            } catch (InterruptedException ignored) {
+              Thread.currentThread().interrupt();
+            }
           }
           firstWrite = false;
         }

--- a/test/src/main/java/org/apache/accumulo/test/MultiTableRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MultiTableRecoveryIT.java
@@ -138,6 +138,9 @@ public class MultiTableRecoveryIT extends ConfigurableMacBase {
         }
         System.out.println("Restarted " + i + " times");
       } catch (IOException | InterruptedException | TableNotFoundException ex) {
+        if (ex instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
         log.error("{}", ex.getMessage(), ex);
       }
     });

--- a/test/src/main/java/org/apache/accumulo/test/ScanConsistencyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ScanConsistencyIT.java
@@ -261,6 +261,7 @@ public class ScanConsistencyIT extends AccumuloClusterHarness {
         try {
           wait(50);
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           throw new RuntimeException(e);
         }
       }

--- a/test/src/main/java/org/apache/accumulo/test/ScanServerMultipleScansIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ScanServerMultipleScansIT.java
@@ -131,6 +131,7 @@ public class ScanServerMultipleScansIT extends SharedMiniClusterBase {
           try {
             latch.await();
           } catch (InterruptedException e1) {
+            Thread.currentThread().interrupt();
             fail("InterruptedException waiting for latch");
           }
           try (Scanner scanner = client.createScanner(tableName, Authorizations.EMPTY)) {
@@ -199,6 +200,7 @@ public class ScanServerMultipleScansIT extends SharedMiniClusterBase {
           try {
             latch.await();
           } catch (InterruptedException e1) {
+            Thread.currentThread().interrupt();
             fail("InterruptedException waiting for latch");
           }
           try (Scanner scanner = client.createScanner(tableName, Authorizations.EMPTY)) {
@@ -254,6 +256,7 @@ public class ScanServerMultipleScansIT extends SharedMiniClusterBase {
           try {
             latch.await();
           } catch (InterruptedException e1) {
+            Thread.currentThread().interrupt();
             fail("InterruptedException waiting for latch");
           }
           try (BatchScanner scanner = client.createBatchScanner(tableName, Authorizations.EMPTY)) {
@@ -321,6 +324,7 @@ public class ScanServerMultipleScansIT extends SharedMiniClusterBase {
           try {
             latch.await();
           } catch (InterruptedException e1) {
+            Thread.currentThread().interrupt();
             fail("InterruptedException waiting for latch");
           }
           try (BatchScanner scanner = client.createBatchScanner(tableName, Authorizations.EMPTY)) {

--- a/test/src/main/java/org/apache/accumulo/test/ZombieScanIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ZombieScanIT.java
@@ -129,6 +129,7 @@ public class ZombieScanIT extends ConfigurableMacBase {
         semaphore.acquire(6);
         return ht;
       } catch (InterruptedException ie) {
+        Thread.currentThread().interrupt();
         throw new IllegalStateException(ie);
       }
     }

--- a/test/src/main/java/org/apache/accumulo/test/ZooKeeperPropertiesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ZooKeeperPropertiesIT.java
@@ -81,6 +81,7 @@ public class ZooKeeperPropertiesIT extends AccumuloClusterHarness {
         try {
           Thread.sleep(250);
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           fail("Thread interrupted while waiting for tablePropUtil update");
         }
         properties = client.tableOperations().getConfiguration(tableName);
@@ -94,6 +95,7 @@ public class ZooKeeperPropertiesIT extends AccumuloClusterHarness {
         try {
           Thread.sleep(250);
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           fail("Thread interrupted while waiting for tablePropUtil update");
         }
         properties = client.tableOperations().getConfiguration(tableName);
@@ -134,6 +136,7 @@ public class ZooKeeperPropertiesIT extends AccumuloClusterHarness {
         try {
           Thread.sleep(250);
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           fail("Thread interrupted while waiting for namespacePropUtil update");
         }
         properties = client.namespaceOperations().getConfiguration(namespace);
@@ -147,6 +150,7 @@ public class ZooKeeperPropertiesIT extends AccumuloClusterHarness {
         try {
           Thread.sleep(250);
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           fail("Thread interrupted while waiting for namespacePropUtil update");
         }
         properties = client.namespaceOperations().getConfiguration(namespace);

--- a/test/src/main/java/org/apache/accumulo/test/conf/store/PropCacheCaffeineImplZkIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/conf/store/PropCacheCaffeineImplZkIT.java
@@ -133,6 +133,9 @@ public class PropCacheCaffeineImplZkIT {
     try {
       ZKUtil.deleteRecursive(zooKeeper, "/accumulo");
     } catch (KeeperException | InterruptedException ex) {
+      if (ex instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new IllegalStateException("Failed to clean-up test zooKeeper nodes.", ex);
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/conf/store/PropStoreZooKeeperIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/conf/store/PropStoreZooKeeperIT.java
@@ -134,6 +134,9 @@ public class PropStoreZooKeeperIT {
     try {
       ZKUtil.deleteRecursive(zooKeeper, "/accumulo");
     } catch (KeeperException | InterruptedException ex) {
+      if (ex instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new IllegalStateException("Failed to clean-up test zooKeeper nodes.", ex);
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/conf/store/ZooBasedConfigIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/conf/store/ZooBasedConfigIT.java
@@ -173,6 +173,9 @@ public class ZooBasedConfigIT {
     try {
       ZKUtil.deleteRecursive(zooKeeper, "/accumulo");
     } catch (KeeperException | InterruptedException ex) {
+      if (ex instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new IllegalStateException("Failed to clean-up test zooKeeper nodes.", ex);
     }
     verify(context);

--- a/test/src/main/java/org/apache/accumulo/test/conf/util/ConfigTransformerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/conf/util/ConfigTransformerIT.java
@@ -121,6 +121,9 @@ public class ConfigTransformerIT {
     try {
       ZKUtil.deleteRecursive(zooKeeper, Constants.ZROOT);
     } catch (KeeperException | InterruptedException ex) {
+      if (ex instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new IllegalStateException("Failed to clean-up test zooKeeper nodes.", ex);
     }
     verify(context, watcher);

--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
@@ -570,6 +570,7 @@ public class FateIT {
       // wait for the signal to exit the method
       finishCall.await();
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       LOG.debug("InterruptedException occurred inCall.");
       interruptedException.set(e);
       throw e;

--- a/test/src/main/java/org/apache/accumulo/test/functional/ConcurrentDeleteTableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ConcurrentDeleteTableIT.java
@@ -94,6 +94,9 @@ public class ConcurrentDeleteTableIT extends AccumuloClusterHarness {
             } catch (TableNotFoundException e) {
               // expected
             } catch (InterruptedException | AccumuloException | AccumuloSecurityException e) {
+              if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+              }
               throw new RuntimeException(e);
             }
           }));
@@ -149,6 +152,9 @@ public class ConcurrentDeleteTableIT extends AccumuloClusterHarness {
           } catch (TableNotFoundException | TableOfflineException e) {
             // expected
           } catch (InterruptedException | AccumuloException | AccumuloSecurityException e) {
+            if (e instanceof InterruptedException) {
+              Thread.currentThread().interrupt();
+            }
             throw new RuntimeException(e);
           }
         }));

--- a/test/src/main/java/org/apache/accumulo/test/functional/FateConcurrencyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FateConcurrencyIT.java
@@ -359,6 +359,9 @@ public class FateConcurrencyIT extends AccumuloClusterHarness {
       }
 
     } catch (TableNotFoundException | InterruptedException ex) {
+      if (ex instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new IllegalStateException(ex);
     }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/FunctionalTestUtils.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FunctionalTestUtils.java
@@ -222,6 +222,9 @@ public class FunctionalTestUtils {
       var lockPath = ServiceLock.path(context.getZooKeeperRoot() + Constants.ZTABLE_LOCKS);
       return admin.getStatus(zs, zk, lockPath, null, null);
     } catch (KeeperException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new RuntimeException(e);
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/HalfDeadServerWatcherIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/HalfDeadServerWatcherIT.java
@@ -105,6 +105,9 @@ public class HalfDeadServerWatcherIT extends AccumuloClusterHarness {
         try {
           this.getContext().getZooReaderWriter().exists(tableZPath, new StuckWatcher());
         } catch (KeeperException | InterruptedException e) {
+          if (e instanceof InterruptedException) {
+            Thread.currentThread().interrupt();
+          }
           LOG.error("Error setting watch at: {}", tableZPath, e);
         }
         LOG.info("Set StuckWatcher at: {}", tableZPath);

--- a/test/src/main/java/org/apache/accumulo/test/functional/SlowIterator.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SlowIterator.java
@@ -62,6 +62,7 @@ public class SlowIterator extends WrappingIterator {
       try {
         Thread.sleep(sleepTime);
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         throw new IOException(e);
       }
     }

--- a/test/src/main/java/org/apache/accumulo/test/replication/ReplicationOperationsImplIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/ReplicationOperationsImplIT.java
@@ -200,6 +200,7 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
     try {
       t.join(5000);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       fail("ReplicationOperations.drain did not complete");
     }
 
@@ -284,6 +285,7 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
     try {
       t.join(5000);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       fail("ReplicationOperations.drain did not complete");
     }
 
@@ -362,6 +364,7 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
     try {
       t.join(5000);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       fail("ReplicationOperations.drain did not complete");
     }
 
@@ -445,6 +448,7 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
     try {
       t.join(5000);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       fail("ReplicationOperations.drain did not complete");
     }
 

--- a/test/src/main/java/org/apache/accumulo/test/upgrade/ConfigPropertyUpgraderIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/upgrade/ConfigPropertyUpgraderIT.java
@@ -118,6 +118,9 @@ public class ConfigPropertyUpgraderIT {
     try {
       ZKUtil.deleteRecursive(zooKeeper, Constants.ZROOT);
     } catch (KeeperException | InterruptedException ex) {
+      if (ex instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw new IllegalStateException("Failed to clean-up test zooKeeper nodes.", ex);
     }
   }


### PR DESCRIPTION
This commit resets the thread interrupted state after catching InterruptedException. These changes were made by running the Maven command below, reviewing the changes, and making some manual modifications.
```
mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
    --define rewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-static-analysis:RELEASE \
    --define rewrite.activeRecipes=org.openrewrite.staticanalysis.InterruptedExceptionHandling \
    --define rewrite.exportDatatables=true
```

The related documentation for this Maven plugin can be found at https://docs.openrewrite.org/recipes/staticanalysis/interruptedexceptionhandling