### PR TITLE
Log ZooKeeper-backed property changes

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/util/PropUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/PropUtil.java
@@ -21,15 +21,25 @@ package org.apache.accumulo.server.util;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
+import java.util.TreeMap;
+import java.util.TreeSet;
 
 import org.apache.accumulo.core.classloader.ClassLoaderUtil;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.conf.store.NamespacePropKey;
 import org.apache.accumulo.server.conf.store.PropStoreKey;
+import org.apache.accumulo.server.conf.store.SystemPropKey;
+import org.apache.accumulo.server.conf.store.TablePropKey;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicyInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class PropUtil {
+
+  private static final Logger CONFIG_LOG =
+      LoggerFactory.getLogger("org.apache.accumulo.configuration");
 
   private PropUtil() {}
 
@@ -44,11 +54,13 @@ public final class PropUtil {
       final Map<String,String> properties) throws IllegalArgumentException {
     PropUtil.validateProperties(context, propStoreKey, properties);
     context.getPropStore().putAll(propStoreKey, properties);
+    logSetProperties(propStoreKey, properties);
   }
 
   public static void removeProperties(final ServerContext context,
       final PropStoreKey<?> propStoreKey, final Collection<String> propertyNames) {
     context.getPropStore().removeProperties(propStoreKey, propertyNames);
+    logRemoveProperties(propStoreKey, propertyNames);
   }
 
   public static void replaceProperties(final ServerContext context,
@@ -56,6 +68,7 @@ public final class PropUtil {
       throws IllegalArgumentException {
     PropUtil.validateProperties(context, propStoreKey, properties);
     context.getPropStore().replaceAll(propStoreKey, version, properties);
+    logReplaceProperties(propStoreKey, version, properties);
   }
 
   protected static void validateProperties(final ServerContext context,
@@ -102,4 +115,66 @@ public final class PropUtil {
       }
     }
   }
+
+  static void logSetProperties(final PropStoreKey<?> propStoreKey,
+      final Map<String,String> properties) {
+    if (properties.isEmpty()) {
+      return;
+    }
+    if (CONFIG_LOG.isInfoEnabled()) {
+      CONFIG_LOG.info("action=set; scope={}; target={}; properties={};", scope(propStoreKey),
+          target(propStoreKey), printableProperties(properties));
+    }
+  }
+
+  static void logRemoveProperties(final PropStoreKey<?> propStoreKey,
+      final Collection<String> propertyNames) {
+    if (CONFIG_LOG.isInfoEnabled()) {
+      CONFIG_LOG.info("action=remove; scope={}; target={}; properties={};", scope(propStoreKey),
+          target(propStoreKey), new TreeSet<>(propertyNames));
+    }
+  }
+
+  static void logReplaceProperties(final PropStoreKey<?> propStoreKey, final long version,
+      final Map<String,String> properties) {
+    if (properties.isEmpty()) {
+      return;
+    }
+    if (CONFIG_LOG.isInfoEnabled()) {
+      CONFIG_LOG.info("action=modify; scope={}; target={}; version={}; properties={};",
+          scope(propStoreKey), target(propStoreKey), version, printableProperties(properties));
+    }
+  }
+
+  private static Map<String,String> printableProperties(Map<String,String> properties) {
+    Map<String,String> printable = new TreeMap<>();
+    for (var prop : properties.entrySet()) {
+      final String key = prop.getKey();
+      final String printableValue = Property.isSensitive(key) ? "<hidden>" : prop.getValue();
+      printable.put(key, printableValue);
+    }
+    return printable;
+  }
+
+  private static String scope(PropStoreKey<?> propStoreKey) {
+    if (propStoreKey instanceof SystemPropKey) {
+      return "system";
+    } else if (propStoreKey instanceof NamespacePropKey) {
+      return "namespace";
+    } else if (propStoreKey instanceof TablePropKey) {
+      return "table";
+    }
+    return propStoreKey.getClass().getSimpleName();
+  }
+
+  private static String target(PropStoreKey<?> propStoreKey) {
+    if (propStoreKey instanceof SystemPropKey) {
+      return "system";
+    } else if (propStoreKey instanceof NamespacePropKey || propStoreKey instanceof TablePropKey) {
+      return propStoreKey.getId().canonical();
+    } else {
+      return propStoreKey.getPath();
+    }
+  }
+
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/SystemPropUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/SystemPropUtil.java
@@ -37,8 +37,10 @@ public class SystemPropUtil {
   public static void setSystemProperty(ServerContext context, String property, String value)
       throws IllegalArgumentException {
     final SystemPropKey key = SystemPropKey.of(context);
-    context.getPropStore().putAll(key,
-        Map.of(validateSystemProperty(context, key, property, value), value));
+    Map<String,String> properties =
+        Map.of(validateSystemProperty(context, key, property, value), value);
+    context.getPropStore().putAll(key, properties);
+    PropUtil.logSetProperties(key, properties);
   }
 
   public static void modifyProperties(ServerContext context, long version,
@@ -50,6 +52,7 @@ public class SystemPropUtil {
                 entry -> validateSystemProperty(context, key, entry.getKey(), entry.getValue()),
                 Map.Entry::getValue));
     context.getPropStore().replaceAll(key, version, checkedProperties);
+    PropUtil.logReplaceProperties(key, version, checkedProperties);
   }
 
   public static void removeSystemProperty(ServerContext context, String property) {
@@ -65,7 +68,9 @@ public class SystemPropUtil {
 
   private static void removePropWithoutDeprecationWarning(ServerContext context, String property) {
     logIfFixed(Property.getPropertyByKey(property), null);
-    context.getPropStore().removeProperties(SystemPropKey.of(context), List.of(property));
+    SystemPropKey key = SystemPropKey.of(context);
+    context.getPropStore().removeProperties(key, List.of(property));
+    PropUtil.logRemoveProperties(key, List.of(property));
   }
 
   private static String validateSystemProperty(ServerContext context, SystemPropKey key,


### PR DESCRIPTION
Fixes #6254 

Adds INFO logging for property changes.

* Logs set, remove, and modify operations for system, resource group, namespace and table properties
* Log output includes user, scope, target, property and value
* Sensitive props values are redacted

Here is some corresponding shell and logs:
```
root@uno> createtable config_log_table
root@uno config_log_table> config -t config_log_table -s table.custom.owner=dom
root@uno config_log_table> config -t config_log_table -s table.custom.owner=domG
root@uno config_log_table> config -t config_log_table -s table.custom.owner=domG
root@uno config_log_table> config -t config_log_table -d table.custom.owner
root@uno config_log_table> createnamespace config_log_ns
root@uno config_log_table> config -ns config_log_ns -s table.custom.owner=dom
root@uno config_log_table> config -ns config_log_ns -d table.custom.owner
root@uno config_log_table> config -s general.custom.test=abc
root@uno config_log_table> config -d general.custom.test
root@uno config_log_table> createresourcegroup config_log_rg
root@uno config_log_table> config -rg config_log_rg -s tserver.group.major.compaction.concurrent.max=2
root@uno config_log_table> config -rg config_log_rg -d tserver.group.major.compaction.concurrent.max
```
```
~ tail -f ~/github/fluo-uno/install/logs/accumulo/manager_default_1_thor.log | grep 'accumulo.configuration'
2026-07-07T16:43:39,880 Thread[126] [accumulo.configuration] INFO : action=set; user=root; scope=table; target=config_log_table; property=table.custom.owner; value=dom;
2026-07-07T16:43:45,559 Thread[182] [accumulo.configuration] INFO : action=set; user=root; scope=table; target=config_log_table; property=table.custom.owner; value=domG;
2026-07-07T16:43:48,830 Thread[111] [accumulo.configuration] INFO : action=set; user=root; scope=table; target=config_log_table; property=table.custom.owner; value=domG;
2026-07-07T16:43:58,552 Thread[108] [accumulo.configuration] INFO : action=remove; user=root; scope=table; target=config_log_table; property=table.custom.owner;
2026-07-07T16:44:33,328 Thread[140] [accumulo.configuration] INFO : action=set; user=root; scope=namespace; target=config_log_ns; property=table.custom.owner; value=dom;
2026-07-07T16:44:41,290 Thread[105] [accumulo.configuration] INFO : action=remove; user=root; scope=namespace; target=config_log_ns; property=table.custom.owner;
2026-07-07T16:44:59,034 Thread[110] [accumulo.configuration] INFO : action=set; user=root; scope=system; target=system; property=general.custom.test; value=abc;
2026-07-07T16:45:10,810 Thread[181] [accumulo.configuration] INFO : action=remove; user=root; scope=system; target=system; property=general.custom.test;
2026-07-07T16:45:35,614 Thread[139] [accumulo.configuration] INFO : action=set; user=root; scope=resourceGroup; target=config_log_rg; property=tserver.group.major.compaction.concurrent.max; value=2;
2026-07-07T16:45:44,676 Thread[108] [accumulo.configuration] INFO : action=remove; user=root; scope=resourceGroup; target=config_log_rg; property=tserver.group.major.compaction.concurrent.max;
```
