### PR TITLE
Fix numFiles check in GracefulShutdownIT

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/functional/GracefulShutdownIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/GracefulShutdownIT.java
@@ -232,9 +232,8 @@ public class GracefulShutdownIT extends SharedMiniClusterBase {
         control.refreshProcesses(ServerType.COMPACTOR);
         return control.getProcesses(ServerType.COMPACTOR).isEmpty();
       });
-      final long numFiles3 = getNumFilesForTable(ctx, tid);
-      assertTrue(numFiles3 < numFiles2);
-      assertEquals(1, numFiles3);
+      Wait.waitFor(() -> getNumFilesForTable(ctx, tid) < numFiles2);
+      assertEquals(1, getNumFilesForTable(ctx, tid));
 
       getCluster().getConfig().setNumScanServers(1);
       control.startScanServer(ScanServer.class, 1, GROUP_NAME);


### PR DESCRIPTION
GracefulShutdownIT was periodically failing when checking if the number of files in the table was lower than before a compaction occurred. This check was happening too quickly and not allowing for the coordinator to notify the tablet server to commit the compaction. Changed the logic to wait for the condition instead of checking it once.