### PR TITLE
Revert "Use private Thrift members (#6430)"

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ActiveScanImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ActiveScanImpl.java
@@ -62,28 +62,28 @@ public final class ActiveScanImpl extends ActiveScan {
   ActiveScanImpl(ClientContext context,
       org.apache.accumulo.core.tabletscan.thrift.ActiveScan activeScan, ServerId server)
       throws TableNotFoundException {
-    this.scanId = activeScan.getScanId();
-    this.client = activeScan.getClient();
-    this.user = activeScan.getUser();
-    this.age = activeScan.getAge();
-    this.idle = activeScan.getIdleTime();
-    this.tableName = context.getQualifiedTableName(TableId.of(activeScan.getTableId()));
+    this.scanId = activeScan.scanId;
+    this.client = activeScan.client;
+    this.user = activeScan.user;
+    this.age = activeScan.age;
+    this.idle = activeScan.idleTime;
+    this.tableName = context.getQualifiedTableName(TableId.of(activeScan.tableId));
     this.type = ScanType.valueOf(activeScan.getType().name());
-    this.state = ScanState.valueOf(activeScan.getState().name());
-    this.extent = KeyExtent.fromThrift(activeScan.getExtent());
-    this.authorizations = new Authorizations(activeScan.getAuthorizations());
+    this.state = ScanState.valueOf(activeScan.state.name());
+    this.extent = KeyExtent.fromThrift(activeScan.extent);
+    this.authorizations = new Authorizations(activeScan.authorizations);
 
-    this.columns = new ArrayList<>(activeScan.getColumns().size());
+    this.columns = new ArrayList<>(activeScan.columns.size());
 
-    for (TColumn tcolumn : activeScan.getColumns()) {
+    for (TColumn tcolumn : activeScan.columns) {
       this.columns.add(new Column(tcolumn));
     }
 
     this.ssiList = new ArrayList<>();
-    for (IterInfo ii : activeScan.getSsiList()) {
-      this.ssiList.add(ii.getIterName() + "=" + ii.getPriority() + "," + ii.getClassName());
+    for (IterInfo ii : activeScan.ssiList) {
+      this.ssiList.add(ii.iterName + "=" + ii.priority + "," + ii.className);
     }
-    this.ssio = activeScan.getSsio();
+    this.ssio = activeScan.ssio;
     this.server = Objects.requireNonNull(server);
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/AuthenticationTokenIdentifier.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/AuthenticationTokenIdentifier.java
@@ -115,7 +115,7 @@ public class AuthenticationTokenIdentifier extends TokenIdentifier {
   }
 
   private void populateFields(TAuthenticationTokenIdentifier tAuthTokenId) {
-    impl.setPrincipal(tAuthTokenId.getPrincipal());
+    impl.principal = tAuthTokenId.getPrincipal();
     setExpirationDate(tAuthTokenId.getExpirationDate());
     setIssueDate(tAuthTokenId.getIssueDate());
     if (tAuthTokenId.getInstanceId() != null) {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
@@ -511,9 +511,9 @@ public class ConditionalWriterImpl implements ConditionalWriter {
     synchronized (cachedSessionIDs) {
       SessionID sid = new SessionID();
       sid.reserved = true;
-      sid.sessionID = tcs.getSessionId();
-      sid.lockId = tcs.getTserverLock();
-      sid.ttl = tcs.getTtl();
+      sid.sessionID = tcs.sessionId;
+      sid.lockId = tcs.tserverLock;
+      sid.ttl = tcs.ttl;
       sid.location = location;
       if (cachedSessionIDs.put(location, sid) != null) {
         throw new IllegalStateException();
@@ -601,13 +601,13 @@ public class ConditionalWriterImpl implements ConditionalWriter {
       ArrayList<QCMutation> ignored = new ArrayList<>();
 
       for (TCMResult tcmResult : tresults) {
-        if (tcmResult.getStatus() == TCMStatus.IGNORED) {
-          CMK cmk = cmidToCm.get(tcmResult.getCmid());
+        if (tcmResult.status == TCMStatus.IGNORED) {
+          CMK cmk = cmidToCm.get(tcmResult.cmid);
           ignored.add(cmk.cm);
           extentsToInvalidate.add(cmk.ke);
         } else {
-          QCMutation qcm = cmidToCm.get(tcmResult.getCmid()).cm;
-          qcm.queueResult(new Result(fromThrift(tcmResult.getStatus()), qcm, location.toString()));
+          QCMutation qcm = cmidToCm.get(tcmResult.cmid).cm;
+          qcm.queueResult(new Result(fromThrift(tcmResult.status), qcm, location.toString()));
         }
       }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
@@ -311,7 +311,7 @@ public class InstanceOperationsImpl implements InstanceOperations {
       }
       return as;
     } catch (ThriftSecurityException e) {
-      throw new AccumuloSecurityException(e.getUser(), e.getCode(), e);
+      throw new AccumuloSecurityException(e.user, e.code, e);
     } catch (TException e) {
       throw new AccumuloException(e);
     } finally {
@@ -365,7 +365,7 @@ public class InstanceOperationsImpl implements InstanceOperations {
       }
       return as;
     } catch (ThriftSecurityException e) {
-      throw new AccumuloSecurityException(e.getUser(), e.getCode(), e);
+      throw new AccumuloSecurityException(e.user, e.code, e);
     } catch (TException e) {
       throw new AccumuloException(e);
     }
@@ -429,7 +429,7 @@ public class InstanceOperationsImpl implements InstanceOperations {
             Thread.currentThread().interrupt();
           }
           if (e.getCause() instanceof ThriftSecurityException tse) {
-            throw new AccumuloSecurityException(tse.getUser(), tse.getCode(), e);
+            throw new AccumuloSecurityException(tse.user, tse.code, e);
           }
           throw new AccumuloException(e);
         }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerOptions.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerOptions.java
@@ -81,7 +81,7 @@ public class ScannerOptions implements ScannerBase {
     }
 
     for (IterInfo ii : serverSideIteratorList) {
-      if (ii.getIterName().equals(si.getName())) {
+      if (ii.iterName.equals(si.getName())) {
         throw new IllegalArgumentException("Iterator name is already in use " + si.getName());
       }
       if (ii.getPriority() == si.getPriority()) {
@@ -108,7 +108,7 @@ public class ScannerOptions implements ScannerBase {
     }
 
     for (IterInfo ii : serverSideIteratorList) {
-      if (ii.getIterName().equals(iteratorName)) {
+      if (ii.iterName.equals(iteratorName)) {
         serverSideIteratorList.remove(ii);
         break;
       }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -400,7 +400,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
               "Target namespace does not exist");
         default:
           String tableInfo = context.getPrintableTableInfoFromName(tableOrNamespaceName);
-          throw new AccumuloSecurityException(e.getUser(), e.getCode(), tableInfo, e);
+          throw new AccumuloSecurityException(e.user, e.code, tableInfo, e);
       }
     } catch (ThriftTableOperationException e) {
       switch (e.getType()) {
@@ -418,7 +418,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
         case BULK_CONCURRENT_MERGE:
           throw new AccumuloBulkMergeException(e);
         default:
-          throw new AccumuloException(e.getDescription(), e);
+          throw new AccumuloException(e.description, e);
       }
     } catch (Exception e) {
       throw new AccumuloException(e.getMessage(), e);
@@ -1016,12 +1016,12 @@ public class TableOperationsImpl extends TableOperationsHelper {
         throw new TableNotFoundException(tableId.canonical(), null, e.getMessage(), e);
       }
       log.debug("flush security exception on table id {}", tableId);
-      throw new AccumuloSecurityException(e.getUser(), e.getCode(), e);
+      throw new AccumuloSecurityException(e.user, e.code, e);
     } catch (ThriftTableOperationException e) {
       if (requireNonNull(e.getType()) == TableOperationExceptionType.NOTFOUND) {
         throw new TableNotFoundException(e);
       }
-      throw new AccumuloException(e.getDescription(), e);
+      throw new AccumuloException(e.description, e);
     } catch (Exception e) {
       throw new AccumuloException(e);
     }
@@ -1592,7 +1592,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
           case NAMESPACE_NOTFOUND:
             throw new TableNotFoundException(e.getTableName(), new NamespaceNotFoundException(e));
           default:
-            throw new AccumuloException(e.getDescription(), e);
+            throw new AccumuloException(e.description, e);
         }
       } catch (ThriftSecurityException e) {
         throw new AccumuloSecurityException(e.getUser(), e.getCode());
@@ -2069,8 +2069,8 @@ public class TableOperationsImpl extends TableOperationsHelper {
         TSummaries ret = ThriftClientTypes.TABLET_SERVER.execute(context, client -> {
           TSummaries tsr =
               client.startGetSummaries(TraceUtil.traceInfo(), context.rpcCreds(), request);
-          while (!tsr.isFinished()) {
-            tsr = client.contiuneGetSummaries(TraceUtil.traceInfo(), tsr.getSessionId());
+          while (!tsr.finished) {
+            tsr = client.contiuneGetSummaries(TraceUtil.traceInfo(), tsr.sessionId);
           }
           return tsr;
         });

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletMergeabilityUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletMergeabilityUtil.java
@@ -95,10 +95,10 @@ public class TabletMergeabilityUtil {
   }
 
   public static TabletMergeability fromThrift(TTabletMergeability thriftTm) {
-    if (thriftTm.isNever()) {
+    if (thriftTm.never) {
       return TabletMergeability.never();
     }
-    return TabletMergeability.after(Duration.ofNanos(thriftTm.getDelay()));
+    return TabletMergeability.after(Duration.ofNanos(thriftTm.delay));
   }
 
   public static TTabletMergeability toThrift(TabletMergeability tabletMergeability) {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java
@@ -767,7 +767,7 @@ public final class TabletServerBatchReaderIterator implements Iterator<Entry<Key
 
     // translate returned failures, remove them from unscanned, and add them to failures
     // @formatter:off
-    Map<KeyExtent, List<Range>> retFailures = scanResult.getFailures().entrySet().stream().collect(Collectors.toMap(
+    Map<KeyExtent, List<Range>> retFailures = scanResult.failures.entrySet().stream().collect(Collectors.toMap(
                     entry -> KeyExtent.fromThrift(entry.getKey()),
                     entry -> entry.getValue().stream().map(Range::new).collect(Collectors.toList())
     ));
@@ -777,25 +777,25 @@ public final class TabletServerBatchReaderIterator implements Iterator<Entry<Key
 
     // translate full scans and remove them from unscanned
     Set<KeyExtent> fullScans =
-        scanResult.getFullScans().stream().map(KeyExtent::fromThrift).collect(Collectors.toSet());
+        scanResult.fullScans.stream().map(KeyExtent::fromThrift).collect(Collectors.toSet());
     unscanned.keySet().removeAll(fullScans);
 
     // remove partial scan from unscanned
-    if (scanResult.getPartScan() != null) {
-      KeyExtent ke = KeyExtent.fromThrift(scanResult.getPartScan());
-      Key nextKey = new Key(scanResult.getPartNextKey());
+    if (scanResult.partScan != null) {
+      KeyExtent ke = KeyExtent.fromThrift(scanResult.partScan);
+      Key nextKey = new Key(scanResult.partNextKey);
 
       ListIterator<Range> iterator = unscanned.get(ke).listIterator();
       while (iterator.hasNext()) {
         Range range = iterator.next();
 
         if (range.afterEndKey(nextKey) || (nextKey.equals(range.getEndKey())
-            && scanResult.isPartNextKeyInclusive() != range.isEndKeyInclusive())) {
+            && scanResult.partNextKeyInclusive != range.isEndKeyInclusive())) {
           iterator.remove();
         } else if (range.contains(nextKey)) {
           iterator.remove();
-          Range partRange = new Range(nextKey, scanResult.isPartNextKeyInclusive(),
-              range.getEndKey(), range.isEndKeyInclusive());
+          Range partRange = new Range(nextKey, scanResult.partNextKeyInclusive, range.getEndKey(),
+              range.isEndKeyInclusive());
           iterator.add(partRange);
         }
       }
@@ -940,35 +940,33 @@ public final class TabletServerBatchReaderIterator implements Iterator<Entry<Key
             ByteBufferUtil.toByteBuffers(authorizations.getAuthorizations()), waitForWrites,
             SamplerConfigurationImpl.toThrift(options.getSamplerConfiguration()),
             options.batchTimeout, options.classLoaderContext, execHints, busyTimeout);
-        scanIdToClose = imsr.getScanID();
+        scanIdToClose = imsr.scanID;
         if (waitForWrites) {
           ThriftScanner.serversWaitedForWrites.get(ttype).add(server.toString());
         }
 
-        MultiScanResult scanResult = imsr.getResult();
+        MultiScanResult scanResult = imsr.result;
 
         if (timer != null) {
-          log.trace("Got 1st multi scan results, #results={} {} in {}",
-              scanResult.getResults().size(),
-              (scanResult.isMore() ? "scanID=" + imsr.getScanID() : ""),
+          log.trace("Got 1st multi scan results, #results={} {} in {}", scanResult.results.size(),
+              (scanResult.more ? "scanID=" + imsr.scanID : ""),
               String.format("%.3f secs", timer.elapsed(MILLISECONDS) / 1000.0));
         }
 
-        ArrayList<Entry<Key,Value>> entries = new ArrayList<>(scanResult.getResults().size());
-        for (TKeyValue kv : scanResult.getResults()) {
-          entries.add(new SimpleImmutableEntry<>(new Key(kv.getKey()), new Value(kv.getValue())));
+        ArrayList<Entry<Key,Value>> entries = new ArrayList<>(scanResult.results.size());
+        for (TKeyValue kv : scanResult.results) {
+          entries.add(new SimpleImmutableEntry<>(new Key(kv.key), new Value(kv.value)));
         }
 
         if (!entries.isEmpty()) {
           receiver.receive(entries);
         }
 
-        if (!entries.isEmpty() || !scanResult.getFullScans().isEmpty()
-            || scanResult.getPartScan() != null) {
+        if (!entries.isEmpty() || !scanResult.fullScans.isEmpty() || scanResult.partScan != null) {
           // Got some data back, finished scanning a tablet w/o getting data, or partially scanned a
           // tablet w/o getting data. Any of these indicate the scan is making progress.
           timeoutSession.madeProgress();
-        } else if (!scanResult.getFailures().isEmpty()) {
+        } else if (!scanResult.failures.isEmpty()) {
           // Observed no progress and only tablets failed. Want to eventually timeout if this
           // situation continues.
           timeoutTracker.sawOnlyFailures(timeoutSession);
@@ -978,45 +976,44 @@ public final class TabletServerBatchReaderIterator implements Iterator<Entry<Key
 
         AtomicLong nextOpid = new AtomicLong();
 
-        while (scanResult.isMore()) {
+        while (scanResult.more) {
 
           timeoutSession.check();
 
           if (timer != null) {
-            log.trace("oid={} Continuing multi scan, scanid={}", nextOpid.get(), imsr.getScanID());
+            log.trace("oid={} Continuing multi scan, scanid={}", nextOpid.get(), imsr.scanID);
             timer.restart();
           }
 
-          scanResult =
-              client.continueMultiScan(TraceUtil.traceInfo(), imsr.getScanID(), busyTimeout);
+          scanResult = client.continueMultiScan(TraceUtil.traceInfo(), imsr.scanID, busyTimeout);
 
           if (timer != null) {
             log.trace("oid={} Got more multi scan results, #results={} {} in {}",
-                nextOpid.getAndIncrement(), scanResult.getResults().size(),
-                (scanResult.isMore() ? " scanID=" + imsr.getScanID() : ""),
+                nextOpid.getAndIncrement(), scanResult.results.size(),
+                (scanResult.more ? " scanID=" + imsr.scanID : ""),
                 String.format("%.3f secs", timer.elapsed(MILLISECONDS) / 1000.0));
           }
 
-          entries = new ArrayList<>(scanResult.getResults().size());
-          for (TKeyValue kv : scanResult.getResults()) {
-            entries.add(new SimpleImmutableEntry<>(new Key(kv.getKey()), new Value(kv.getValue())));
+          entries = new ArrayList<>(scanResult.results.size());
+          for (TKeyValue kv : scanResult.results) {
+            entries.add(new SimpleImmutableEntry<>(new Key(kv.key), new Value(kv.value)));
           }
 
           if (!entries.isEmpty()) {
             receiver.receive(entries);
           }
 
-          if (!entries.isEmpty() || !scanResult.getFullScans().isEmpty()
-              || scanResult.getPartScan() != null) {
+          if (!entries.isEmpty() || !scanResult.fullScans.isEmpty()
+              || scanResult.partScan != null) {
             timeoutSession.madeProgress();
-          } else if (!scanResult.getFailures().isEmpty()) {
+          } else if (!scanResult.failures.isEmpty()) {
             timeoutTracker.sawOnlyFailures(timeoutSession);
           }
 
           trackScanning(failures, unscanned, scanResult);
         }
 
-        client.closeMultiScan(TraceUtil.traceInfo(), imsr.getScanID());
+        client.closeMultiScan(TraceUtil.traceInfo(), imsr.scanID);
         scanIdToClose = null;
 
       } finally {
@@ -1041,7 +1038,7 @@ public final class TabletServerBatchReaderIterator implements Iterator<Entry<Key
       throw new IOException(e);
     } catch (ThriftSecurityException e) {
       log.debug("Server : {} msg : {}", server, e.getMessage(), e);
-      throw new AccumuloSecurityException(e.getUser(), e.getCode(), e);
+      throw new AccumuloSecurityException(e.user, e.code, e);
     } catch (TApplicationException e) {
       log.debug("Server : {} msg : {}", server, e.getMessage(), e);
       throw new AccumuloServerException(server, e);

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchWriter.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchWriter.java
@@ -883,8 +883,8 @@ public class TabletServerBatchWriter implements AutoCloseable {
                   sessionCloser);
             } catch (ThriftSecurityException e) {
               updateAuthorizationFailures(
-                  mutationBatch.keySet().stream().collect(toMap(identity(), ke -> e.getCode())));
-              throw new AccumuloSecurityException(e.getUser(), e.getCode(), e);
+                  mutationBatch.keySet().stream().collect(toMap(identity(), ke -> e.code)));
+              throw new AccumuloSecurityException(e.user, e.code, e);
             }
 
             long st2 = System.currentTimeMillis();
@@ -984,15 +984,15 @@ public class TabletServerBatchWriter implements AutoCloseable {
           sessionCloser.clearSession();
 
         // @formatter:off
-            Map<KeyExtent,Long> failures = updateErrors.getFailedExtents().entrySet().stream().collect(toMap(
+            Map<KeyExtent,Long> failures = updateErrors.failedExtents.entrySet().stream().collect(toMap(
                             entry -> KeyExtent.fromThrift(entry.getKey()),
                             Entry::getValue
             ));
             // @formatter:on
-          updatedConstraintViolations(updateErrors.getViolationSummaries().stream()
+          updatedConstraintViolations(updateErrors.violationSummaries.stream()
               .map(ConstraintViolationSummary::new).collect(toList()));
         // @formatter:off
-            updateAuthorizationFailures(updateErrors.getAuthorizationFailures().entrySet().stream().collect(toMap(
+            updateAuthorizationFailures(updateErrors.authorizationFailures.entrySet().stream().collect(toMap(
                             entry -> KeyExtent.fromThrift(entry.getKey()),
                             Entry::getValue
             )));
@@ -1036,8 +1036,8 @@ public class TabletServerBatchWriter implements AutoCloseable {
         // no need to close the session when unretryable errors happen
         sessionCloser.clearSession();
         updateAuthorizationFailures(
-            tabMuts.keySet().stream().collect(toMap(identity(), ke -> e.getCode())));
-        throw new AccumuloSecurityException(e.getUser(), e.getCode(), e);
+            tabMuts.keySet().stream().collect(toMap(identity(), ke -> e.code)));
+        throw new AccumuloSecurityException(e.user, e.code, e);
       } catch (TException e) {
         throw new IOException(e);
       }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftScanner.java
@@ -152,15 +152,15 @@ public final class ThriftScanner {
           serversWaitedForWrites.get(ttype).add(server);
         }
 
-        Key.decompress(isr.getResult().getResults());
+        Key.decompress(isr.result.results);
 
-        for (TKeyValue kv : isr.getResult().getResults()) {
-          results.put(new Key(kv.getKey()), new Value(kv.getValue()));
+        for (TKeyValue kv : isr.result.results) {
+          results.put(new Key(kv.key), new Value(kv.value));
         }
 
-        client.closeScan(tinfo, isr.getScanID());
+        client.closeScan(tinfo, isr.scanID);
 
-        return isr.getResult().isMore();
+        return isr.result.more;
       } finally {
         ThriftUtil.returnClient(client, context);
       }
@@ -170,7 +170,7 @@ public final class ThriftScanner {
       log.debug("Tablet ({}) has too many files {} : {}", extent, server, e.getMessage());
     } catch (ThriftSecurityException e) {
       log.warn("Security Violation in scan request to {}: {}", server, e.getMessage());
-      throw new AccumuloSecurityException(e.getUser(), e.getCode(), e);
+      throw new AccumuloSecurityException(e.user, e.code, e);
     } catch (TException e) {
       log.debug("Error getting transport to {}: {}", server, e.getMessage());
     }
@@ -897,12 +897,12 @@ public final class ThriftScanner {
           serversWaitedForWrites.get(ttype).add(addr.serverAddress);
         }
 
-        sr = is.getResult();
+        sr = is.result;
 
-        if (sr.isMore()) {
-          scanState.scanID = is.getScanID();
+        if (sr.more) {
+          scanState.scanID = is.scanID;
         } else {
-          client.closeScan(tinfo, is.getScanID());
+          client.closeScan(tinfo, is.scanID);
         }
 
       } else {
@@ -916,17 +916,17 @@ public final class ThriftScanner {
         }
 
         sr = client.continueScan(tinfo, scanState.scanID, busyTimeout);
-        if (!sr.isMore()) {
+        if (!sr.more) {
           client.closeScan(tinfo, scanState.scanID);
           scanState.scanID = null;
         }
       }
 
-      if (sr.isMore()) {
+      if (sr.more) {
         if (timer != null) {
           log.trace("Finished scan in {} #results={} scanid={}",
-              String.format("%.3f secs", timer.elapsed(MILLISECONDS) / 1000.0),
-              sr.getResults().size(), scanState.scanID);
+              String.format("%.3f secs", timer.elapsed(MILLISECONDS) / 1000.0), sr.results.size(),
+              scanState.scanID);
         }
       } else {
         if (addr.getExtent().endRow() == null) {
@@ -935,7 +935,7 @@ public final class ThriftScanner {
           if (timer != null) {
             log.trace("Completely finished scan in {} #results={}",
                 String.format("%.3f secs", timer.elapsed(MILLISECONDS) / 1000.0),
-                sr.getResults().size());
+                sr.results.size());
           }
 
         } else if (scanState.range.getEndKey() == null || !scanState.range
@@ -946,35 +946,34 @@ public final class ThriftScanner {
           if (timer != null) {
             log.trace("Finished scanning tablet in {} #results={}",
                 String.format("%.3f secs", timer.elapsed(MILLISECONDS) / 1000.0),
-                sr.getResults().size());
+                sr.results.size());
           }
         } else {
           scanState.finished = true;
           if (timer != null) {
             log.trace("Completely finished in {} #results={}",
                 String.format("%.3f secs", timer.elapsed(MILLISECONDS) / 1000.0),
-                sr.getResults().size());
+                sr.results.size());
           }
         }
       }
 
-      Key.decompress(sr.getResults());
+      Key.decompress(sr.results);
 
-      if (!sr.getResults().isEmpty() && !scanState.finished) {
-        scanState.range =
-            new Range(new Key(sr.getResults().get(sr.getResults().size() - 1).getKey()), false,
-                scanState.range.getEndKey(), scanState.range.isEndKeyInclusive());
+      if (!sr.results.isEmpty() && !scanState.finished) {
+        scanState.range = new Range(new Key(sr.results.get(sr.results.size() - 1).key), false,
+            scanState.range.getEndKey(), scanState.range.isEndKeyInclusive());
       }
 
-      List<KeyValue> results = new ArrayList<>(sr.getResults().size());
-      for (TKeyValue tkv : sr.getResults()) {
-        results.add(new KeyValue(new Key(tkv.getKey()), tkv.getValue()));
+      List<KeyValue> results = new ArrayList<>(sr.results.size());
+      for (TKeyValue tkv : sr.results) {
+        results.add(new KeyValue(new Key(tkv.key), tkv.value));
       }
 
       return results;
 
     } catch (ThriftSecurityException e) {
-      throw new AccumuloSecurityException(e.getUser(), e.getCode(), e);
+      throw new AccumuloSecurityException(e.user, e.code, e);
     } finally {
       ThriftUtil.returnClient(client, context);
       Thread.currentThread().setName(old);

--- a/core/src/main/java/org/apache/accumulo/core/data/Column.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Column.java
@@ -139,8 +139,7 @@ public class Column implements WritableComparable<Column> {
    * @param tcol Thrift column
    */
   public Column(TColumn tcol) {
-    this(toBytes(tcol.bufferForColumnFamily()), toBytes(tcol.bufferForColumnQualifier()),
-        toBytes(tcol.bufferForColumnVisibility()));
+    this(toBytes(tcol.columnFamily), toBytes(tcol.columnQualifier), toBytes(tcol.columnVisibility));
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/data/ConstraintViolationSummary.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/ConstraintViolationSummary.java
@@ -55,8 +55,8 @@ public class ConstraintViolationSummary implements Serializable {
    * @param tcvs Thrift summary
    */
   public ConstraintViolationSummary(TConstraintViolationSummary tcvs) {
-    this(tcvs.getConstrainClass(), tcvs.getViolationCode(), tcvs.getViolationDescription(),
-        tcvs.getNumberOfViolatingMutations());
+    this(tcvs.constrainClass, tcvs.violationCode, tcvs.violationDescription,
+        tcvs.numberOfViolatingMutations);
   }
 
   public String getConstrainClass() {

--- a/core/src/main/java/org/apache/accumulo/core/data/Key.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Key.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.core.data;
 
+import static org.apache.accumulo.core.util.ByteBufferUtil.toBytes;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -29,7 +31,6 @@ import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.dataImpl.thrift.TKey;
 import org.apache.accumulo.core.dataImpl.thrift.TKeyValue;
 import org.apache.accumulo.core.security.ColumnVisibility;
-import org.apache.accumulo.core.util.ByteBufferUtil;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.WritableComparable;
 import org.apache.hadoop.io.WritableComparator;
@@ -685,11 +686,11 @@ public class Key implements WritableComparable<Key>, Cloneable {
    * @param tkey Thrift key
    */
   public Key(TKey tkey) {
-    this.row = ByteBufferUtil.toBytes(tkey.bufferForRow());
-    this.colFamily = ByteBufferUtil.toBytes(tkey.bufferForColFamily());
-    this.colQualifier = ByteBufferUtil.toBytes(tkey.bufferForColQualifier());
-    this.colVisibility = ByteBufferUtil.toBytes(tkey.bufferForColVisibility());
-    this.timestamp = tkey.getTimestamp();
+    this.row = toBytes(tkey.row);
+    this.colFamily = toBytes(tkey.colFamily);
+    this.colQualifier = toBytes(tkey.colQualifier);
+    this.colVisibility = toBytes(tkey.colVisibility);
+    this.timestamp = tkey.timestamp;
     this.deleted = false;
 
     if (row == null) {
@@ -1317,28 +1318,28 @@ public class Key implements WritableComparable<Key>, Cloneable {
 
       if (isEqual(prevKey.row, key.row)) {
         newKey = key.toThrift();
-        newKey.setRow((byte[]) null);
+        newKey.row = null;
       }
 
       if (isEqual(prevKey.colFamily, key.colFamily)) {
         if (newKey == null) {
           newKey = key.toThrift();
         }
-        newKey.setColFamily((byte[]) null);
+        newKey.colFamily = null;
       }
 
       if (isEqual(prevKey.colQualifier, key.colQualifier)) {
         if (newKey == null) {
           newKey = key.toThrift();
         }
-        newKey.setColQualifier((byte[]) null);
+        newKey.colQualifier = null;
       }
 
       if (isEqual(prevKey.colVisibility, key.colVisibility)) {
         if (newKey == null) {
           newKey = key.toThrift();
         }
-        newKey.setColVisibility((byte[]) null);
+        newKey.colVisibility = null;
       }
 
       if (newKey == null) {
@@ -1359,20 +1360,20 @@ public class Key implements WritableComparable<Key>, Cloneable {
    */
   public static void decompress(List<TKeyValue> param) {
     for (int i = 1; i < param.size(); i++) {
-      TKey prevKey = param.get(i - 1).getKey();
-      TKey key = param.get(i).getKey();
+      TKey prevKey = param.get(i - 1).key;
+      TKey key = param.get(i).key;
 
-      if (key.getRow() == null) {
-        key.setRow(prevKey.getRow());
+      if (key.row == null) {
+        key.row = prevKey.row;
       }
-      if (key.getColFamily() == null) {
-        key.setColFamily(prevKey.getColFamily());
+      if (key.colFamily == null) {
+        key.colFamily = prevKey.colFamily;
       }
-      if (key.getColQualifier() == null) {
-        key.setColQualifier(prevKey.getColQualifier());
+      if (key.colQualifier == null) {
+        key.colQualifier = prevKey.colQualifier;
       }
-      if (key.getColVisibility() == null) {
-        key.setColVisibility(prevKey.getColVisibility());
+      if (key.colVisibility == null) {
+        key.colVisibility = prevKey.colVisibility;
       }
     }
   }

--- a/core/src/main/java/org/apache/accumulo/core/data/Mutation.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Mutation.java
@@ -236,10 +236,10 @@ public class Mutation implements Writable {
    * @param tmutation Thrift mutation
    */
   public Mutation(TMutation tmutation) {
-    this.row = ByteBufferUtil.toBytes(tmutation.bufferForRow());
-    this.data = ByteBufferUtil.toBytes(tmutation.bufferForData());
-    this.entries = tmutation.getEntries();
-    this.values = ByteBufferUtil.toBytesList(tmutation.getValues());
+    this.row = ByteBufferUtil.toBytes(tmutation.row);
+    this.data = ByteBufferUtil.toBytes(tmutation.data);
+    this.entries = tmutation.entries;
+    this.values = ByteBufferUtil.toBytesList(tmutation.values);
 
     if (this.row == null) {
       throw new IllegalArgumentException("null row");

--- a/core/src/main/java/org/apache/accumulo/core/data/Range.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Range.java
@@ -235,10 +235,9 @@ public class Range implements WritableComparable<Range> {
    * @param trange Thrift range
    */
   public Range(TRange trange) {
-    this(trange.getStart() == null ? null : new Key(trange.getStart()),
-        trange.isStartKeyInclusive(), trange.isInfiniteStartKey(),
-        trange.getStop() == null ? null : new Key(trange.getStop()), trange.isStopKeyInclusive(),
-        trange.isInfiniteStopKey());
+    this(trange.start == null ? null : new Key(trange.start), trange.startKeyInclusive,
+        trange.infiniteStartKey, trange.stop == null ? null : new Key(trange.stop),
+        trange.stopKeyInclusive, trange.infiniteStopKey);
     if (!infiniteStartKey && !infiniteStopKey && beforeStartKeyImpl(stop)) {
       throw new IllegalArgumentException(
           "Start key must be less than end key in range (" + start + ", " + stop + ")");

--- a/core/src/main/java/org/apache/accumulo/core/dataImpl/KeyExtent.java
+++ b/core/src/main/java/org/apache/accumulo/core/dataImpl/KeyExtent.java
@@ -53,6 +53,7 @@ import org.apache.accumulo.core.dataImpl.thrift.TKeyExtent;
 import org.apache.accumulo.core.metadata.SystemTables;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
+import org.apache.accumulo.core.util.ByteBufferUtil;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.core.util.TextUtil;
 import org.apache.hadoop.io.BinaryComparable;
@@ -115,9 +116,10 @@ public final class KeyExtent implements Comparable<KeyExtent> {
    * @param tke the KeyExtent in its Thrift object form
    */
   public static KeyExtent fromThrift(TKeyExtent tke) {
-    TableId tableId = TableId.of(new String(tke.getTable(), UTF_8));
-    Text endRow = tke.getEndRow() == null ? null : new Text(tke.getEndRow());
-    Text prevEndRow = tke.getPrevEndRow() == null ? null : new Text(tke.getPrevEndRow());
+    TableId tableId = TableId.of(new String(ByteBufferUtil.toBytes(tke.table), UTF_8));
+    Text endRow = tke.endRow == null ? null : new Text(ByteBufferUtil.toBytes(tke.endRow));
+    Text prevEndRow =
+        tke.prevEndRow == null ? null : new Text(ByteBufferUtil.toBytes(tke.prevEndRow));
     return new KeyExtent(tableId, endRow, prevEndRow);
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/fate/FatePartition.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/FatePartition.java
@@ -29,7 +29,7 @@ public record FatePartition(FateId start, FateId end) {
   }
 
   public static FatePartition from(TFatePartition tfp) {
-    return new FatePartition(FateId.from(tfp.getStart()), FateId.from(tfp.getStop()));
+    return new FatePartition(FateId.from(tfp.start), FateId.from(tfp.stop));
   }
 
   private static final FatePartition ALL_USER =

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/IteratorConfigUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/IteratorConfigUtil.java
@@ -215,13 +215,13 @@ public class IteratorConfigUtil {
       for (IterInfo iterInfo : iteratorBuilder.iters) {
 
         Class<SortedKeyValueIterator<Key,Value>> clazz = null;
-        log.trace("Attempting to load iterator class {}", iterInfo.getClassName());
+        log.trace("Attempting to load iterator class {}", iterInfo.className);
         if (iteratorBuilder.useClassCache) {
-          clazz = classCache.get(iterInfo.getClassName());
+          clazz = classCache.get(iterInfo.className);
 
           if (clazz == null) {
             clazz = loadClass(useClassLoader, iteratorBuilder.context, iterInfo);
-            classCache.put(iterInfo.getClassName(), clazz);
+            classCache.put(iterInfo.className, clazz);
           }
         } else {
           clazz = loadClass(useClassLoader, iteratorBuilder.context, iterInfo);
@@ -229,7 +229,7 @@ public class IteratorConfigUtil {
 
         SortedKeyValueIterator<Key,Value> skvi = clazz.getDeclaredConstructor().newInstance();
 
-        Map<String,String> options = iteratorBuilder.iterOpts.get(iterInfo.getIterName());
+        Map<String,String> options = iteratorBuilder.iterOpts.get(iterInfo.iterName);
 
         if (options == null) {
           options = Collections.emptyMap();
@@ -252,15 +252,15 @@ public class IteratorConfigUtil {
     if (useAccumuloClassLoader) {
       @SuppressWarnings("unchecked")
       var clazz = (Class<SortedKeyValueIterator<Key,Value>>) ClassLoaderUtil.loadClass(context,
-          iterInfo.getClassName(), SortedKeyValueIterator.class);
-      log.trace("Iterator class {} loaded from context {}, classloader: {}",
-          iterInfo.getClassName(), context, clazz.getClassLoader());
+          iterInfo.className, SortedKeyValueIterator.class);
+      log.trace("Iterator class {} loaded from context {}, classloader: {}", iterInfo.className,
+          context, clazz.getClassLoader());
       return clazz;
     }
     @SuppressWarnings("unchecked")
-    var clazz = (Class<SortedKeyValueIterator<Key,Value>>) Class.forName(iterInfo.getClassName())
+    var clazz = (Class<SortedKeyValueIterator<Key,Value>>) Class.forName(iterInfo.className)
         .asSubclass(SortedKeyValueIterator.class);
-    log.trace("Iterator class {} loaded from classpath", iterInfo.getClassName());
+    log.trace("Iterator class {} loaded from classpath", iterInfo.className);
     return clazz;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/rpc/clients/ManagerThriftClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/clients/ManagerThriftClient.java
@@ -63,7 +63,7 @@ public class ManagerThriftClient extends ThriftClientTypes<Client>
         LOG.debug("ManagerClient request failed, retrying ... ", tte);
         sleepUninterruptibly(100, MILLISECONDS);
       } catch (ThriftSecurityException e) {
-        throw new AccumuloSecurityException(e.getUser(), e.getCode(), e);
+        throw new AccumuloSecurityException(e.user, e.code, e);
       } catch (ThriftTableOperationException e) {
         switch (e.getType()) {
           case NAMESPACE_NOTFOUND:
@@ -111,7 +111,7 @@ public class ManagerThriftClient extends ThriftClientTypes<Client>
         LOG.debug("ManagerClient request failed, retrying ... ", tte);
         sleepUninterruptibly(100, MILLISECONDS);
       } catch (ThriftSecurityException e) {
-        throw new AccumuloSecurityException(e.getUser(), e.getCode(), e);
+        throw new AccumuloSecurityException(e.user, e.code, e);
       } catch (ThriftTableOperationException e) {
         switch (e.getType()) {
           case NAMESPACE_NOTFOUND:

--- a/core/src/main/java/org/apache/accumulo/core/rpc/clients/TServerClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/clients/TServerClient.java
@@ -173,7 +173,7 @@ public interface TServerClient<C extends TServiceClient> {
         client = pair.getSecond();
         return exec.execute(client);
       } catch (ThriftSecurityException e) {
-        throw new AccumuloSecurityException(e.getUser(), e.getCode(), e);
+        throw new AccumuloSecurityException(e.user, e.code, e);
       } catch (TApplicationException tae) {
         throw new AccumuloServerException(server, tae);
       } catch (TTransportException tte) {
@@ -214,7 +214,7 @@ public interface TServerClient<C extends TServiceClient> {
         exec.execute(client);
         return;
       } catch (ThriftSecurityException e) {
-        throw new AccumuloSecurityException(e.getUser(), e.getCode(), e);
+        throw new AccumuloSecurityException(e.user, e.code, e);
       } catch (TApplicationException tae) {
         throw new AccumuloServerException(server, tae);
       } catch (TTransportException tte) {

--- a/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
@@ -126,9 +126,9 @@ public class Gatherer {
   public Gatherer(ClientContext context, TSummaryRequest request, AccumuloConfiguration tableConfig,
       CryptoService cryptoService) {
     this.ctx = context;
-    this.tableId = TableId.of(request.getTableId());
-    this.startRow = ByteBufferUtil.toText(request.getBounds().bufferForStartRow());
-    this.endRow = ByteBufferUtil.toText(request.getBounds().bufferForEndRow());
+    this.tableId = TableId.of(request.tableId);
+    this.startRow = ByteBufferUtil.toText(request.bounds.startRow);
+    this.endRow = ByteBufferUtil.toText(request.bounds.endRow);
     this.clipRange = new Range(startRow, false, endRow, true);
     this.summaries = request.getSummarizers().stream().map(SummarizerConfigurationUtil::fromThrift)
         .collect(Collectors.toSet());
@@ -319,8 +319,8 @@ public class Gatherer {
             TSummaries tSums = client.startGetSummariesFromFiles(tinfo, ctx.rpcCreds(),
                 getRequest(), files.entrySet().stream().collect(Collectors
                     .toMap(entry -> entry.getKey().getNormalizedPathStr(), Entry::getValue)));
-            while (!tSums.isFinished() && !cancelFlag.get()) {
-              tSums = client.contiuneGetSummaries(tinfo, tSums.getSessionId());
+            while (!tSums.finished && !cancelFlag.get()) {
+              tSums = client.contiuneGetSummaries(tinfo, tSums.sessionId);
             }
 
             pfiles.summaries.merge(new SummaryCollection(tSums), factory);
@@ -436,8 +436,8 @@ public class Gatherer {
       Map<String,List<TRowRange>> files, BlockCache summaryCache, BlockCache indexCache,
       Cache<String,Long> fileLenCache, ExecutorService srp) {
     Function<TRowRange,RowRange> fromThrift = tRowRange -> {
-      Text lowerBound = ByteBufferUtil.toText(tRowRange.bufferForStartRow());
-      Text upperBound = ByteBufferUtil.toText(tRowRange.bufferForEndRow());
+      Text lowerBound = ByteBufferUtil.toText(tRowRange.startRow);
+      Text upperBound = ByteBufferUtil.toText(tRowRange.endRow);
       return RowRange.range(lowerBound, false, upperBound, true);
     };
     List<CompletableFuture<SummaryCollection>> futures = new ArrayList<>();
@@ -483,8 +483,8 @@ public class Gatherer {
         tSums = ThriftClientTypes.TABLET_SERVER.execute(ctx, client -> {
           TSummaries tsr =
               client.startGetSummariesForPartition(tinfo, ctx.rpcCreds(), req, modulus, remainder);
-          while (!tsr.isFinished() && !cancelFlag.get()) {
-            tsr = client.contiuneGetSummaries(tinfo, tsr.getSessionId());
+          while (!tsr.finished && !cancelFlag.get()) {
+            tsr = client.contiuneGetSummaries(tinfo, tsr.sessionId);
           }
           return tsr;
         });

--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/RunningCompactionInfo.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/RunningCompactionInfo.java
@@ -110,7 +110,7 @@ public class RunningCompactionInfo {
       if (updates.isEmpty()) {
         status = "na";
       } else {
-        status = last.getState().name();
+        status = last.state.name();
       }
       log.trace("Parsed running compaction {} for {} with progress = {}%", status, ecid, progress);
       if (sinceLastUpdateSeconds > 30) {
@@ -124,8 +124,8 @@ public class RunningCompactionInfo {
       status = "na";
       duration = 0;
     }
-    this.inputFiles = convertInputFiles(job.getFiles());
-    this.outputFile = job.getOutputFile();
+    this.inputFiles = convertInputFiles(job.files);
+    this.outputFile = job.outputFile;
 
   }
 
@@ -138,8 +138,8 @@ public class RunningCompactionInfo {
    */
   private List<CompactionInputFileDetails> convertInputFiles(List<InputFile> files) {
     return files.stream()
-        .map(file -> new CompactionInputFileDetails(file.getMetadataFileEntry(), file.getSize(),
-            file.getEntries(), file.getTimestamp()))
+        .map(file -> new CompactionInputFileDetails(file.metadataFileEntry, file.size, file.entries,
+            file.timestamp))
         .sorted(Comparator.comparingLong(CompactionInputFileDetails::size).reversed()).toList();
   }
 

--- a/core/src/main/scripts/generate-thrift.sh
+++ b/core/src/main/scripts/generate-thrift.sh
@@ -67,7 +67,7 @@ THRIFT_ARGS=("${THRIFT_ARGS[@]}" -o "$BUILD_DIR")
 mkdir -p "$BUILD_DIR"
 rm -rf "$BUILD_DIR"/gen-java
 for f in src/main/thrift/*.thrift; do
-  thrift "${THRIFT_ARGS[@]}" --gen java:generated_annotations=suppress,private-members "$f" || fail unable to generate java thrift classes
+  thrift "${THRIFT_ARGS[@]}" --gen java:generated_annotations=suppress "$f" || fail unable to generate java thrift classes
   thrift "${THRIFT_ARGS[@]}" --gen py "$f" || fail unable to generate python thrift classes
   thrift "${THRIFT_ARGS[@]}" --gen rb "$f" || fail unable to generate ruby thrift classes
   thrift "${THRIFT_ARGS[@]}" --gen cpp "$f" || fail unable to generate cpp thrift classes

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/clientImpl/thrift/ClientService.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/clientImpl/thrift/ClientService.java
@@ -6347,7 +6347,7 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new ping_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new ping_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -6741,7 +6741,7 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new ping_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new ping_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -7132,8 +7132,8 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getDiskUsage_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getDiskUsage_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable java.util.Set<java.lang.String> tables; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.util.Set<java.lang.String> tables; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -7682,9 +7682,9 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getDiskUsage_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getDiskUsage_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable java.util.List<TDiskUsage> success; // required
-    private @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable ThriftTableOperationException toe; // required
+    public @org.apache.thrift.annotation.Nullable java.util.List<TDiskUsage> success; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable ThriftTableOperationException toe; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -8338,8 +8338,8 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new listLocalUsers_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new listLocalUsers_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -8842,8 +8842,8 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new listLocalUsers_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new listLocalUsers_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable java.util.Set<java.lang.String> success; // required
-    private @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable java.util.Set<java.lang.String> success; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -9389,10 +9389,10 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new createLocalUser_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new createLocalUser_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String principal; // required
-    private @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer password; // required
+    public @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String principal; // required
+    public @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer password; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -10113,7 +10113,7 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new createLocalUser_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new createLocalUser_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -10505,9 +10505,9 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new dropLocalUser_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new dropLocalUser_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String principal; // required
+    public @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String principal; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -11112,7 +11112,7 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new dropLocalUser_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new dropLocalUser_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -11505,10 +11505,10 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new changeLocalUserPassword_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new changeLocalUserPassword_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String principal; // required
-    private @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer password; // required
+    public @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String principal; // required
+    public @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer password; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -12229,7 +12229,7 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new changeLocalUserPassword_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new changeLocalUserPassword_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -12620,8 +12620,8 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new authenticate_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new authenticate_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -13124,8 +13124,8 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new authenticate_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new authenticate_resultTupleSchemeFactory();
 
-    private boolean success; // required
-    private @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
+    public boolean success; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -13617,9 +13617,9 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new authenticateUser_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new authenticateUser_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials toAuth; // required
+    public @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials toAuth; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -14230,8 +14230,8 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new authenticateUser_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new authenticateUser_resultTupleSchemeFactory();
 
-    private boolean success; // required
-    private @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
+    public boolean success; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -14724,10 +14724,10 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new changeAuthorizations_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new changeAuthorizations_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String principal; // required
-    private @org.apache.thrift.annotation.Nullable java.util.List<java.nio.ByteBuffer> authorizations; // required
+    public @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String principal; // required
+    public @org.apache.thrift.annotation.Nullable java.util.List<java.nio.ByteBuffer> authorizations; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -15485,7 +15485,7 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new changeAuthorizations_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new changeAuthorizations_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -15877,9 +15877,9 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getUserAuthorizations_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getUserAuthorizations_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String principal; // required
+    public @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String principal; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -16485,8 +16485,8 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getUserAuthorizations_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getUserAuthorizations_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable java.util.List<java.nio.ByteBuffer> success; // required
-    private @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable java.util.List<java.nio.ByteBuffer> success; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -17032,10 +17032,10 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new hasSystemPermission_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new hasSystemPermission_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String principal; // required
-    private byte sysPerm; // required
+    public @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String principal; // required
+    public byte sysPerm; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -17739,8 +17739,8 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new hasSystemPermission_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new hasSystemPermission_resultTupleSchemeFactory();
 
-    private boolean success; // required
-    private @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
+    public boolean success; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -18234,11 +18234,11 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new hasTablePermission_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new hasTablePermission_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String principal; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String tableName; // required
-    private byte tblPerm; // required
+    public @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String principal; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String tableName; // required
+    public byte tblPerm; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -19046,9 +19046,9 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new hasTablePermission_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new hasTablePermission_resultTupleSchemeFactory();
 
-    private boolean success; // required
-    private @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable ThriftTableOperationException tope; // required
+    public boolean success; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable ThriftTableOperationException tope; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -19647,11 +19647,11 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new hasNamespacePermission_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new hasNamespacePermission_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String principal; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String ns; // required
-    private byte tblNspcPerm; // required
+    public @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String principal; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String ns; // required
+    public byte tblNspcPerm; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -20459,9 +20459,9 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new hasNamespacePermission_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new hasNamespacePermission_resultTupleSchemeFactory();
 
-    private boolean success; // required
-    private @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable ThriftTableOperationException tope; // required
+    public boolean success; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable ThriftTableOperationException tope; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -21059,10 +21059,10 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new grantSystemPermission_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new grantSystemPermission_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String principal; // required
-    private byte permission; // required
+    public @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String principal; // required
+    public byte permission; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -21765,7 +21765,7 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new grantSystemPermission_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new grantSystemPermission_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -22158,10 +22158,10 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new revokeSystemPermission_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new revokeSystemPermission_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String principal; // required
-    private byte permission; // required
+    public @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String principal; // required
+    public byte permission; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -22864,7 +22864,7 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new revokeSystemPermission_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new revokeSystemPermission_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -23258,11 +23258,11 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new grantTablePermission_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new grantTablePermission_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String principal; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String tableName; // required
-    private byte permission; // required
+    public @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String principal; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String tableName; // required
+    public byte permission; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -24069,8 +24069,8 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new grantTablePermission_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new grantTablePermission_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable ThriftTableOperationException tope; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable ThriftTableOperationException tope; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -24569,11 +24569,11 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new revokeTablePermission_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new revokeTablePermission_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String principal; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String tableName; // required
-    private byte permission; // required
+    public @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String principal; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String tableName; // required
+    public byte permission; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -25380,8 +25380,8 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new revokeTablePermission_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new revokeTablePermission_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable ThriftTableOperationException tope; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable ThriftTableOperationException tope; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -25880,11 +25880,11 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new grantNamespacePermission_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new grantNamespacePermission_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String principal; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String ns; // required
-    private byte permission; // required
+    public @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String principal; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String ns; // required
+    public byte permission; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -26691,8 +26691,8 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new grantNamespacePermission_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new grantNamespacePermission_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable ThriftTableOperationException tope; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable ThriftTableOperationException tope; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -27191,11 +27191,11 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new revokeNamespacePermission_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new revokeNamespacePermission_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String principal; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String ns; // required
-    private byte permission; // required
+    public @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String principal; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String ns; // required
+    public byte permission; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -28002,8 +28002,8 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new revokeNamespacePermission_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new revokeNamespacePermission_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable ThriftTableOperationException tope; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable ThriftTableOperationException tope; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -28500,9 +28500,13 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getConfiguration_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getConfiguration_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable ConfigurationType type; // required
+    public @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    /**
+     * 
+     * @see ConfigurationType
+     */
+    public @org.apache.thrift.annotation.Nullable ConfigurationType type; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -29120,8 +29124,8 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getConfiguration_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getConfiguration_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.String> success; // required
-    private @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.String> success; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -29667,8 +29671,8 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getSystemProperties_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getSystemProperties_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -30171,8 +30175,8 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getSystemProperties_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getSystemProperties_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.String> success; // required
-    private @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.String> success; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -30718,8 +30722,8 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getVersionedSystemProperties_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getVersionedSystemProperties_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -31222,8 +31226,8 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getVersionedSystemProperties_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getVersionedSystemProperties_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TVersionedProperties success; // required
-    private @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable TVersionedProperties success; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -31723,9 +31727,9 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getVersionedResourceGroupProperties_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getVersionedResourceGroupProperties_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String resourceGroup; // required
+    public @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String resourceGroup; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -32332,9 +32336,9 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getVersionedResourceGroupProperties_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getVersionedResourceGroupProperties_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TVersionedProperties success; // required
-    private @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable ThriftResourceGroupNotExistsException rgne; // required
+    public @org.apache.thrift.annotation.Nullable TVersionedProperties success; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable ThriftResourceGroupNotExistsException rgne; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -32939,9 +32943,9 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getTableConfiguration_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getTableConfiguration_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String tableName; // required
+    public @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String tableName; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -33548,9 +33552,9 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getTableConfiguration_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getTableConfiguration_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.String> success; // required
-    private @org.apache.thrift.annotation.Nullable ThriftTableOperationException tope; // required
-    private @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.String> success; // required
+    public @org.apache.thrift.annotation.Nullable ThriftTableOperationException tope; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -34202,9 +34206,9 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getTableProperties_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getTableProperties_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String tableName; // required
+    public @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String tableName; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -34811,9 +34815,9 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getTableProperties_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getTableProperties_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.String> success; // required
-    private @org.apache.thrift.annotation.Nullable ThriftTableOperationException tope; // required
-    private @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.String> success; // required
+    public @org.apache.thrift.annotation.Nullable ThriftTableOperationException tope; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -35465,9 +35469,9 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getVersionedTableProperties_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getVersionedTableProperties_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String tableName; // required
+    public @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String tableName; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -36074,9 +36078,9 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getVersionedTableProperties_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getVersionedTableProperties_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TVersionedProperties success; // required
-    private @org.apache.thrift.annotation.Nullable ThriftTableOperationException tope; // required
-    private @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable TVersionedProperties success; // required
+    public @org.apache.thrift.annotation.Nullable ThriftTableOperationException tope; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -36681,9 +36685,9 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getNamespaceConfiguration_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getNamespaceConfiguration_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String ns; // required
+    public @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String ns; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -37290,9 +37294,9 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getNamespaceConfiguration_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getNamespaceConfiguration_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.String> success; // required
-    private @org.apache.thrift.annotation.Nullable ThriftTableOperationException tope; // required
-    private @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.String> success; // required
+    public @org.apache.thrift.annotation.Nullable ThriftTableOperationException tope; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -37944,9 +37948,9 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getNamespaceProperties_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getNamespaceProperties_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String ns; // required
+    public @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String ns; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -38553,9 +38557,9 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getNamespaceProperties_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getNamespaceProperties_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.String> success; // required
-    private @org.apache.thrift.annotation.Nullable ThriftTableOperationException tope; // required
-    private @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.String> success; // required
+    public @org.apache.thrift.annotation.Nullable ThriftTableOperationException tope; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -39207,9 +39211,9 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getVersionedNamespaceProperties_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getVersionedNamespaceProperties_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String ns; // required
+    public @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String ns; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -39816,9 +39820,9 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getVersionedNamespaceProperties_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getVersionedNamespaceProperties_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TVersionedProperties success; // required
-    private @org.apache.thrift.annotation.Nullable ThriftTableOperationException tope; // required
-    private @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable TVersionedProperties success; // required
+    public @org.apache.thrift.annotation.Nullable ThriftTableOperationException tope; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -40424,10 +40428,10 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new checkClass_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new checkClass_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String className; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String interfaceMatch; // required
+    public @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String className; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String interfaceMatch; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -41135,7 +41139,7 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new checkClass_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new checkClass_resultTupleSchemeFactory();
 
-    private boolean success; // required
+    public boolean success; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -41524,11 +41528,11 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new checkTableClass_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new checkTableClass_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String tableId; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String className; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String interfaceMatch; // required
+    public @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String tableId; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String className; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String interfaceMatch; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -42341,9 +42345,9 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new checkTableClass_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new checkTableClass_resultTupleSchemeFactory();
 
-    private boolean success; // required
-    private @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable ThriftTableOperationException tope; // required
+    public boolean success; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable ThriftTableOperationException tope; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -42942,11 +42946,11 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new checkNamespaceClass_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new checkNamespaceClass_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String namespaceId; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String className; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String interfaceMatch; // required
+    public @org.apache.thrift.annotation.Nullable TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String namespaceId; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String className; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String interfaceMatch; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -43759,9 +43763,9 @@ public class ClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new checkNamespaceClass_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new checkNamespaceClass_resultTupleSchemeFactory();
 
-    private boolean success; // required
-    private @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable ThriftTableOperationException tope; // required
+    public boolean success; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable ThriftTableOperationException tope; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/clientImpl/thrift/TDiskUsage.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/clientImpl/thrift/TDiskUsage.java
@@ -34,8 +34,8 @@ public class TDiskUsage implements org.apache.thrift.TBase<TDiskUsage, TDiskUsag
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TDiskUsageStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TDiskUsageTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.util.List<java.lang.String> tables; // required
-  private long usage; // required
+  public @org.apache.thrift.annotation.Nullable java.util.List<java.lang.String> tables; // required
+  public long usage; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/clientImpl/thrift/TInfo.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/clientImpl/thrift/TInfo.java
@@ -33,7 +33,7 @@ public class TInfo implements org.apache.thrift.TBase<TInfo, TInfo._Fields>, jav
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TInfoStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TInfoTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.String> headers; // required
+  public @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.String> headers; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/clientImpl/thrift/TVersionedProperties.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/clientImpl/thrift/TVersionedProperties.java
@@ -34,8 +34,8 @@ public class TVersionedProperties implements org.apache.thrift.TBase<TVersionedP
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TVersionedPropertiesStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TVersionedPropertiesTupleSchemeFactory();
 
-  private long version; // required
-  private @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.String> properties; // required
+  public long version; // required
+  public @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.String> properties; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/clientImpl/thrift/ThriftConcurrentModificationException.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/clientImpl/thrift/ThriftConcurrentModificationException.java
@@ -33,7 +33,7 @@ public class ThriftConcurrentModificationException extends org.apache.thrift.TEx
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new ThriftConcurrentModificationExceptionStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new ThriftConcurrentModificationExceptionTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.lang.String description; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String description; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/clientImpl/thrift/ThriftNotActiveServiceException.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/clientImpl/thrift/ThriftNotActiveServiceException.java
@@ -34,8 +34,8 @@ public class ThriftNotActiveServiceException extends org.apache.thrift.TExceptio
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new ThriftNotActiveServiceExceptionStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new ThriftNotActiveServiceExceptionTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.lang.String serv; // required
-  private @org.apache.thrift.annotation.Nullable java.lang.String description; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String serv; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String description; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/clientImpl/thrift/ThriftResourceGroupNotExistsException.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/clientImpl/thrift/ThriftResourceGroupNotExistsException.java
@@ -33,7 +33,7 @@ public class ThriftResourceGroupNotExistsException extends org.apache.thrift.TEx
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new ThriftResourceGroupNotExistsExceptionStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new ThriftResourceGroupNotExistsExceptionTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.lang.String resourceGroupName; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String resourceGroupName; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/clientImpl/thrift/ThriftSecurityException.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/clientImpl/thrift/ThriftSecurityException.java
@@ -34,8 +34,12 @@ public class ThriftSecurityException extends org.apache.thrift.TException implem
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new ThriftSecurityExceptionStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new ThriftSecurityExceptionTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.lang.String user; // required
-  private @org.apache.thrift.annotation.Nullable SecurityErrorCode code; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String user; // required
+  /**
+   * 
+   * @see SecurityErrorCode
+   */
+  public @org.apache.thrift.annotation.Nullable SecurityErrorCode code; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/clientImpl/thrift/ThriftTableOperationException.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/clientImpl/thrift/ThriftTableOperationException.java
@@ -37,11 +37,19 @@ public class ThriftTableOperationException extends org.apache.thrift.TException 
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new ThriftTableOperationExceptionStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new ThriftTableOperationExceptionTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.lang.String tableId; // required
-  private @org.apache.thrift.annotation.Nullable java.lang.String tableName; // required
-  private @org.apache.thrift.annotation.Nullable TableOperation op; // required
-  private @org.apache.thrift.annotation.Nullable TableOperationExceptionType type; // required
-  private @org.apache.thrift.annotation.Nullable java.lang.String description; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String tableId; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String tableName; // required
+  /**
+   * 
+   * @see TableOperation
+   */
+  public @org.apache.thrift.annotation.Nullable TableOperation op; // required
+  /**
+   * 
+   * @see TableOperationExceptionType
+   */
+  public @org.apache.thrift.annotation.Nullable TableOperationExceptionType type; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String description; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/clientImpl/thrift/ThriftTest.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/clientImpl/thrift/ThriftTest.java
@@ -910,7 +910,7 @@ public class ThriftTest {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new success_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new success_resultTupleSchemeFactory();
 
-    private boolean success; // required
+    public boolean success; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -1571,7 +1571,7 @@ public class ThriftTest {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new fails_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new fails_resultTupleSchemeFactory();
 
-    private boolean success; // required
+    public boolean success; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -2233,8 +2233,8 @@ public class ThriftTest {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new throwsError_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new throwsError_resultTupleSchemeFactory();
 
-    private boolean success; // required
-    private @org.apache.thrift.annotation.Nullable ThriftSecurityException ex; // required
+    public boolean success; // required
+    public @org.apache.thrift.annotation.Nullable ThriftSecurityException ex; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/compaction/thrift/CompactionCoordinatorService.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/compaction/thrift/CompactionCoordinatorService.java
@@ -757,13 +757,13 @@ public class CompactionCoordinatorService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new compactionCompleted_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new compactionCompleted_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String externalCompactionId; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.tabletserver.thrift.TCompactionStats stats; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String groupName; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String compactor; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String externalCompactionId; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.tabletserver.thrift.TCompactionStats stats; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String groupName; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String compactor; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -1791,8 +1791,8 @@ public class CompactionCoordinatorService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new compactionCompleted_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new compactionCompleted_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -2291,11 +2291,11 @@ public class CompactionCoordinatorService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getCompactionJob_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getCompactionJob_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String groupName; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String compactor; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String externalCompactionId; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String groupName; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String compactor; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String externalCompactionId; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -3108,9 +3108,9 @@ public class CompactionCoordinatorService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getCompactionJob_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getCompactionJob_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TNextCompactionJob success; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable TNextCompactionJob success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -3720,14 +3720,18 @@ public class CompactionCoordinatorService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new compactionFailed_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new compactionFailed_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String externalCompactionId; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String exceptionClassName; // required
-    private @org.apache.thrift.annotation.Nullable TCompactionState failureState; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String groupName; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String compactor; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String externalCompactionId; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String exceptionClassName; // required
+    /**
+     * 
+     * @see TCompactionState
+     */
+    public @org.apache.thrift.annotation.Nullable TCompactionState failureState; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String groupName; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String compactor; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -4865,8 +4869,8 @@ public class CompactionCoordinatorService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new compactionFailed_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new compactionFailed_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/compaction/thrift/CompactorService.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/compaction/thrift/CompactorService.java
@@ -850,8 +850,8 @@ public class CompactorService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getRunningCompaction_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getRunningCompaction_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -1354,8 +1354,8 @@ public class CompactorService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getRunningCompaction_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getRunningCompaction_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TExternalCompaction success; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable TExternalCompaction success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -1854,8 +1854,8 @@ public class CompactorService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getRunningCompactionId_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getRunningCompactionId_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -2358,8 +2358,8 @@ public class CompactorService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getRunningCompactionId_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getRunningCompactionId_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable java.lang.String success; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -2853,8 +2853,8 @@ public class CompactorService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getActiveCompactions_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getActiveCompactions_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -3357,8 +3357,8 @@ public class CompactorService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getActiveCompactions_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getActiveCompactions_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.tabletserver.thrift.ActiveCompaction> success; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.tabletserver.thrift.ActiveCompaction> success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -3908,9 +3908,9 @@ public class CompactorService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new cancel_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new cancel_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String externalCompactionId; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String externalCompactionId; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/compaction/thrift/TCompactionStatusUpdate.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/compaction/thrift/TCompactionStatusUpdate.java
@@ -38,12 +38,16 @@ public class TCompactionStatusUpdate implements org.apache.thrift.TBase<TCompact
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TCompactionStatusUpdateStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TCompactionStatusUpdateTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable TCompactionState state; // required
-  private @org.apache.thrift.annotation.Nullable java.lang.String message; // required
-  private long entriesToBeCompacted; // required
-  private long entriesRead; // required
-  private long entriesWritten; // required
-  private long compactionAgeNanos; // required
+  /**
+   * 
+   * @see TCompactionState
+   */
+  public @org.apache.thrift.annotation.Nullable TCompactionState state; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String message; // required
+  public long entriesToBeCompacted; // required
+  public long entriesRead; // required
+  public long entriesWritten; // required
+  public long compactionAgeNanos; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/compaction/thrift/TExternalCompaction.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/compaction/thrift/TExternalCompaction.java
@@ -37,11 +37,11 @@ public class TExternalCompaction implements org.apache.thrift.TBase<TExternalCom
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TExternalCompactionStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TExternalCompactionTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.lang.String groupName; // required
-  private @org.apache.thrift.annotation.Nullable java.lang.String compactor; // required
-  private @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.Long,TCompactionStatusUpdate> updates; // required
-  private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.tabletserver.thrift.TExternalCompactionJob job; // required
-  private long startTime; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String groupName; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String compactor; // required
+  public @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.Long,TCompactionStatusUpdate> updates; // required
+  public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.tabletserver.thrift.TExternalCompactionJob job; // required
+  public long startTime; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/compaction/thrift/TExternalCompactionList.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/compaction/thrift/TExternalCompactionList.java
@@ -33,7 +33,7 @@ public class TExternalCompactionList implements org.apache.thrift.TBase<TExterna
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TExternalCompactionListStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TExternalCompactionListTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.util.List<TExternalCompaction> compactions; // required
+  public @org.apache.thrift.annotation.Nullable java.util.List<TExternalCompaction> compactions; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/compaction/thrift/TNextCompactionJob.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/compaction/thrift/TNextCompactionJob.java
@@ -34,8 +34,8 @@ public class TNextCompactionJob implements org.apache.thrift.TBase<TNextCompacti
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TNextCompactionJobStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TNextCompactionJobTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.tabletserver.thrift.TExternalCompactionJob job; // required
-  private int compactorCount; // required
+  public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.tabletserver.thrift.TExternalCompactionJob job; // required
+  public int compactorCount; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/InitialMultiScan.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/InitialMultiScan.java
@@ -34,8 +34,8 @@ public class InitialMultiScan implements org.apache.thrift.TBase<InitialMultiSca
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new InitialMultiScanStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new InitialMultiScanTupleSchemeFactory();
 
-  private long scanID; // required
-  private @org.apache.thrift.annotation.Nullable MultiScanResult result; // required
+  public long scanID; // required
+  public @org.apache.thrift.annotation.Nullable MultiScanResult result; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/InitialScan.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/InitialScan.java
@@ -34,8 +34,8 @@ public class InitialScan implements org.apache.thrift.TBase<InitialScan, Initial
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new InitialScanStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new InitialScanTupleSchemeFactory();
 
-  private long scanID; // required
-  private @org.apache.thrift.annotation.Nullable ScanResult result; // required
+  public long scanID; // required
+  public @org.apache.thrift.annotation.Nullable ScanResult result; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/IterInfo.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/IterInfo.java
@@ -35,9 +35,9 @@ public class IterInfo implements org.apache.thrift.TBase<IterInfo, IterInfo._Fie
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new IterInfoStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new IterInfoTupleSchemeFactory();
 
-  private int priority; // required
-  private @org.apache.thrift.annotation.Nullable java.lang.String className; // required
-  private @org.apache.thrift.annotation.Nullable java.lang.String iterName; // required
+  public int priority; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String className; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String iterName; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/MultiScanResult.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/MultiScanResult.java
@@ -39,13 +39,13 @@ public class MultiScanResult implements org.apache.thrift.TBase<MultiScanResult,
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new MultiScanResultStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new MultiScanResultTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.util.List<TKeyValue> results; // required
-  private @org.apache.thrift.annotation.Nullable java.util.Map<TKeyExtent,java.util.List<TRange>> failures; // required
-  private @org.apache.thrift.annotation.Nullable java.util.List<TKeyExtent> fullScans; // required
-  private @org.apache.thrift.annotation.Nullable TKeyExtent partScan; // required
-  private @org.apache.thrift.annotation.Nullable TKey partNextKey; // required
-  private boolean partNextKeyInclusive; // required
-  private boolean more; // required
+  public @org.apache.thrift.annotation.Nullable java.util.List<TKeyValue> results; // required
+  public @org.apache.thrift.annotation.Nullable java.util.Map<TKeyExtent,java.util.List<TRange>> failures; // required
+  public @org.apache.thrift.annotation.Nullable java.util.List<TKeyExtent> fullScans; // required
+  public @org.apache.thrift.annotation.Nullable TKeyExtent partScan; // required
+  public @org.apache.thrift.annotation.Nullable TKey partNextKey; // required
+  public boolean partNextKeyInclusive; // required
+  public boolean more; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/ScanResult.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/ScanResult.java
@@ -34,8 +34,8 @@ public class ScanResult implements org.apache.thrift.TBase<ScanResult, ScanResul
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new ScanResultStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new ScanResultTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.util.List<TKeyValue> results; // required
-  private boolean more; // required
+  public @org.apache.thrift.annotation.Nullable java.util.List<TKeyValue> results; // required
+  public boolean more; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TCMResult.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TCMResult.java
@@ -34,8 +34,12 @@ public class TCMResult implements org.apache.thrift.TBase<TCMResult, TCMResult._
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TCMResultStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TCMResultTupleSchemeFactory();
 
-  private long cmid; // required
-  private @org.apache.thrift.annotation.Nullable TCMStatus status; // required
+  public long cmid; // required
+  /**
+   * 
+   * @see TCMStatus
+   */
+  public @org.apache.thrift.annotation.Nullable TCMStatus status; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TColumn.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TColumn.java
@@ -35,9 +35,9 @@ public class TColumn implements org.apache.thrift.TBase<TColumn, TColumn._Fields
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TColumnStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TColumnTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer columnFamily; // required
-  private @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer columnQualifier; // required
-  private @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer columnVisibility; // required
+  public @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer columnFamily; // required
+  public @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer columnQualifier; // required
+  public @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer columnVisibility; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TCondition.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TCondition.java
@@ -39,13 +39,13 @@ public class TCondition implements org.apache.thrift.TBase<TCondition, TConditio
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TConditionStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TConditionTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer cf; // required
-  private @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer cq; // required
-  private @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer cv; // required
-  private long ts; // required
-  private boolean hasTimestamp; // required
-  private @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer val; // required
-  private @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer iterators; // required
+  public @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer cf; // required
+  public @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer cq; // required
+  public @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer cv; // required
+  public long ts; // required
+  public boolean hasTimestamp; // required
+  public @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer val; // required
+  public @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer iterators; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TConditionalMutation.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TConditionalMutation.java
@@ -35,9 +35,9 @@ public class TConditionalMutation implements org.apache.thrift.TBase<TConditiona
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TConditionalMutationStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TConditionalMutationTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.util.List<TCondition> conditions; // required
-  private @org.apache.thrift.annotation.Nullable TMutation mutation; // required
-  private long id; // required
+  public @org.apache.thrift.annotation.Nullable java.util.List<TCondition> conditions; // required
+  public @org.apache.thrift.annotation.Nullable TMutation mutation; // required
+  public long id; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TConditionalSession.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TConditionalSession.java
@@ -35,9 +35,9 @@ public class TConditionalSession implements org.apache.thrift.TBase<TConditional
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TConditionalSessionStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TConditionalSessionTupleSchemeFactory();
 
-  private long sessionId; // required
-  private @org.apache.thrift.annotation.Nullable java.lang.String tserverLock; // required
-  private long ttl; // required
+  public long sessionId; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String tserverLock; // required
+  public long ttl; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TConstraintViolationSummary.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TConstraintViolationSummary.java
@@ -36,10 +36,10 @@ public class TConstraintViolationSummary implements org.apache.thrift.TBase<TCon
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TConstraintViolationSummaryStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TConstraintViolationSummaryTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.lang.String constrainClass; // required
-  private short violationCode; // required
-  private @org.apache.thrift.annotation.Nullable java.lang.String violationDescription; // required
-  private long numberOfViolatingMutations; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String constrainClass; // required
+  public short violationCode; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String violationDescription; // required
+  public long numberOfViolatingMutations; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TKey.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TKey.java
@@ -37,11 +37,11 @@ public class TKey implements org.apache.thrift.TBase<TKey, TKey._Fields>, java.i
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TKeyStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TKeyTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer row; // required
-  private @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer colFamily; // required
-  private @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer colQualifier; // required
-  private @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer colVisibility; // required
-  private long timestamp; // required
+  public @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer row; // required
+  public @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer colFamily; // required
+  public @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer colQualifier; // required
+  public @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer colVisibility; // required
+  public long timestamp; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TKeyExtent.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TKeyExtent.java
@@ -35,9 +35,9 @@ public class TKeyExtent implements org.apache.thrift.TBase<TKeyExtent, TKeyExten
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TKeyExtentStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TKeyExtentTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer table; // required
-  private @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer endRow; // required
-  private @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer prevEndRow; // required
+  public @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer table; // required
+  public @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer endRow; // required
+  public @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer prevEndRow; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TKeyValue.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TKeyValue.java
@@ -34,8 +34,8 @@ public class TKeyValue implements org.apache.thrift.TBase<TKeyValue, TKeyValue._
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TKeyValueStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TKeyValueTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable TKey key; // required
-  private @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer value; // required
+  public @org.apache.thrift.annotation.Nullable TKey key; // required
+  public @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer value; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TMutation.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TMutation.java
@@ -37,11 +37,11 @@ public class TMutation implements org.apache.thrift.TBase<TMutation, TMutation._
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TMutationStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TMutationTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer row; // required
-  private @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer data; // required
-  private @org.apache.thrift.annotation.Nullable java.util.List<java.nio.ByteBuffer> values; // required
-  private int entries; // required
-  private @org.apache.thrift.annotation.Nullable java.util.List<java.lang.String> sources; // optional
+  public @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer row; // required
+  public @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer data; // required
+  public @org.apache.thrift.annotation.Nullable java.util.List<java.nio.ByteBuffer> values; // required
+  public int entries; // required
+  public @org.apache.thrift.annotation.Nullable java.util.List<java.lang.String> sources; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TRange.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TRange.java
@@ -38,12 +38,12 @@ public class TRange implements org.apache.thrift.TBase<TRange, TRange._Fields>, 
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TRangeStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TRangeTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable TKey start; // required
-  private @org.apache.thrift.annotation.Nullable TKey stop; // required
-  private boolean startKeyInclusive; // required
-  private boolean stopKeyInclusive; // required
-  private boolean infiniteStartKey; // required
-  private boolean infiniteStopKey; // required
+  public @org.apache.thrift.annotation.Nullable TKey start; // required
+  public @org.apache.thrift.annotation.Nullable TKey stop; // required
+  public boolean startKeyInclusive; // required
+  public boolean stopKeyInclusive; // required
+  public boolean infiniteStartKey; // required
+  public boolean infiniteStopKey; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TRowRange.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TRowRange.java
@@ -34,8 +34,8 @@ public class TRowRange implements org.apache.thrift.TBase<TRowRange, TRowRange._
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TRowRangeStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TRowRangeTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer startRow; // required
-  private @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer endRow; // required
+  public @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer startRow; // required
+  public @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer endRow; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TSummaries.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TSummaries.java
@@ -37,11 +37,11 @@ public class TSummaries implements org.apache.thrift.TBase<TSummaries, TSummarie
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TSummariesStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TSummariesTupleSchemeFactory();
 
-  private boolean finished; // required
-  private long sessionId; // required
-  private long totalFiles; // required
-  private long deletedFiles; // required
-  private @org.apache.thrift.annotation.Nullable java.util.List<TSummary> summaries; // required
+  public boolean finished; // required
+  public long sessionId; // required
+  public long totalFiles; // required
+  public long deletedFiles; // required
+  public @org.apache.thrift.annotation.Nullable java.util.List<TSummary> summaries; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TSummarizerConfiguration.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TSummarizerConfiguration.java
@@ -35,9 +35,9 @@ public class TSummarizerConfiguration implements org.apache.thrift.TBase<TSummar
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TSummarizerConfigurationStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TSummarizerConfigurationTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.lang.String classname; // required
-  private @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.String> options; // required
-  private @org.apache.thrift.annotation.Nullable java.lang.String configId; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String classname; // required
+  public @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.String> options; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String configId; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TSummary.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TSummary.java
@@ -37,11 +37,11 @@ public class TSummary implements org.apache.thrift.TBase<TSummary, TSummary._Fie
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TSummaryStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TSummaryTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.Long> summary; // required
-  private @org.apache.thrift.annotation.Nullable TSummarizerConfiguration config; // required
-  private long filesContaining; // required
-  private long filesExceeding; // required
-  private long filesLarge; // required
+  public @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.Long> summary; // required
+  public @org.apache.thrift.annotation.Nullable TSummarizerConfiguration config; // required
+  public long filesContaining; // required
+  public long filesExceeding; // required
+  public long filesLarge; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TSummaryRequest.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TSummaryRequest.java
@@ -36,10 +36,10 @@ public class TSummaryRequest implements org.apache.thrift.TBase<TSummaryRequest,
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TSummaryRequestStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TSummaryRequestTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.lang.String tableId; // required
-  private @org.apache.thrift.annotation.Nullable TRowRange bounds; // required
-  private @org.apache.thrift.annotation.Nullable java.util.List<TSummarizerConfiguration> summarizers; // required
-  private @org.apache.thrift.annotation.Nullable java.lang.String summarizerPattern; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String tableId; // required
+  public @org.apache.thrift.annotation.Nullable TRowRange bounds; // required
+  public @org.apache.thrift.annotation.Nullable java.util.List<TSummarizerConfiguration> summarizers; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String summarizerPattern; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/UpdateErrors.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/UpdateErrors.java
@@ -35,9 +35,9 @@ public class UpdateErrors implements org.apache.thrift.TBase<UpdateErrors, Updat
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new UpdateErrorsStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new UpdateErrorsTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.util.Map<TKeyExtent,java.lang.Long> failedExtents; // required
-  private @org.apache.thrift.annotation.Nullable java.util.List<TConstraintViolationSummary> violationSummaries; // required
-  private @org.apache.thrift.annotation.Nullable java.util.Map<TKeyExtent,org.apache.accumulo.core.clientImpl.thrift.SecurityErrorCode> authorizationFailures; // required
+  public @org.apache.thrift.annotation.Nullable java.util.Map<TKeyExtent,java.lang.Long> failedExtents; // required
+  public @org.apache.thrift.annotation.Nullable java.util.List<TConstraintViolationSummary> violationSummaries; // required
+  public @org.apache.thrift.annotation.Nullable java.util.Map<TKeyExtent,org.apache.accumulo.core.clientImpl.thrift.SecurityErrorCode> authorizationFailures; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/gc/thrift/GCMonitorService.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/gc/thrift/GCMonitorService.java
@@ -305,8 +305,8 @@ public class GCMonitorService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getStatus_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getStatus_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -809,8 +809,8 @@ public class GCMonitorService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getStatus_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getStatus_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable GCStatus success; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable GCStatus success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/gc/thrift/GCStatus.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/gc/thrift/GCStatus.java
@@ -36,10 +36,10 @@ public class GCStatus implements org.apache.thrift.TBase<GCStatus, GCStatus._Fie
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new GCStatusStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new GCStatusTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable GcCycleStats last; // required
-  private @org.apache.thrift.annotation.Nullable GcCycleStats lastLog; // required
-  private @org.apache.thrift.annotation.Nullable GcCycleStats current; // required
-  private @org.apache.thrift.annotation.Nullable GcCycleStats currentLog; // required
+  public @org.apache.thrift.annotation.Nullable GcCycleStats last; // required
+  public @org.apache.thrift.annotation.Nullable GcCycleStats lastLog; // required
+  public @org.apache.thrift.annotation.Nullable GcCycleStats current; // required
+  public @org.apache.thrift.annotation.Nullable GcCycleStats currentLog; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/gc/thrift/GcCycleStats.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/gc/thrift/GcCycleStats.java
@@ -39,13 +39,13 @@ public class GcCycleStats implements org.apache.thrift.TBase<GcCycleStats, GcCyc
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new GcCycleStatsStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new GcCycleStatsTupleSchemeFactory();
 
-  private long started; // required
-  private long finished; // required
-  private long candidates; // required
-  private long inUse; // required
-  private long deleted; // required
-  private long errors; // required
-  private long bulks; // required
+  public long started; // required
+  public long finished; // required
+  public long candidates; // required
+  public long inUse; // required
+  public long deleted; // required
+  public long errors; // required
+  public long bulks; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/Compacting.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/Compacting.java
@@ -34,8 +34,8 @@ public class Compacting implements org.apache.thrift.TBase<Compacting, Compactin
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new CompactingStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new CompactingTupleSchemeFactory();
 
-  private int running; // required
-  private int queued; // required
+  public int running; // required
+  public int queued; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/FateService.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/FateService.java
@@ -1141,9 +1141,13 @@ public class FateService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new beginFateOperation_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new beginFateOperation_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable TFateInstanceType type; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    /**
+     * 
+     * @see TFateInstanceType
+     */
+    public @org.apache.thrift.annotation.Nullable TFateInstanceType type; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -1762,9 +1766,9 @@ public class FateService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new beginFateOperation_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new beginFateOperation_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TFateId success; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable TFateId success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -2373,13 +2377,17 @@ public class FateService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new executeFateOperation_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new executeFateOperation_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable TFateId opid; // required
-    private @org.apache.thrift.annotation.Nullable TFateOperation op; // required
-    private @org.apache.thrift.annotation.Nullable java.util.List<java.nio.ByteBuffer> arguments; // required
-    private @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.String> options; // required
-    private boolean autoClean; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable TFateId opid; // required
+    /**
+     * 
+     * @see TFateOperation
+     */
+    public @org.apache.thrift.annotation.Nullable TFateOperation op; // required
+    public @org.apache.thrift.annotation.Nullable java.util.List<java.nio.ByteBuffer> arguments; // required
+    public @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.String> options; // required
+    public boolean autoClean; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -3512,9 +3520,9 @@ public class FateService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new executeFateOperation_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new executeFateOperation_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException tope; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException tope; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -4116,9 +4124,9 @@ public class FateService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new waitForFateOperation_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new waitForFateOperation_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable TFateId opid; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable TFateId opid; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -4731,10 +4739,10 @@ public class FateService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new waitForFateOperation_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new waitForFateOperation_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable java.lang.String success; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException tope; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException tope; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -5439,9 +5447,9 @@ public class FateService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new finishFateOperation_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new finishFateOperation_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable TFateId opid; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable TFateId opid; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -6052,8 +6060,8 @@ public class FateService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new finishFateOperation_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new finishFateOperation_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -6550,9 +6558,9 @@ public class FateService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new cancelFateOperation_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new cancelFateOperation_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable TFateId opid; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable TFateId opid; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -7164,9 +7172,9 @@ public class FateService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new cancelFateOperation_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new cancelFateOperation_resultTupleSchemeFactory();
 
-    private boolean success; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public boolean success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/FateWorkerService.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/FateWorkerService.java
@@ -675,8 +675,8 @@ public class FateWorkerService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getPartitions_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getPartitions_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -1179,8 +1179,8 @@ public class FateWorkerService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getPartitions_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getPartitions_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TFatePartitions success; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable TFatePartitions success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -1681,10 +1681,10 @@ public class FateWorkerService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new setPartitions_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new setPartitions_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private long updateId; // required
-    private @org.apache.thrift.annotation.Nullable java.util.List<TFatePartition> desired; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public long updateId; // required
+    public @org.apache.thrift.annotation.Nullable java.util.List<TFatePartition> desired; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -2443,8 +2443,8 @@ public class FateWorkerService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new setPartitions_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new setPartitions_resultTupleSchemeFactory();
 
-    private boolean success; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public boolean success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -2936,9 +2936,9 @@ public class FateWorkerService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new seeded_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new seeded_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.util.List<TFatePartition> tpartitions; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.util.List<TFatePartition> tpartitions; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/ManagerClientService.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/ManagerClientService.java
@@ -5845,9 +5845,9 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new initiateFlush_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new initiateFlush_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String tableName; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String tableName; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -6455,10 +6455,10 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new initiateFlush_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new initiateFlush_resultTupleSchemeFactory();
 
-    private long success; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException tope; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public long success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException tope; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -7164,13 +7164,13 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new waitForFlush_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new waitForFlush_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String tableName; // required
-    private @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer startRow; // required
-    private @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer endRow; // required
-    private long flushID; // required
-    private long maxLoops; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String tableName; // required
+    public @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer startRow; // required
+    public @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer endRow; // required
+    public long flushID; // required
+    public long maxLoops; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -8201,9 +8201,9 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new waitForFlush_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new waitForFlush_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException tope; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException tope; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -8807,11 +8807,11 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new setTableProperty_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new setTableProperty_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String tableName; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String property; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String value; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String tableName; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String property; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String value; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -9625,10 +9625,10 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new setTableProperty_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new setTableProperty_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException tope; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
-    private @org.apache.thrift.annotation.Nullable ThriftPropertyException tpe; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException tope; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable ThriftPropertyException tpe; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -10336,10 +10336,10 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new modifyTableProperties_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new modifyTableProperties_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String tableName; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TVersionedProperties vProperties; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String tableName; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TVersionedProperties vProperties; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -11056,11 +11056,11 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new modifyTableProperties_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new modifyTableProperties_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException tope; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftConcurrentModificationException tcme; // required
-    private @org.apache.thrift.annotation.Nullable ThriftPropertyException tpe; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException tope; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftConcurrentModificationException tcme; // required
+    public @org.apache.thrift.annotation.Nullable ThriftPropertyException tpe; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -11873,10 +11873,10 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new removeTableProperty_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new removeTableProperty_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String tableName; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String property; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String tableName; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String property; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -12586,9 +12586,9 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new removeTableProperty_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new removeTableProperty_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException tope; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException tope; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -13192,11 +13192,11 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new setNamespaceProperty_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new setNamespaceProperty_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String ns; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String property; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String value; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String ns; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String property; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String value; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -14010,10 +14010,10 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new setNamespaceProperty_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new setNamespaceProperty_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException tope; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
-    private @org.apache.thrift.annotation.Nullable ThriftPropertyException tpe; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException tope; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable ThriftPropertyException tpe; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -14721,10 +14721,10 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new modifyNamespaceProperties_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new modifyNamespaceProperties_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String ns; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TVersionedProperties vProperties; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String ns; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TVersionedProperties vProperties; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -15441,11 +15441,11 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new modifyNamespaceProperties_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new modifyNamespaceProperties_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException tope; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftConcurrentModificationException tcme; // required
-    private @org.apache.thrift.annotation.Nullable ThriftPropertyException tpe; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException tope; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftConcurrentModificationException tcme; // required
+    public @org.apache.thrift.annotation.Nullable ThriftPropertyException tpe; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -16258,10 +16258,10 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new removeNamespaceProperty_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new removeNamespaceProperty_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String ns; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String property; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String ns; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String property; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -16971,9 +16971,9 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new removeNamespaceProperty_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new removeNamespaceProperty_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException tope; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException tope; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -17575,9 +17575,13 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new setManagerGoalState_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new setManagerGoalState_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable ManagerGoalState state; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    /**
+     * 
+     * @see ManagerGoalState
+     */
+    public @org.apache.thrift.annotation.Nullable ManagerGoalState state; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -18195,8 +18199,8 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new setManagerGoalState_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new setManagerGoalState_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -18693,9 +18697,9 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new shutdown_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new shutdown_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private boolean stopTabletServers; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public boolean stopTabletServers; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -19296,8 +19300,8 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new shutdown_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new shutdown_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -19795,10 +19799,10 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new shutdownTabletServer_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new shutdownTabletServer_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String tabletServer; // required
-    private boolean force; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String tabletServer; // required
+    public boolean force; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -20502,8 +20506,8 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new shutdownTabletServer_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new shutdownTabletServer_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -21001,10 +21005,10 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new tabletServerStopping_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new tabletServerStopping_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String tabletServer; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String resourceGroup; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String tabletServer; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String resourceGroup; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -21713,8 +21717,8 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new tabletServerStopping_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new tabletServerStopping_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -22212,10 +22216,10 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new setSystemProperty_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new setSystemProperty_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String property; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String value; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String property; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String value; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -22925,9 +22929,9 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new setSystemProperty_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new setSystemProperty_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
-    private @org.apache.thrift.annotation.Nullable ThriftPropertyException tpe; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable ThriftPropertyException tpe; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -23529,9 +23533,9 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new modifySystemProperties_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new modifySystemProperties_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TVersionedProperties vProperties; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TVersionedProperties vProperties; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -24144,10 +24148,10 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new modifySystemProperties_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new modifySystemProperties_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftConcurrentModificationException tcme; // required
-    private @org.apache.thrift.annotation.Nullable ThriftPropertyException tpe; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftConcurrentModificationException tcme; // required
+    public @org.apache.thrift.annotation.Nullable ThriftPropertyException tpe; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -24854,9 +24858,9 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new removeSystemProperty_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new removeSystemProperty_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String property; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String property; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -25462,8 +25466,8 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new removeSystemProperty_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new removeSystemProperty_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -25960,9 +25964,9 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new createResourceGroupNode_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new createResourceGroupNode_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String resourceGroup; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String resourceGroup; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -26568,8 +26572,8 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new createResourceGroupNode_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new createResourceGroupNode_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -27066,9 +27070,9 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new removeResourceGroupNode_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new removeResourceGroupNode_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String resourceGroup; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String resourceGroup; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -27675,9 +27679,9 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new removeResourceGroupNode_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new removeResourceGroupNode_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftResourceGroupNotExistsException rgne; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftResourceGroupNotExistsException rgne; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -28281,11 +28285,11 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new setResourceGroupProperty_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new setResourceGroupProperty_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String resourceGroup; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String property; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String value; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String resourceGroup; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String property; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String value; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -29099,10 +29103,10 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new setResourceGroupProperty_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new setResourceGroupProperty_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
-    private @org.apache.thrift.annotation.Nullable ThriftPropertyException tpe; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftResourceGroupNotExistsException rgne; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable ThriftPropertyException tpe; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftResourceGroupNotExistsException rgne; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -29810,10 +29814,10 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new modifyResourceGroupProperties_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new modifyResourceGroupProperties_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String resourceGroup; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TVersionedProperties vProperties; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String resourceGroup; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TVersionedProperties vProperties; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -30530,11 +30534,11 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new modifyResourceGroupProperties_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new modifyResourceGroupProperties_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftConcurrentModificationException tcme; // required
-    private @org.apache.thrift.annotation.Nullable ThriftPropertyException tpe; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftResourceGroupNotExistsException rgne; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftConcurrentModificationException tcme; // required
+    public @org.apache.thrift.annotation.Nullable ThriftPropertyException tpe; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftResourceGroupNotExistsException rgne; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -31347,10 +31351,10 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new removeResourceGroupProperty_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new removeResourceGroupProperty_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String resourceGroup; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String property; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String resourceGroup; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String property; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -32060,9 +32064,9 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new removeResourceGroupProperty_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new removeResourceGroupProperty_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftResourceGroupNotExistsException rgne; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftResourceGroupNotExistsException rgne; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -32662,7 +32666,7 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new waitForBalance_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new waitForBalance_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -33056,7 +33060,7 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new waitForBalance_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new waitForBalance_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -33450,11 +33454,15 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new reportTabletStatus_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new reportTabletStatus_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String serverName; // required
-    private @org.apache.thrift.annotation.Nullable TabletLoadState status; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent tablet; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String serverName; // required
+    /**
+     * 
+     * @see TabletLoadState
+     */
+    public @org.apache.thrift.annotation.Nullable TabletLoadState status; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent tablet; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -34283,8 +34291,8 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getActiveTservers_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getActiveTservers_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -34788,9 +34796,9 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getActiveTservers_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getActiveTservers_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable java.util.List<java.lang.String> success; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable java.util.List<java.lang.String> success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -35440,9 +35448,9 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getDelegationToken_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getDelegationToken_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TDelegationTokenConfig cfg; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TDelegationTokenConfig cfg; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -36054,9 +36062,9 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getDelegationToken_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getDelegationToken_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TDelegationToken success; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TDelegationToken success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -36662,10 +36670,10 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new requestTabletHosting_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new requestTabletHosting_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String tableId; // required
-    private @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.dataImpl.thrift.TKeyExtent> extents; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String tableId; // required
+    public @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.dataImpl.thrift.TKeyExtent> extents; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -37430,9 +37438,9 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new requestTabletHosting_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new requestTabletHosting_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException toe; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException toe; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -38035,10 +38043,10 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new updateTabletMergeability_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new updateTabletMergeability_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String tableName; // required
-    private @org.apache.thrift.annotation.Nullable java.util.Map<org.apache.accumulo.core.dataImpl.thrift.TKeyExtent,TTabletMergeability> splits; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String tableName; // required
+    public @org.apache.thrift.annotation.Nullable java.util.Map<org.apache.accumulo.core.dataImpl.thrift.TKeyExtent,TTabletMergeability> splits; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -38816,10 +38824,10 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new updateTabletMergeability_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new updateTabletMergeability_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.dataImpl.thrift.TKeyExtent> success; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException toe; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.dataImpl.thrift.TKeyExtent> success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException toe; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -39578,8 +39586,8 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getManagerTimeNanos_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getManagerTimeNanos_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -40083,9 +40091,9 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getManagerTimeNanos_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getManagerTimeNanos_resultTupleSchemeFactory();
 
-    private long success; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public long success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -40682,9 +40690,9 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new processEvents_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new processEvents_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.util.List<TEvent> events; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.util.List<TEvent> events; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -41345,8 +41353,8 @@ public class ManagerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new processEvents_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new processEvents_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException tnase; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/RecoveryStatus.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/RecoveryStatus.java
@@ -35,9 +35,9 @@ public class RecoveryStatus implements org.apache.thrift.TBase<RecoveryStatus, R
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new RecoveryStatusStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new RecoveryStatusTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.lang.String name; // required
-  private int runtime; // required
-  private double progress; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String name; // required
+  public int runtime; // required
+  public double progress; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/TEvent.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/TEvent.java
@@ -34,8 +34,8 @@ public class TEvent implements org.apache.thrift.TBase<TEvent, TEvent._Fields>, 
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TEventStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TEventTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.lang.String level; // required
-  private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String level; // required
+  public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/TFateId.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/TFateId.java
@@ -34,8 +34,12 @@ public class TFateId implements org.apache.thrift.TBase<TFateId, TFateId._Fields
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TFateIdStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TFateIdTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable TFateInstanceType type; // required
-  private @org.apache.thrift.annotation.Nullable java.lang.String txUUIDStr; // required
+  /**
+   * 
+   * @see TFateInstanceType
+   */
+  public @org.apache.thrift.annotation.Nullable TFateInstanceType type; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String txUUIDStr; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/TFatePartition.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/TFatePartition.java
@@ -34,8 +34,8 @@ public class TFatePartition implements org.apache.thrift.TBase<TFatePartition, T
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TFatePartitionStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TFatePartitionTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.lang.String start; // required
-  private @org.apache.thrift.annotation.Nullable java.lang.String stop; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String start; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String stop; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/TFatePartitions.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/TFatePartitions.java
@@ -34,8 +34,8 @@ public class TFatePartitions implements org.apache.thrift.TBase<TFatePartitions,
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TFatePartitionsStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TFatePartitionsTupleSchemeFactory();
 
-  private long updateId; // required
-  private @org.apache.thrift.annotation.Nullable java.util.List<TFatePartition> partitions; // required
+  public long updateId; // required
+  public @org.apache.thrift.annotation.Nullable java.util.List<TFatePartition> partitions; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/TTabletMergeability.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/TTabletMergeability.java
@@ -34,8 +34,8 @@ public class TTabletMergeability implements org.apache.thrift.TBase<TTabletMerge
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TTabletMergeabilityStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TTabletMergeabilityTupleSchemeFactory();
 
-  private boolean never; // required
-  private long delay; // required
+  public boolean never; // required
+  public long delay; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/TableInfo.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/TableInfo.java
@@ -43,17 +43,17 @@ public class TableInfo implements org.apache.thrift.TBase<TableInfo, TableInfo._
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TableInfoStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TableInfoTupleSchemeFactory();
 
-  private long recs; // required
-  private long recsInMemory; // required
-  private int tablets; // required
-  private int onlineTablets; // required
-  private double ingestRate; // required
-  private double ingestByteRate; // required
-  private double queryRate; // required
-  private double queryByteRate; // required
-  private @org.apache.thrift.annotation.Nullable Compacting minors; // required
-  private @org.apache.thrift.annotation.Nullable Compacting scans; // required
-  private double scanRate; // required
+  public long recs; // required
+  public long recsInMemory; // required
+  public int tablets; // required
+  public int onlineTablets; // required
+  public double ingestRate; // required
+  public double ingestByteRate; // required
+  public double queryRate; // required
+  public double queryByteRate; // required
+  public @org.apache.thrift.annotation.Nullable Compacting minors; // required
+  public @org.apache.thrift.annotation.Nullable Compacting scans; // required
+  public double scanRate; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/TabletServerStatus.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/TabletServerStatus.java
@@ -47,21 +47,21 @@ public class TabletServerStatus implements org.apache.thrift.TBase<TabletServerS
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TabletServerStatusStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TabletServerStatusTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,TableInfo> tableMap; // required
-  private long lastContact; // required
-  private @org.apache.thrift.annotation.Nullable java.lang.String name; // required
-  private double osLoad; // required
-  private long holdTime; // required
-  private long lookups; // required
-  private long indexCacheHits; // required
-  private long indexCacheRequest; // required
-  private long dataCacheHits; // required
-  private long dataCacheRequest; // required
-  private @org.apache.thrift.annotation.Nullable java.util.List<RecoveryStatus> logSorts; // required
-  private long flushs; // required
-  private long syncs; // required
-  private @org.apache.thrift.annotation.Nullable java.lang.String version; // required
-  private long responseTime; // required
+  public @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,TableInfo> tableMap; // required
+  public long lastContact; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String name; // required
+  public double osLoad; // required
+  public long holdTime; // required
+  public long lookups; // required
+  public long indexCacheHits; // required
+  public long indexCacheRequest; // required
+  public long dataCacheHits; // required
+  public long dataCacheRequest; // required
+  public @org.apache.thrift.annotation.Nullable java.util.List<RecoveryStatus> logSorts; // required
+  public long flushs; // required
+  public long syncs; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String version; // required
+  public long responseTime; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/TabletSplit.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/TabletSplit.java
@@ -34,8 +34,8 @@ public class TabletSplit implements org.apache.thrift.TBase<TabletSplit, TabletS
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TabletSplitStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TabletSplitTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent oldTablet; // required
-  private @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.dataImpl.thrift.TKeyExtent> newTablets; // required
+  public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent oldTablet; // required
+  public @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.dataImpl.thrift.TKeyExtent> newTablets; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/ThriftPropertyException.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/ThriftPropertyException.java
@@ -35,9 +35,9 @@ public class ThriftPropertyException extends org.apache.thrift.TException implem
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new ThriftPropertyExceptionStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new ThriftPropertyExceptionTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.lang.String property; // required
-  private @org.apache.thrift.annotation.Nullable java.lang.String value; // required
-  private @org.apache.thrift.annotation.Nullable java.lang.String description; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String property; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String value; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String description; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/process/thrift/MetricResponse.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/process/thrift/MetricResponse.java
@@ -37,11 +37,15 @@ public class MetricResponse implements org.apache.thrift.TBase<MetricResponse, M
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new MetricResponseStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new MetricResponseTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable MetricSource serverType; // required
-  private @org.apache.thrift.annotation.Nullable java.lang.String server; // required
-  private @org.apache.thrift.annotation.Nullable java.lang.String resourceGroup; // required
-  private long timestamp; // required
-  private @org.apache.thrift.annotation.Nullable java.util.List<java.nio.ByteBuffer> metrics; // required
+  /**
+   * 
+   * @see MetricSource
+   */
+  public @org.apache.thrift.annotation.Nullable MetricSource serverType; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String server; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String resourceGroup; // required
+  public long timestamp; // required
+  public @org.apache.thrift.annotation.Nullable java.util.List<java.nio.ByteBuffer> metrics; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/process/thrift/ServerProcessService.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/process/thrift/ServerProcessService.java
@@ -436,8 +436,8 @@ public class ServerProcessService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getMetrics_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getMetrics_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -940,8 +940,8 @@ public class ServerProcessService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getMetrics_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getMetrics_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable MetricResponse success; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable MetricResponse success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -1439,7 +1439,7 @@ public class ServerProcessService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new gracefulShutdown_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new gracefulShutdown_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/securityImpl/thrift/TAuthenticationKey.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/securityImpl/thrift/TAuthenticationKey.java
@@ -36,10 +36,10 @@ public class TAuthenticationKey implements org.apache.thrift.TBase<TAuthenticati
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TAuthenticationKeyStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TAuthenticationKeyTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer secret; // required
-  private int keyId; // optional
-  private long expirationDate; // optional
-  private long creationDate; // optional
+  public @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer secret; // required
+  public int keyId; // optional
+  public long expirationDate; // optional
+  public long creationDate; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/securityImpl/thrift/TAuthenticationTokenIdentifier.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/securityImpl/thrift/TAuthenticationTokenIdentifier.java
@@ -37,11 +37,11 @@ public class TAuthenticationTokenIdentifier implements org.apache.thrift.TBase<T
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TAuthenticationTokenIdentifierStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TAuthenticationTokenIdentifierTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.lang.String principal; // required
-  private int keyId; // optional
-  private long issueDate; // optional
-  private long expirationDate; // optional
-  private @org.apache.thrift.annotation.Nullable java.lang.String instanceId; // optional
+  public @org.apache.thrift.annotation.Nullable java.lang.String principal; // required
+  public int keyId; // optional
+  public long issueDate; // optional
+  public long expirationDate; // optional
+  public @org.apache.thrift.annotation.Nullable java.lang.String instanceId; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/securityImpl/thrift/TCredentials.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/securityImpl/thrift/TCredentials.java
@@ -36,10 +36,10 @@ public class TCredentials implements org.apache.thrift.TBase<TCredentials, TCred
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TCredentialsStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TCredentialsTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.lang.String principal; // required
-  private @org.apache.thrift.annotation.Nullable java.lang.String tokenClassName; // required
-  private @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer token; // required
-  private @org.apache.thrift.annotation.Nullable java.lang.String instanceId; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String principal; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String tokenClassName; // required
+  public @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer token; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String instanceId; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/securityImpl/thrift/TDelegationToken.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/securityImpl/thrift/TDelegationToken.java
@@ -34,8 +34,8 @@ public class TDelegationToken implements org.apache.thrift.TBase<TDelegationToke
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TDelegationTokenStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TDelegationTokenTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer password; // required
-  private @org.apache.thrift.annotation.Nullable TAuthenticationTokenIdentifier identifier; // required
+  public @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer password; // required
+  public @org.apache.thrift.annotation.Nullable TAuthenticationTokenIdentifier identifier; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/securityImpl/thrift/TDelegationTokenConfig.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/securityImpl/thrift/TDelegationTokenConfig.java
@@ -33,7 +33,7 @@ public class TDelegationTokenConfig implements org.apache.thrift.TBase<TDelegati
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TDelegationTokenConfigStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TDelegationTokenConfigTupleSchemeFactory();
 
-  private long lifetime; // optional
+  public long lifetime; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/tablet/thrift/TabletManagementClientService.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/tablet/thrift/TabletManagementClientService.java
@@ -559,10 +559,10 @@ public class TabletManagementClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new loadTablet_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new loadTablet_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String lock; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String lock; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -1280,12 +1280,16 @@ public class TabletManagementClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new unloadTablet_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new unloadTablet_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String lock; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent; // required
-    private @org.apache.thrift.annotation.Nullable TUnloadTabletGoal goal; // required
-    private long requestTime; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String lock; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent; // required
+    /**
+     * 
+     * @see TUnloadTabletGoal
+     */
+    public @org.apache.thrift.annotation.Nullable TUnloadTabletGoal goal; // required
+    public long requestTime; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -2214,10 +2218,10 @@ public class TabletManagementClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new flushTablet_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new flushTablet_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String lock; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String lock; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletingest/thrift/ConstraintViolationException.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletingest/thrift/ConstraintViolationException.java
@@ -33,7 +33,7 @@ public class ConstraintViolationException extends org.apache.thrift.TException i
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new ConstraintViolationExceptionStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new ConstraintViolationExceptionTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.dataImpl.thrift.TConstraintViolationSummary> violationSummaries; // required
+  public @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.dataImpl.thrift.TConstraintViolationSummary> violationSummaries; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletingest/thrift/DataFileInfo.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletingest/thrift/DataFileInfo.java
@@ -33,7 +33,7 @@ public class DataFileInfo implements org.apache.thrift.TBase<DataFileInfo, DataF
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new DataFileInfoStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new DataFileInfoTupleSchemeFactory();
 
-  private long estimatedSize; // required
+  public long estimatedSize; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletingest/thrift/TabletIngestClientService.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletingest/thrift/TabletIngestClientService.java
@@ -1516,9 +1516,13 @@ public class TabletIngestClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new startUpdate_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new startUpdate_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable TDurability durability; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    /**
+     * 
+     * @see TDurability
+     */
+    public @org.apache.thrift.annotation.Nullable TDurability durability; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -2136,8 +2140,8 @@ public class TabletIngestClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new startUpdate_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new startUpdate_resultTupleSchemeFactory();
 
-    private long success; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public long success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -2630,10 +2634,10 @@ public class TabletIngestClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new applyUpdates_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new applyUpdates_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private long updateID; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent keyExtent; // required
-    private @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.dataImpl.thrift.TMutation> mutations; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public long updateID; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent keyExtent; // required
+    public @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.dataImpl.thrift.TMutation> mutations; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -3392,8 +3396,8 @@ public class TabletIngestClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new closeUpdate_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new closeUpdate_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private long updateID; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public long updateID; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -3886,8 +3890,8 @@ public class TabletIngestClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new closeUpdate_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new closeUpdate_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.UpdateErrors success; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.tabletserver.thrift.NoSuchScanIDException nssi; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.UpdateErrors success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.tabletserver.thrift.NoSuchScanIDException nssi; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -4386,8 +4390,8 @@ public class TabletIngestClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new cancelUpdate_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new cancelUpdate_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private long updateID; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public long updateID; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -4879,7 +4883,7 @@ public class TabletIngestClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new cancelUpdate_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new cancelUpdate_resultTupleSchemeFactory();
 
-    private boolean success; // required
+    public boolean success; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -5269,12 +5273,16 @@ public class TabletIngestClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new startConditionalUpdate_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new startConditionalUpdate_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.util.List<java.nio.ByteBuffer> authorizations; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String tableID; // required
-    private @org.apache.thrift.annotation.Nullable TDurability durability; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String classLoaderContext; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.util.List<java.nio.ByteBuffer> authorizations; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String tableID; // required
+    /**
+     * 
+     * @see TDurability
+     */
+    public @org.apache.thrift.annotation.Nullable TDurability durability; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String classLoaderContext; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -6251,8 +6259,8 @@ public class TabletIngestClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new startConditionalUpdate_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new startConditionalUpdate_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TConditionalSession success; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TConditionalSession success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -6753,10 +6761,10 @@ public class TabletIngestClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new conditionalUpdate_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new conditionalUpdate_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private long sessID; // required
-    private @org.apache.thrift.annotation.Nullable java.util.Map<org.apache.accumulo.core.dataImpl.thrift.TKeyExtent,java.util.List<org.apache.accumulo.core.dataImpl.thrift.TConditionalMutation>> mutations; // required
-    private @org.apache.thrift.annotation.Nullable java.util.List<java.lang.String> symbols; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public long sessID; // required
+    public @org.apache.thrift.annotation.Nullable java.util.Map<org.apache.accumulo.core.dataImpl.thrift.TKeyExtent,java.util.List<org.apache.accumulo.core.dataImpl.thrift.TConditionalMutation>> mutations; // required
+    public @org.apache.thrift.annotation.Nullable java.util.List<java.lang.String> symbols; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -7608,8 +7616,8 @@ public class TabletIngestClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new conditionalUpdate_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new conditionalUpdate_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.dataImpl.thrift.TCMResult> success; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.tabletserver.thrift.NoSuchScanIDException nssi; // required
+    public @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.dataImpl.thrift.TCMResult> success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.tabletserver.thrift.NoSuchScanIDException nssi; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -8158,8 +8166,8 @@ public class TabletIngestClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new invalidateConditionalUpdate_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new invalidateConditionalUpdate_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private long sessID; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public long sessID; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -8927,8 +8935,8 @@ public class TabletIngestClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new closeConditionalUpdate_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new closeConditionalUpdate_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private long sessID; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public long sessID; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletscan/thrift/ActiveScan.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletscan/thrift/ActiveScan.java
@@ -46,20 +46,28 @@ public class ActiveScan implements org.apache.thrift.TBase<ActiveScan, ActiveSca
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new ActiveScanStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new ActiveScanTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.lang.String client; // required
-  private @org.apache.thrift.annotation.Nullable java.lang.String user; // required
-  private @org.apache.thrift.annotation.Nullable java.lang.String tableId; // required
-  private long age; // required
-  private long idleTime; // required
-  private @org.apache.thrift.annotation.Nullable ScanType type; // required
-  private @org.apache.thrift.annotation.Nullable ScanState state; // required
-  private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent; // required
-  private @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.dataImpl.thrift.TColumn> columns; // required
-  private @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.dataImpl.thrift.IterInfo> ssiList; // required
-  private @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.util.Map<java.lang.String,java.lang.String>> ssio; // required
-  private @org.apache.thrift.annotation.Nullable java.util.List<java.nio.ByteBuffer> authorizations; // required
-  private long scanId; // optional
-  private @org.apache.thrift.annotation.Nullable java.lang.String classLoaderContext; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String client; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String user; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String tableId; // required
+  public long age; // required
+  public long idleTime; // required
+  /**
+   * 
+   * @see ScanType
+   */
+  public @org.apache.thrift.annotation.Nullable ScanType type; // required
+  /**
+   * 
+   * @see ScanState
+   */
+  public @org.apache.thrift.annotation.Nullable ScanState state; // required
+  public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent; // required
+  public @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.dataImpl.thrift.TColumn> columns; // required
+  public @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.dataImpl.thrift.IterInfo> ssiList; // required
+  public @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.util.Map<java.lang.String,java.lang.String>> ssio; // required
+  public @org.apache.thrift.annotation.Nullable java.util.List<java.nio.ByteBuffer> authorizations; // required
+  public long scanId; // optional
+  public @org.apache.thrift.annotation.Nullable java.lang.String classLoaderContext; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletscan/thrift/TSampleNotPresentException.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletscan/thrift/TSampleNotPresentException.java
@@ -33,7 +33,7 @@ public class TSampleNotPresentException extends org.apache.thrift.TException imp
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TSampleNotPresentExceptionStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TSampleNotPresentExceptionTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent; // required
+  public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletscan/thrift/TSamplerConfiguration.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletscan/thrift/TSamplerConfiguration.java
@@ -34,8 +34,8 @@ public class TSamplerConfiguration implements org.apache.thrift.TBase<TSamplerCo
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TSamplerConfigurationStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TSamplerConfigurationTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.lang.String className; // required
-  private @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.String> options; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String className; // required
+  public @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.String> options; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletscan/thrift/TabletScanClientService.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletscan/thrift/TabletScanClientService.java
@@ -1597,23 +1597,23 @@ public class TabletScanClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new startScan_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new startScan_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TRange range; // required
-    private @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.dataImpl.thrift.TColumn> columns; // required
-    private int batchSize; // required
-    private @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.dataImpl.thrift.IterInfo> ssiList; // required
-    private @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.util.Map<java.lang.String,java.lang.String>> ssio; // required
-    private @org.apache.thrift.annotation.Nullable java.util.List<java.nio.ByteBuffer> authorizations; // required
-    private boolean waitForWrites; // required
-    private boolean isolated; // required
-    private long readaheadThreshold; // required
-    private @org.apache.thrift.annotation.Nullable TSamplerConfiguration samplerConfig; // required
-    private long batchTimeOut; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String classLoaderContext; // required
-    private @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.String> executionHints; // required
-    private long busyTimeout; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TRange range; // required
+    public @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.dataImpl.thrift.TColumn> columns; // required
+    public int batchSize; // required
+    public @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.dataImpl.thrift.IterInfo> ssiList; // required
+    public @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.util.Map<java.lang.String,java.lang.String>> ssio; // required
+    public @org.apache.thrift.annotation.Nullable java.util.List<java.nio.ByteBuffer> authorizations; // required
+    public boolean waitForWrites; // required
+    public boolean isolated; // required
+    public long readaheadThreshold; // required
+    public @org.apache.thrift.annotation.Nullable TSamplerConfiguration samplerConfig; // required
+    public long batchTimeOut; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String classLoaderContext; // required
+    public @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.String> executionHints; // required
+    public long busyTimeout; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -3945,12 +3945,12 @@ public class TabletScanClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new startScan_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new startScan_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.InitialScan success; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.tabletserver.thrift.NotServingTabletException nste; // required
-    private @org.apache.thrift.annotation.Nullable TooManyFilesException tmfe; // required
-    private @org.apache.thrift.annotation.Nullable TSampleNotPresentException tsnpe; // required
-    private @org.apache.thrift.annotation.Nullable ScanServerBusyException ssbe; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.InitialScan success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.tabletserver.thrift.NotServingTabletException nste; // required
+    public @org.apache.thrift.annotation.Nullable TooManyFilesException tmfe; // required
+    public @org.apache.thrift.annotation.Nullable TSampleNotPresentException tsnpe; // required
+    public @org.apache.thrift.annotation.Nullable ScanServerBusyException ssbe; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -4870,9 +4870,9 @@ public class TabletScanClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new continueScan_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new continueScan_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private long scanID; // required
-    private long busyTimeout; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public long scanID; // required
+    public long busyTimeout; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -5463,12 +5463,12 @@ public class TabletScanClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new continueScan_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new continueScan_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.ScanResult success; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.tabletserver.thrift.NoSuchScanIDException nssi; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.tabletserver.thrift.NotServingTabletException nste; // required
-    private @org.apache.thrift.annotation.Nullable TooManyFilesException tmfe; // required
-    private @org.apache.thrift.annotation.Nullable TSampleNotPresentException tsnpe; // required
-    private @org.apache.thrift.annotation.Nullable ScanServerBusyException ssbe; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.ScanResult success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.tabletserver.thrift.NoSuchScanIDException nssi; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.tabletserver.thrift.NotServingTabletException nste; // required
+    public @org.apache.thrift.annotation.Nullable TooManyFilesException tmfe; // required
+    public @org.apache.thrift.annotation.Nullable TSampleNotPresentException tsnpe; // required
+    public @org.apache.thrift.annotation.Nullable ScanServerBusyException ssbe; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -6387,8 +6387,8 @@ public class TabletScanClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new closeScan_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new closeScan_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private long scanID; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public long scanID; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -6892,19 +6892,19 @@ public class TabletScanClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new startMultiScan_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new startMultiScan_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.util.Map<org.apache.accumulo.core.dataImpl.thrift.TKeyExtent,java.util.List<org.apache.accumulo.core.dataImpl.thrift.TRange>> batch; // required
-    private @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.dataImpl.thrift.TColumn> columns; // required
-    private @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.dataImpl.thrift.IterInfo> ssiList; // required
-    private @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.util.Map<java.lang.String,java.lang.String>> ssio; // required
-    private @org.apache.thrift.annotation.Nullable java.util.List<java.nio.ByteBuffer> authorizations; // required
-    private boolean waitForWrites; // required
-    private @org.apache.thrift.annotation.Nullable TSamplerConfiguration samplerConfig; // required
-    private long batchTimeOut; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String classLoaderContext; // required
-    private @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.String> executionHints; // required
-    private long busyTimeout; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.util.Map<org.apache.accumulo.core.dataImpl.thrift.TKeyExtent,java.util.List<org.apache.accumulo.core.dataImpl.thrift.TRange>> batch; // required
+    public @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.dataImpl.thrift.TColumn> columns; // required
+    public @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.dataImpl.thrift.IterInfo> ssiList; // required
+    public @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.util.Map<java.lang.String,java.lang.String>> ssio; // required
+    public @org.apache.thrift.annotation.Nullable java.util.List<java.nio.ByteBuffer> authorizations; // required
+    public boolean waitForWrites; // required
+    public @org.apache.thrift.annotation.Nullable TSamplerConfiguration samplerConfig; // required
+    public long batchTimeOut; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String classLoaderContext; // required
+    public @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.String> executionHints; // required
+    public long busyTimeout; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -8942,10 +8942,10 @@ public class TabletScanClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new startMultiScan_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new startMultiScan_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.InitialMultiScan success; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable TSampleNotPresentException tsnpe; // required
-    private @org.apache.thrift.annotation.Nullable ScanServerBusyException ssbe; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.InitialMultiScan success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable TSampleNotPresentException tsnpe; // required
+    public @org.apache.thrift.annotation.Nullable ScanServerBusyException ssbe; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -9655,9 +9655,9 @@ public class TabletScanClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new continueMultiScan_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new continueMultiScan_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private long scanID; // required
-    private long busyTimeout; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public long scanID; // required
+    public long busyTimeout; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -10246,10 +10246,10 @@ public class TabletScanClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new continueMultiScan_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new continueMultiScan_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.MultiScanResult success; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.tabletserver.thrift.NoSuchScanIDException nssi; // required
-    private @org.apache.thrift.annotation.Nullable TSampleNotPresentException tsnpe; // required
-    private @org.apache.thrift.annotation.Nullable ScanServerBusyException ssbe; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.MultiScanResult success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.tabletserver.thrift.NoSuchScanIDException nssi; // required
+    public @org.apache.thrift.annotation.Nullable TSampleNotPresentException tsnpe; // required
+    public @org.apache.thrift.annotation.Nullable ScanServerBusyException ssbe; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -10958,8 +10958,8 @@ public class TabletScanClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new closeMultiScan_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new closeMultiScan_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private long scanID; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public long scanID; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -11451,7 +11451,7 @@ public class TabletScanClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new closeMultiScan_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new closeMultiScan_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.tabletserver.thrift.NoSuchScanIDException nssi; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.tabletserver.thrift.NoSuchScanIDException nssi; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -11842,8 +11842,8 @@ public class TabletScanClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getActiveScans_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getActiveScans_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -12346,8 +12346,8 @@ public class TabletScanClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getActiveScans_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getActiveScans_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable java.util.List<ActiveScan> success; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable java.util.List<ActiveScan> success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletscan/thrift/TooManyFilesException.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletscan/thrift/TooManyFilesException.java
@@ -33,7 +33,7 @@ public class TooManyFilesException extends org.apache.thrift.TException implemen
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TooManyFilesExceptionStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TooManyFilesExceptionTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent; // required
+  public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletserver/thrift/ActionStats.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletserver/thrift/ActionStats.java
@@ -40,14 +40,14 @@ public class ActionStats implements org.apache.thrift.TBase<ActionStats, ActionS
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new ActionStatsStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new ActionStatsTupleSchemeFactory();
 
-  private int status; // required
-  private double elapsed; // required
-  private int num; // required
-  private long count; // required
-  private double sumDev; // required
-  private int fail; // required
-  private double queueTime; // required
-  private double queueSumDev; // required
+  public int status; // required
+  public double elapsed; // required
+  public int num; // required
+  public long count; // required
+  public double sumDev; // required
+  public int fail; // required
+  public double queueTime; // required
+  public double queueSumDev; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletserver/thrift/ActiveCompaction.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletserver/thrift/ActiveCompaction.java
@@ -44,18 +44,26 @@ public class ActiveCompaction implements org.apache.thrift.TBase<ActiveCompactio
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new ActiveCompactionStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new ActiveCompactionTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent; // required
-  private long age; // required
-  private @org.apache.thrift.annotation.Nullable java.util.List<java.lang.String> inputFiles; // required
-  private @org.apache.thrift.annotation.Nullable java.lang.String outputFile; // required
-  private @org.apache.thrift.annotation.Nullable TCompactionType type; // required
-  private @org.apache.thrift.annotation.Nullable TCompactionReason reason; // required
-  private @org.apache.thrift.annotation.Nullable java.lang.String localityGroup; // required
-  private long entriesRead; // required
-  private long entriesWritten; // required
-  private @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.dataImpl.thrift.IterInfo> ssiList; // required
-  private @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.util.Map<java.lang.String,java.lang.String>> ssio; // required
-  private long timesPaused; // required
+  public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent; // required
+  public long age; // required
+  public @org.apache.thrift.annotation.Nullable java.util.List<java.lang.String> inputFiles; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String outputFile; // required
+  /**
+   * 
+   * @see TCompactionType
+   */
+  public @org.apache.thrift.annotation.Nullable TCompactionType type; // required
+  /**
+   * 
+   * @see TCompactionReason
+   */
+  public @org.apache.thrift.annotation.Nullable TCompactionReason reason; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String localityGroup; // required
+  public long entriesRead; // required
+  public long entriesWritten; // required
+  public @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.dataImpl.thrift.IterInfo> ssiList; // required
+  public @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.util.Map<java.lang.String,java.lang.String>> ssio; // required
+  public long timesPaused; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletserver/thrift/InputFile.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletserver/thrift/InputFile.java
@@ -36,10 +36,10 @@ public class InputFile implements org.apache.thrift.TBase<InputFile, InputFile._
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new InputFileStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new InputFileTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.lang.String metadataFileEntry; // required
-  private long size; // required
-  private long entries; // required
-  private long timestamp; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String metadataFileEntry; // required
+  public long size; // required
+  public long entries; // required
+  public long timestamp; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletserver/thrift/IteratorConfig.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletserver/thrift/IteratorConfig.java
@@ -33,7 +33,7 @@ public class IteratorConfig implements org.apache.thrift.TBase<IteratorConfig, I
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new IteratorConfigStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new IteratorConfigTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.util.List<TIteratorSetting> iterators; // required
+  public @org.apache.thrift.annotation.Nullable java.util.List<TIteratorSetting> iterators; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletserver/thrift/NotServingTabletException.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletserver/thrift/NotServingTabletException.java
@@ -33,7 +33,7 @@ public class NotServingTabletException extends org.apache.thrift.TException impl
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new NotServingTabletExceptionStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new NotServingTabletExceptionTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent; // required
+  public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletserver/thrift/TCompactionGroupSummary.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletserver/thrift/TCompactionGroupSummary.java
@@ -34,8 +34,8 @@ public class TCompactionGroupSummary implements org.apache.thrift.TBase<TCompact
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TCompactionGroupSummaryStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TCompactionGroupSummaryTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.lang.String group; // required
-  private short priority; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String group; // required
+  public short priority; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletserver/thrift/TCompactionStats.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletserver/thrift/TCompactionStats.java
@@ -35,9 +35,9 @@ public class TCompactionStats implements org.apache.thrift.TBase<TCompactionStat
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TCompactionStatsStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TCompactionStatsTupleSchemeFactory();
 
-  private long entriesRead; // required
-  private long entriesWritten; // required
-  private long fileSize; // required
+  public long entriesRead; // required
+  public long entriesWritten; // required
+  public long fileSize; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletserver/thrift/TExternalCompactionJob.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletserver/thrift/TExternalCompactionJob.java
@@ -41,15 +41,19 @@ public class TExternalCompactionJob implements org.apache.thrift.TBase<TExternal
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TExternalCompactionJobStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TExternalCompactionJobTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable java.lang.String externalCompactionId; // required
-  private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent; // required
-  private @org.apache.thrift.annotation.Nullable java.util.List<InputFile> files; // required
-  private @org.apache.thrift.annotation.Nullable IteratorConfig iteratorSettings; // required
-  private @org.apache.thrift.annotation.Nullable java.lang.String outputFile; // required
-  private boolean propagateDeletes; // required
-  private @org.apache.thrift.annotation.Nullable TCompactionKind kind; // required
-  private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.manager.thrift.TFateId fateId; // required
-  private @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.String> overrides; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String externalCompactionId; // required
+  public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent; // required
+  public @org.apache.thrift.annotation.Nullable java.util.List<InputFile> files; // required
+  public @org.apache.thrift.annotation.Nullable IteratorConfig iteratorSettings; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String outputFile; // required
+  public boolean propagateDeletes; // required
+  /**
+   * 
+   * @see TCompactionKind
+   */
+  public @org.apache.thrift.annotation.Nullable TCompactionKind kind; // required
+  public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.manager.thrift.TFateId fateId; // required
+  public @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.String> overrides; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletserver/thrift/TIteratorSetting.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletserver/thrift/TIteratorSetting.java
@@ -36,10 +36,10 @@ public class TIteratorSetting implements org.apache.thrift.TBase<TIteratorSettin
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TIteratorSettingStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TIteratorSettingTupleSchemeFactory();
 
-  private int priority; // required
-  private @org.apache.thrift.annotation.Nullable java.lang.String name; // required
-  private @org.apache.thrift.annotation.Nullable java.lang.String iteratorClass; // required
-  private @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.String> properties; // required
+  public int priority; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String name; // required
+  public @org.apache.thrift.annotation.Nullable java.lang.String iteratorClass; // required
+  public @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.String> properties; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletserver/thrift/TabletServerClientService.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletserver/thrift/TabletServerClientService.java
@@ -2786,12 +2786,12 @@ public class TabletServerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new flush_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new flush_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String lock; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String tableId; // required
-    private @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer startRow; // required
-    private @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer endRow; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String lock; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String tableId; // required
+    public @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer startRow; // required
+    public @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer endRow; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -3732,8 +3732,8 @@ public class TabletServerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getTabletServerStatus_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getTabletServerStatus_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -4236,8 +4236,8 @@ public class TabletServerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getTabletServerStatus_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getTabletServerStatus_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.manager.thrift.TabletServerStatus success; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.manager.thrift.TabletServerStatus success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -4737,9 +4737,9 @@ public class TabletServerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getTabletStats_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getTabletStats_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String tableId; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String tableId; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -5345,8 +5345,8 @@ public class TabletServerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getTabletStats_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getTabletStats_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable java.util.List<TabletStats> success; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable java.util.List<TabletStats> success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -5895,8 +5895,8 @@ public class TabletServerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getHistoricalStats_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getHistoricalStats_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -6399,8 +6399,8 @@ public class TabletServerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getHistoricalStats_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getHistoricalStats_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable TabletStats success; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable TabletStats success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -6900,9 +6900,9 @@ public class TabletServerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new halt_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new halt_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String lock; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String lock; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -7507,7 +7507,7 @@ public class TabletServerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new halt_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new halt_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -7899,9 +7899,9 @@ public class TabletServerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new fastHalt_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new fastHalt_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.lang.String lock; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String lock; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -8507,8 +8507,8 @@ public class TabletServerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getActiveCompactions_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getActiveCompactions_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -9011,8 +9011,8 @@ public class TabletServerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getActiveCompactions_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getActiveCompactions_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable java.util.List<ActiveCompaction> success; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable java.util.List<ActiveCompaction> success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -9562,9 +9562,9 @@ public class TabletServerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new removeLogs_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new removeLogs_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.util.List<java.lang.String> filenames; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.util.List<java.lang.String> filenames; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -10220,8 +10220,8 @@ public class TabletServerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getActiveLogs_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getActiveLogs_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -10723,7 +10723,7 @@ public class TabletServerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new getActiveLogs_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new getActiveLogs_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable java.util.List<java.lang.String> success; // required
+    public @org.apache.thrift.annotation.Nullable java.util.List<java.lang.String> success; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -11163,9 +11163,9 @@ public class TabletServerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new startGetSummaries_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new startGetSummaries_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TSummaryRequest request; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TSummaryRequest request; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -11777,9 +11777,9 @@ public class TabletServerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new startGetSummaries_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new startGetSummaries_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TSummaries success; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException tope; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TSummaries success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException tope; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -12386,11 +12386,11 @@ public class TabletServerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new startGetSummariesForPartition_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new startGetSummariesForPartition_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TSummaryRequest request; // required
-    private int modulus; // required
-    private int remainder; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TSummaryRequest request; // required
+    public int modulus; // required
+    public int remainder; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -13193,8 +13193,8 @@ public class TabletServerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new startGetSummariesForPartition_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new startGetSummariesForPartition_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TSummaries success; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TSummaries success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -13695,10 +13695,10 @@ public class TabletServerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new startGetSummariesFromFiles_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new startGetSummariesFromFiles_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TSummaryRequest request; // required
-    private @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.util.List<org.apache.accumulo.core.dataImpl.thrift.TRowRange>> files; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TSummaryRequest request; // required
+    public @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.util.List<org.apache.accumulo.core.dataImpl.thrift.TRowRange>> files; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -14513,8 +14513,8 @@ public class TabletServerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new startGetSummariesFromFiles_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new startGetSummariesFromFiles_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TSummaries success; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TSummaries success; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException sec; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -15013,8 +15013,8 @@ public class TabletServerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new contiuneGetSummaries_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new contiuneGetSummaries_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private long sessionId; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public long sessionId; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -15507,8 +15507,8 @@ public class TabletServerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new contiuneGetSummaries_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new contiuneGetSummaries_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TSummaries success; // required
-    private @org.apache.thrift.annotation.Nullable NoSuchScanIDException nssi; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TSummaries success; // required
+    public @org.apache.thrift.annotation.Nullable NoSuchScanIDException nssi; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -16008,9 +16008,9 @@ public class TabletServerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new refreshTablets_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new refreshTablets_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.dataImpl.thrift.TKeyExtent> tabletsToRefresh; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.dataImpl.thrift.TKeyExtent> tabletsToRefresh; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -16670,7 +16670,7 @@ public class TabletServerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new refreshTablets_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new refreshTablets_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.dataImpl.thrift.TKeyExtent> success; // required
+    public @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.dataImpl.thrift.TKeyExtent> success; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -17115,9 +17115,9 @@ public class TabletServerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new allocateTimestamps_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new allocateTimestamps_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
-    private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
-    private @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.dataImpl.thrift.TKeyExtent> tablets; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.clientImpl.thrift.TInfo tinfo; // required
+    public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.securityImpl.thrift.TCredentials credentials; // required
+    public @org.apache.thrift.annotation.Nullable java.util.List<org.apache.accumulo.core.dataImpl.thrift.TKeyExtent> tablets; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -17777,7 +17777,7 @@ public class TabletServerClientService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new allocateTimestamps_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new allocateTimestamps_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable java.util.Map<org.apache.accumulo.core.dataImpl.thrift.TKeyExtent,java.lang.Long> success; // required
+    public @org.apache.thrift.annotation.Nullable java.util.Map<org.apache.accumulo.core.dataImpl.thrift.TKeyExtent,java.lang.Long> success; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletserver/thrift/TabletStats.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletserver/thrift/TabletStats.java
@@ -37,11 +37,11 @@ public class TabletStats implements org.apache.thrift.TBase<TabletStats, TabletS
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TabletStatsStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TabletStatsTupleSchemeFactory();
 
-  private @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent; // required
-  private @org.apache.thrift.annotation.Nullable ActionStats minors; // required
-  private long numEntries; // required
-  private double ingestRate; // required
-  private double queryRate; // required
+  public @org.apache.thrift.annotation.Nullable org.apache.accumulo.core.dataImpl.thrift.TKeyExtent extent; // required
+  public @org.apache.thrift.annotation.Nullable ActionStats minors; // required
+  public long numEntries; // required
+  public double ingestRate; // required
+  public double queryRate; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/core/src/test/java/org/apache/accumulo/core/data/OldMutation.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/OldMutation.java
@@ -177,10 +177,10 @@ public class OldMutation implements Writable {
   public OldMutation() {}
 
   public OldMutation(TMutation tmutation) {
-    this.row = tmutation.getRow();
-    this.data = tmutation.getData();
-    this.entries = tmutation.getEntries();
-    this.values = ByteBufferUtil.toBytesList(tmutation.getValues());
+    this.row = ByteBufferUtil.toBytes(tmutation.row);
+    this.data = ByteBufferUtil.toBytes(tmutation.data);
+    this.entries = tmutation.entries;
+    this.values = ByteBufferUtil.toBytesList(tmutation.values);
 
     if (this.row == null) {
       throw new IllegalArgumentException("null row");

--- a/core/src/test/java/org/apache/accumulo/core/spi/balancer/SimpleLoadBalancerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/balancer/SimpleLoadBalancerTest.java
@@ -61,16 +61,16 @@ public class SimpleLoadBalancerTest {
     TServerStatus getStatus() {
       org.apache.accumulo.core.manager.thrift.TabletServerStatus result =
           new org.apache.accumulo.core.manager.thrift.TabletServerStatus();
-      result.setTableMap(new HashMap<>());
+      result.tableMap = new HashMap<>();
       for (TabletId tabletId : tablets) {
-        TableInfo info = result.getTableMap().get(tabletId.getTable().canonical());
+        TableInfo info = result.tableMap.get(tabletId.getTable().canonical());
         if (info == null) {
-          result.getTableMap().put(tabletId.getTable().canonical(), info = new TableInfo());
+          result.tableMap.put(tabletId.getTable().canonical(), info = new TableInfo());
         }
-        info.setOnlineTablets(info.getOnlineTablets() + 1);
-        info.setRecs(info.getOnlineTablets());
-        info.setIngestRate(123.);
-        info.setQueryRate(456.);
+        info.onlineTablets++;
+        info.recs = info.onlineTablets;
+        info.ingestRate = 123.;
+        info.queryRate = 456.;
       }
       return new TServerStatusImpl(result);
     }

--- a/core/src/test/java/org/apache/accumulo/core/spi/balancer/TableLoadBalancerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/balancer/TableLoadBalancerTest.java
@@ -69,7 +69,7 @@ public class TableLoadBalancerTest {
   private static TServerStatus status(Object... config) {
     org.apache.accumulo.core.manager.thrift.TabletServerStatus thriftStatus =
         new org.apache.accumulo.core.manager.thrift.TabletServerStatus();
-    thriftStatus.setTableMap(new HashMap<>());
+    thriftStatus.tableMap = new HashMap<>();
     String tablename = null;
     for (Object c : config) {
       if (c instanceof String) {
@@ -77,9 +77,9 @@ public class TableLoadBalancerTest {
       } else {
         TableInfo info = new TableInfo();
         int count = (Integer) c;
-        info.setOnlineTablets(count);
-        info.setTablets(count);
-        thriftStatus.getTableMap().put(tablename, info);
+        info.onlineTablets = count;
+        info.tablets = count;
+        thriftStatus.tableMap.put(tablename, info);
       }
     }
     return new TServerStatusImpl(thriftStatus);
@@ -94,9 +94,9 @@ public class TableLoadBalancerTest {
     for (int i = 0; i < tableInfo.getTableMap().get(tableId.canonical()).getOnlineTabletCount();
         i++) {
       TabletStats stats = new TabletStats();
-      stats.setExtent(
+      stats.extent =
           new KeyExtent(tableId, new Text(tserver.getHost() + String.format("%03d", i + 1)),
-              new Text(tserver.getHost() + String.format("%03d", i))).toThrift());
+              new Text(tserver.getHost() + String.format("%03d", i))).toThrift();
       result.add(new TabletStatisticsImpl(stats));
     }
     return result;

--- a/server/base/src/main/java/org/apache/accumulo/server/data/ServerConditionalMutation.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/data/ServerConditionalMutation.java
@@ -29,10 +29,10 @@ public class ServerConditionalMutation extends ServerMutation {
   private final List<TCondition> conditions;
 
   public ServerConditionalMutation(TConditionalMutation input) {
-    super(input.getMutation());
+    super(input.mutation);
 
-    this.cmid = input.getId();
-    this.conditions = input.getConditions();
+    this.cmid = input.id;
+    this.conditions = input.conditions;
   }
 
   public long getID() {

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/TCredentialsUpdatingInvocationHandler.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/TCredentialsUpdatingInvocationHandler.java
@@ -91,8 +91,7 @@ public class TCredentialsUpdatingInvocationHandler<I> implements InvocationHandl
       return;
     }
 
-    Class<? extends AuthenticationToken> tokenClass =
-        getTokenClassFromName(tcreds.getTokenClassName());
+    Class<? extends AuthenticationToken> tokenClass = getTokenClassFromName(tcreds.tokenClassName);
 
     // The Accumulo principal extracted from the SASL transport
     final String principal = UGIAssumingProcessor.rpcPrincipal();
@@ -101,9 +100,9 @@ public class TCredentialsUpdatingInvocationHandler<I> implements InvocationHandl
     // should match
     if (UGIAssumingProcessor.rpcMechanism() == SaslMechanism.DIGEST_MD5
         && DelegationTokenImpl.class.isAssignableFrom(tokenClass)) {
-      if (!principal.equals(tcreds.getPrincipal())) {
+      if (!principal.equals(tcreds.principal)) {
         log.warn("{} issued RPC with delegation token over DIGEST-MD5 as the "
-            + "Accumulo principal {}. Disallowing RPC", principal, tcreds.getPrincipal());
+            + "Accumulo principal {}. Disallowing RPC", principal, tcreds.principal);
         throw new ThriftSecurityException("RPC principal did not match provided Accumulo principal",
             SecurityErrorCode.BAD_CREDENTIALS);
       }
@@ -129,13 +128,13 @@ public class TCredentialsUpdatingInvocationHandler<I> implements InvocationHandl
 
     // The principal from the SASL transport should match what the user requested as their Accumulo
     // principal
-    if (!principal.equals(tcreds.getPrincipal())) {
+    if (!principal.equals(tcreds.principal)) {
       UsersWithHosts usersWithHosts = impersonation.get(principal);
       if (usersWithHosts == null) {
-        principalMismatch(principal, tcreds.getPrincipal());
+        principalMismatch(principal, tcreds.principal);
       }
-      if (!usersWithHosts.getUsers().contains(tcreds.getPrincipal())) {
-        principalMismatch(principal, tcreds.getPrincipal());
+      if (!usersWithHosts.getUsers().contains(tcreds.principal)) {
+        principalMismatch(principal, tcreds.principal);
       }
       String clientAddr = TServerUtils.clientAddress.get();
       if (!usersWithHosts.getHosts().contains(clientAddr)) {

--- a/server/base/src/main/java/org/apache/accumulo/server/security/SecurityOperation.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/SecurityOperation.java
@@ -590,7 +590,7 @@ public class SecurityOperation {
     // This is a bit hackier then I (vines) wanted, but I think this one hackiness makes the overall
     // SecurityOperations more succinct.
     return hasSystemPermissionWithNamespaceId(c, SystemPermission.ALTER_NAMESPACE, namespace, false)
-        || hasNamespacePermission(c, c.getPrincipal(), namespace, NamespacePermission.GRANT);
+        || hasNamespacePermission(c, c.principal, namespace, NamespacePermission.GRANT);
   }
 
   protected boolean canRevokeSystem(TCredentials c, String user, SystemPermission sysPerm)

--- a/server/base/src/main/java/org/apache/accumulo/server/tablets/ConditionCheckerContext.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tablets/ConditionCheckerContext.java
@@ -21,7 +21,6 @@ package org.apache.accumulo.server.tablets;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -89,10 +88,10 @@ public class ConditionCheckerContext {
   SortedKeyValueIterator<Key,Value> buildIterator(SortedKeyValueIterator<Key,Value> systemIter,
       TCondition tc) throws IOException, ReflectiveOperationException {
 
-    ArrayByteSequence key = new ArrayByteSequence(tc.getIterators());
+    ArrayByteSequence key = new ArrayByteSequence(tc.iterators);
     MergedIterConfig mic = mergedIterCache.get(key);
     if (mic == null) {
-      IterConfig ic = compressedIters.decompress(ByteBuffer.wrap(tc.getIterators()));
+      IterConfig ic = compressedIters.decompress(tc.iterators);
 
       List<IterInfo> mergedIters = new ArrayList<>(tableIters.size() + ic.ssiList.size());
       Map<String,Map<String,String>> mergedItersOpts =
@@ -118,7 +117,7 @@ public class ConditionCheckerContext {
     for (TCondition tc : scm.getConditions()) {
 
       Range range;
-      if (tc.isHasTimestamp()) {
+      if (tc.hasTimestamp) {
         range = Range.exact(new Text(scm.getRow()), new Text(tc.getCf()), new Text(tc.getCq()),
             new Text(tc.getCv()), tc.getTs());
       } else {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ActionStatsUpdator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ActionStatsUpdator.java
@@ -23,14 +23,14 @@ import org.apache.accumulo.core.tabletserver.thrift.ActionStats;
 public class ActionStatsUpdator {
 
   public static void update(ActionStats summary, ActionStats td) {
-    summary.setStatus(summary.getStatus() + td.getStatus());
-    summary.setElapsed(summary.getElapsed() + td.getElapsed());
-    summary.setNum(summary.getNum() + td.getNum());
-    summary.setCount(summary.getCount() + td.getCount());
-    summary.setSumDev(summary.getSumDev() + td.getSumDev());
-    summary.setQueueTime(summary.getQueueTime() + td.getQueueTime());
-    summary.setQueueSumDev(summary.getQueueSumDev() + td.getQueueSumDev());
-    summary.setFail(summary.getFail() + td.getFail());
+    summary.status += td.status;
+    summary.elapsed += td.elapsed;
+    summary.num += td.num;
+    summary.count += td.count;
+    summary.sumDev += td.sumDev;
+    summary.queueTime += td.queueTime;
+    summary.queueSumDev += td.queueSumDev;
+    summary.fail += td.fail;
   }
 
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ListCompactions.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ListCompactions.java
@@ -64,9 +64,9 @@ public class ListCompactions extends ServerKeywordExecutable<RunningCommandOpts>
       super();
       ecid = runningCompaction.getJob().getExternalCompactionId();
       addr = runningCompaction.getCompactor();
-      kind = runningCompaction.getJob().getKind();
+      kind = runningCompaction.getJob().kind;
       groupName = ResourceGroupId.of(runningCompaction.getGroupName());
-      KeyExtent extent = KeyExtent.fromThrift(runningCompaction.getJob().getExtent());
+      KeyExtent extent = KeyExtent.fromThrift(runningCompaction.getJob().extent);
       ke = extent.obscured();
       tableId = extent.tableId().canonical();
       if (addDetail) {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/adminCommand/VerifyTabletAssignments.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/adminCommand/VerifyTabletAssignments.java
@@ -180,7 +180,7 @@ public class VerifyTabletAssignments extends ServerKeywordExecutable<VerifyTable
 
   private void checkFailures(HostAndPort server, HashSet<KeyExtent> failures,
       MultiScanResult scanResult) {
-    for (TKeyExtent tke : scanResult.getFailures().keySet()) {
+    for (TKeyExtent tke : scanResult.failures.keySet()) {
       KeyExtent ke = KeyExtent.fromThrift(tke);
       System.out.println(" Tablet " + ke + " failed at " + server);
       failures.add(ke);
@@ -227,17 +227,17 @@ public class VerifyTabletAssignments extends ServerKeywordExecutable<VerifyTable
     InitialMultiScan is = client.startMultiScan(tinfo, context.rpcCreds(), batch, emptyListColumn,
         emptyListIterInfo, emptyMapSMapSS, Authorizations.EMPTY.getAuthorizationsBB(), false, null,
         0L, null, null, 0L);
-    if (is.getResult().isMore()) {
-      MultiScanResult result = client.continueMultiScan(tinfo, is.getScanID(), 0L);
+    if (is.result.more) {
+      MultiScanResult result = client.continueMultiScan(tinfo, is.scanID, 0L);
       checkFailures(entry.getKey(), failures, result);
 
-      while (result.isMore()) {
-        result = client.continueMultiScan(tinfo, is.getScanID(), 0L);
+      while (result.more) {
+        result = client.continueMultiScan(tinfo, is.scanID, 0L);
         checkFailures(entry.getKey(), failures, result);
       }
     }
 
-    client.closeMultiScan(tinfo, is.getScanID());
+    client.closeMultiScan(tinfo, is.scanID);
 
     ThriftUtil.returnClient((TServiceClient) client, context);
   }

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -492,7 +492,7 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
           Client coordinatorClient = getCoordinatorClient();
           try {
             coordinatorClient.compactionFailed(TraceUtil.traceInfo(), getContext().rpcCreds(),
-                job.getExternalCompactionId(), job.getExtent(), message, why,
+                job.getExternalCompactionId(), job.extent, message, why,
                 getResourceGroup().canonical(), getAdvertiseAddress().toString());
             return "";
           } finally {
@@ -516,8 +516,8 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
           Client coordinatorClient = getCoordinatorClient();
           try {
             coordinatorClient.compactionCompleted(TraceUtil.traceInfo(), getContext().rpcCreds(),
-                job.getExternalCompactionId(), job.getExtent(), stats,
-                getResourceGroup().canonical(), getAdvertiseAddress().toString());
+                job.getExternalCompactionId(), job.extent, stats, getResourceGroup().canonical(),
+                getAdvertiseAddress().toString());
             return "";
           } finally {
             ThriftUtil.returnClient(coordinatorClient, getContext());

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
@@ -131,7 +131,7 @@ public class GarbageCollectWriteAheadLogs {
 
       Span span = TraceUtil.startSpan(this.getClass(), "getCandidates");
       try (Scope scope = span.makeCurrent()) {
-        status.getCurrentLog().setStarted(System.currentTimeMillis());
+        status.currentLog.started = System.currentTimeMillis();
 
         recoveryLogs = getSortedWALogs();
 
@@ -147,8 +147,8 @@ public class GarbageCollectWriteAheadLogs {
         fileScanStop = System.currentTimeMillis();
 
         log.info(String.format("Fetched %d files for %d servers in %.2f seconds", count,
-            logsByServer.size(), (fileScanStop - status.getCurrentLog().getStarted()) / 1000.));
-        status.getCurrentLog().setCandidates(count);
+            logsByServer.size(), (fileScanStop - status.currentLog.started) / 1000.));
+        status.currentLog.candidates = count;
       } catch (Exception e) {
         TraceUtil.setException(span, e, true);
         throw e;
@@ -212,9 +212,9 @@ public class GarbageCollectWriteAheadLogs {
     } catch (Exception e) {
       log.error("exception occurred while garbage collecting write ahead logs", e);
     } finally {
-      status.getCurrentLog().setFinished(System.currentTimeMillis());
-      status.setLastLog(status.getCurrentLog());
-      status.setCurrentLog(new GcCycleStats());
+      status.currentLog.finished = System.currentTimeMillis();
+      status.lastLog = status.currentLog;
+      status.currentLog = new GcCycleStats();
     }
   }
 
@@ -300,7 +300,7 @@ public class GarbageCollectWriteAheadLogs {
     } finally {
       deleteThreadPool.shutdownNow();
     }
-    status.getCurrentLog().setDeleted(status.getCurrentLog().getDeleted() + counter.get());
+    status.currentLog.deleted += counter.get();
     return counter.get();
   }
 

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -223,26 +223,23 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
             try {
               System.gc(); // make room
 
-              status.getCurrent().setStarted(System.currentTimeMillis());
+              status.current.started = System.currentTimeMillis();
               var rootGC = new GCRun(DataLevel.ROOT, getContext());
               var mdGC = new GCRun(DataLevel.METADATA, getContext());
               var userGC = new GCRun(DataLevel.USER, getContext());
 
               log.info("Starting Root table Garbage Collection.");
-              status.getCurrent().setBulks(status.getCurrent().getBulks()
-                  + new GarbageCollectionAlgorithm().collect(rootGC));
+              status.current.bulks += new GarbageCollectionAlgorithm().collect(rootGC);
               incrementStatsForRun(rootGC);
               logStats();
 
               log.info("Starting Metadata table Garbage Collection.");
-              status.getCurrent().setBulks(
-                  status.getCurrent().getBulks() + new GarbageCollectionAlgorithm().collect(mdGC));
+              status.current.bulks += new GarbageCollectionAlgorithm().collect(mdGC);
               incrementStatsForRun(mdGC);
               logStats();
 
               log.info("Starting User table Garbage Collection.");
-              status.getCurrent().setBulks(status.getCurrent().getBulks()
-                  + new GarbageCollectionAlgorithm().collect(userGC));
+              status.current.bulks += new GarbageCollectionAlgorithm().collect(userGC);
               incrementStatsForRun(userGC);
               logStats();
 
@@ -250,10 +247,10 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
               TraceUtil.setException(innerSpan, e, false);
               log.error("{}", e.getMessage(), e);
             } finally {
-              status.getCurrent().setFinished(System.currentTimeMillis());
-              status.setLast(status.getCurrent());
-              gcCycleMetrics.setLastCollect(status.getCurrent());
-              status.setCurrent(new GcCycleStats());
+              status.current.finished = System.currentTimeMillis();
+              status.last = status.current;
+              gcCycleMetrics.setLastCollect(status.current);
+              status.current = new GcCycleStats();
             }
 
             log.info(String.format("Collect cycle took %.2f seconds",
@@ -266,7 +263,7 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
                   new GarbageCollectWriteAheadLogs(getContext(), fs, liveTServerSet);
               log.info("Beginning garbage collection of write-ahead logs");
               walogCollector.collect(status);
-              gcCycleMetrics.setLastWalCollect(status.getLastLog());
+              gcCycleMetrics.setLastWalCollect(status.lastLog);
             } catch (Exception e) {
               TraceUtil.setException(walSpan, e, false);
               log.error("{}", e.getMessage(), e);
@@ -361,21 +358,19 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
   }
 
   private void incrementStatsForRun(GCRun gcRun) {
-    status.getCurrent()
-        .setCandidates(status.getCurrent().getCandidates() + gcRun.getCandidatesStat());
-    status.getCurrent().setInUse(status.getCurrent().getInUse() + gcRun.getInUseStat());
-    status.getCurrent().setDeleted(status.getCurrent().getDeleted() + gcRun.getDeletedStat());
-    status.getCurrent().setErrors(status.getCurrent().getErrors() + gcRun.getErrorsStat());
+    status.current.candidates += gcRun.getCandidatesStat();
+    status.current.inUse += gcRun.getInUseStat();
+    status.current.deleted += gcRun.getDeletedStat();
+    status.current.errors += gcRun.getErrorsStat();
   }
 
   // public for ExitCodesIT
   public void logStats() {
-    log.info("Number of data file candidates for deletion: {}",
-        status.getCurrent().getCandidates());
-    log.info("Number of data file candidates still in use: {}", status.getCurrent().getInUse());
-    log.info("Number of successfully deleted data files: {}", status.getCurrent().getDeleted());
-    log.info("Number of data files delete failures: {}", status.getCurrent().getErrors());
-    log.info("Number of bulk imports in progress: {}", status.getCurrent().getBulks());
+    log.info("Number of data file candidates for deletion: {}", status.current.candidates);
+    log.info("Number of data file candidates still in use: {}", status.current.inUse);
+    log.info("Number of successfully deleted data files: {}", status.current.deleted);
+    log.info("Number of data files delete failures: {}", status.current.errors);
+    log.info("Number of bulk imports in progress: {}", status.current.bulks);
   }
 
   /**

--- a/server/manager/src/main/java/org/apache/accumulo/manager/ManagerClientServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/ManagerClientServiceHandler.java
@@ -720,7 +720,7 @@ public class ManagerClientServiceHandler implements ManagerClientService.Iface {
     final AuthenticationTokenSecretManager secretManager = context.getSecretManager();
     try {
       Entry<Token<AuthenticationTokenIdentifier>,AuthenticationTokenIdentifier> pair =
-          secretManager.generateToken(credentials.getPrincipal(), config);
+          secretManager.generateToken(credentials.principal, config);
 
       return new TDelegationToken(ByteBuffer.wrap(pair.getKey().getPassword()),
           pair.getValue().getThriftIdentifier());

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/CompactionCommitData.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/commit/CompactionCommitData.java
@@ -55,9 +55,9 @@ public class CompactionCommitData implements Serializable {
       obj.addProperty("ecid", src.ecid);
       obj.addProperty("extent", src.textent.toString());
       obj.addProperty("outputTmpPath", src.outputTmpPath);
-      obj.addProperty("entriesRead", src.stats.getEntriesRead());
-      obj.addProperty("entriesWritten", src.stats.getEntriesWritten());
-      obj.addProperty("fileSize", src.stats.getFileSize());
+      obj.addProperty("entriesRead", src.stats.entriesRead);
+      obj.addProperty("entriesWritten", src.stats.entriesWritten);
+      obj.addProperty("fileSize", src.stats.fileSize);
       JsonArray arr = new JsonArray();
       src.inputPaths.forEach(arr::add);
       obj.add("inputs", arr);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/fate/FateManager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/fate/FateManager.java
@@ -397,10 +397,9 @@ public class FateManager {
       try {
 
         var tparitions = client.getPartitions(TraceUtil.traceInfo(), context.rpcCreds());
-        var partitions = tparitions.getPartitions().stream().map(FatePartition::from)
-            .collect(Collectors.toSet());
-        currentAssignments.put(address,
-            new CurrentPartitions(tparitions.getUpdateId(), partitions));
+        var partitions =
+            tparitions.partitions.stream().map(FatePartition::from).collect(Collectors.toSet());
+        currentAssignments.put(address, new CurrentPartitions(tparitions.updateId, partitions));
       } finally {
         ThriftUtil.returnClient(client, context);
       }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/availability/LockTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/availability/LockTable.java
@@ -88,7 +88,7 @@ public class LockTable extends AbstractFateOperation {
    * be converted to a RowRange, an infinite LockRange is returned.
    */
   private LockRange getLockRange(FateEnv env) {
-    if (tRange.isInfiniteStartKey() && tRange.isInfiniteStopKey()) {
+    if (tRange.infiniteStartKey && tRange.infiniteStopKey) {
       return LockRange.infinite();
     }
     Range range = new Range(tRange);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tserverOps/ShutdownTServer.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tserverOps/ShutdownTServer.java
@@ -75,7 +75,7 @@ public class ShutdownTServer extends AbstractFateOperation {
             ThriftUtil.getClient(ThriftClientTypes.TABLET_SERVER, hostAndPort, env.getContext());
         TabletServerStatus status =
             client.getTabletServerStatus(TraceUtil.traceInfo(), env.getContext().rpcCreds());
-        if (status.getTableMap() != null && status.getTableMap().isEmpty()) {
+        if (status.tableMap != null && status.tableMap.isEmpty()) {
           log.info("tablet server hosts no tablets {}", server);
           client.halt(TraceUtil.traceInfo(), env.getContext().rpcCreds(),
               env.getServiceLock().getLockID().serialize());
@@ -83,7 +83,7 @@ public class ShutdownTServer extends AbstractFateOperation {
           return 0;
         } else {
           log.info("tablet server {} still has tablets for tables: {}", server,
-              (status.getTableMap() == null) ? "null" : status.getTableMap().keySet());
+              (status.tableMap == null) ? "null" : status.tableMap.keySet());
         }
       } catch (TTransportException ex) {
         // expected

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/next/SystemInformation.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/next/SystemInformation.java
@@ -907,7 +907,7 @@ public class SystemInformation {
     captureRecoveriesInProgress(server, response);
     FMetric flatbuffer = new FMetric();
     FTag tag = new FTag();
-    switch (response.getServerType()) {
+    switch (response.serverType) {
       case COMPACTOR:
         compactors
             .computeIfAbsent(response.getResourceGroup(), (rg) -> ConcurrentHashMap.newKeySet())
@@ -1086,13 +1086,13 @@ public class SystemInformation {
         }
         break;
       default:
-        LOG.error("Unhandled server type in fetch metric response: {}", response.getServerType());
+        LOG.error("Unhandled server type in fetch metric response: {}", response.serverType);
         break;
     }
   }
 
   public void processExternalCompaction(TExternalCompaction tec) {
-    var tableId = KeyExtent.fromThrift(tec.getJob().getExtent()).tableId();
+    var tableId = KeyExtent.fromThrift(tec.getJob().extent).tableId();
     runningCompactionsPerTable.computeIfAbsent(tableId, t -> new LongAdder()).increment();
     runningCompactionsPerGroup.computeIfAbsent(tec.getGroupName(), t -> new LongAdder())
         .increment();
@@ -1347,7 +1347,7 @@ public class SystemInformation {
       ServerId sid = e.getKey();
       MetricResponse mr = e.getValue();
       if (mr != null) {
-        List<ByteBuffer> metrics = mr.getMetrics();
+        List<ByteBuffer> metrics = mr.metrics;
         if (sid.getType() == ServerId.Type.SCAN_SERVER
             || sid.getType() == ServerId.Type.TABLET_SERVER) {
           for (ByteBuffer binary : metrics) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
@@ -924,10 +924,10 @@ public class TabletClientHandler implements TabletServerClientService.Iface,
       if (ke.tableId().compareTo(text) == 0) {
         Tablet tablet = entry.getValue();
         TabletStats stats = tablet.getTabletStats();
-        stats.setExtent(ke.toThrift());
-        stats.setIngestRate(tablet.ingestRate());
-        stats.setQueryRate(tablet.queryRate());
-        stats.setNumEntries(tablet.getNumEntries());
+        stats.extent = ke.toThrift();
+        stats.ingestRate = tablet.ingestRate();
+        stats.queryRate = tablet.queryRate();
+        stats.numEntries = tablet.getNumEntries();
         result.add(stats);
       }
     }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -796,25 +796,25 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
       TableInfo table = tables.get(tableId);
       if (table == null) {
         table = new TableInfo();
-        table.setMinors(new Compacting());
+        table.minors = new Compacting();
         tables.put(tableId, table);
       }
       long recs = tablet.getNumEntries();
-      table.setTablets(table.getTablets() + 1);
-      table.setOnlineTablets(table.getOnlineTablets() + 1);
-      table.setRecs(table.getRecs() + recs);
-      table.setQueryRate(table.getQueryRate() + tablet.queryRate());
-      table.setQueryByteRate(table.getQueryByteRate() + tablet.queryByteRate());
-      table.setIngestRate(table.getIngestRate() + tablet.ingestRate());
-      table.setIngestByteRate(table.getIngestByteRate() + tablet.ingestByteRate());
-      table.setScanRate(table.getScanRate() + tablet.scanRate());
+      table.tablets++;
+      table.onlineTablets++;
+      table.recs += recs;
+      table.queryRate += tablet.queryRate();
+      table.queryByteRate += tablet.queryByteRate();
+      table.ingestRate += tablet.ingestRate();
+      table.ingestByteRate += tablet.ingestByteRate();
+      table.scanRate += tablet.scanRate();
       long recsInMemory = tablet.getNumEntriesInMemory();
-      table.setRecsInMemory(table.getRecsInMemory() + recsInMemory);
+      table.recsInMemory += recsInMemory;
       if (tablet.isMinorCompactionRunning()) {
-        table.getMinors().setRunning(table.getMinors().getRunning() + 1);
+        table.minors.running++;
       }
       if (tablet.isMinorCompactionQueued()) {
-        table.getMinors().setQueued(table.getMinors().getQueued() + 1);
+        table.minors.queued++;
       }
     });
 
@@ -825,14 +825,12 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
         tables.put(tableId.canonical(), table);
       }
 
-      if (table.getScans() == null) {
-        table.setScans(new Compacting());
+      if (table.scans == null) {
+        table.scans = new Compacting();
       }
 
-      table.getScans()
-          .setQueued(table.getScans().getQueued() + mapCounter.getInt(ScanRunState.QUEUED));
-      table.getScans()
-          .setRunning(table.getScans().getRunning() + mapCounter.getInt(ScanRunState.RUNNING));
+      table.scans.queued += mapCounter.getInt(ScanRunState.QUEUED);
+      table.scans.running += mapCounter.getInt(ScanRunState.RUNNING);
     });
 
     ArrayList<KeyExtent> offlineTabletsCopy = new ArrayList<>();
@@ -850,24 +848,24 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
         table = new TableInfo();
         tables.put(tableId, table);
       }
-      table.setTablets(table.getTablets() + 1);
+      table.tablets++;
     }
 
-    result.setLastContact(RelativeTime.currentTimeMillis());
-    result.setTableMap(tables);
-    result.setOsLoad(ManagementFactory.getOperatingSystemMXBean().getSystemLoadAverage());
-    result.setName(String.valueOf(getAdvertiseAddress()));
-    result.setHoldTime(resourceManager.holdTime());
-    result.setLookups(seekCount.sum());
-    result.setIndexCacheHits(resourceManager.getIndexCache().getStats().hitCount());
-    result.setIndexCacheRequest(resourceManager.getIndexCache().getStats().requestCount());
-    result.setDataCacheHits(resourceManager.getDataCache().getStats().hitCount());
-    result.setDataCacheRequest(resourceManager.getDataCache().getStats().requestCount());
-    result.setLogSorts(logSorter.getLogSorts());
-    result.setFlushs(flushCounter.get());
-    result.setSyncs(syncCounter.get());
-    result.setVersion(getVersion());
-    result.setResponseTime(System.currentTimeMillis() - start);
+    result.lastContact = RelativeTime.currentTimeMillis();
+    result.tableMap = tables;
+    result.osLoad = ManagementFactory.getOperatingSystemMXBean().getSystemLoadAverage();
+    result.name = String.valueOf(getAdvertiseAddress());
+    result.holdTime = resourceManager.holdTime();
+    result.lookups = seekCount.sum();
+    result.indexCacheHits = resourceManager.getIndexCache().getStats().hitCount();
+    result.indexCacheRequest = resourceManager.getIndexCache().getStats().requestCount();
+    result.dataCacheHits = resourceManager.getDataCache().getStats().hitCount();
+    result.dataCacheRequest = resourceManager.getDataCache().getStats().requestCount();
+    result.logSorts = logSorter.getLogSorts();
+    result.flushs = flushCounter.get();
+    result.syncs = syncCounter.get();
+    result.version = getVersion();
+    result.responseTime = System.currentTimeMillis() - start;
     return result;
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletStatsKeeper.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletStatsKeeper.java
@@ -38,21 +38,20 @@ public class TabletStatsKeeper {
     try {
       ActionStats data = map[operation.ordinal()];
       if (failed) {
-        data.setFail(data.getFail() + 1);
-        data.setStatus(data.getStatus() - 1);
+        data.fail++;
+        data.status--;
       } else {
         double t = (System.currentTimeMillis() - start) / 1000.0;
         double q = (start - queued) / 1000.0;
 
-        data.setStatus(data.getStatus() - 1);
-        data.setCount(data.getCount() + count);
-        data.setNum(data.getNum() + 1);
-        data.setElapsed(data.getElapsed() + t);
-        data.setQueueTime(data.getQueueTime() + q);
-        data.setSumDev(data.getSumDev() + t * t);
-        data.setQueueSumDev(data.getQueueSumDev() + q * q);
-        if (data.getElapsed() < 0 || data.getSumDev() < 0 || data.getQueueSumDev() < 0
-            || data.getQueueTime() < 0) {
+        data.status--;
+        data.count += count;
+        data.num++;
+        data.elapsed += t;
+        data.queueTime += q;
+        data.sumDev += t * t;
+        data.queueSumDev += q * q;
+        if (data.elapsed < 0 || data.sumDev < 0 || data.queueSumDev < 0 || data.queueTime < 0) {
           resetTimes();
         }
       }
@@ -63,7 +62,7 @@ public class TabletStatsKeeper {
   }
 
   public void saveMajorMinorTimes(TabletStats t) {
-    ActionStatsUpdator.update(minor, t.getMinors());
+    ActionStatsUpdator.update(minor, t.minors);
   }
 
   private void resetTimes() {
@@ -71,7 +70,7 @@ public class TabletStatsKeeper {
   }
 
   public void incrementStatusMinor() {
-    minor.setStatus(minor.getStatus() + 1);
+    minor.status++;
   }
 
   public TabletStats getTabletStats() {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ThriftScanClientHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ThriftScanClientHandler.java
@@ -308,11 +308,11 @@ public class ThriftScanClientHandler implements TabletScanClientService.Iface {
 
     ScanResult scanResult = new ScanResult(Key.compress(bresult.getResults()), bresult.isMore());
 
-    scanSession.entriesReturned += scanResult.getResults().size();
+    scanSession.entriesReturned += scanResult.results.size();
 
     scanSession.batchCount++;
 
-    if (scanResult.isMore() && scanSession.batchCount > scanSession.readaheadThreshold) {
+    if (scanResult.more && scanSession.batchCount > scanSession.readaheadThreshold) {
       // start reading next batch while current batch is transmitted
       // to client
       scanSession.setScanTask(new NextBatchTask(server, scanID, scanSession.interruptFlag));
@@ -320,7 +320,7 @@ public class ThriftScanClientHandler implements TabletScanClientService.Iface {
           getScanDispatcher(scanSession.extent), scanSession, scanSession.getScanTask());
     }
 
-    if (!scanResult.isMore()) {
+    if (!scanResult.more) {
       closeScan(tinfo, scanID);
     }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
@@ -338,15 +338,15 @@ public class LogSorter implements MetricsProducer {
     synchronized (currentWork) {
       for (Entry<String,LogProcessor> entries : currentWork.entrySet()) {
         RecoveryStatus status = new RecoveryStatus();
-        status.setName(entries.getKey());
+        status.name = entries.getKey();
         try {
           double progress = entries.getValue().getBytesCopied() / walBlockSize;
           // to be sure progress does not exceed 100%
-          status.setProgress(Math.min(progress, 99.9));
+          status.progress = Math.min(progress, 99.9);
         } catch (IOException ex) {
           log.warn("Error getting bytes read");
         }
-        status.setRuntime((int) entries.getValue().getSortTime());
+        status.runtime = (int) entries.getValue().getSortTime();
         result.add(status);
       }
       return result;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/ScanSession.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/ScanSession.java
@@ -147,22 +147,22 @@ public abstract class ScanSession<T> extends Session implements ScanInfo {
 
     @Override
     public String getIteratorClass() {
-      return ii.getClassName();
+      return ii.className;
     }
 
     @Override
     public String getName() {
-      return ii.getIterName();
+      return ii.iterName;
     }
 
     @Override
     public int getPriority() {
-      return ii.getPriority();
+      return ii.priority;
     }
 
     @Override
     public Map<String,String> getOptions() {
-      Map<String,String> opts = scanParams.getSsio().get(ii.getIterName());
+      Map<String,String> opts = scanParams.getSsio().get(ii.iterName);
       return opts == null || opts.isEmpty() ? Collections.emptyMap()
           : Collections.unmodifiableMap(opts);
     }

--- a/shell/src/main/java/org/apache/accumulo/shell/Shell.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/Shell.java
@@ -1113,9 +1113,9 @@ public class Shell extends ClientKeywordExecutable<ShellOptionsJC> {
         "Constraint class", "Violation code", "Violation Description"));
     logError(String.format("%" + COL1 + "s-+-%" + COL2 + "s-+-%" + col3 + "s%n", repeat("-", COL1),
         repeat("-", COL2), repeat("-", col3)));
-    for (TConstraintViolationSummary cvs : cve.getViolationSummaries()) {
+    for (TConstraintViolationSummary cvs : cve.violationSummaries) {
       logError(String.format("%-" + COL1 + "s | %" + COL2 + "d | %-" + col3 + "s%n",
-          cvs.getConstrainClass(), cvs.getViolationCode(), cvs.getViolationDescription()));
+          cvs.constrainClass, cvs.violationCode, cvs.violationDescription));
     }
     logError(String.format("%" + COL1 + "s-+-%" + COL2 + "s-+-%" + col3 + "s%n", repeat("-", COL1),
         repeat("-", COL2), repeat("-", col3)));

--- a/test/src/main/java/org/apache/accumulo/test/CorruptMutationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/CorruptMutationIT.java
@@ -94,7 +94,7 @@ public class CorruptMutationIT extends AccumuloClusterHarness {
 
         // Simulate data corruption in the serialized mutation
         TMutation badMutation = createTMutation("ghi", "z3");
-        badMutation.setEntries(-42);
+        badMutation.entries = -42;
 
         // Write some good and bad mutations to the session. The server side will see an error here,
         // however since this is a thrift oneway method no exception is expected here. This should

--- a/test/src/main/java/org/apache/accumulo/test/ListCompactionsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ListCompactionsIT.java
@@ -123,11 +123,10 @@ public class ListCompactionsIT extends SharedMiniClusterBase {
       }, 10000);
 
       expectedCompactions.values().forEach(tec -> {
-        RunningCompactionSummary rcs =
-            compactionsByEcid.get(tec.getJob().getExternalCompactionId());
+        RunningCompactionSummary rcs = compactionsByEcid.get(tec.job.getExternalCompactionId());
         assertNotNull(rcs);
         assertEquals(tec.getJob().getExternalCompactionId(), rcs.getEcid());
-        assertEquals(tec.getGroupName(), rcs.getGroup().canonical());
+        assertEquals(tec.groupName, rcs.getGroup().canonical());
         assertEquals(tec.getCompactor(), rcs.getAddr());
       });
 

--- a/test/src/main/java/org/apache/accumulo/test/TotalQueuedIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TotalQueuedIT.java
@@ -142,7 +142,7 @@ public class TotalQueuedIT extends ConfigurableMacBase {
           ThriftUtil.getClient(ThriftClientTypes.TABLET_SERVER,
               HostAndPort.fromParts(tserver.getHost(), tserver.getPort()), context);
       TabletServerStatus status = client.getTabletServerStatus(null, context.rpcCreds());
-      return status.getSyncs();
+      return status.syncs;
     }
     return 0;
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/ZombieTServer.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ZombieTServer.java
@@ -84,7 +84,7 @@ public class ZombieTServer {
       synchronized (this) {
         if (statusCount++ < 1) {
           TabletServerStatus result = new TabletServerStatus();
-          result.setTableMap(new HashMap<>());
+          result.tableMap = new HashMap<>();
           return result;
         }
       }

--- a/test/src/main/thrift-gen-java/org/apache/accumulo/test/rpc/thrift/SimpleThriftService.java
+++ b/test/src/main/thrift-gen-java/org/apache/accumulo/test/rpc/thrift/SimpleThriftService.java
@@ -1189,7 +1189,7 @@ public class SimpleThriftService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new echoPass_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new echoPass_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable java.lang.String value; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String value; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -1578,7 +1578,7 @@ public class SimpleThriftService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new echoPass_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new echoPass_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable java.lang.String success; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String success; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -1966,7 +1966,7 @@ public class SimpleThriftService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new onewayPass_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new onewayPass_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable java.lang.String value; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String value; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -2355,7 +2355,7 @@ public class SimpleThriftService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new echoFail_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new echoFail_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable java.lang.String value; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String value; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -2744,7 +2744,7 @@ public class SimpleThriftService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new echoFail_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new echoFail_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable java.lang.String success; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String success; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -3132,7 +3132,7 @@ public class SimpleThriftService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new onewayFail_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new onewayFail_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable java.lang.String value; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String value; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -3521,7 +3521,7 @@ public class SimpleThriftService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new echoRuntimeFail_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new echoRuntimeFail_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable java.lang.String value; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String value; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -3910,7 +3910,7 @@ public class SimpleThriftService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new echoRuntimeFail_resultStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new echoRuntimeFail_resultTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable java.lang.String success; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String success; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -4298,7 +4298,7 @@ public class SimpleThriftService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new onewayRuntimeFail_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new onewayRuntimeFail_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable java.lang.String value; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String value; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -4687,7 +4687,7 @@ public class SimpleThriftService {
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new echoPassVoid_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new echoPassVoid_argsTupleSchemeFactory();
 
-    private @org.apache.thrift.annotation.Nullable java.lang.String value; // required
+    public @org.apache.thrift.annotation.Nullable java.lang.String value; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {

--- a/test/src/test/java/org/apache/accumulo/test/ChaoticLoadBalancerTest.java
+++ b/test/src/test/java/org/apache/accumulo/test/ChaoticLoadBalancerTest.java
@@ -58,17 +58,17 @@ public class ChaoticLoadBalancerTest {
     TServerStatus getStatus() {
       org.apache.accumulo.core.manager.thrift.TabletServerStatus thriftStatus =
           new org.apache.accumulo.core.manager.thrift.TabletServerStatus();
-      thriftStatus.setTableMap(new HashMap<>());
+      thriftStatus.tableMap = new HashMap<>();
       for (TabletId extent : tablets) {
         TableId table = extent.getTable();
-        TableInfo info = thriftStatus.getTableMap().get(table.canonical());
+        TableInfo info = thriftStatus.tableMap.get(table.canonical());
         if (info == null) {
-          thriftStatus.getTableMap().put(table.canonical(), info = new TableInfo());
+          thriftStatus.tableMap.put(table.canonical(), info = new TableInfo());
         }
-        info.setOnlineTablets(info.getOnlineTablets() + 1);
-        info.setRecs(info.getOnlineTablets());
-        info.setIngestRate(123.);
-        info.setQueryRate(456.);
+        info.onlineTablets++;
+        info.recs = info.onlineTablets;
+        info.ingestRate = 123.;
+        info.queryRate = 456.;
       }
 
       return new TServerStatusImpl(thriftStatus);


### PR DESCRIPTION
`GarbageCollectorIT.gcLotsOfCandidatesIT` has consistently failed on a server since #6430 was merged. The failure happens when the garbage collector process is started with 32 MB of memory. This PR branch exists so that I can test this on that server.

This reverts commit bdcd798bcc3bf3040086c440e8be4ed5d26985a8.