### PR TITLE
Re-throw IOE in FileOperations.openFile instead of wrapping

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/file/FileOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/FileOperations.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.core.file;
 
-import static java.util.Objects.requireNonNull;
 import static org.apache.accumulo.core.file.blockfile.impl.CacheProvider.NULL_PROVIDER;
 
 import java.io.IOException;
@@ -106,6 +105,9 @@ public abstract class FileOperations {
     } catch (CancellationException e) {
       throw new IOException("Cancelled while opening file: " + path, e);
     } catch (ExecutionException e) {
+      if (e.getCause() instanceof IOException) {
+        throw (IOException) e.getCause();
+      }
       throw new IOException("Error trying to open file: " + path, e);
     }
   }


### PR DESCRIPTION
FileOperations.openFile was wrapping IOExceptions causing an issue in BulkNewIT. This was introduced by #6484.