### PR TITLE
Create ArrayList with initial sizes where possible

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/IsolatedScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/IsolatedScanner.java
@@ -143,7 +143,7 @@ public class IsolatedScanner extends ScannerOptions implements Scanner {
       this.batchSize = batchSize;
       this.readaheadThreshold = readaheadThreshold;
 
-      buffer = bufferFactory.newBuffer();
+      buffer = bufferFactory.newBuffer(this.batchSize);
 
       this.source = newIterator(range);
 
@@ -172,11 +172,11 @@ public class IsolatedScanner extends ScannerOptions implements Scanner {
 
   }
 
-  public interface RowBufferFactory {
-    RowBuffer newBuffer();
+  private interface RowBufferFactory {
+    RowBuffer newBuffer(int initialSize);
   }
 
-  public interface RowBuffer extends Iterable<Entry<Key,Value>> {
+  private interface RowBuffer extends Iterable<Entry<Key,Value>> {
     void add(Entry<Key,Value> entry);
 
     @Override
@@ -185,17 +185,21 @@ public class IsolatedScanner extends ScannerOptions implements Scanner {
     void clear();
   }
 
-  public static class MemoryRowBufferFactory implements RowBufferFactory {
+  private static class MemoryRowBufferFactory implements RowBufferFactory {
 
     @Override
-    public RowBuffer newBuffer() {
-      return new MemoryRowBuffer();
+    public RowBuffer newBuffer(int initialSize) {
+      return new MemoryRowBuffer(initialSize);
     }
   }
 
   public static class MemoryRowBuffer implements RowBuffer {
 
-    private final ArrayList<Entry<Key,Value>> buffer = new ArrayList<>();
+    private final ArrayList<Entry<Key,Value>> buffer;
+
+    private MemoryRowBuffer(int initialSize) {
+      buffer = new ArrayList<>(initialSize);
+    }
 
     @Override
     public void add(Entry<Key,Value> entry) {

--- a/core/src/main/java/org/apache/accumulo/core/client/IsolatedScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/IsolatedScanner.java
@@ -172,11 +172,11 @@ public class IsolatedScanner extends ScannerOptions implements Scanner {
 
   }
 
-  private interface RowBufferFactory {
+  public interface RowBufferFactory {
     RowBuffer newBuffer(int initialSize);
   }
 
-  private interface RowBuffer extends Iterable<Entry<Key,Value>> {
+  public interface RowBuffer extends Iterable<Entry<Key,Value>> {
     void add(Entry<Key,Value> entry);
 
     @Override
@@ -185,7 +185,7 @@ public class IsolatedScanner extends ScannerOptions implements Scanner {
     void clear();
   }
 
-  private static class MemoryRowBufferFactory implements RowBufferFactory {
+  public static class MemoryRowBufferFactory implements RowBufferFactory {
 
     @Override
     public RowBuffer newBuffer(int initialSize) {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
@@ -229,9 +229,10 @@ public class InstanceOperationsImpl implements InstanceOperations {
   @Override
   public List<String> getTabletServers() {
     ZooCache cache = context.getZooCache();
-    String path = context.getZooKeeperRoot() + Constants.ZTSERVERS;
-    List<String> results = new ArrayList<>();
-    for (String candidate : cache.getChildren(path)) {
+    final String path = context.getZooKeeperRoot() + Constants.ZTSERVERS;
+    final List<String> candidates = cache.getChildren(path);
+    final List<String> results = new ArrayList<>(candidates.size());
+    for (String candidate : candidates) {
       var children = cache.getChildren(path + "/" + candidate);
       if (children != null && !children.isEmpty()) {
         var copy = new ArrayList<>(children);
@@ -253,8 +254,9 @@ public class InstanceOperationsImpl implements InstanceOperations {
     try {
       client = getClient(ThriftClientTypes.TABLET_SCAN, parsedTserver, context);
 
-      List<ActiveScan> as = new ArrayList<>();
-      for (var activeScan : client.getActiveScans(TraceUtil.traceInfo(), context.rpcCreds())) {
+      final var scans = client.getActiveScans(TraceUtil.traceInfo(), context.rpcCreds());
+      List<ActiveScan> as = new ArrayList<>(scans.size());
+      for (var activeScan : scans) {
         try {
           as.add(new ActiveScanImpl(context, activeScan));
         } catch (TableNotFoundException e) {
@@ -326,7 +328,7 @@ public class InstanceOperationsImpl implements InstanceOperations {
     var executorService = context.threadPools().getPoolBuilder(INSTANCE_OPS_COMPACTIONS_FINDER_POOL)
         .numCoreThreads(numThreads).build();
     try {
-      List<Future<List<ActiveCompaction>>> futures = new ArrayList<>();
+      List<Future<List<ActiveCompaction>>> futures = new ArrayList<>(tservers.size());
 
       for (String tserver : tservers) {
         futures.add(executorService.submit(() -> getActiveCompactions(tserver)));
@@ -344,7 +346,7 @@ public class InstanceOperationsImpl implements InstanceOperations {
         }
       });
 
-      List<ActiveCompaction> ret = new ArrayList<>();
+      List<ActiveCompaction> ret = new ArrayList<>(futures.size());
       for (Future<List<ActiveCompaction>> future : futures) {
         try {
           ret.addAll(future.get());

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java
@@ -303,7 +303,7 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
       binnedRanges2.put(entry.getKey(), tabletMap);
       for (Entry<KeyExtent,List<Range>> tabletRanges : entry.getValue().entrySet()) {
         Range tabletRange = tabletRanges.getKey().toDataRange();
-        List<Range> clippedRanges = new ArrayList<>();
+        List<Range> clippedRanges = new ArrayList<>(tabletRanges.getValue().size());
         tabletMap.put(tabletRanges.getKey(), clippedRanges);
         for (Range range : tabletRanges.getValue()) {
           clippedRanges.add(tabletRange.clip(range));
@@ -339,7 +339,7 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
     failSleepTime = Math.min(5000, failSleepTime * 2);
 
     Map<String,Map<KeyExtent,List<Range>>> binnedRanges = new HashMap<>();
-    List<Range> allRanges = new ArrayList<>();
+    List<Range> allRanges = new ArrayList<>(failures.values().stream().mapToInt(List::size).sum());
 
     for (List<Range> ranges : failures.values()) {
       allRanges.addAll(ranges);
@@ -562,7 +562,7 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
     List<String> locations = new ArrayList<>(binnedRanges.keySet());
     Collections.shuffle(locations);
 
-    List<QueryTask> queryTasks = new ArrayList<>();
+    List<QueryTask> queryTasks = new ArrayList<>(locations.size());
 
     for (final String tsLocation : locations) {
 
@@ -828,7 +828,7 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
 
     // copy requested to unscanned map. we will remove ranges as they are scanned in trackScanning()
     for (Entry<KeyExtent,List<Range>> entry : requested.entrySet()) {
-      ArrayList<Range> ranges = new ArrayList<>();
+      ArrayList<Range> ranges = new ArrayList<>(entry.getValue().size());
       for (Range range : entry.getValue()) {
         ranges.add(new Range(range));
       }

--- a/core/src/main/java/org/apache/accumulo/core/data/Mutation.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Mutation.java
@@ -1440,8 +1440,8 @@ public class Mutation implements Writable {
 
     boolean valuesPresent = (first & 0x01) == 0x01;
     if (valuesPresent) {
-      values = new ArrayList<>();
       int numValues = WritableUtils.readVInt(in);
+      values = new ArrayList<>(numValues);
       for (int i = 0; i < numValues; i++) {
         len = WritableUtils.readVInt(in);
         byte[] val = new byte[len];
@@ -1480,8 +1480,8 @@ public class Mutation implements Writable {
     List<byte[]> localValues;
     boolean valuesPresent = in.readBoolean();
     if (valuesPresent) {
-      localValues = new ArrayList<>();
       int numValues = in.readInt();
+      localValues = new ArrayList<>(numValues);
       for (int i = 0; i < numValues; i++) {
         len = in.readInt();
         byte[] val = new byte[len];

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/MultiLevelIndex.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/MultiLevelIndex.java
@@ -361,7 +361,7 @@ public class MultiLevelIndex {
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         DataOutputStream dos = new DataOutputStream(baos);
-        ArrayList<Integer> oal = new ArrayList<>();
+        ArrayList<Integer> oal = new ArrayList<>(size);
 
         for (int i = 0; i < size; i++) {
           IndexEntry ie = new IndexEntry(false);

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/IteratorConfigUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/IteratorConfigUtil.java
@@ -196,8 +196,8 @@ public class IteratorConfigUtil {
       List<IteratorSetting> iterators, IteratorEnvironment env)
       throws IOException, ReflectiveOperationException {
 
-    List<IterInfo> ssiList = new ArrayList<>();
-    Map<String,Map<String,String>> ssio = new HashMap<>();
+    List<IterInfo> ssiList = new ArrayList<>(iterators.size());
+    Map<String,Map<String,String>> ssio = new HashMap<>(iterators.size());
 
     for (IteratorSetting is : iterators) {
       ssiList.add(new IterInfo(is.getPriority(), is.getIteratorClass(), is.getName()));

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/SystemIteratorUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/SystemIteratorUtil.java
@@ -53,7 +53,7 @@ public class SystemIteratorUtil {
   }
 
   public static IteratorConfig toIteratorConfig(List<IteratorSetting> iterators) {
-    ArrayList<TIteratorSetting> tisList = new ArrayList<>();
+    ArrayList<TIteratorSetting> tisList = new ArrayList<>(iterators.size());
 
     for (IteratorSetting iteratorSetting : iterators) {
       tisList.add(toTIteratorSetting(iteratorSetting));
@@ -63,7 +63,7 @@ public class SystemIteratorUtil {
   }
 
   public static List<IteratorSetting> toIteratorSettings(IteratorConfig ic) {
-    List<IteratorSetting> ret = new ArrayList<>();
+    List<IteratorSetting> ret = new ArrayList<>(ic.getIterators().size());
     for (TIteratorSetting tIteratorSetting : ic.getIterators()) {
       ret.add(toIteratorSetting(tIteratorSetting));
     }

--- a/core/src/main/java/org/apache/accumulo/core/rpc/clients/TServerClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/clients/TServerClient.java
@@ -72,9 +72,8 @@ public interface TServerClient<C extends TServiceClient> {
 
     final long rpcTimeout = context.getClientTimeoutInMillis();
     final ZooCache zc = context.getZooCache();
-    final List<String> tservers = new ArrayList<>();
-
-    tservers.addAll(zc.getChildren(context.getZooKeeperRoot() + Constants.ZTSERVERS));
+    final List<String> tservers =
+        new ArrayList<>(zc.getChildren(context.getZooKeeperRoot() + Constants.ZTSERVERS));
 
     if (tservers.isEmpty()) {
       if (warned.compareAndSet(false, true)) {

--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/GroupBalancer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/GroupBalancer.java
@@ -143,7 +143,8 @@ public abstract class GroupBalancer implements TabletBalancer {
 
     Function<TabletId,String> partitioner = getLoggingPartitioner();
 
-    List<ComparablePair<String,TabletId>> tabletsByGroup = new ArrayList<>();
+    List<ComparablePair<String,TabletId>> tabletsByGroup =
+        new ArrayList<>(params.unassignedTablets().size());
     for (Entry<TabletId,TabletServerId> entry : params.unassignedTablets().entrySet()) {
       TabletServerId last = entry.getValue();
       if (last != null) {

--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/SimpleLoadBalancer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/SimpleLoadBalancer.java
@@ -168,7 +168,7 @@ public class SimpleLoadBalancer implements TabletBalancer {
 
       // Sort by total number of online tablets, per server
       int total = 0;
-      ArrayList<ServerCounts> totals = new ArrayList<>();
+      ArrayList<ServerCounts> totals = new ArrayList<>(current.size());
       for (Entry<TabletServerId,TServerStatus> entry : current.entrySet()) {
         int serverTotal = 0;
         if (entry.getValue() != null && entry.getValue().getTableMap() != null) {
@@ -241,11 +241,11 @@ public class SimpleLoadBalancer implements TabletBalancer {
   List<TabletMigration> move(ServerCounts tooMuch, ServerCounts tooLittle, int count,
       Map<TableId,Map<TabletId,TabletStatistics>> donerTabletStats) {
 
-    if (count == 0) {
+    if (count <= 0) {
       return Collections.emptyList();
     }
 
-    List<TabletMigration> result = new ArrayList<>();
+    List<TabletMigration> result = new ArrayList<>(count);
     // Copy counts so we can update them as we propose migrations
     Map<TableId,Integer> tooMuchMap = tabletCountsPerTable(tooMuch.status);
     Map<TableId,Integer> tooLittleMap = tabletCountsPerTable(tooLittle.status);

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
@@ -180,7 +180,7 @@ public class DefaultCompactionPlanner implements CompactionPlanner {
       ExecutorConfig[] execConfigs =
           new Gson().fromJson(params.getOptions().get("executors"), ExecutorConfig[].class);
 
-      List<Executor> tmpExec = new ArrayList<>();
+      List<Executor> tmpExec = new ArrayList<>(execConfigs.length);
 
       for (ExecutorConfig executorConfig : execConfigs) {
         Long maxSize = executorConfig.maxSize == null ? null

--- a/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
@@ -359,7 +359,7 @@ public class Gatherer {
         Map<String,Map<TabletFile,List<TRowRange>>> filesGBL;
         filesGBL = getFilesGroupedByLocation(fileSelector);
 
-        List<CompletableFuture<ProcessedFiles>> futures = new ArrayList<>();
+        List<CompletableFuture<ProcessedFiles>> futures = new ArrayList<>(filesGBL.size() + 1);
         if (previousWork != null) {
           futures.add(CompletableFuture
               .completedFuture(new ProcessedFiles(previousWork.summaries, factory)));
@@ -433,7 +433,7 @@ public class Gatherer {
   public Future<SummaryCollection> processFiles(FileSystemResolver volMgr,
       Map<String,List<TRowRange>> files, BlockCache summaryCache, BlockCache indexCache,
       Cache<String,Long> fileLenCache, ExecutorService srp) {
-    List<CompletableFuture<SummaryCollection>> futures = new ArrayList<>();
+    List<CompletableFuture<SummaryCollection>> futures = new ArrayList<>(files.size());
     for (Entry<String,List<TRowRange>> entry : files.entrySet()) {
       futures.add(CompletableFuture.supplyAsync(() -> {
         List<RowRange> rrl =
@@ -504,7 +504,7 @@ public class Gatherer {
     // have each tablet server process ~100K files
     int numRequest = Math.max(numFiles / 100_000, 1);
 
-    List<CompletableFuture<SummaryCollection>> futures = new ArrayList<>();
+    List<CompletableFuture<SummaryCollection>> futures = new ArrayList<>(numRequest);
 
     AtomicBoolean cancelFlag = new AtomicBoolean(false);
 

--- a/core/src/main/java/org/apache/accumulo/core/util/ByteArraySet.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/ByteArraySet.java
@@ -40,7 +40,7 @@ public class ByteArraySet extends TreeSet<byte[]> {
   }
 
   public static ByteArraySet fromStrings(Collection<String> c) {
-    List<byte[]> lst = new ArrayList<>();
+    List<byte[]> lst = new ArrayList<>(c.size());
     for (String s : c) {
       lst.add(s.getBytes(UTF_8));
     }

--- a/core/src/main/java/org/apache/accumulo/core/util/ByteBufferUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/ByteBufferUtil.java
@@ -56,7 +56,7 @@ public class ByteBufferUtil {
     if (bytesList == null) {
       return null;
     }
-    ArrayList<ByteBuffer> result = new ArrayList<>();
+    ArrayList<ByteBuffer> result = new ArrayList<>(bytesList.size());
     for (byte[] bytes : bytesList) {
       result.add(ByteBuffer.wrap(bytes));
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/compaction/FileCompactor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/compaction/FileCompactor.java
@@ -263,7 +263,7 @@ public class FileCompactor implements Callable<CompactionStats> {
       Collections.synchronizedSet(new HashSet<>());
 
   public static List<CompactionInfo> getRunningCompactions() {
-    ArrayList<CompactionInfo> compactions = new ArrayList<>();
+    ArrayList<CompactionInfo> compactions = new ArrayList<>(runningCompactions.size());
 
     runningCompactions.forEach(compactor -> compactions.add(new CompactionInfo(compactor)));
 

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/FileManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/FileManager.java
@@ -187,7 +187,7 @@ public class FileManager {
 
   private List<FileSKVIterator> takeLRUOpenFiles(int numToTake) {
 
-    ArrayList<OpenReader> openReaders = new ArrayList<>();
+    ArrayList<OpenReader> openReaders = new ArrayList<>(openFiles.size());
 
     for (Entry<String,List<OpenReader>> entry : openFiles.entrySet()) {
       openReaders.addAll(entry.getValue());
@@ -195,7 +195,7 @@ public class FileManager {
 
     Collections.sort(openReaders);
 
-    ArrayList<FileSKVIterator> ret = new ArrayList<>();
+    ArrayList<FileSKVIterator> ret = new ArrayList<>(openReaders.size());
 
     for (int i = 0; i < numToTake && i < openReaders.size(); i++) {
       OpenReader or = openReaders.get(i);
@@ -517,7 +517,7 @@ public class FileManager {
       Map<FileSKVIterator,String> newlyReservedReaders = openFiles(
           files.keySet().stream().map(TabletFile::getPathStr).collect(Collectors.toList()));
 
-      ArrayList<InterruptibleIterator> iters = new ArrayList<>();
+      ArrayList<InterruptibleIterator> iters = new ArrayList<>(newlyReservedReaders.size());
 
       boolean sawTimeSet = files.values().stream().anyMatch(DataFileValue::isTimeSet);
 

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManagerImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManagerImpl.java
@@ -322,7 +322,7 @@ public class VolumeManagerImpl implements VolumeManager {
   @Override
   public void bulkRename(Map<Path,Path> oldToNewPathMap, int poolSize, String poolName,
       String transactionId) throws IOException {
-    List<Future<Void>> results = new ArrayList<>();
+    List<Future<Void>> results = new ArrayList<>(oldToNewPathMap.size());
     ExecutorService workerPool = ThreadPools.getServerThreadPools().getPoolBuilder(poolName)
         .numCoreThreads(poolSize).build();
     oldToNewPathMap.forEach((oldPath, newPath) -> results.add(workerPool.submit(() -> {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
@@ -375,7 +375,6 @@ public class MetadataTableUtil {
 
   public static Pair<List<LogEntry>,SortedMap<StoredTabletFile,DataFileValue>>
       getFileAndLogEntries(ServerContext context, KeyExtent extent) throws IOException {
-    ArrayList<LogEntry> result = new ArrayList<>();
     TreeMap<StoredTabletFile,DataFileValue> sizes = new TreeMap<>();
 
     TabletMetadata tablet = context.getAmple().readTablet(extent, FILES, LOGS, PREV_ROW, DIR);
@@ -384,7 +383,7 @@ public class MetadataTableUtil {
       throw new RuntimeException("Tablet " + extent + " not found in metadata");
     }
 
-    result.addAll(tablet.getLogs());
+    ArrayList<LogEntry> result = new ArrayList<>(tablet.getLogs());
 
     tablet.getFilesMap().forEach(sizes::put);
 

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionFinalizer.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionFinalizer.java
@@ -193,13 +193,14 @@ public class CompactionFinalizer {
 
     while (!Thread.interrupted()) {
       try {
-        ArrayList<ExternalCompactionFinalState> batch = new ArrayList<>();
+        ArrayList<ExternalCompactionFinalState> batch =
+            new ArrayList<>(pendingNotifications.size());
         batch.add(pendingNotifications.take());
         pendingNotifications.drainTo(batch);
 
         LOG.trace("Processing pending of batch size {}", batch.size());
 
-        List<Future<?>> futures = new ArrayList<>();
+        List<Future<?>> futures = new ArrayList<>(batch.size());
 
         List<ExternalCompactionId> statusesToDelete = new ArrayList<>();
 

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/SharedBatchWriter.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/SharedBatchWriter.java
@@ -83,7 +83,7 @@ public class SharedBatchWriter {
   private void processMutations() {
     Timer timer = Timer.startNew();
     while (true) {
-      ArrayList<Work> batch = new ArrayList<>();
+      ArrayList<Work> batch = new ArrayList<>(mutations.size());
       try {
         batch.add(mutations.take());
       } catch (InterruptedException e) {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/ManagerClientServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/ManagerClientServiceHandler.java
@@ -626,7 +626,7 @@ public class ManagerClientServiceHandler implements ManagerClientService.Iface {
     }
 
     Set<TServerInstance> tserverInstances = manager.onlineTabletServers();
-    List<String> servers = new ArrayList<>();
+    List<String> servers = new ArrayList<>(tserverInstances.size());
     for (TServerInstance tserverInstance : tserverInstances) {
       servers.add(tserverInstance.getHostPort());
     }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
@@ -174,7 +174,7 @@ public class LogSorter {
       final long bufferSize = sortedLogConf.getAsBytes(prop);
       Thread.currentThread().setName("Sorting " + name + " for recovery");
       while (true) {
-        final ArrayList<Pair<LogFileKey,LogFileValue>> buffer = new ArrayList<>();
+        final ArrayList<Pair<LogFileKey,LogFileValue>> buffer = new ArrayList<>(512);
         try {
           long start = input.getPos();
           while (input.getPos() - start < bufferSize) {
@@ -274,7 +274,8 @@ public class LogSorter {
       var logFileKey = pair.getFirst();
       var logFileValue = pair.getSecond();
       Key k = logFileKey.toKey();
-      keyListMap.computeIfAbsent(k, (key) -> new ArrayList<>()).addAll(logFileValue.getMutations());
+      keyListMap.computeIfAbsent(k, (key) -> new ArrayList<>(logFileValue.getMutations().size()))
+          .addAll(logFileValue.getMutations());
     }
 
     try (var writer = FileOperations.getInstance().newWriterBuilder()
@@ -302,8 +303,8 @@ public class LogSorter {
   }
 
   public List<RecoveryStatus> getLogSorts() {
-    List<RecoveryStatus> result = new ArrayList<>();
     synchronized (currentWork) {
+      List<RecoveryStatus> result = new ArrayList<>(currentWork.size());
       for (Entry<String,LogProcessor> entries : currentWork.entrySet()) {
         RecoveryStatus status = new RecoveryStatus();
         status.name = entries.getKey();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SessionManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SessionManager.java
@@ -444,7 +444,8 @@ public class SessionManager {
 
   public List<ActiveScan> getActiveScans() {
 
-    final List<ActiveScan> activeScans = new ArrayList<>();
+    final List<ActiveScan> activeScans =
+        new ArrayList<>(sessions.size() + deferredCleanupQueue.size());
     final long ct = System.currentTimeMillis();
     final Set<Entry<Long,Session>> copiedIdleSessions = new HashSet<>();
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
@@ -697,7 +697,8 @@ public class CompactableImpl implements Compactable {
       tabletMutator.mutate();
     }
 
-    ArrayList<StoredTabletFile> extCompactingFiles = new ArrayList<>();
+    ArrayList<StoredTabletFile> extCompactingFiles = new ArrayList<>(
+        extCompactions.values().stream().mapToInt(ecm -> ecm.getJobFiles().size()).sum());
 
     extCompactions.forEach((ecid, ecMeta) -> {
       if (!extCompactionsToRemove.containsKey(ecid)) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
@@ -216,8 +216,7 @@ class ScanDataSource implements DataSource {
     }
 
     var builder = new SystemIteratorEnvironmentImpl.Builder(tablet.getContext())
-        .withTopLevelIterators(new ArrayList<>()).withScope(IteratorScope.scan)
-        .withTableId(tablet.getExtent().tableId())
+        .withScope(IteratorScope.scan).withTableId(tablet.getExtent().tableId())
         .withAuthorizations(scanParams.getAuthorizations());
     if (samplerConfig != null) {
       builder.withSamplingEnabled();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Scanner.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Scanner.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.tserver.tablet;
 
 import java.io.IOException;
-import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
@@ -142,7 +142,7 @@ public class Scanner {
 
       if (results.getResults() == null) {
         range = null;
-        return new Pair<>(new ScanBatch(new ArrayList<>(), false), dataSource);
+        return new Pair<>(new ScanBatch(List.of(), false), dataSource);
       } else if (results.getContinueKey() == null) {
         return new Pair<>(new ScanBatch(results.getResults(), false), dataSource);
       } else {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -1819,7 +1819,7 @@ public class Tablet extends TabletBase {
   public void importMapFiles(long tid, Map<TabletFile,MapFileInfo> fileMap, boolean setTime)
       throws IOException {
     Map<TabletFile,DataFileValue> entries = new HashMap<>(fileMap.size());
-    List<String> files = new ArrayList<>();
+    List<String> files = new ArrayList<>(fileMap.size());
 
     for (Entry<TabletFile,MapFileInfo> entry : fileMap.entrySet()) {
       entries.put(entry.getKey(), new DataFileValue(entry.getValue().estimatedSize, 0L));
@@ -1891,7 +1891,8 @@ public class Tablet extends TabletBase {
 
       synchronized (this) {
         // only mark the bulk import a success if no exception was thrown
-        bulkImported.computeIfAbsent(tid, k -> new ArrayList<>()).addAll(fileMap.keySet());
+        bulkImported.computeIfAbsent(tid, k -> new ArrayList<>(fileMap.size()))
+            .addAll(fileMap.keySet());
       }
 
       if (isSplitPossible()) {
@@ -1996,8 +1997,8 @@ public class Tablet extends TabletBase {
     Preconditions.checkState(logLock.isHeldByCurrentThread());
     Set<String> unusedLogs = new HashSet<>();
 
-    ArrayList<String> otherLogsCopy = new ArrayList<>();
-    ArrayList<String> currentLogsCopy = new ArrayList<>();
+    ArrayList<String> otherLogsCopy = new ArrayList<>(otherLogs.size());
+    ArrayList<String> currentLogsCopy = new ArrayList<>(currentLogs.size());
 
     synchronized (this) {
       if (removingLogs) {


### PR DESCRIPTION
Where possible set the initial size of the ArrayList when creating it to avoid the expense of the resize operation (new list creation and copy).