### PR TITLE
Rename the property change logger to org.apache.accumulo.CONFIG

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/util/PropUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/PropUtil.java
@@ -38,8 +38,7 @@ import org.slf4j.LoggerFactory;
 
 public final class PropUtil {
 
-  private static final Logger CONFIG_LOG =
-      LoggerFactory.getLogger("org.apache.accumulo.configuration");
+  private static final Logger CONFIG_LOG = LoggerFactory.getLogger("org.apache.accumulo.CONFIG");
 
   private PropUtil() {}
 


### PR DESCRIPTION
Renames the property change logger from `org.apache.accumulo.configuration` to `org.apache.accumulo.CONFIG`

This matches the existing logger convention like the metrics logger `org.apache.accumulo.METRICS`

This change was first mentioned/suggested [here](https://github.com/apache/accumulo/pull/6465#discussion_r3626582003)