### PR TITLE
Note that cache impls are monotonically increasing counters in Javadoc

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/spi/cache/BlockCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/cache/BlockCache.java
@@ -97,9 +97,9 @@ public interface BlockCache {
   /**
    * Cache statistics.
    * <p>
-   * All counts returned by this interface must be monotonically increasing. The counter must never
-   * reset or decrease the counts as the values for the metrics are read periodically and must
-   * increase over each reading.
+   * All counts returned by this interface must be monotonically increasing. They must never reset
+   * or decrease, as the values are read periodically and the increase between readings is what gets
+   * reported.
    */
   interface Stats {
 

--- a/core/src/main/java/org/apache/accumulo/core/spi/cache/BlockCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/cache/BlockCache.java
@@ -94,7 +94,13 @@ public interface BlockCache {
    */
   Stats getStats();
 
-  /** Cache statistics. */
+  /**
+   * Cache statistics.
+   * <p>
+   * All counts returned by this interface must be monotonically increasing. The counter must never
+   * reset or decrease the counts as the values for the metrics are read periodically and must
+   * increase over each reading.
+   */
   interface Stats {
 
     /**

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/BlockCacheMetrics.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/BlockCacheMetrics.java
@@ -38,6 +38,10 @@ public class BlockCacheMetrics implements MetricsProducer {
     this.summaryCache = summaryCache;
   }
 
+  /**
+   * This BlockCache implementation is a monotonically increasing counter, the counter should not reset or
+   * decrease the counts as the metrics rely on these values being monotonically increasing.
+   */
   @Override
   public void registerMetrics(MeterRegistry registry) {
     ToDoubleFunction<BlockCache> getHitCount = cache -> cache.getStats().hitCount();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/BlockCacheMetrics.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/BlockCacheMetrics.java
@@ -38,10 +38,6 @@ public class BlockCacheMetrics implements MetricsProducer {
     this.summaryCache = summaryCache;
   }
 
-  /**
-   * This BlockCache implementation is a monotonically increasing counter, the counter should not reset or
-   * decrease the counts as the metrics rely on these values being monotonically increasing.
-   */
   @Override
   public void registerMetrics(MeterRegistry registry) {
     ToDoubleFunction<BlockCache> getHitCount = cache -> cache.getStats().hitCount();


### PR DESCRIPTION
Update SPI javadoc to note that cache impls are monotonically increasing counters.

Added to javadoc in `BlockCache.Stats.java` interface.

This pr closes #4530 