### PR TITLE
Track ZooKeeper property creation and modification times

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/conf/codec/VersionedPropCodec.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/codec/VersionedPropCodec.java
@@ -24,6 +24,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -31,7 +32,9 @@ import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 
+import org.apache.accumulo.server.conf.codec.VersionedProperties.PropertyMetadata;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
@@ -132,9 +135,9 @@ public abstract class VersionedPropCodec {
 
       var timestamp = TIMESTAMP_FORMATTER.parse(dis.readUTF(), Instant::from);
 
-      Map<String,String> props = decodePayload(bis, encodingOpts);
+      Payload props = decodePayload(bis, encodingOpts);
 
-      return new VersionedProperties(version, timestamp, props);
+      return new VersionedProperties(version, timestamp, props.properties(), props.metadata());
     } catch (NullPointerException | DateTimeParseException ex) {
       throw new IllegalArgumentException("Invalid data cannot decode byte array", ex);
     }
@@ -185,16 +188,18 @@ public abstract class VersionedPropCodec {
   }
 
   /**
-   * Decode the payload and any optional encoding specific metadata and return a map of the property
-   * name, value pairs.
+   * Decode the payload and any optional encoding specific metadata.
    *
    * @param inStream an input stream
    * @param encodingOpts the general encoding options.
-   * @return a map of properties name, value pairs.
+   * @return the decoded payload
    * @throws IOException if an exception occurs reading from the input stream.
    */
