### PR TITLE
Reduce HostRegexTableLoadBalancer RPCs for OOB checks

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancer.java
@@ -421,6 +421,14 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer {
                   + " it may have been deleted or renamed.", table);
               continue;
             }
+            // If current information in the Manager indicates that the tserver
+            // is not hosting tablets for the table, then move on to the next
+            // tserver
+            if (e.getValue().getTableMap() != null
+                && !e.getValue().getTableMap().containsKey(tid.canonical())) {
+              LOG.debug("TServer {} is not hosting any tablets for table {}", e.getKey(), table);
+              continue;
+            }
             try {
               List<TabletStatistics> outOfBoundsTablets = getOnlineTabletsForTable(e.getKey(), tid);
               if (outOfBoundsTablets == null) {


### PR DESCRIPTION
The StatusThread.updateStatus() method in the Manager calls gatherTableInformation to get information about all of the TabletServers in the cluster, then calls balanceTablets().

balanceTablets() creates a partitioned view of the status information and uses that when creating the BalanceParams to pass to table balancer's balance().

The HostRegexTableLoadBalancer.balance method will periodically check for tablets that are hosted outside of the defined regex. Prior to this change it was making an RPC call to every tablet server outside of the defined regex.

This change uses the gathered tablet server information such that the RPC call is made to the tablet server if the information indicates that the tablet server is hosting tablets for the table. The RPC is necessary to get the extent information to create the migrations, but it's only necessary when the tablet server is hosting tablets for the table.