### PR TITLE
Properly pass in DataTables variables in constructors

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/alerts.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/alerts.js
@@ -80,7 +80,7 @@ function refresh() {
 }
 
 function createDataTable() {
-  dataTableRef = new DataTable('#alertHtmlTable', {
+  dataTableRef = new DataTable(alertHtmlTable, {
     "autoWidth": false,
     "ajax": function (data, callback) {
       callback({

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/coordinator.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/coordinator.js
@@ -67,7 +67,7 @@ $(function () {
   sessionStorage[RUNNING_COMPACTIONS_BY_GROUP] = JSON.stringify([]);
 
   // Create a table for scans list
-  tableRunning = new DataTable('#runningTableHtmlTable', {
+  tableRunning = new DataTable(runningTableHtmlTable, {
     "ajax": function (data, callback) {
       callback({
         data: getStoredArray(RUNNING_COMPACTIONS_BY_TABLE)
@@ -98,7 +98,7 @@ $(function () {
     ]
   });
 
-  queueRunning = new DataTable('#runningQueueHtmlTable', {
+  queueRunning = new DataTable(runningQueueHtmlTable, {
     "ajax": function (data, callback) {
       callback({
         data: getStoredArray(RUNNING_COMPACTIONS_BY_GROUP)

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/fate.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/fate.js
@@ -45,7 +45,7 @@ function renderListOrDash(data, type) {
 function createDataTable() {
   $(fateHtmlTable).find('thead').remove();
   $(fateHtmlTable).find('tbody').remove();
-  dataTableRef = new DataTable('#fateHtmlTable', {
+  dataTableRef = new DataTable(fateHtmlTable, {
     "autoWidth": false,
     "ajax": function (data, callback) {
       callback({

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/recovery.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/recovery.js
@@ -89,7 +89,7 @@ $(function () {
     serversSortingLogs: []
   });
 
-  overviewDataTable = new DataTable('#overviewTableElement', {
+  overviewDataTable = new DataTable(overviewTableElement, {
     "ajax": function (data, callback) {
       callback({
         data: getOverview()
@@ -117,7 +117,7 @@ $(function () {
     ]
   });
 
-  tabletDataTable = new DataTable('#tabletRecoveryTableElement', {
+  tabletDataTable = new DataTable(tabletRecoveryTableElement, {
     "ajax": function (data, callback) {
       callback({
         data: getTablets()
@@ -145,7 +145,7 @@ $(function () {
     ]
   });
 
-  sortingDataTable = new DataTable('#sortingServersTableElement', {
+  sortingDataTable = new DataTable(sortingServersTableElement, {
     "ajax": function (data, callback) {
       callback({
         data: getSorting()
@@ -210,7 +210,7 @@ $(function () {
       }
     ]
   });
-  replayingDataTable = new DataTable('#replayingServersTableElement', {
+  replayingDataTable = new DataTable(replayingServersTableElement, {
     "ajax": function (data, callback) {
       callback({
         data: getReplaying()

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/server_process_common.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/server_process_common.js
@@ -245,7 +245,7 @@ function refreshServerInformation(callback, table, storageKey, banner, bannerMsg
  * css class.
  */
 function createDataTable(table, storageKey) {
-  var dataTableRef = new DataTable('#table', {
+  var dataTableRef = new DataTable(table, {
     "autoWidth": false,
     "ajax": function (data, callback) {
       callback({


### PR DESCRIPTION
Fixes #6511

 #6497 upgraded to DataTables 3 in the monitor which has a new constructor for the DataTable JavaScript variables. Some of those new constructors were using the wrong literal or variable.

This PR corrects all those usages and now all tables are working again.
