### PR TITLE
Update to the latest log4j version

### DIFF
--- a/core/src/test/java/org/apache/accumulo/core/logging/EscalatingLoggerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/logging/EscalatingLoggerTest.java
@@ -48,8 +48,8 @@ public class EscalatingLoggerTest {
     // Programatically modify the Log4j2 Logging configuration to add an appender
     LoggerContext ctx = LoggerContext.getContext(false);
     Configuration cfg = ctx.getConfiguration();
-    PatternLayout layout = PatternLayout.newBuilder().withConfiguration(cfg)
-        .withPattern(PatternLayout.SIMPLE_CONVERSION_PATTERN).build();
+    PatternLayout layout = PatternLayout.newBuilder().setConfiguration(cfg)
+        .setPattern(PatternLayout.SIMPLE_CONVERSION_PATTERN).build();
     Appender appender = WriterAppender.createAppender(layout, null, writer,
         "EscalatingLoggerTestAppender", false, true);
     appender.start();

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@ under the License.
     <version.curator>5.8.0</version.curator>
     <version.errorprone>2.41.0</version.errorprone>
     <version.hadoop>3.3.6</version.hadoop>
-    <version.log4j>2.25.4</version.log4j>
+    <version.log4j>2.26.1</version.log4j>
     <version.opentelemetry>1.48.0</version.opentelemetry>
     <version.powermock>2.0.9</version.powermock>
     <version.slf4j>2.0.17</version.slf4j>


### PR DESCRIPTION
Bumps version and fixes deprecated builder pattern. 

Separating this change out from #6486 to avoid the possible merge conflicts with the spot bugs changes when merging to main.