### PR TITLE
Remove protective copies in Thrift APIs

### DIFF
--- a/core/src/main/scripts/generate-thrift.sh
+++ b/core/src/main/scripts/generate-thrift.sh
@@ -67,7 +67,7 @@ THRIFT_ARGS=("${THRIFT_ARGS[@]}" -o "$BUILD_DIR")
 mkdir -p "$BUILD_DIR"
 rm -rf "$BUILD_DIR"/gen-java
 for f in src/main/thrift/*.thrift; do
-  thrift "${THRIFT_ARGS[@]}" --gen java:generated_annotations=suppress,private-members "$f" || fail unable to generate java thrift classes
+  thrift "${THRIFT_ARGS[@]}" --gen java:generated_annotations=suppress,private_members,unsafe_binaries "$f" || fail unable to generate java thrift classes
   thrift "${THRIFT_ARGS[@]}" --gen py "$f" || fail unable to generate python thrift classes
   thrift "${THRIFT_ARGS[@]}" --gen rb "$f" || fail unable to generate ruby thrift classes
   thrift "${THRIFT_ARGS[@]}" --gen cpp "$f" || fail unable to generate cpp thrift classes

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/clientImpl/thrift/ClientService.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/clientImpl/thrift/ClientService.java
@@ -9494,7 +9494,7 @@ public class ClientService {
       this.tinfo = tinfo;
       this.credentials = credentials;
       this.principal = principal;
-      this.password = org.apache.thrift.TBaseHelper.copyBinary(password);
+      this.password = password;
     }
 
     /**
@@ -9609,16 +9609,16 @@ public class ClientService {
     }
 
     public java.nio.ByteBuffer bufferForPassword() {
-      return org.apache.thrift.TBaseHelper.copyBinary(password);
+      return password;
     }
 
     public createLocalUser_args setPassword(byte[] password) {
-      this.password = password == null ? (java.nio.ByteBuffer)null     : java.nio.ByteBuffer.wrap(password.clone());
+      this.password = password == null ? (java.nio.ByteBuffer)null     : java.nio.ByteBuffer.wrap(password);
       return this;
     }
 
     public createLocalUser_args setPassword(@org.apache.thrift.annotation.Nullable java.nio.ByteBuffer password) {
-      this.password = org.apache.thrift.TBaseHelper.copyBinary(password);
+      this.password = password;
       return this;
     }
 
@@ -11610,7 +11610,7 @@ public class ClientService {
       this.tinfo = tinfo;
       this.credentials = credentials;
       this.principal = principal;
-      this.password = org.apache.thrift.TBaseHelper.copyBinary(password);
+      this.password = password;
     }
 
     /**
@@ -11725,16 +11725,16 @@ public class ClientService {
     }
 
     public java.nio.ByteBuffer bufferForPassword() {
-      return org.apache.thrift.TBaseHelper.copyBinary(password);
+      return password;
     }
 
     public changeLocalUserPassword_args setPassword(byte[] password) {
-      this.password = password == null ? (java.nio.ByteBuffer)null     : java.nio.ByteBuffer.wrap(password.clone());
+      this.password = password == null ? (java.nio.ByteBuffer)null     : java.nio.ByteBuffer.wrap(password);
       return this;
     }
 
     public changeLocalUserPassword_args setPassword(@org.apache.thrift.annotation.Nullable java.nio.ByteBuffer password) {
-      this.password = org.apache.thrift.TBaseHelper.copyBinary(password);
+      this.password = password;
       return this;
     }
 

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TColumn.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TColumn.java
@@ -130,9 +130,9 @@ public class TColumn implements org.apache.thrift.TBase<TColumn, TColumn._Fields
     java.nio.ByteBuffer columnVisibility)
   {
     this();
-    this.columnFamily = org.apache.thrift.TBaseHelper.copyBinary(columnFamily);
-    this.columnQualifier = org.apache.thrift.TBaseHelper.copyBinary(columnQualifier);
-    this.columnVisibility = org.apache.thrift.TBaseHelper.copyBinary(columnVisibility);
+    this.columnFamily = columnFamily;
+    this.columnQualifier = columnQualifier;
+    this.columnVisibility = columnVisibility;
   }
 
   /**
@@ -168,16 +168,16 @@ public class TColumn implements org.apache.thrift.TBase<TColumn, TColumn._Fields
   }
 
   public java.nio.ByteBuffer bufferForColumnFamily() {
-    return org.apache.thrift.TBaseHelper.copyBinary(columnFamily);
+    return columnFamily;
   }
 
   public TColumn setColumnFamily(byte[] columnFamily) {
-    this.columnFamily = columnFamily == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(columnFamily.clone());
+    this.columnFamily = columnFamily == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(columnFamily);
     return this;
   }
 
   public TColumn setColumnFamily(@org.apache.thrift.annotation.Nullable java.nio.ByteBuffer columnFamily) {
-    this.columnFamily = org.apache.thrift.TBaseHelper.copyBinary(columnFamily);
+    this.columnFamily = columnFamily;
     return this;
   }
 
@@ -202,16 +202,16 @@ public class TColumn implements org.apache.thrift.TBase<TColumn, TColumn._Fields
   }
 
   public java.nio.ByteBuffer bufferForColumnQualifier() {
-    return org.apache.thrift.TBaseHelper.copyBinary(columnQualifier);
+    return columnQualifier;
   }
 
   public TColumn setColumnQualifier(byte[] columnQualifier) {
-    this.columnQualifier = columnQualifier == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(columnQualifier.clone());
+    this.columnQualifier = columnQualifier == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(columnQualifier);
     return this;
   }
 
   public TColumn setColumnQualifier(@org.apache.thrift.annotation.Nullable java.nio.ByteBuffer columnQualifier) {
-    this.columnQualifier = org.apache.thrift.TBaseHelper.copyBinary(columnQualifier);
+    this.columnQualifier = columnQualifier;
     return this;
   }
 
@@ -236,16 +236,16 @@ public class TColumn implements org.apache.thrift.TBase<TColumn, TColumn._Fields
   }
 
   public java.nio.ByteBuffer bufferForColumnVisibility() {
-    return org.apache.thrift.TBaseHelper.copyBinary(columnVisibility);
+    return columnVisibility;
   }
 
   public TColumn setColumnVisibility(byte[] columnVisibility) {
-    this.columnVisibility = columnVisibility == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(columnVisibility.clone());
+    this.columnVisibility = columnVisibility == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(columnVisibility);
     return this;
   }
 
   public TColumn setColumnVisibility(@org.apache.thrift.annotation.Nullable java.nio.ByteBuffer columnVisibility) {
-    this.columnVisibility = org.apache.thrift.TBaseHelper.copyBinary(columnVisibility);
+    this.columnVisibility = columnVisibility;
     return this;
   }
 

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TCondition.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TCondition.java
@@ -165,15 +165,15 @@ public class TCondition implements org.apache.thrift.TBase<TCondition, TConditio
     java.nio.ByteBuffer iterators)
   {
     this();
-    this.cf = org.apache.thrift.TBaseHelper.copyBinary(cf);
-    this.cq = org.apache.thrift.TBaseHelper.copyBinary(cq);
-    this.cv = org.apache.thrift.TBaseHelper.copyBinary(cv);
+    this.cf = cf;
+    this.cq = cq;
+    this.cv = cv;
     this.ts = ts;
     setTsIsSet(true);
     this.hasTimestamp = hasTimestamp;
     setHasTimestampIsSet(true);
-    this.val = org.apache.thrift.TBaseHelper.copyBinary(val);
-    this.iterators = org.apache.thrift.TBaseHelper.copyBinary(iterators);
+    this.val = val;
+    this.iterators = iterators;
   }
 
   /**
@@ -224,16 +224,16 @@ public class TCondition implements org.apache.thrift.TBase<TCondition, TConditio
   }
 
   public java.nio.ByteBuffer bufferForCf() {
-    return org.apache.thrift.TBaseHelper.copyBinary(cf);
+    return cf;
   }
 
   public TCondition setCf(byte[] cf) {
-    this.cf = cf == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(cf.clone());
+    this.cf = cf == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(cf);
     return this;
   }
 
   public TCondition setCf(@org.apache.thrift.annotation.Nullable java.nio.ByteBuffer cf) {
-    this.cf = org.apache.thrift.TBaseHelper.copyBinary(cf);
+    this.cf = cf;
     return this;
   }
 
@@ -258,16 +258,16 @@ public class TCondition implements org.apache.thrift.TBase<TCondition, TConditio
   }
 
   public java.nio.ByteBuffer bufferForCq() {
-    return org.apache.thrift.TBaseHelper.copyBinary(cq);
+    return cq;
   }
 
   public TCondition setCq(byte[] cq) {
-    this.cq = cq == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(cq.clone());
+    this.cq = cq == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(cq);
     return this;
   }
 
   public TCondition setCq(@org.apache.thrift.annotation.Nullable java.nio.ByteBuffer cq) {
-    this.cq = org.apache.thrift.TBaseHelper.copyBinary(cq);
+    this.cq = cq;
     return this;
   }
 
@@ -292,16 +292,16 @@ public class TCondition implements org.apache.thrift.TBase<TCondition, TConditio
   }
 
   public java.nio.ByteBuffer bufferForCv() {
-    return org.apache.thrift.TBaseHelper.copyBinary(cv);
+    return cv;
   }
 
   public TCondition setCv(byte[] cv) {
-    this.cv = cv == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(cv.clone());
+    this.cv = cv == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(cv);
     return this;
   }
 
   public TCondition setCv(@org.apache.thrift.annotation.Nullable java.nio.ByteBuffer cv) {
-    this.cv = org.apache.thrift.TBaseHelper.copyBinary(cv);
+    this.cv = cv;
     return this;
   }
 
@@ -372,16 +372,16 @@ public class TCondition implements org.apache.thrift.TBase<TCondition, TConditio
   }
 
   public java.nio.ByteBuffer bufferForVal() {
-    return org.apache.thrift.TBaseHelper.copyBinary(val);
+    return val;
   }
 
   public TCondition setVal(byte[] val) {
-    this.val = val == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(val.clone());
+    this.val = val == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(val);
     return this;
   }
 
   public TCondition setVal(@org.apache.thrift.annotation.Nullable java.nio.ByteBuffer val) {
-    this.val = org.apache.thrift.TBaseHelper.copyBinary(val);
+    this.val = val;
     return this;
   }
 
@@ -406,16 +406,16 @@ public class TCondition implements org.apache.thrift.TBase<TCondition, TConditio
   }
 
   public java.nio.ByteBuffer bufferForIterators() {
-    return org.apache.thrift.TBaseHelper.copyBinary(iterators);
+    return iterators;
   }
 
   public TCondition setIterators(byte[] iterators) {
-    this.iterators = iterators == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(iterators.clone());
+    this.iterators = iterators == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(iterators);
     return this;
   }
 
   public TCondition setIterators(@org.apache.thrift.annotation.Nullable java.nio.ByteBuffer iterators) {
-    this.iterators = org.apache.thrift.TBaseHelper.copyBinary(iterators);
+    this.iterators = iterators;
     return this;
   }
 

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TKey.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TKey.java
@@ -148,10 +148,10 @@ public class TKey implements org.apache.thrift.TBase<TKey, TKey._Fields>, java.i
     long timestamp)
   {
     this();
-    this.row = org.apache.thrift.TBaseHelper.copyBinary(row);
-    this.colFamily = org.apache.thrift.TBaseHelper.copyBinary(colFamily);
-    this.colQualifier = org.apache.thrift.TBaseHelper.copyBinary(colQualifier);
-    this.colVisibility = org.apache.thrift.TBaseHelper.copyBinary(colVisibility);
+    this.row = row;
+    this.colFamily = colFamily;
+    this.colQualifier = colQualifier;
+    this.colVisibility = colVisibility;
     this.timestamp = timestamp;
     setTimestampIsSet(true);
   }
@@ -197,16 +197,16 @@ public class TKey implements org.apache.thrift.TBase<TKey, TKey._Fields>, java.i
   }
 
   public java.nio.ByteBuffer bufferForRow() {
-    return org.apache.thrift.TBaseHelper.copyBinary(row);
+    return row;
   }
 
   public TKey setRow(byte[] row) {
-    this.row = row == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(row.clone());
+    this.row = row == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(row);
     return this;
   }
 
   public TKey setRow(@org.apache.thrift.annotation.Nullable java.nio.ByteBuffer row) {
-    this.row = org.apache.thrift.TBaseHelper.copyBinary(row);
+    this.row = row;
     return this;
   }
 
@@ -231,16 +231,16 @@ public class TKey implements org.apache.thrift.TBase<TKey, TKey._Fields>, java.i
   }
 
   public java.nio.ByteBuffer bufferForColFamily() {
-    return org.apache.thrift.TBaseHelper.copyBinary(colFamily);
+    return colFamily;
   }
 
   public TKey setColFamily(byte[] colFamily) {
-    this.colFamily = colFamily == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(colFamily.clone());
+    this.colFamily = colFamily == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(colFamily);
     return this;
   }
 
   public TKey setColFamily(@org.apache.thrift.annotation.Nullable java.nio.ByteBuffer colFamily) {
-    this.colFamily = org.apache.thrift.TBaseHelper.copyBinary(colFamily);
+    this.colFamily = colFamily;
     return this;
   }
 
@@ -265,16 +265,16 @@ public class TKey implements org.apache.thrift.TBase<TKey, TKey._Fields>, java.i
   }
 
   public java.nio.ByteBuffer bufferForColQualifier() {
-    return org.apache.thrift.TBaseHelper.copyBinary(colQualifier);
+    return colQualifier;
   }
 
   public TKey setColQualifier(byte[] colQualifier) {
-    this.colQualifier = colQualifier == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(colQualifier.clone());
+    this.colQualifier = colQualifier == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(colQualifier);
     return this;
   }
 
   public TKey setColQualifier(@org.apache.thrift.annotation.Nullable java.nio.ByteBuffer colQualifier) {
-    this.colQualifier = org.apache.thrift.TBaseHelper.copyBinary(colQualifier);
+    this.colQualifier = colQualifier;
     return this;
   }
 
@@ -299,16 +299,16 @@ public class TKey implements org.apache.thrift.TBase<TKey, TKey._Fields>, java.i
   }
 
   public java.nio.ByteBuffer bufferForColVisibility() {
-    return org.apache.thrift.TBaseHelper.copyBinary(colVisibility);
+    return colVisibility;
   }
 
   public TKey setColVisibility(byte[] colVisibility) {
-    this.colVisibility = colVisibility == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(colVisibility.clone());
+    this.colVisibility = colVisibility == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(colVisibility);
     return this;
   }
 
   public TKey setColVisibility(@org.apache.thrift.annotation.Nullable java.nio.ByteBuffer colVisibility) {
-    this.colVisibility = org.apache.thrift.TBaseHelper.copyBinary(colVisibility);
+    this.colVisibility = colVisibility;
     return this;
   }
 

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TKeyExtent.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TKeyExtent.java
@@ -130,9 +130,9 @@ public class TKeyExtent implements org.apache.thrift.TBase<TKeyExtent, TKeyExten
     java.nio.ByteBuffer prevEndRow)
   {
     this();
-    this.table = org.apache.thrift.TBaseHelper.copyBinary(table);
-    this.endRow = org.apache.thrift.TBaseHelper.copyBinary(endRow);
-    this.prevEndRow = org.apache.thrift.TBaseHelper.copyBinary(prevEndRow);
+    this.table = table;
+    this.endRow = endRow;
+    this.prevEndRow = prevEndRow;
   }
 
   /**
@@ -168,16 +168,16 @@ public class TKeyExtent implements org.apache.thrift.TBase<TKeyExtent, TKeyExten
   }
 
   public java.nio.ByteBuffer bufferForTable() {
-    return org.apache.thrift.TBaseHelper.copyBinary(table);
+    return table;
   }
 
   public TKeyExtent setTable(byte[] table) {
-    this.table = table == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(table.clone());
+    this.table = table == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(table);
     return this;
   }
 
   public TKeyExtent setTable(@org.apache.thrift.annotation.Nullable java.nio.ByteBuffer table) {
-    this.table = org.apache.thrift.TBaseHelper.copyBinary(table);
+    this.table = table;
     return this;
   }
 
@@ -202,16 +202,16 @@ public class TKeyExtent implements org.apache.thrift.TBase<TKeyExtent, TKeyExten
   }
 
   public java.nio.ByteBuffer bufferForEndRow() {
-    return org.apache.thrift.TBaseHelper.copyBinary(endRow);
+    return endRow;
   }
 
   public TKeyExtent setEndRow(byte[] endRow) {
-    this.endRow = endRow == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(endRow.clone());
+    this.endRow = endRow == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(endRow);
     return this;
   }
 
   public TKeyExtent setEndRow(@org.apache.thrift.annotation.Nullable java.nio.ByteBuffer endRow) {
-    this.endRow = org.apache.thrift.TBaseHelper.copyBinary(endRow);
+    this.endRow = endRow;
     return this;
   }
 
@@ -236,16 +236,16 @@ public class TKeyExtent implements org.apache.thrift.TBase<TKeyExtent, TKeyExten
   }
 
   public java.nio.ByteBuffer bufferForPrevEndRow() {
-    return org.apache.thrift.TBaseHelper.copyBinary(prevEndRow);
+    return prevEndRow;
   }
 
   public TKeyExtent setPrevEndRow(byte[] prevEndRow) {
-    this.prevEndRow = prevEndRow == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(prevEndRow.clone());
+    this.prevEndRow = prevEndRow == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(prevEndRow);
     return this;
   }
 
   public TKeyExtent setPrevEndRow(@org.apache.thrift.annotation.Nullable java.nio.ByteBuffer prevEndRow) {
-    this.prevEndRow = org.apache.thrift.TBaseHelper.copyBinary(prevEndRow);
+    this.prevEndRow = prevEndRow;
     return this;
   }
 

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TKeyValue.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TKeyValue.java
@@ -123,7 +123,7 @@ public class TKeyValue implements org.apache.thrift.TBase<TKeyValue, TKeyValue._
   {
     this();
     this.key = key;
-    this.value = org.apache.thrift.TBaseHelper.copyBinary(value);
+    this.value = value;
   }
 
   /**
@@ -180,16 +180,16 @@ public class TKeyValue implements org.apache.thrift.TBase<TKeyValue, TKeyValue._
   }
 
   public java.nio.ByteBuffer bufferForValue() {
-    return org.apache.thrift.TBaseHelper.copyBinary(value);
+    return value;
   }
 
   public TKeyValue setValue(byte[] value) {
-    this.value = value == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(value.clone());
+    this.value = value == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(value);
     return this;
   }
 
   public TKeyValue setValue(@org.apache.thrift.annotation.Nullable java.nio.ByteBuffer value) {
-    this.value = org.apache.thrift.TBaseHelper.copyBinary(value);
+    this.value = value;
     return this;
   }
 

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TMutation.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TMutation.java
@@ -150,8 +150,8 @@ public class TMutation implements org.apache.thrift.TBase<TMutation, TMutation._
     int entries)
   {
     this();
-    this.row = org.apache.thrift.TBaseHelper.copyBinary(row);
-    this.data = org.apache.thrift.TBaseHelper.copyBinary(data);
+    this.row = row;
+    this.data = data;
     this.values = values;
     this.entries = entries;
     setEntriesIsSet(true);
@@ -200,16 +200,16 @@ public class TMutation implements org.apache.thrift.TBase<TMutation, TMutation._
   }
 
   public java.nio.ByteBuffer bufferForRow() {
-    return org.apache.thrift.TBaseHelper.copyBinary(row);
+    return row;
   }
 
   public TMutation setRow(byte[] row) {
-    this.row = row == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(row.clone());
+    this.row = row == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(row);
     return this;
   }
 
   public TMutation setRow(@org.apache.thrift.annotation.Nullable java.nio.ByteBuffer row) {
-    this.row = org.apache.thrift.TBaseHelper.copyBinary(row);
+    this.row = row;
     return this;
   }
 
@@ -234,16 +234,16 @@ public class TMutation implements org.apache.thrift.TBase<TMutation, TMutation._
   }
 
   public java.nio.ByteBuffer bufferForData() {
-    return org.apache.thrift.TBaseHelper.copyBinary(data);
+    return data;
   }
 
   public TMutation setData(byte[] data) {
-    this.data = data == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(data.clone());
+    this.data = data == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(data);
     return this;
   }
 
   public TMutation setData(@org.apache.thrift.annotation.Nullable java.nio.ByteBuffer data) {
-    this.data = org.apache.thrift.TBaseHelper.copyBinary(data);
+    this.data = data;
     return this;
   }
 

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TRowRange.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/dataImpl/thrift/TRowRange.java
@@ -122,8 +122,8 @@ public class TRowRange implements org.apache.thrift.TBase<TRowRange, TRowRange._
     java.nio.ByteBuffer endRow)
   {
     this();
-    this.startRow = org.apache.thrift.TBaseHelper.copyBinary(startRow);
-    this.endRow = org.apache.thrift.TBaseHelper.copyBinary(endRow);
+    this.startRow = startRow;
+    this.endRow = endRow;
   }
 
   /**
@@ -155,16 +155,16 @@ public class TRowRange implements org.apache.thrift.TBase<TRowRange, TRowRange._
   }
 
   public java.nio.ByteBuffer bufferForStartRow() {
-    return org.apache.thrift.TBaseHelper.copyBinary(startRow);
+    return startRow;
   }
 
   public TRowRange setStartRow(byte[] startRow) {
-    this.startRow = startRow == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(startRow.clone());
+    this.startRow = startRow == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(startRow);
     return this;
   }
 
   public TRowRange setStartRow(@org.apache.thrift.annotation.Nullable java.nio.ByteBuffer startRow) {
-    this.startRow = org.apache.thrift.TBaseHelper.copyBinary(startRow);
+    this.startRow = startRow;
     return this;
   }
 
@@ -189,16 +189,16 @@ public class TRowRange implements org.apache.thrift.TBase<TRowRange, TRowRange._
   }
 
   public java.nio.ByteBuffer bufferForEndRow() {
-    return org.apache.thrift.TBaseHelper.copyBinary(endRow);
+    return endRow;
   }
 
   public TRowRange setEndRow(byte[] endRow) {
-    this.endRow = endRow == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(endRow.clone());
+    this.endRow = endRow == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(endRow);
     return this;
   }
 
   public TRowRange setEndRow(@org.apache.thrift.annotation.Nullable java.nio.ByteBuffer endRow) {
-    this.endRow = org.apache.thrift.TBaseHelper.copyBinary(endRow);
+    this.endRow = endRow;
     return this;
   }
 

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/ManagerClientService.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/ManagerClientService.java
@@ -7293,8 +7293,8 @@ public class ManagerClientService {
       this.tinfo = tinfo;
       this.credentials = credentials;
       this.tableName = tableName;
-      this.startRow = org.apache.thrift.TBaseHelper.copyBinary(startRow);
-      this.endRow = org.apache.thrift.TBaseHelper.copyBinary(endRow);
+      this.startRow = startRow;
+      this.endRow = endRow;
       this.flushID = flushID;
       setFlushIDIsSet(true);
       this.maxLoops = maxLoops;
@@ -7424,16 +7424,16 @@ public class ManagerClientService {
     }
 
     public java.nio.ByteBuffer bufferForStartRow() {
-      return org.apache.thrift.TBaseHelper.copyBinary(startRow);
+      return startRow;
     }
 
     public waitForFlush_args setStartRow(byte[] startRow) {
-      this.startRow = startRow == null ? (java.nio.ByteBuffer)null     : java.nio.ByteBuffer.wrap(startRow.clone());
+      this.startRow = startRow == null ? (java.nio.ByteBuffer)null     : java.nio.ByteBuffer.wrap(startRow);
       return this;
     }
 
     public waitForFlush_args setStartRow(@org.apache.thrift.annotation.Nullable java.nio.ByteBuffer startRow) {
-      this.startRow = org.apache.thrift.TBaseHelper.copyBinary(startRow);
+      this.startRow = startRow;
       return this;
     }
 
@@ -7458,16 +7458,16 @@ public class ManagerClientService {
     }
 
     public java.nio.ByteBuffer bufferForEndRow() {
-      return org.apache.thrift.TBaseHelper.copyBinary(endRow);
+      return endRow;
     }
 
     public waitForFlush_args setEndRow(byte[] endRow) {
-      this.endRow = endRow == null ? (java.nio.ByteBuffer)null     : java.nio.ByteBuffer.wrap(endRow.clone());
+      this.endRow = endRow == null ? (java.nio.ByteBuffer)null     : java.nio.ByteBuffer.wrap(endRow);
       return this;
     }
 
     public waitForFlush_args setEndRow(@org.apache.thrift.annotation.Nullable java.nio.ByteBuffer endRow) {
-      this.endRow = org.apache.thrift.TBaseHelper.copyBinary(endRow);
+      this.endRow = endRow;
       return this;
     }
 

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/securityImpl/thrift/TAuthenticationKey.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/securityImpl/thrift/TAuthenticationKey.java
@@ -140,7 +140,7 @@ public class TAuthenticationKey implements org.apache.thrift.TBase<TAuthenticati
     java.nio.ByteBuffer secret)
   {
     this();
-    this.secret = org.apache.thrift.TBaseHelper.copyBinary(secret);
+    this.secret = secret;
   }
 
   /**
@@ -178,16 +178,16 @@ public class TAuthenticationKey implements org.apache.thrift.TBase<TAuthenticati
   }
 
   public java.nio.ByteBuffer bufferForSecret() {
-    return org.apache.thrift.TBaseHelper.copyBinary(secret);
+    return secret;
   }
 
   public TAuthenticationKey setSecret(byte[] secret) {
-    this.secret = secret == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(secret.clone());
+    this.secret = secret == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(secret);
     return this;
   }
 
   public TAuthenticationKey setSecret(@org.apache.thrift.annotation.Nullable java.nio.ByteBuffer secret) {
-    this.secret = org.apache.thrift.TBaseHelper.copyBinary(secret);
+    this.secret = secret;
     return this;
   }
 

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/securityImpl/thrift/TCredentials.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/securityImpl/thrift/TCredentials.java
@@ -140,7 +140,7 @@ public class TCredentials implements org.apache.thrift.TBase<TCredentials, TCred
     this();
     this.principal = principal;
     this.tokenClassName = tokenClassName;
-    this.token = org.apache.thrift.TBaseHelper.copyBinary(token);
+    this.token = token;
     this.instanceId = instanceId;
   }
 
@@ -231,16 +231,16 @@ public class TCredentials implements org.apache.thrift.TBase<TCredentials, TCred
   }
 
   public java.nio.ByteBuffer bufferForToken() {
-    return org.apache.thrift.TBaseHelper.copyBinary(token);
+    return token;
   }
 
   public TCredentials setToken(byte[] token) {
-    this.token = token == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(token.clone());
+    this.token = token == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(token);
     return this;
   }
 
   public TCredentials setToken(@org.apache.thrift.annotation.Nullable java.nio.ByteBuffer token) {
-    this.token = org.apache.thrift.TBaseHelper.copyBinary(token);
+    this.token = token;
     return this;
   }
 

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/securityImpl/thrift/TDelegationToken.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/securityImpl/thrift/TDelegationToken.java
@@ -122,7 +122,7 @@ public class TDelegationToken implements org.apache.thrift.TBase<TDelegationToke
     TAuthenticationTokenIdentifier identifier)
   {
     this();
-    this.password = org.apache.thrift.TBaseHelper.copyBinary(password);
+    this.password = password;
     this.identifier = identifier;
   }
 
@@ -155,16 +155,16 @@ public class TDelegationToken implements org.apache.thrift.TBase<TDelegationToke
   }
 
   public java.nio.ByteBuffer bufferForPassword() {
-    return org.apache.thrift.TBaseHelper.copyBinary(password);
+    return password;
   }
 
   public TDelegationToken setPassword(byte[] password) {
-    this.password = password == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(password.clone());
+    this.password = password == null ? (java.nio.ByteBuffer)null   : java.nio.ByteBuffer.wrap(password);
     return this;
   }
 
   public TDelegationToken setPassword(@org.apache.thrift.annotation.Nullable java.nio.ByteBuffer password) {
-    this.password = org.apache.thrift.TBaseHelper.copyBinary(password);
+    this.password = password;
     return this;
   }
 

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletserver/thrift/TabletServerClientService.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/tabletserver/thrift/TabletServerClientService.java
@@ -2906,8 +2906,8 @@ public class TabletServerClientService {
       this.credentials = credentials;
       this.lock = lock;
       this.tableId = tableId;
-      this.startRow = org.apache.thrift.TBaseHelper.copyBinary(startRow);
-      this.endRow = org.apache.thrift.TBaseHelper.copyBinary(endRow);
+      this.startRow = startRow;
+      this.endRow = endRow;
     }
 
     /**
@@ -3055,16 +3055,16 @@ public class TabletServerClientService {
     }
 
     public java.nio.ByteBuffer bufferForStartRow() {
-      return org.apache.thrift.TBaseHelper.copyBinary(startRow);
+      return startRow;
     }
 
     public flush_args setStartRow(byte[] startRow) {
-      this.startRow = startRow == null ? (java.nio.ByteBuffer)null     : java.nio.ByteBuffer.wrap(startRow.clone());
+      this.startRow = startRow == null ? (java.nio.ByteBuffer)null     : java.nio.ByteBuffer.wrap(startRow);
       return this;
     }
 
     public flush_args setStartRow(@org.apache.thrift.annotation.Nullable java.nio.ByteBuffer startRow) {
-      this.startRow = org.apache.thrift.TBaseHelper.copyBinary(startRow);
+      this.startRow = startRow;
       return this;
     }
 
@@ -3089,16 +3089,16 @@ public class TabletServerClientService {
     }
 
     public java.nio.ByteBuffer bufferForEndRow() {
-      return org.apache.thrift.TBaseHelper.copyBinary(endRow);
+      return endRow;
     }
 
     public flush_args setEndRow(byte[] endRow) {
-      this.endRow = endRow == null ? (java.nio.ByteBuffer)null     : java.nio.ByteBuffer.wrap(endRow.clone());
+      this.endRow = endRow == null ? (java.nio.ByteBuffer)null     : java.nio.ByteBuffer.wrap(endRow);
       return this;
     }
 
     public flush_args setEndRow(@org.apache.thrift.annotation.Nullable java.nio.ByteBuffer endRow) {
-      this.endRow = org.apache.thrift.TBaseHelper.copyBinary(endRow);
+      this.endRow = endRow;
       return this;
     }
 


### PR DESCRIPTION
Generate thrift with unsafe_binaries flag to remove unwanted protective copies of ByteBuffer types (we will copy as needed ourselves).