### PR TITLE
Replace table name Pair with new record class

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/TableNotFoundException.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/TableNotFoundException.java
@@ -70,7 +70,7 @@ public class TableNotFoundException extends Exception {
    */
   public TableNotFoundException(String tableName, NamespaceNotFoundException e) {
     this(null, tableName,
-        "Namespace " + TableNameUtil.qualify(tableName).getFirst() + " does not exist.", e);
+        "Namespace " + TableNameUtil.qualify(tableName).namespaceName() + " does not exist.", e);
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
@@ -599,14 +599,14 @@ public class ClientContext implements AccumuloClient {
    */
   public synchronized TableId getTableId(String tableName) throws TableNotFoundException {
     ensureOpen();
-    Pair<String,String> qualified = TableNameUtil.qualify(tableName);
+    var qualified = TableNameUtil.qualify(tableName);
     NamespaceId nid;
     try {
-      nid = getNamespaceId(qualified.getFirst());
+      nid = getNamespaceId(qualified.namespaceName());
     } catch (NamespaceNotFoundException e) {
       throw new TableNotFoundException(tableName, e);
     }
-    TableId tid = getTableMapping(nid).getNameToIdMap().get(qualified.getSecond());
+    TableId tid = getTableMapping(nid).getNameToIdMap().get(qualified.tableName());
     if (tid == null) {
       throw new TableNotFoundException(null, tableName,
           "No entry for this table found in the given namespace mapping");

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -2265,7 +2265,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
 
   @Override
   public String getNamespace(String table) {
-    return TableNameUtil.qualify(table).getFirst();
+    return TableNameUtil.qualify(table).namespaceName();
   }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/util/Validators.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/Validators.java
@@ -167,16 +167,16 @@ public class Validators {
   });
 
   public static final Validator<String> NOT_BUILTIN_TABLE = new Validator<>(t -> {
-    if (Namespace.ACCUMULO.name().equals(TableNameUtil.qualify(t).getFirst())) {
+    if (Namespace.ACCUMULO.name().equals(TableNameUtil.qualify(t).namespaceName())) {
       return Optional.of("Table must not be in the '" + Namespace.ACCUMULO.name() + "' namespace");
     }
     return Validator.OK;
   });
 
   public static Validator<String> sameNamespaceAs(String oldTableName) {
-    final String oldNamespace = TableNameUtil.qualify(oldTableName).getFirst();
+    final String oldNamespace = TableNameUtil.qualify(oldTableName).namespaceName();
     return new Validator<>(newName -> {
-      if (!oldNamespace.equals(TableNameUtil.qualify(newName).getFirst())) {
+      if (!oldNamespace.equals(TableNameUtil.qualify(newName).namespaceName())) {
         return Optional
             .of("Unable to move tables to a new namespace by renaming. The namespace for " + newName
                 + " does not match " + oldTableName);

--- a/core/src/main/java/org/apache/accumulo/core/util/tables/TableMapping.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/tables/TableMapping.java
@@ -65,7 +65,7 @@ public class TableMapping {
           "Putting built-in tables into the Accumulo namespace table map after init should not be possible");
     }
     requireNonNull(tableId);
-    var rawTableName = TableNameUtil.qualify(requireNonNull(tableName)).getSecond();
+    var rawTableName = TableNameUtil.qualify(requireNonNull(tableName)).tableName();
     requireNonNull(operation);
     context.getZooSession().asReaderWriter().mutateExisting(mappingPath, data -> {
       var tables = deserializeMap(data);
@@ -112,8 +112,8 @@ public class TableMapping {
           "Renaming built-in tables in the Accumulo namespace table map should not be possible");
     }
     requireNonNull(tableId);
-    var rawOldName = TableNameUtil.qualify(requireNonNull(oldName)).getSecond();
-    var rawNewName = TableNameUtil.qualify(requireNonNull(newName)).getSecond();
+    var rawOldName = TableNameUtil.qualify(requireNonNull(oldName)).tableName();
+    var rawNewName = TableNameUtil.qualify(requireNonNull(newName)).tableName();
     context.getZooSession().asReaderWriter().mutateExisting(mappingPath, data -> {
       var tables = deserializeMap(data);
       final String currentName = tables.get(tableId.canonical());

--- a/core/src/main/java/org/apache/accumulo/core/util/tables/TableNameUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/tables/TableNameUtil.java
@@ -21,35 +21,37 @@ package org.apache.accumulo.core.util.tables;
 import static org.apache.accumulo.core.util.Validators.EXISTING_TABLE_NAME;
 
 import org.apache.accumulo.core.clientImpl.Namespace;
-import org.apache.accumulo.core.util.Pair;
 
 public class TableNameUtil {
   // static utility only; don't allow instantiation
   private TableNameUtil() {}
+
+  public record QualifiedTableName(String namespaceName, String tableName) {
+  }
 
   public static String qualified(String tableName) {
     return qualified(tableName, Namespace.DEFAULT.name());
   }
 
   public static String qualified(String tableName, String defaultNamespace) {
-    Pair<String,String> qualifiedTableName = qualify(tableName, defaultNamespace);
-    if (Namespace.DEFAULT.name().equals(qualifiedTableName.getFirst())) {
-      return qualifiedTableName.getSecond();
+    QualifiedTableName qualifiedTableName = qualify(tableName, defaultNamespace);
+    if (Namespace.DEFAULT.name().equals(qualifiedTableName.namespaceName())) {
+      return qualifiedTableName.tableName();
     } else {
-      return qualifiedTableName.toString("", ".", "");
+      return qualifiedTableName.namespaceName() + "." + qualifiedTableName.tableName();
     }
   }
 
-  public static Pair<String,String> qualify(String tableName) {
+  public static QualifiedTableName qualify(String tableName) {
     return qualify(tableName, Namespace.DEFAULT.name());
   }
 
-  private static Pair<String,String> qualify(String tableName, String defaultNamespace) {
+  private static QualifiedTableName qualify(String tableName, String defaultNamespace) {
     EXISTING_TABLE_NAME.validate(tableName);
     if (tableName.contains(".")) {
       String[] s = tableName.split("\\.", 2);
-      return new Pair<>(s[0], s[1]);
+      return new QualifiedTableName(s[0], s[1]);
     }
-    return new Pair<>(defaultNamespace, tableName);
+    return new QualifiedTableName(defaultNamespace, tableName);
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
@@ -229,7 +229,7 @@ class FateServiceHandler implements FateService.Iface {
           }
         }
         NamespaceId namespaceId = ClientServiceHandler.checkNamespaceId(manager.getContext(),
-            TableNameUtil.qualify(tableName).getFirst(), tableOp);
+            TableNameUtil.qualify(tableName).namespaceName(), tableOp);
 
         if (!security.canCreateTable(c, tableName, namespaceId)) {
           throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
@@ -318,7 +318,7 @@ class FateServiceHandler implements FateService.Iface {
         }
 
         NamespaceId namespaceId = ClientServiceHandler.checkNamespaceId(manager.getContext(),
-            TableNameUtil.qualify(tableName).getFirst(), tableOp);
+            TableNameUtil.qualify(tableName).namespaceName(), tableOp);
 
         final boolean canCloneTable;
         try {
@@ -593,7 +593,7 @@ class FateServiceHandler implements FateService.Iface {
         List<ByteBuffer> exportDirArgs = arguments.stream().skip(3).collect(Collectors.toList());
         Set<String> exportDirs = ByteBufferUtil.toStringSet(exportDirArgs);
         NamespaceId namespaceId = ClientServiceHandler.checkNamespaceId(manager.getContext(),
-            TableNameUtil.qualify(tableName).getFirst(), tableOp);
+            TableNameUtil.qualify(tableName).namespaceName(), tableOp);
 
         final boolean canImport;
         try {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/rename/RenameTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/rename/RenameTable.java
@@ -27,7 +27,6 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.FateId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.fate.zookeeper.DistributedReadWriteLock.LockType;
-import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.core.util.tables.TableNameUtil;
 import org.apache.accumulo.manager.tableOps.AbstractFateOperation;
 import org.apache.accumulo.manager.tableOps.FateEnv;
@@ -62,13 +61,13 @@ public class RenameTable extends AbstractFateOperation {
 
   @Override
   public Repo<FateEnv> call(FateId fateId, FateEnv env) throws Exception {
-    Pair<String,String> qualifiedOldTableName = TableNameUtil.qualify(oldTableName);
+    var qualifiedOldTableName = TableNameUtil.qualify(oldTableName);
     // the namespace name was already checked before starting the fate operation
-    String newSimpleTableName = TableNameUtil.qualify(newTableName).getSecond();
+    String newSimpleTableName = TableNameUtil.qualify(newTableName).tableName();
     var context = env.getContext();
 
     try {
-      context.getTableMapping(namespaceId).rename(tableId, qualifiedOldTableName.getSecond(),
+      context.getTableMapping(namespaceId).rename(tableId, qualifiedOldTableName.tableName(),
           newSimpleTableName);
 
       context.clearTableListCache();

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader11to12.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader11to12.java
@@ -79,7 +79,6 @@ import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.core.schema.Section;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.Encoding;
-import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.core.util.TextUtil;
 import org.apache.accumulo.core.util.compaction.CompactionServicesConfig;
 import org.apache.accumulo.core.util.tables.TableNameUtil;
@@ -611,8 +610,8 @@ public class Upgrader11to12 implements Upgrader {
     // state gets created last
     LOG.debug("Creating ZooKeeper entries for new table {} (ID: {}) in namespace (ID: {})",
         tableName, tableId, namespaceId);
-    Pair<String,String> qualifiedTableName = TableNameUtil.qualify(tableName);
-    tableName = qualifiedTableName.getSecond();
+    var qualifiedTableName = TableNameUtil.qualify(tableName);
+    tableName = qualifiedTableName.tableName();
     String zTablePath = Constants.ZTABLES + "/" + tableId;
     final ZooReaderWriter zoo = context.getZooSession().asReaderWriter();
     zoo.putPersistentData(zTablePath, new byte[0], existsPolicy);

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ConfigCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ConfigCommand.java
@@ -266,7 +266,7 @@ public class ConfigCommand extends Command {
 
       final TreeMap<String,String> namespaceConfig = new TreeMap<>();
       if (tableName != null) {
-        String n = TableNameUtil.qualify(tableName).getFirst();
+        String n = TableNameUtil.qualify(tableName).namespaceName();
         try {
           namespaceConfig
               .putAll(shellState.getAccumuloClient().namespaceOperations().getConfiguration(n));

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteTableCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteTableCommand.java
@@ -22,7 +22,6 @@ import java.util.Iterator;
 import java.util.Set;
 
 import org.apache.accumulo.core.clientImpl.Namespace;
-import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.core.util.tables.TableNameUtil;
 import org.apache.accumulo.shell.Shell;
 import org.apache.commons.cli.CommandLine;
@@ -73,8 +72,8 @@ public class DeleteTableCommand extends TableOperation {
     Iterator<String> tableNames = tables.iterator();
     while (tableNames.hasNext()) {
       String table = tableNames.next();
-      Pair<String,String> qualifiedName = TableNameUtil.qualify(table);
-      if (Namespace.ACCUMULO.name().equals(qualifiedName.getFirst())) {
+      var qualifiedName = TableNameUtil.qualify(table);
+      if (Namespace.ACCUMULO.name().equals(qualifiedName.namespaceName())) {
         Shell.log.trace("Removing table from deletion set: {}", table);
         tableNames.remove();
       }

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/TablesCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/TablesCommand.java
@@ -54,7 +54,7 @@ public class TablesCommand extends Command {
 
     // filter only specified namespace
     tables = Maps.filterKeys(tables, tableName -> namespace == null
-        || TableNameUtil.qualify(tableName).getFirst().equals(namespace));
+        || TableNameUtil.qualify(tableName).namespaceName().equals(namespace));
 
     final boolean sortByTableId = cl.hasOption(sortByTableIdOption.getOpt());
     tables = new TreeMap<>((sortByTableId ? MapUtils.invertMap(tables) : tables));
@@ -63,7 +63,7 @@ public class TablesCommand extends Command {
       String tableName = String.valueOf(sortByTableId ? entry.getValue() : entry.getKey());
       String tableId = String.valueOf(sortByTableId ? entry.getKey() : entry.getValue());
       if (namespace != null) {
-        tableName = TableNameUtil.qualify(tableName).getSecond();
+        tableName = TableNameUtil.qualify(tableName).tableName();
       }
       if (cl.hasOption(tableIdOption.getOpt())) {
         return String.format(NAME_AND_ID_FORMAT, tableName, tableId);

--- a/test/src/main/java/org/apache/accumulo/test/NamespacesIT_SimpleSuite.java
+++ b/test/src/main/java/org/apache/accumulo/test/NamespacesIT_SimpleSuite.java
@@ -130,7 +130,7 @@ public class NamespacesIT_SimpleSuite extends SharedMiniClusterBase {
     }
     // clean up any added tables, namespaces, and users, after each test
     for (String t : c.tableOperations().list()) {
-      if (!TableNameUtil.qualify(t).getFirst().equals(Namespace.ACCUMULO.name())) {
+      if (!TableNameUtil.qualify(t).namespaceName().equals(Namespace.ACCUMULO.name())) {
         c.tableOperations().delete(t);
       }
     }


### PR DESCRIPTION
Fixes #5907 

Replaces `TableNameUtil.qualify`'s `Pair<String,String>` return type with `QualifiedTableName` record so callers can use `namespaceName()` and `tableName()` instead of `getFirst()` and `getSecond()`.