### PR TITLE
Changed required Java runtime version from 17 to 21.

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/FateExecutor.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/FateExecutor.java
@@ -434,7 +434,7 @@ public class FateExecutor<T> {
     public void run() {
       runnerLog.trace("A TransactionRunner is starting for {} {} ", fate.getStore().type(),
           fateOps);
-      threadId = Thread.currentThread().getId();
+      threadId = Thread.currentThread().threadId();
       try {
         while (fate.getKeepRunning().get() && !isShutdown() && !stop.get()) {
           FateTxStore<T> txStore = null;

--- a/core/src/main/java/org/apache/accumulo/core/trace/ScanInstrumentation.java
+++ b/core/src/main/java/org/apache/accumulo/core/trace/ScanInstrumentation.java
@@ -85,9 +85,9 @@ public abstract class ScanInstrumentation {
   public static ScanScope enable(Span span) {
     if (span.isRecording()) {
       INSTRUMENTED_SCANS.set(new ScanInstrumentationImpl());
-      var id = Thread.currentThread().getId();
+      var id = Thread.currentThread().threadId();
       return () -> {
-        Preconditions.checkState(id == Thread.currentThread().getId());
+        Preconditions.checkState(id == Thread.currentThread().threadId());
         INSTRUMENTED_SCANS.remove();
       };
     } else {

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/Threads.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/Threads.java
@@ -95,7 +95,7 @@ public class Threads {
   // required Java version is at least 19
   public static String toString(Thread t) {
     StringBuilder sb = new StringBuilder("Thread[#");
-    sb.append(t.getId()).append(",").append(t.getName()).append(",").append(t.getPriority())
+    sb.append(t.threadId()).append(",").append(t.getName()).append(",").append(t.getPriority())
         .append(",");
     ThreadGroup group = t.getThreadGroup();
     if (group != null) {

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@ under the License.
     <failsafe.forkCount>1</failsafe.forkCount>
     <failsafe.groups />
     <failsafe.reuseForks>false</failsafe.reuseForks>
-    <javaVersion>17</javaVersion>
+    <javaVersion>21</javaVersion>
     <!-- prevent introduction of new compiler warnings -->
     <maven.compiler.failOnWarning>true</maven.compiler.failOnWarning>
     <maven.javadoc.failOnWarnings>true</maven.javadoc.failOnWarnings>

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/AsyncConditionalTabletsMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/AsyncConditionalTabletsMutatorImpl.java
@@ -48,7 +48,7 @@ public class AsyncConditionalTabletsMutatorImpl implements Ample.AsyncConditiona
     this.resultsConsumer = Objects.requireNonNull(resultsConsumer);
     this.mutatorFactory = mutatorFactory;
     this.bufferingMutator = mutatorFactory.get();
-    var creatorId = Thread.currentThread().getId();
+    var creatorId = Thread.currentThread().threadId();
     this.executor = Executors.newSingleThreadExecutor(runnable -> Threads.createCriticalThread(
         "Async conditional tablets mutator background thread, created by : #" + creatorId,
         runnable));

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/scan/ScanTask.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/scan/ScanTask.java
@@ -88,7 +88,7 @@ public abstract class ScanTask<T> implements Runnable {
     public final StackTraceElement[] stackTrace;
 
     private ScanThreadStackTrace(Thread thread) {
-      this.threadId = thread.getId();
+      this.threadId = thread.threadId();
       this.stackTrace = thread.getStackTrace();
       this.threadName = thread.getName();
     }


### PR DESCRIPTION
This change also changes references to Thread.getId() to Thread.threadId() due to deprecation.