### PR TITLE
Rework server percentage check to remove 1 TODO 

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelector.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelector.java
@@ -233,6 +233,7 @@ public class ConfigurableScanServerSelector implements ScanServerSelector {
       if (servers.endsWith("%")) {
         double percent = Double.parseDouble(servers.substring(0, servers.length() - 1));
         if (percent <= 0 || percent > 100 || !Double.isFinite(percent)) {
+          isServersPercent = false;
           throw new IllegalArgumentException("Bad servers percentage : " + servers);
         }
         else {

--- a/core/src/main/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelector.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelector.java
@@ -235,8 +235,7 @@ public class ConfigurableScanServerSelector implements ScanServerSelector {
         if (percent <= 0 || percent > 100 || !Double.isFinite(percent)) {
           isServersPercent = false;
           throw new IllegalArgumentException("Bad servers percentage : " + servers);
-        }
-        else {
+        } else {
           serversRatio = percent / 100.0;
           isServersPercent = true;
         }

--- a/core/src/main/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelector.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelector.java
@@ -235,8 +235,10 @@ public class ConfigurableScanServerSelector implements ScanServerSelector {
         if (percent <= 0 || percent > 100 || !Double.isFinite(percent)) {
           throw new IllegalArgumentException("Bad servers percentage : " + servers);
         }
-        serversRatio = percent / 100.0;
-        isServersPercent = true;
+        else {
+          serversRatio = percent / 100.0;
+          isServersPercent = true;
+        }
       } else {
         parsedServers = Integer.parseInt(servers);
         if (parsedServers <= 0) {

--- a/core/src/main/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelector.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelector.java
@@ -233,12 +233,10 @@ public class ConfigurableScanServerSelector implements ScanServerSelector {
       if (servers.endsWith("%")) {
         double percent = Double.parseDouble(servers.substring(0, servers.length() - 1));
         if (percent <= 0 || percent > 100 || !Double.isFinite(percent)) {
-          isServersPercent = false;
           throw new IllegalArgumentException("Bad servers percentage : " + servers);
-        } else {
-          serversRatio = percent / 100.0;
-          isServersPercent = true;
         }
+        serversRatio = percent / 100.0;
+        isServersPercent = true;
       } else {
         parsedServers = Integer.parseInt(servers);
         if (parsedServers <= 0) {

--- a/core/src/main/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelector.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelector.java
@@ -231,11 +231,11 @@ public class ConfigurableScanServerSelector implements ScanServerSelector {
       }
 
       if (servers.endsWith("%")) {
-        // TODO check < 100
-        serversRatio = Double.parseDouble(servers.substring(0, servers.length() - 1)) / 100.0;
-        if (serversRatio < 0 || serversRatio > 1) {
+        double percent = Double.parseDouble(servers.substring(0, servers.length() - 1));
+        if (percent <= 0 || percent > 100 || !Double.isFinite(percent)) {
           throw new IllegalArgumentException("Bad servers percentage : " + servers);
         }
+        serversRatio = percent / 100.0;
         isServersPercent = true;
       } else {
         parsedServers = Integer.parseInt(servers);

--- a/core/src/test/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelectorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelectorTest.java
@@ -743,7 +743,7 @@ public class ConfigurableScanServerSelectorTest {
   }
 
   /**
-   * Test that a NaN server percentage value throws the expected exception 
+   * Test that a NaN server percentage value throws the expected exception
    */
   @Test
   public void testInfiniteServerPercentage() {

--- a/core/src/test/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelectorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelectorTest.java
@@ -741,4 +741,20 @@ public class ConfigurableScanServerSelectorTest {
       assertEquals(Duration.ofMillis(expected), selections.getDelay());
     }
   }
+
+  @Test
+  public void testInfiniteServerPercentage(){
+    String defaultProfile =
+            "{'isDefault':true,'maxBusyTimeout':'5m','busyTimeoutMultiplier':4, 'attemptPlans':"
+                    + "[{'servers':'50%', 'busyTimeout':'60s'}]}";
+
+    String profile1 =
+            "{'scanTypeActivations':['mega'],'maxBusyTimeout':'60m','busyTimeoutMultiplier':2, "
+                    + "'attemptPlans':[{'servers':'Double.POSITIVE_INFINITY%', 'busyTimeout':'10m'}]}";
+
+    var opts = Map.of("profiles",
+            ("[" + profile1 + "," + defaultProfile + "]").replace('\'', '"'));
+
+      assertThrows(IllegalArgumentException.class, () -> runBusyTest(100, 1, 5, 66, opts));
+  }
 }

--- a/core/src/test/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelectorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelectorTest.java
@@ -750,7 +750,8 @@ public class ConfigurableScanServerSelectorTest {
 
     var opts = Map.of("profiles", ("[" + defaultProfile + "]").replace('\'', '"'));
 
-    var exception = assertThrows(IllegalArgumentException.class, () -> runBusyTest(100, 1, 5, 66, opts));
-    assertTrue(exception.getMessage().contains("Bad"));
+    var exception =
+        assertThrows(IllegalArgumentException.class, () -> runBusyTest(100, 1, 5, 66, opts));
+    assertTrue(exception.getMessage().contains("Bad servers percentage"));
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelectorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelectorTest.java
@@ -746,7 +746,7 @@ public class ConfigurableScanServerSelectorTest {
   public void testInfiniteServerPercentage() {
     String defaultProfile =
         "{'isDefault':true,'maxBusyTimeout':'5m','busyTimeoutMultiplier':4, 'attemptPlans':"
-            + "[{'servers':'Double.POSITIVE_INFINITY%', 'busyTimeout':'60s'}]}";
+            + "[{'servers':'NaN%', 'busyTimeout':'60s'}]}";
 
     var opts = Map.of("profiles", ("[" + defaultProfile + "]").replace('\'', '"'));
 

--- a/core/src/test/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelectorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelectorTest.java
@@ -743,18 +743,14 @@ public class ConfigurableScanServerSelectorTest {
   }
 
   @Test
-  public void testInfiniteServerPercentage(){
+  public void testInfiniteServerPercentage() {
     String defaultProfile =
-            "{'isDefault':true,'maxBusyTimeout':'5m','busyTimeoutMultiplier':4, 'attemptPlans':"
-                    + "[{'servers':'50%', 'busyTimeout':'60s'}]}";
+        "{'isDefault':true,'maxBusyTimeout':'5m','busyTimeoutMultiplier':4, 'attemptPlans':"
+            + "[{'servers':'Double.POSITIVE_INFINITY%', 'busyTimeout':'60s'}]}";
 
-    String profile1 =
-            "{'scanTypeActivations':['mega'],'maxBusyTimeout':'60m','busyTimeoutMultiplier':2, "
-                    + "'attemptPlans':[{'servers':'Double.POSITIVE_INFINITY%', 'busyTimeout':'10m'}]}";
+    var opts = Map.of("profiles", ("[" + defaultProfile + "]").replace('\'', '"'));
 
-    var opts = Map.of("profiles",
-            ("[" + profile1 + "," + defaultProfile + "]").replace('\'', '"'));
-
-      assertThrows(IllegalArgumentException.class, () -> runBusyTest(100, 1, 5, 66, opts));
+    var exception = assertThrows(IllegalArgumentException.class, () -> runBusyTest(100, 1, 5, 66, opts));
+    assertTrue(exception.getMessage().contains("Bad"));
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelectorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelectorTest.java
@@ -742,6 +742,9 @@ public class ConfigurableScanServerSelectorTest {
     }
   }
 
+  /**
+   * Test that a NaN server percentage value throws the expected exception 
+   */
   @Test
   public void testInfiniteServerPercentage() {
     String defaultProfile =


### PR DESCRIPTION
Removing `// TODO check < 100` from line 234 of ConfigurableScanServerSelector.java

- if statement reworked to check server percentage instead of ratio, this way the TODO condition can be checked 
- Add third condition to the if to make sure the computed percent is not infinite (NaN)