### PR TITLE
Remove monitor REST dropdown containing 2 unused endpoints

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/navbar.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/navbar.ftl
@@ -63,15 +63,6 @@
             </li>
             <li>
               <a id="alert-anchor" class="nav-link" aria-current="page" href="alerts">Alerts</a>
-            </li>            
-            <li class="dropdown">
-              <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown"
-              role="button" data-bs-toggle="dropdown" aria-expanded="false">REST
-              </a>
-              <ul class="dropdown-menu dropdown-menu-end">
-                <li><a class="link-body-emphasis dropdown-item" href="rest/xml">XML Summary</a></li>
-                <li><a class="link-body-emphasis dropdown-item" href="rest/json">JSON Summary</a></li>
-              </ul>
             </li>
             <li class="dropdown">
               <a class="nav-link" href="#" id="navbarDropdown"


### PR DESCRIPTION
Endpoints `rest/xml` and `rest/json` were previously removed endpoints in Monitor, but not removed from the Monitor REST dropdown. 

Removed the dropdown menu containing the removed endpoints.

Related to #6319 
_________________________________________________________________________________________________________________________

Monitor with REST dropdown menu
<img width="266" height="147" alt="image" src="https://github.com/user-attachments/assets/ee3c4fc7-8915-4c12-ae4f-bf4da6f4ffe9" />

Monitor with REST dropdown menu removed 
<img width="339" height="91" alt="image" src="https://github.com/user-attachments/assets/be26b736-f38e-4ac8-92d0-04036d509b53" />