-  abstract Map<String,String> decodePayload(final InputStream inStream,
-      final EncodingOptions encodingOpts) throws IOException;
+  abstract Payload decodePayload(final InputStream inStream, final EncodingOptions encodingOpts)
+      throws IOException;
+
+  record Payload(Map<String,String> properties, Map<String,PropertyMetadata> metadata) {
+  }
 
   /**
    * Read the property map from a data input stream as UTF strings. The input stream should be
@@ -242,6 +247,51 @@ public abstract class VersionedPropCodec {
     for (Map.Entry<String,String> e : aMap.entrySet()) {
       dos.writeUTF(e.getKey());
       dos.writeUTF(e.getValue());
+    }
+    dos.flush();
+  }
+
+  /**
+   * Read optional property metadata written after the property map.
+   *
+   * @return the property metadata map, or an empty map when absent.
+   */
+  Map<String,PropertyMetadata> readMetadataAsUTF(DataInputStream dis) throws IOException {
+    if (dis.available() == 0) {
+      return Map.of();
+    }
+
+    int items;
+    try {
+      items = dis.readInt();
+    } catch (EOFException e) {
+      return Map.of();
+    }
+
+    Map<String,PropertyMetadata> metadata = new HashMap<>(items);
+    for (int i = 0; i < items; i++) {
+      String key = dis.readUTF();
+      Instant created = TIMESTAMP_FORMATTER.parse(dis.readUTF(), Instant::from);
+      Instant modified = TIMESTAMP_FORMATTER.parse(dis.readUTF(), Instant::from);
+      metadata.put(key, new PropertyMetadata(created, modified));
+    }
+    return metadata;
+  }
+
+  /**
+   * Write the property metadata to the data output stream.
+   *
+   * @param dos a data output stream
+   * @param metadata the property metadata map.
+   */
+  void writeMetadataAsUTF(final DataOutputStream dos, final Map<String,PropertyMetadata> metadata)
+      throws IOException {
+    dos.writeInt(metadata.size());
+
+    for (Entry<String,PropertyMetadata> e : metadata.entrySet()) {
+      dos.writeUTF(e.getKey());
+      dos.writeUTF(TIMESTAMP_FORMATTER.format(e.getValue().created()));
+      dos.writeUTF(TIMESTAMP_FORMATTER.format(e.getValue().modified()));
     }
     dos.flush();
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/codec/VersionedPropGzipCodec.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/codec/VersionedPropGzipCodec.java
@@ -27,6 +27,8 @@ import java.util.Map;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
+import org.apache.accumulo.server.conf.codec.VersionedProperties.PropertyMetadata;
+
 /**
  * Initial property encoding that (optionally) uses gzip to compress the property map. The encoding
  * version supported is EncodingVersion.V1_0.
@@ -53,6 +55,7 @@ public class VersionedPropGzipCodec extends VersionedPropCodec {
           DataOutputStream zdos = new DataOutputStream(gzipOut)) {
 
         writeMapAsUTF(zdos, props);
+        writeMetadataAsUTF(zdos, vProps.getMetadata());
 
         // finalize compression
         gzipOut.flush();
@@ -61,6 +64,7 @@ public class VersionedPropGzipCodec extends VersionedPropCodec {
     } else {
       try (DataOutputStream dos = new DataOutputStream(out)) {
         writeMapAsUTF(dos, props);
+        writeMetadataAsUTF(dos, vProps.getMetadata());
       }
     }
 
@@ -72,21 +76,24 @@ public class VersionedPropGzipCodec extends VersionedPropCodec {
   }
 
   @Override
-  Map<String,String> decodePayload(final InputStream inStream, final EncodingOptions encodingOpts)
-      throws IOException {
+  VersionedPropCodec.Payload decodePayload(final InputStream inStream,
+      final EncodingOptions encodingOpts) throws IOException {
     // read the property map keys, values
     Map<String,String> aMap;
+    Map<String,PropertyMetadata> metadata;
     if (encodingOpts.isCompressed()) {
       // Read and uncompress an input stream compressed with GZip
       try (GZIPInputStream gzipIn = new GZIPInputStream(inStream);
           DataInputStream zdis = new DataInputStream(gzipIn)) {
         aMap = readMapAsUTF(zdis);
+        metadata = readMetadataAsUTF(zdis);
       }
     } else {
       try (DataInputStream dis = new DataInputStream(inStream)) {
         aMap = readMapAsUTF(dis);
+        metadata = readMetadataAsUTF(dis);
       }
     }
-    return aMap;
+    return new Payload(aMap, metadata);
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/codec/VersionedProperties.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/codec/VersionedProperties.java
@@ -27,6 +27,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.TreeMap;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -55,6 +56,15 @@ public class VersionedProperties {
   private final long dataVersion;
   private final Instant timestamp;
   private final Map<String,String> props;
+  private final Map<String,PropertyMetadata> metadata;
+
+  public record PropertyMetadata(Instant created, Instant modified) {
+
+    public PropertyMetadata {
+      requireNonNull(created, "A created timestamp must be supplied");
+      requireNonNull(modified, "A modified timestamp must be supplied");
+    }
+  }
 
   /**
    * Instantiate an initial instance with default version info and empty map.
@@ -70,7 +80,7 @@ public class VersionedProperties {
    *        have been previously validated (if required)
    */
   public VersionedProperties(Map<String,String> props) {
-    this(INIT_VERSION, Instant.now(), props);
+    this(INIT_VERSION, Instant.now(), props, null);
   }
 
   /**
@@ -83,10 +93,41 @@ public class VersionedProperties {
    */
   public VersionedProperties(final long zkDataVersion, final Instant timestamp,
       final Map<String,String> props) {
+    this(zkDataVersion, timestamp, props, null);
+  }
+
+  /**
+   * Instantiate an instance with the provided properties and metadata.
+   *
+   * @param zkDataVersion the ZooKeeper node data version.
+   * @param timestamp timestamp of this version.
+   * @param props optional map of property key, value pairs.
+   * @param metadata optional map of metadata for property keys.
+   */
+  public VersionedProperties(final long zkDataVersion, final Instant timestamp,
+      final Map<String,String> props, final Map<String,PropertyMetadata> metadata) {
     // convert the signed integer ZK version to an unsigned value stored in a long.
     this.dataVersion = zkDataVersion & 0xffffffffL;
     this.timestamp = requireNonNull(timestamp, "A timestamp must be supplied");
     this.props = props == null ? Map.of() : Map.copyOf(props);
+    this.metadata = initMetadata(this.props, metadata, timestamp);
+  }
+
+  /**
+   * Initialize the metadata map for the given properties.
+   */
+  private static Map<String,PropertyMetadata> initMetadata(Map<String,String> props,
+      Map<String,PropertyMetadata> metadata, Instant timestamp) {
+    if (props.isEmpty()) {
+      return Map.of();
+    }
+
+    var propMetadata = new HashMap<String,PropertyMetadata>();
+    for (String key : props.keySet()) {
+      propMetadata.put(key, metadata == null ? new PropertyMetadata(timestamp, timestamp)
+          : metadata.getOrDefault(key, new PropertyMetadata(timestamp, timestamp)));
+    }
+    return Map.copyOf(propMetadata);
   }
 
   /**
@@ -127,6 +168,13 @@ public class VersionedProperties {
   }
 
   /**
+   * Get an unmodifiable map with metadata for each property key.
+   */
+  public @NonNull Map<String,PropertyMetadata> getMetadata() {
+    return metadata;
+  }
+
+  /**
    * The timestamp formatted as an ISO 8601 string with format of
    * {@code YYYY-MM-DDTHH:mm:ss.SSSSSSZ}
    *
@@ -151,9 +199,7 @@ public class VersionedProperties {
    * @return A new instance of this class with the property added or updated.
    */
   public VersionedProperties addOrUpdate(final String key, final String value) {
-    var updated = new HashMap<>(props);
-    updated.put(key, value);
-    return new VersionedProperties(dataVersion, Instant.now(), updated);
+    return addOrUpdate(Map.of(key, value));
   }
 
   /**
@@ -168,9 +214,20 @@ public class VersionedProperties {
    * @return A new instance of this class with the properties added or updated.
    */
   public VersionedProperties addOrUpdate(final Map<String,String> updates) {
+    Instant now = Instant.now();
     var updated = new HashMap<>(props);
+    var updatedMetadata = new HashMap<>(metadata);
+    updates.forEach((key, value) -> {
+      PropertyMetadata existing = metadata.get(key);
+      if (existing == null) {
+        updatedMetadata.put(key, new PropertyMetadata(now, now));
+      } else {
+        updatedMetadata.put(key, new PropertyMetadata(existing.created(),
+            value.equals(props.get(key)) ? existing.modified() : now));
+      }
+    });
     updated.putAll(updates);
-    return new VersionedProperties(dataVersion, Instant.now(), updated);
+    return new VersionedProperties(dataVersion, now, updated, updatedMetadata);
   }
 
   /**
@@ -181,8 +238,19 @@ public class VersionedProperties {
    * @return A new instance of this class with the replaced properties.
    */
   public VersionedProperties replaceAll(final Map<String,String> updates) {
-    // Constructor will copy the map to a new map already
-    return new VersionedProperties(dataVersion, Instant.now(), updates);
+    Instant now = Instant.now();
+    var updatedMetadata = new HashMap<String,PropertyMetadata>();
+    updates.forEach((key, value) -> {
+      PropertyMetadata existing = metadata.get(key);
+      if (existing == null) {
+        updatedMetadata.put(key, new PropertyMetadata(now, now));
+      } else {
+        updatedMetadata.put(key, new PropertyMetadata(existing.created(),
+            value.equals(props.get(key)) ? existing.modified() : now));
+      }
+    });
+    // Constructor will copy the maps already
+    return new VersionedProperties(dataVersion, now, updates, updatedMetadata);
   }
 
   /**
@@ -197,9 +265,12 @@ public class VersionedProperties {
    * @return A new instance of this class.
    */
   public VersionedProperties remove(Collection<String> keys) {
+    Instant now = Instant.now();
     var updated = new HashMap<>(props);
     updated.keySet().removeAll(keys);
-    return new VersionedProperties(dataVersion, Instant.now(), updated);
+    var updatedMetadata = new HashMap<>(metadata);
+    updatedMetadata.keySet().removeAll(keys);
+    return new VersionedProperties(dataVersion, now, updated, updatedMetadata);
   }
 
   /**
@@ -218,14 +289,14 @@ public class VersionedProperties {
         .append(prettyPrint ? "\n" : ", ");
 
     Map<String,String> sorted = new TreeMap<>(props);
-    sorted.forEach((k, v) -> {
+    for (Entry<String,String> e : sorted.entrySet()) {
       if (prettyPrint) {
         // indent if pretty
         sb.append("  ");
       }
-      sb.append(k).append("=").append(v);
+      sb.append(e.getKey()).append("=").append(e.getValue());
       sb.append(prettyPrint ? "\n" : ", ");
-    });
+    }
     return sb.toString();
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/util/ZooInfoViewer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/util/ZooInfoViewer.java
@@ -465,7 +465,14 @@ public class ZooInfoViewer extends ServerKeywordExecutable<ViewerOpts> {
           writer.println("-- none --");
         } else {
           TreeMap<String,String> sorted = new TreeMap<>(pMap);
-          sorted.forEach((name, value) -> writer.printf("%s%s=%s\n", INDENT, name, value));
+          sorted.forEach((name, value) -> {
+            var metadata = p.getMetadata().get(name);
+            writer.printf("%s%s=%s\n", INDENT, name, value);
+            writer.printf("%s%screated:  %s\n", INDENT, INDENT,
+                tsFormat.format(metadata.created()));
+            writer.printf("%s%smodified: %s\n", INDENT, INDENT,
+                tsFormat.format(metadata.modified()));
+          });
         }
         writer.println();
       }

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/codec/VersionedPropEncryptCodec.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/codec/VersionedPropEncryptCodec.java
@@ -45,6 +45,8 @@ import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
 
+import org.apache.accumulo.server.conf.codec.VersionedProperties.PropertyMetadata;
+
 /**
  * EXPERIMENTAL - demonstrates using an alternate encoding scheme. The sample is completely
  * functional, however, certain elements such as password / key handling may not be suitable for
@@ -116,6 +118,7 @@ public class VersionedPropEncryptCodec extends VersionedPropCodec {
           DataOutputStream dos = new DataOutputStream(gzipOut)) {
 
         writeMapAsUTF(dos, props);
+        writeMetadataAsUTF(dos, vProps.getMetadata());
 
         // finalize the compression.
         gzipOut.flush();
@@ -128,6 +131,7 @@ public class VersionedPropEncryptCodec extends VersionedPropCodec {
       try (ByteArrayOutputStream ba = new ByteArrayOutputStream();
           DataOutputStream dos = new DataOutputStream(ba)) {
         writeMapAsUTF(dos, props);
+        writeMetadataAsUTF(dos, vProps.getMetadata());
         bytes = ba.toByteArray();
       }
     }
@@ -156,8 +160,7 @@ public class VersionedPropEncryptCodec extends VersionedPropCodec {
    * @throws IOException if an error occurs reading from the input stream.
    */
   @Override
-  Map<String,String> decodePayload(InputStream inStream, EncodingOptions encodingOpts)
-      throws IOException {
+  Payload decodePayload(InputStream inStream, EncodingOptions encodingOpts) throws IOException {
 
     Cipher cipher;
 
@@ -186,13 +189,17 @@ public class VersionedPropEncryptCodec extends VersionedPropCodec {
         try (CipherInputStream cis = new CipherInputStream(inStream, cipher);
             GZIPInputStream gzipIn = new GZIPInputStream(cis);
             DataInputStream cdis = new DataInputStream(gzipIn)) {
-          return readMapAsUTF(cdis);
+          Map<String,String> props = readMapAsUTF(cdis);
+          Map<String,PropertyMetadata> metadata = readMetadataAsUTF(cdis);
+          return new Payload(props, metadata);
         }
       } else {
         // read the property map keys, values.
         try (CipherInputStream cis = new CipherInputStream(inStream, cipher);
             DataInputStream cdis = new DataInputStream(cis)) {
-          return readMapAsUTF(cdis);
+          Map<String,String> props = readMapAsUTF(cdis);
+          Map<String,PropertyMetadata> metadata = readMetadataAsUTF(cdis);
+          return new Payload(props, metadata);
         }
       }
     }

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/codec/VersionedPropGzipCodecTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/codec/VersionedPropGzipCodecTest.java
@@ -19,11 +19,15 @@
 package org.apache.accumulo.server.conf.codec;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Map;
+import java.util.zip.GZIPOutputStream;
 
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -53,6 +57,7 @@ public class VersionedPropGzipCodecTest {
     assertTrue(vProps.getTimestamp().compareTo(Instant.now()) <= 0,
         "timestamp should be now or earlier");
     assertEquals(vProps.asMap(), decodedProps.asMap());
+    assertEquals(vProps.getMetadata(), decodedProps.getMetadata());
   }
 
   @Test
@@ -71,6 +76,7 @@ public class VersionedPropGzipCodecTest {
     assertTrue(vProps.getTimestamp().compareTo(Instant.now()) <= 0,
         "timestamp should be now or earlier");
     assertEquals(vProps.asMap(), decodedProps.asMap());
+    assertEquals(vProps.getMetadata(), decodedProps.getMetadata());
   }
 
   /**
@@ -105,6 +111,20 @@ public class VersionedPropGzipCodecTest {
   }
 
   @Test
+  public void decodesPayloadWithoutPropertyMetadata() throws IOException {
+    VersionedPropCodec codec = VersionedPropGzipCodec.codec(true);
+    Instant timestamp = Instant.now();
+    byte[] encodedBytes = gzipBytesWithoutPropertyMetadata(timestamp, Map.of("k1", "v1"));
+
+    VersionedProperties decodedProps = codec.fromBytes(0, encodedBytes);
+
+    assertEquals(Map.of("k1", "v1"), decodedProps.asMap());
+    assertNotNull(decodedProps.getMetadata().get("k1"));
+    assertEquals(timestamp, decodedProps.getMetadata().get("k1").created());
+    assertEquals(timestamp, decodedProps.getMetadata().get("k1").modified());
+  }
+
+  @Test
   public void roundTrip2() throws IOException {
 
     int aVersion = 13;
@@ -120,5 +140,25 @@ public class VersionedPropGzipCodecTest {
 
     assertEquals(vProps.asMap(), decodedProps.asMap());
 
+  }
+
+  // Write the pre-metadata payload shape so old ZooKeeper data stays readable.
+  private static byte[] gzipBytesWithoutPropertyMetadata(Instant timestamp,
+      Map<String,String> props) throws IOException {
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(bos)) {
+      EncodingOptions.V1_0(true).encode(dos);
+      dos.writeUTF(VersionedProperties.TIMESTAMP_FORMATTER.format(timestamp));
+      try (GZIPOutputStream gzipOut = new GZIPOutputStream(bos);
+          DataOutputStream zdos = new DataOutputStream(gzipOut)) {
+        zdos.writeInt(props.size());
+        for (var entry : props.entrySet()) {
+          zdos.writeUTF(entry.getKey());
+          zdos.writeUTF(entry.getValue());
+        }
+        gzipOut.finish();
+      }
+      return bos.toByteArray();
+    }
   }
 }

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/codec/VersionedPropertiesTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/codec/VersionedPropertiesTest.java
@@ -100,10 +100,26 @@ public class VersionedPropertiesTest {
 
     assertEquals("v1", vProps.asMap().get("k1"));
     assertEquals(1, vProps.asMap().size());
+    var created = vProps.getMetadata().get("k1").created();
+    var modified = vProps.getMetadata().get("k1").modified();
+    assertEquals(created, modified);
 
     vProps = vProps.addOrUpdate("k1", "v1-2");
 
     assertEquals("v1-2", vProps.asMap().get("k1"));
+    assertEquals(created, vProps.getMetadata().get("k1").created());
+    assertTrue(vProps.getMetadata().get("k1").modified().compareTo(modified) >= 0);
+  }
+
+  @Test
+  public void updateSinglePropWithSameValuePreservesMetadata() {
+    VersionedProperties vProps = new VersionedProperties();
+    vProps = vProps.addOrUpdate("k1", "v1");
+    var metadata = vProps.getMetadata().get("k1");
+
+    VersionedProperties updated = vProps.addOrUpdate("k1", "v1");
+
+    assertEquals(metadata, updated.getMetadata().get("k1"));
   }
 
   @Test
@@ -128,6 +144,9 @@ public class VersionedPropertiesTest {
     assertEquals(3, updated.asMap().size());
 
     assertEquals("v1-1", updated.asMap().get("k1"));
+    assertEquals(vProps.getMetadata().get("k1").created(),
+        updated.getMetadata().get("k1").created());
+    assertNotNull(updated.getMetadata().get("k3"));
 
   }
 
@@ -148,7 +167,20 @@ public class VersionedPropertiesTest {
 
     assertEquals(1, vProps2.asMap().size());
     assertNull(vProps2.asMap().get("k1"));
+    assertNull(vProps2.getMetadata().get("k1"));
     assertEquals("v2", vProps2.asMap().get("k2"));
+  }
+
+  @Test
+  public void replacePropsPreservesMetadataForUnchangedProps() {
+    VersionedProperties vProps = new VersionedProperties(Map.of("k1", "v1", "k2", "v2"));
+    var k1Metadata = vProps.getMetadata().get("k1");
+
+    VersionedProperties updated = vProps.replaceAll(Map.of("k1", "v1", "k3", "v3"));
+
+    assertEquals(k1Metadata, updated.getMetadata().get("k1"));
+    assertNull(updated.getMetadata().get("k2"));
+    assertNotNull(updated.getMetadata().get("k3"));
   }
 
   @Test

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/util/ZooInfoViewerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/util/ZooInfoViewerTest.java
@@ -332,6 +332,7 @@ public class ZooInfoViewerTest {
     verify(context, zk);
 
     Map<String,String> props = new HashMap<>();
+    int metadataLines = 0;
     try (Scanner scanner = new Scanner(Path.of(testFileName))) {
       while (scanner.hasNext()) {
         String line = scanner.nextLine();
@@ -340,10 +341,13 @@ public class ZooInfoViewerTest {
           String trimmed = line.trim();
           String[] kv = trimmed.split("=");
           props.put(kv[0], kv[1]);
+        } else if (line.trim().startsWith("created:")) {
+          metadataLines++;
         }
       }
     }
     assertEquals(Map.of("s1", "sv1", "s2", "sv2", "n1", "nv1", "t1", "tv1"), props);
+    assertEquals(6, metadataLines);
   }
 
   @SuppressFBWarnings(value = {"CRLF_INJECTION_LOGS", "PATH_TRAVERSAL_IN"},


### PR DESCRIPTION
Fixes #6254

* adds per-property `created` and `modified` metadata to `VersionedProperties`
  * this metadata is preserved across set, replace, and remove operations
* for existing property data in ZooKeeper, metadata is backfilled using the blob timestamp
* this new metadata is displayed in `zk info-viewer --print-props`

Here is some example output from running on a test table "ts_meta_test" with one custom prop set `accumulo zk info-viewer --print-props -t ts_meta_test`:
```
-----------------------------------------------
Report Time: 2026-07-02T17:55:34.493156802Z
-----------------------------------------------
ZooKeeper properties for instance ID: fa04c4d8-ae79-42c2-8d9f-e3200a19079e

Tables:
Name: ts_meta_test, Data Version:6, Data Timestamp: 2026-07-02T17:55:29.749431901Z:
  table.constraint.1=org.apache.accumulo.core.data.constraints.DefaultKeySizeConstraint
    created:  2026-07-02T17:34:09.334956155Z
    modified: 2026-07-02T17:34:09.334956155Z
  table.custom.owner=domG
    created:  2026-07-02T17:34:53.6940349Z
    modified: 2026-07-02T17:55:07.085812366Z
  table.iterator.majc.vers=20,org.apache.accumulo.core.iterators.user.VersioningIterator
    created:  2026-07-02T17:34:09.334956155Z
    modified: 2026-07-02T17:34:09.334956155Z
  table.iterator.majc.vers.opt.maxVersions=1
    created:  2026-07-02T17:34:09.334956155Z
    modified: 2026-07-02T17:34:09.334956155Z
  table.iterator.minc.vers=20,org.apache.accumulo.core.iterators.user.VersioningIterator
    created:  2026-07-02T17:34:09.334956155Z
    modified: 2026-07-02T17:34:09.334956155Z
  table.iterator.minc.vers.opt.maxVersions=1
    created:  2026-07-02T17:34:09.334956155Z
    modified: 2026-07-02T17:34:09.334956155Z
  table.iterator.scan.vers=20,org.apache.accumulo.core.iterators.user.VersioningIterator
    created:  2026-07-02T17:34:09.334956155Z
    modified: 2026-07-02T17:34:09.334956155Z
  table.iterator.scan.vers.opt.maxVersions=1
    created:  2026-07-02T17:34:09.334956155Z
    modified: 2026-07-02T17:34:09.334956155Z


-----------------------------------------------
```

Here is some pasted lines from some more testing where you can see updating of the `created` and `modified` times.

in the shell I ran this:
```
root@uno> createtable ts_meta_test
root@uno ts_meta_test> config -t ts_meta_test -s table.custom.owner=dom
root@uno ts_meta_test> config -t ts_meta_test -s table.custom.property=fooBar
root@uno ts_meta_test> config -t ts_meta_test -s table.custom.owner=domG
root@uno ts_meta_test> config -t ts_meta_test -s table.custom.owner=domG
root@uno ts_meta_test> config -t ts_meta_test -d table.custom.property
```
and in between each step I printed the output:

You can see the initial set creates matching timestamps:
```
  table.custom.owner=dom
    created:  2026-07-02T17:34:53.6940349Z
    modified: 2026-07-02T17:34:53.6940349Z
```
  You can see adding a second property gives it its own timestamps:
```
  table.custom.property=fooBar
    created:  2026-07-02T17:54:55.574298612Z
    modified: 2026-07-02T17:54:55.574298612Z
```
  You can see changing owner preserves created and updates modified:
```
  table.custom.owner=domG
    created:  2026-07-02T17:34:53.6940349Z
    modified: 2026-07-02T17:55:07.085812366Z
```
  You can see setting owner=domG again does not update modified:
```
  Data Version:5
  Data Timestamp: 2026-07-02T17:55:16.216132303Z

  table.custom.owner=domG
    created:  2026-07-02T17:34:53.6940349Z
    modified: 2026-07-02T17:55:07.085812366Z
```
  You can see deleting table.custom.property removes it from the output:
```
  table.custom.owner=domG
    created:  2026-07-02T17:34:53.6940349Z
    modified: 2026-07-02T17:55:07.085812366Z
```