### PR TITLE
Fixed intermittent failures in ServiceLockIT.testLockSerial

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ServiceLockIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ServiceLockIT.java
@@ -497,7 +497,6 @@ public class ServiceLockIT {
       zl1.unlock();
       assertFalse(zlw1.isLockHeld());
       assertFalse(zl1.verifyLockAtSource());
-      assertFalse(zl2.verifyLockAtSource());
       zk1.close();
 
       while (!zlw2.isLockHeld()) {


### PR DESCRIPTION
Removed one line that was checking that the 2nd lock was not holding the lock in ZooKeeper after unlocking the 1st lock. This line of code introduced a race condition in the test. Further down in the test method we expect that the 2nd lock is holding the lock, so that line of code succeeded or failed based on timing.