### PR TITLE
Fixed some minor bugs in FileOperations and CachableBlockFile

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/file/FileOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/FileOperations.java
@@ -89,14 +89,6 @@ public abstract class FileOperations {
       builder.withFileStatus(status);
     }
     final CompletableFuture<FSDataInputStream> future = builder.build();
-    while (!future.isDone()) {
-      try {
-        Thread.sleep(10);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        throw new IOException("Interrupted while opening file: " + path, e);
-      }
-    }
     try {
       return future.get();
     } catch (InterruptedException e) {

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/CachableBlockFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/CachableBlockFile.java
@@ -53,6 +53,7 @@ import org.apache.hadoop.fs.Seekable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Preconditions;
 import com.google.common.cache.Cache;
 
 /**
@@ -98,6 +99,10 @@ public class CachableBlockFile {
 
     public CachableBuilder fsPath(FileSystem fs, Path dataFile, boolean dropCacheBehind,
         FileStatus status) {
+      Preconditions.checkState(this.inputSupplier == null,
+          "file input already set via call to input()");
+      Preconditions.checkState(this.lengthSupplier == null,
+          "file length already set via call to length()");
       this.cacheId = pathToCacheId(dataFile);
       this.inputSupplier = () -> {
         FSDataInputStream is = FileOperations.openFile(fs, dataFile, status);
@@ -122,12 +127,16 @@ public class CachableBlockFile {
     }
 
     public CachableBuilder input(InputStream is, String cacheId) {
+      Preconditions.checkState(this.inputSupplier == null,
+          "file input already set via call to fsPath()");
       this.cacheId = cacheId;
       this.inputSupplier = () -> is;
       return this;
     }
 
     public CachableBuilder length(long len) {
+      Preconditions.checkState(this.lengthSupplier == null,
+          "file length already set via call to fsPath()");
       this.lengthSupplier = () -> len;
       return this;
     }


### PR DESCRIPTION
Removed the wait loop in FileOperations.openFile as the call to future.get performs a non-blocking wait.

Added checks in CachableBuilder to help users use the object correctly. Calls to input() and fsPath() will open the same file twice and create two InputStreams.