### PR TITLE
Remove redundant minimalMavenBuildVersion override

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,6 @@ under the License.
     <!-- versions-maven-plugin ignore patterns for snapshots, alpha, beta, milestones, and release candidates -->
     <maven.version.ignore>.+-SNAPSHOT,(?i).*(alpha|beta)[0-9.-]*,(?i).*[.-](m|rc)[0-9]+</maven.version.ignore>
     <minimalJavaBuildVersion>21</minimalJavaBuildVersion>
-    <minimalMavenBuildVersion>3.9</minimalMavenBuildVersion>
     <modernizer.javaVersion>${javaVersion}</modernizer.javaVersion>
     <!-- timestamp for reproducible outputs, updated on release by the release plugin -->
     <project.build.outputTimestamp>2026-06-30T00:16:12Z</project.build.outputTimestamp>


### PR DESCRIPTION
Remove the local `minimalMavenBuildVersion` property from the pom.

Apache parent pom version 36 added the same Maven 3.9 minimum via a PR I made at https://github.com/apache/maven-apache-parent/pull/533. We use version 37 which includes this so the override is now redundant and we can remove it.

Refs:
  - https://github.com/apache/maven-apache-parent/pull/533
  - https://github.com/apache/maven-apache-parent/releases#release-apache-36