### PR TITLE
Remove TODOs from RootTabletMutatorImpl.java

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/RootConditionalWriter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/RootConditionalWriter.java
@@ -89,7 +89,17 @@ public class RootConditionalWriter implements ConditionalWriter {
 
     ServerConditionalMutation scm = new ServerConditionalMutation(tcm);
 
-    context.getZooCache().clear(RootTable.ZROOT_TABLET);
+    try {
+      context.getZooCache().clear(RootTable.ZROOT_TABLET);
+
+      // In order to avoid race condition, wait for ZROOT_TABLET to clear before attempting another
+      // clear() below.
+      while (context.getZooCache().get(RootTable.ZROOT_TABLET).length != 0) {
+        Thread.sleep(100);
+      }
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
 
     List<ServerConditionalMutation> okMutations = new ArrayList<>();
     List<TCMResult> results = new ArrayList<>();

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/RootConditionalWriter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/RootConditionalWriter.java
@@ -127,6 +127,7 @@ public class RootConditionalWriter implements ConditionalWriter {
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
+    context.getZooCache().clear(RootTable.ZROOT_TABLET);
     return getResult(okMutations, results, mutation);
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/RootConditionalWriter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/RootConditionalWriter.java
@@ -89,18 +89,6 @@ public class RootConditionalWriter implements ConditionalWriter {
 
     ServerConditionalMutation scm = new ServerConditionalMutation(tcm);
 
-    try {
-      context.getZooCache().clear(RootTable.ZROOT_TABLET);
-
-      // In order to avoid race condition, wait for ZROOT_TABLET to clear before attempting another
-      // clear() below.
-      while (context.getZooCache().get(RootTable.ZROOT_TABLET).length != 0) {
-        Thread.sleep(100);
-      }
-    } catch (InterruptedException e) {
-      throw new RuntimeException(e);
-    }
-
     List<ServerConditionalMutation> okMutations = new ArrayList<>();
     List<TCMResult> results = new ArrayList<>();
 
@@ -139,10 +127,6 @@ public class RootConditionalWriter implements ConditionalWriter {
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
-
-    // TODO this is racy...
-    context.getZooCache().clear(RootTable.ZROOT_TABLET);
-
     return getResult(okMutations, results, mutation);
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/RootTabletMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/RootTabletMutatorImpl.java
@@ -97,14 +97,14 @@ public class RootTabletMutatorImpl extends TabletMutatorBase<Ample.TabletMutator
     }
 
     try {
-
       context.getZooCache().clear(RootTable.ZROOT_TABLET);
-
-      // In order to avoid race condition, wait for ZROOT_TABLET to clear before attempting another
+      // Avoid race condition, wait for ZROOT_TABLET to clear before attempting another
       // clear() below.
+      final Object lock = new Object();
       while (context.getZooCache().get(RootTable.ZROOT_TABLET).length != 0) {
-        Thread.sleep(100);
+        lock.wait();
       }
+      lock.notifyAll();
 
       context.getZooSession().asReaderWriter().mutateExisting(RootTable.ZROOT_TABLET, currVal -> {
         String currJson = new String(currVal, UTF_8);

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/RootTabletMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/RootTabletMutatorImpl.java
@@ -106,6 +106,8 @@ public class RootTabletMutatorImpl extends TabletMutatorBase<Ample.TabletMutator
         return newJson.getBytes(UTF_8);
       });
 
+      context.getZooCache().clear(RootTable.ZROOT_TABLET);
+
       if (closeAfterMutate != null) {
         closeAfterMutate.close();
       }

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/RootTabletMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/RootTabletMutatorImpl.java
@@ -97,14 +97,6 @@ public class RootTabletMutatorImpl extends TabletMutatorBase<Ample.TabletMutator
     }
 
     try {
-      context.getZooCache().clear(RootTable.ZROOT_TABLET);
-
-      // In order to avoid race condition, wait for ZROOT_TABLET to clear before attempting another
-      // clear() below.
-      while (context.getZooCache().get(RootTable.ZROOT_TABLET).length != 0) {
-        Thread.sleep(100);
-      }
-
       context.getZooSession().asReaderWriter().mutateExisting(RootTable.ZROOT_TABLET, currVal -> {
         String currJson = new String(currVal, UTF_8);
         var rtm = new RootTabletMetadata(currJson);
@@ -113,8 +105,6 @@ public class RootTabletMutatorImpl extends TabletMutatorBase<Ample.TabletMutator
         log.debug("mutation: from:[{}] to: [{}]", currJson, newJson);
         return newJson.getBytes(UTF_8);
       });
-
-      context.getZooCache().clear(RootTable.ZROOT_TABLET);
 
       if (closeAfterMutate != null) {
         closeAfterMutate.close();

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/RootTabletMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/RootTabletMutatorImpl.java
@@ -100,17 +100,14 @@ public class RootTabletMutatorImpl extends TabletMutatorBase<Ample.TabletMutator
 
       context.getZooCache().clear(RootTable.ZROOT_TABLET);
 
-      // TODO examine implementation of getZooReaderWriter().mutate()
-      // TODO for efficiency this should maybe call mutateExisting
-      context.getZooSession().asReaderWriter().mutateOrCreate(RootTable.ZROOT_TABLET, new byte[0],
-          currVal -> {
-            String currJson = new String(currVal, UTF_8);
-            var rtm = new RootTabletMetadata(currJson);
-            rtm.update(mutation);
-            String newJson = rtm.toJson();
-            log.debug("mutation: from:[{}] to: [{}]", currJson, newJson);
-            return newJson.getBytes(UTF_8);
-          });
+      context.getZooSession().asReaderWriter().mutateExisting(RootTable.ZROOT_TABLET, currVal -> {
+        String currJson = new String(currVal, UTF_8);
+        var rtm = new RootTabletMetadata(currJson);
+        rtm.update(mutation);
+        String newJson = rtm.toJson();
+        log.debug("mutation: from:[{}] to: [{}]", currJson, newJson);
+        return newJson.getBytes(UTF_8);
+      });
 
       // TODO this is racy...
       context.getZooCache().clear(RootTable.ZROOT_TABLET);

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/RootTabletMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/RootTabletMutatorImpl.java
@@ -100,6 +100,12 @@ public class RootTabletMutatorImpl extends TabletMutatorBase<Ample.TabletMutator
 
       context.getZooCache().clear(RootTable.ZROOT_TABLET);
 
+      // In order to avoid race condition, wait for ZROOT_TABLET to clear before attempting another
+      // clear() below.
+      while (context.getZooCache().get(RootTable.ZROOT_TABLET).length != 0) {
+        Thread.sleep(100);
+      }
+
       context.getZooSession().asReaderWriter().mutateExisting(RootTable.ZROOT_TABLET, currVal -> {
         String currJson = new String(currVal, UTF_8);
         var rtm = new RootTabletMetadata(currJson);
@@ -109,7 +115,6 @@ public class RootTabletMutatorImpl extends TabletMutatorBase<Ample.TabletMutator
         return newJson.getBytes(UTF_8);
       });
 
-      // TODO this is racy...
       context.getZooCache().clear(RootTable.ZROOT_TABLET);
 
       if (closeAfterMutate != null) {

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/RootTabletMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/RootTabletMutatorImpl.java
@@ -98,13 +98,12 @@ public class RootTabletMutatorImpl extends TabletMutatorBase<Ample.TabletMutator
 
     try {
       context.getZooCache().clear(RootTable.ZROOT_TABLET);
-      // Avoid race condition, wait for ZROOT_TABLET to clear before attempting another
+
+      // In order to avoid race condition, wait for ZROOT_TABLET to clear before attempting another
       // clear() below.
-      final Object lock = new Object();
       while (context.getZooCache().get(RootTable.ZROOT_TABLET).length != 0) {
-        lock.wait();
+        Thread.sleep(100);
       }
-      lock.notifyAll();
 
       context.getZooSession().asReaderWriter().mutateExisting(RootTable.ZROOT_TABLET, currVal -> {
         String currJson = new String(currVal, UTF_8);


### PR DESCRIPTION
Removed the following TODOs:

- `RootTabletMutatorImpl.java`: ` // TODO examine implementation of getZooReaderWriter().mutate()`: This TODO may be outdated, current version of code does not use `context.getZooReaderWriter()`, uses `context.getZooSession()` instead
- `RootTabletMutatorImpl.java`: ` // TODO for efficiency this should maybe call mutateExisting`: Updated line 103 to use `mutateExisting()` instead of `mutateOrCreate()`
- `RootTabletMutatorImpl.java`: `// TODO this is racy... `. Removed 1 usage of `getZooCache().clear()`. Since Zoocache already invalidates data when ZooKeeper reports a data change,  this call is redundant and racy.
- `RootConditionalWriter.java`: `// TODO this is racy... `. Same as above

<img width="867" height="579" alt="image" src="https://github.com/user-attachments/assets/38bfba54-3159-4c93-9a2f-6a3895951c55" />


This pr resolves 4 TODOs from #2699 
