### PR TITLE
Monitor scan page improvements

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/scans.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/scans.js
@@ -57,6 +57,15 @@ $(function () {
         }
       },
       {
+        "targets": "scan-state",
+        "render": function (data, type) {
+          if (type === 'display') {
+            return renderActivityState(data === 'IDLE' ? 1 : 0, type);
+          }
+          return data;
+        }
+      },
+      {
         "targets": "date",
         "render": function (data, type, row) {
           if (type === 'display') data = dateFormat(data);
@@ -100,6 +109,8 @@ $(function () {
       }
     ]
   });
+
+  refresh();
 });
 
 

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/scans.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/scans.ftl
@@ -32,10 +32,10 @@
                 <th>Session ID</th>
                 <th>Client</th>
                 <th>User</th>
-                <th>Scan State</th>
+                <th class="scan-state">Scan State</th>
                 <th>Scan Type</th>
-                <th>Age</th>
-                <th>Idle Time</th>
+                <th class="duration">Age</th>
+                <th class="duration">Idle Time</th>
               </tr>
             </thead>
             <tbody></tbody>


### PR DESCRIPTION
This PR...
* calls `refresh()` on page load. Before this only auto-refresh would load the data so that needed to be enabled for things to work on this page
* added duration formatting for the Age and Idle Time columns
* added the existing idle icon renderer to the Scan State column

The formatting changes are visible here:
<img width="1339" height="301" alt="Screenshot_2026-06-25_18-08-54" src="https://github.com/user-attachments/assets/a6b956b4-937b-4996-a4bb-958fe8d6d79c" />
