### PR TITLE
Updating bootstrap.bundle.js to remove TODOs

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/external/bootstrap/js/bootstrap.bundle.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/external/bootstrap/js/bootstrap.bundle.js
@@ -1182,10 +1182,9 @@
       this._slide(ORDER_NEXT);
     }
     nextWhenVisible() {
-      // FIXME TODO use `document.visibilityState`
       // Don't call next when the page isn't visible
       // or the carousel or its parent isn't visible
-      if (!document.hidden && isVisible(this._element)) {
+      if (!document.hidden && document.visibilityState === "visible") {
         this.next();
       }
     }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/external/bootstrap/js/bootstrap.bundle.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/external/bootstrap/js/bootstrap.bundle.js
@@ -753,27 +753,6 @@
       }
       return parents;
     },
-    prev(element, selector) {
-      let previous = element.previousElementSibling;
-      while (previous) {
-        if (previous.matches(selector)) {
-          return [previous];
-        }
-        previous = previous.previousElementSibling;
-      }
-      return [];
-    },
-    // TODO: this is now unused; remove later along with prev()
-    next(element, selector) {
-      let next = element.nextElementSibling;
-      while (next) {
-        if (next.matches(selector)) {
-          return [next];
-        }
-        next = next.nextElementSibling;
-      }
-      return [];
-    },
     focusableChildren(element) {
       const focusables = ['a', 'button', 'input', 'textarea', 'select', 'details', '[tabindex]', '[contenteditable="true"]'].map(selector => `${selector}:not([tabindex^="-"])`).join(',');
       return this.find(focusables, element).filter(el => !isDisabled(el) && isVisible(el));


### PR DESCRIPTION
- Removing `// FIXME TODO use document.visibilityState` by using `document.visibilityState === "visible")` instead of  `isVisible(this._element))` on line 1187 

- Removing `// TODO: this is now unused; remove later along with prev()` by deleting unused functions prev() and next()

----------------------------------------------------------------------------------------------------
13 remaining TODOs in this file to be removed in v6