### PR TITLE
TODO Cleanup

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
@@ -334,11 +334,6 @@ public class ClientContext implements AccumuloClient {
     });
 
     zkLockChecker = memoize(() -> {
-      // make this use its own ZooSession and ZooCache, because this is used by the
-      // tablet location cache, which is a static singleton reused by multiple clients
-      // so, it can't rely on being able to continue to use the same client's ZooCache,
-      // because that client could be closed, and its ZooSession also closed
-      // this needs to be fixed; TODO https://github.com/apache/accumulo/issues/2301
       var zk = info.getZooKeeperSupplier(ZookeeperLockChecker.class.getSimpleName(),
           ZooUtil.getRoot(getInstanceID())).get();
       return new ZookeeperLockChecker(new ZooCache(zk, Set.of(Constants.ZTSERVERS)));

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java
@@ -305,7 +305,6 @@ public final class TabletServerBatchReaderIterator implements Iterator<Entry<Key
         }
 
         if (retryCountDownTimer.isExpired()) {
-          // TODO exception used for timeout is inconsistent
           throw new TimedOutException(
               "Failed to find servers to process scans before timeout was exceeded.");
         }

--- a/core/src/main/java/org/apache/accumulo/core/data/Value.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Value.java
@@ -92,7 +92,6 @@ public class Value implements WritableComparable<Object> {
    * @param bytes May not be null
    */
   public Value(ByteBuffer bytes) {
-    /* TODO ACCUMULO-2509 right now this uses the entire backing array, which must be accessible. */
     this(toBytes(bytes), false);
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/util/ThrottledBalancerProblemReporter.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/util/ThrottledBalancerProblemReporter.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.data.TabletId;
+import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,13 +78,17 @@ public class ThrottledBalancerProblemReporter {
       @Override
       public void report() {
         log.warn("Not balancing due to {} outstanding migrations.", migrations.size());
-        /*
-         * TODO ACCUMULO-2938 redact key extents in this output to avoid leaking protected
-         * information.
-         */
+
+        // convert each tabletId in migrations to keyExtent
+        Set<KeyExtent> keyExtents = migrations.stream().map(tabletId -> {
+          KeyExtent extent = KeyExtent.fromTabletId(tabletId);
+          extent.obscured();
+          return extent;
+        }).collect(Collectors.toSet());
+
         if (log.isDebugEnabled()) {
           log.debug("Sample up to 10 outstanding migrations: {}",
-              migrations.stream().limit(10).map(String::valueOf).collect(Collectors.joining(", ")));
+              keyExtents.stream().limit(10).map(String::valueOf).collect(Collectors.joining(", ")));
         }
         // Now that we've reported, clear out the migrations list so we don't hold it in memory.
         migrations = Collections.emptySet();

--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/util/ThrottledBalancerProblemReporter.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/util/ThrottledBalancerProblemReporter.java
@@ -81,11 +81,11 @@ public class ThrottledBalancerProblemReporter {
         if (log.isDebugEnabled()) {
           // convert each tabletId in migrations to keyExtent for redacting
           log.debug("Sample up to 10 outstanding migrations: {}",
-              String.join(", ", migrations.stream().limit(10).map(tabletId -> {
+              migrations.stream().limit(10).map(tabletId -> {
                 KeyExtent extent = KeyExtent.fromTabletId(tabletId);
                 extent.obscured();
                 return extent.toString();
-              }).map(String::valueOf).collect(Collectors.toSet())));
+              }).collect(Collectors.joining(", ")));
         }
         // Now that we've reported, clear out the migrations list so we don't hold it in memory.
         migrations = Collections.emptySet();

--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/util/ThrottledBalancerProblemReporter.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/util/ThrottledBalancerProblemReporter.java
@@ -82,7 +82,7 @@ public class ThrottledBalancerProblemReporter {
           // convert each tabletId in migrations to keyExtent for redacting
           log.debug("Sample up to 10 outstanding migrations: {}",
               migrations.stream().limit(10)
-                  .map(tabletId -> KeyExtent.fromTabletId(tabletId).obscured())
+                  .map(tabletId -> tabletId.getTable() + ";" + KeyExtent.fromTabletId(tabletId).obscured())
                   .collect(Collectors.joining(", ")));
         }
         // Now that we've reported, clear out the migrations list so we don't hold it in memory.

--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/util/ThrottledBalancerProblemReporter.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/util/ThrottledBalancerProblemReporter.java
@@ -78,17 +78,14 @@ public class ThrottledBalancerProblemReporter {
       @Override
       public void report() {
         log.warn("Not balancing due to {} outstanding migrations.", migrations.size());
-
-        // convert each tabletId in migrations to keyExtent
-        Set<KeyExtent> keyExtents = migrations.stream().map(tabletId -> {
-          KeyExtent extent = KeyExtent.fromTabletId(tabletId);
-          extent.obscured();
-          return extent;
-        }).collect(Collectors.toSet());
-
         if (log.isDebugEnabled()) {
+          // convert each tabletId in migrations to keyExtent for redacting
           log.debug("Sample up to 10 outstanding migrations: {}",
-              keyExtents.stream().limit(10).map(String::valueOf).collect(Collectors.joining(", ")));
+              String.join(", ", migrations.stream().limit(10).map(tabletId -> {
+                KeyExtent extent = KeyExtent.fromTabletId(tabletId);
+                extent.obscured();
+                return extent.toString();
+              }).map(String::valueOf).collect(Collectors.toSet())));
         }
         // Now that we've reported, clear out the migrations list so we don't hold it in memory.
         migrations = Collections.emptySet();

--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/util/ThrottledBalancerProblemReporter.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/util/ThrottledBalancerProblemReporter.java
@@ -80,10 +80,9 @@ public class ThrottledBalancerProblemReporter {
         log.warn("Not balancing due to {} outstanding migrations.", migrations.size());
         if (log.isDebugEnabled()) {
           // convert each tabletId in migrations to keyExtent for redacting
-          log.debug("Sample up to 10 outstanding migrations: {}",
-              migrations.stream().limit(10)
-                  .map(tabletId -> tabletId.getTable() + ";" + KeyExtent.fromTabletId(tabletId).obscured())
-                  .collect(Collectors.joining(", ")));
+          log.debug("Sample up to 10 outstanding migrations: {}", migrations.stream().limit(10).map(
+              tabletId -> tabletId.getTable() + ";" + KeyExtent.fromTabletId(tabletId).obscured())
+              .collect(Collectors.joining(", ")));
         }
         // Now that we've reported, clear out the migrations list so we don't hold it in memory.
         migrations = Collections.emptySet();

--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/util/ThrottledBalancerProblemReporter.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/util/ThrottledBalancerProblemReporter.java
@@ -81,11 +81,9 @@ public class ThrottledBalancerProblemReporter {
         if (log.isDebugEnabled()) {
           // convert each tabletId in migrations to keyExtent for redacting
           log.debug("Sample up to 10 outstanding migrations: {}",
-              migrations.stream().limit(10).map(tabletId -> {
-                KeyExtent extent = KeyExtent.fromTabletId(tabletId);
-                extent.obscured();
-                return extent.toString();
-              }).collect(Collectors.joining(", ")));
+              migrations.stream().limit(10)
+                  .map(tabletId -> KeyExtent.fromTabletId(tabletId).obscured())
+                  .collect(Collectors.joining(", ")));
         }
         // Now that we've reported, clear out the migrations list so we don't hold it in memory.
         migrations = Collections.emptySet();


### PR DESCRIPTION
- Redact keyExtents in outstanding migrations output to remove TODO in `ThrottledBalancerProblemReporter.java`. Added this logic onto existing .stream in the logger that logs 10 outstanding migrations. Related to Jira issue [2938](https://issues.apache.org/jira/browse/ACCUMULO-2938)
- Removed outdated TODO from `ClientContext.java`. Github issue #2301 mentioned in the TODO has been closed for over a year.
- Removed TODO from `TabletServerBatchReaderIterator.java`, the exception used here does not seem inconsistent since the retryCountDownTimer has expired.
- Removed TODO from `Value.java` Jira issue [2509](https://issues.apache.org/jira/browse/ACCUMULO-2509) mentioned in the TODO has been resolved as Not A Problem.

_____________________________________________________________________________________________________________________

Removes 4 TODOs , partially addresses #2699 