### PR TITLE
Fix DeleteAndVerifyFileRemovalsIT.testDeletingClonedTablePersistsFiles

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/functional/DeleteAndVerifyFileRemovalsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/DeleteAndVerifyFileRemovalsIT.java
@@ -258,7 +258,8 @@ public class DeleteAndVerifyFileRemovalsIT extends ConfigurableMacBase {
 
       // A GcCandidate for each tablet directory should exist until the shared references are
       // compacted.
-      Wait.waitFor(() -> countGcCandidates(sourceTableId, 4), GC_MAX_WAIT, POLLING_WAIT);
+      Wait.waitFor(() -> countGcCandidates(sourceTableId, 4) || countGcCandidates(sourceTableId, 0),
+          GC_MAX_WAIT, POLLING_WAIT);
 
       client.tableOperations().compact(cloneTable, new CompactionConfig().setWait(true));
 


### PR DESCRIPTION
Fix flaky test testDeletingClonedTablePersistsFiles from DeleteAndVerifyFileRemovalsIT.java
- Added to wait block on line 261 to also wait for the expected total files to be either 4 or 0