### PR TITLE
Replace AbstractFateStore.verifyReserved() with new method FateMutator.requireReserved()

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/fate/user/FateMutator.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/FateMutator.java
@@ -53,6 +53,11 @@ public interface FateMutator<T> {
   FateMutator<T> requireUnreserved();
 
   /**
+   * Require the transaction has a reservation.
+   */
+  FateMutator<T> requireReserved();
+
+  /**
    * Require the transaction has no fate key set.
    */
   FateMutator<T> requireAbsentKey();

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/FateMutator.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/FateMutator.java
@@ -55,7 +55,7 @@ public interface FateMutator<T> {
   /**
    * Require the transaction has a reservation.
    */
-  FateMutator<T> requireReserved();
+  FateMutator<T> requireReserved(FateStore.FateReservation fateReservation);
 
   /**
    * Require the transaction has no fate key set.

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/FateMutatorImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/FateMutatorImpl.java
@@ -75,7 +75,6 @@ public class FateMutatorImpl<T> implements FateMutator<T> {
 
   @Override
   public FateMutator<T> putStatus(TStatus status) {
-    requireReserved();
     TxAdminColumnFamily.STATUS_COLUMN.put(mutation, new Value(status.name()));
     return this;
   }
@@ -111,10 +110,11 @@ public class FateMutatorImpl<T> implements FateMutator<T> {
   }
 
   @Override
-  public FateMutator<T> requireReserved() {
+  public FateMutator<T> requireReserved(FateStore.FateReservation fateReservation) {
     Preconditions.checkState(!requiredReserved);
     Condition condition = new Condition(TxAdminColumnFamily.RESERVATION_COLUMN.getColumnFamily(),
-        TxAdminColumnFamily.RESERVATION_COLUMN.getColumnQualifier());
+        TxAdminColumnFamily.RESERVATION_COLUMN.getColumnQualifier())
+        .setValue(fateReservation.getSerialized());
     mutation.addCondition(condition);
     requiredReserved = true;
     return this;
@@ -137,7 +137,10 @@ public class FateMutatorImpl<T> implements FateMutator<T> {
 
   @Override
   public FateMutator<T> putUnreserveTx(FateStore.FateReservation reservation) {
-    requireReserved();
+    Condition condition = new Condition(TxAdminColumnFamily.RESERVATION_COLUMN.getColumnFamily(),
+        TxAdminColumnFamily.RESERVATION_COLUMN.getColumnQualifier())
+        .setValue(reservation.getSerialized());
+    mutation.addCondition(condition);
     TxAdminColumnFamily.RESERVATION_COLUMN.putDelete(mutation);
     return this;
   }
@@ -174,7 +177,6 @@ public class FateMutatorImpl<T> implements FateMutator<T> {
 
   @Override
   public FateMutator<T> putTxInfo(TxInfo txInfo, byte[] data) {
-    requireReserved();
     switch (txInfo) {
       case FATE_OP:
         putFateOp(data);
@@ -199,7 +201,6 @@ public class FateMutatorImpl<T> implements FateMutator<T> {
 
   @Override
   public FateMutator<T> putRepo(int position, Repo<T> repo) {
-    requireReserved();
     final Text cq = invertRepo(position);
     // ensure this repo is not already set
     mutation.addCondition(new Condition(RepoColumnFamily.NAME, cq));
@@ -209,13 +210,11 @@ public class FateMutatorImpl<T> implements FateMutator<T> {
 
   @Override
   public FateMutator<T> deleteRepo(int position) {
-    requireReserved();
     mutation.putDelete(RepoColumnFamily.NAME, invertRepo(position));
     return this;
   }
 
   public FateMutator<T> delete() {
-    requireReserved();
     try (Scanner scanner = context.createScanner(tableName, Authorizations.EMPTY)) {
       scanner.setRange(getRow(fateId));
       scanner.forEach(

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/FateMutatorImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/FateMutatorImpl.java
@@ -113,7 +113,7 @@ public class FateMutatorImpl<T> implements FateMutator<T> {
   public FateMutator<T> requireReserved() {
     Preconditions.checkState(!requiredReserved);
     Condition condition = new Condition(TxAdminColumnFamily.RESERVATION_COLUMN.getColumnFamily(),
-            TxAdminColumnFamily.RESERVATION_COLUMN.getColumnQualifier());
+        TxAdminColumnFamily.RESERVATION_COLUMN.getColumnQualifier());
     mutation.addCondition(condition);
     requiredReserved = true;
     return this;

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/FateMutatorImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/FateMutatorImpl.java
@@ -75,6 +75,7 @@ public class FateMutatorImpl<T> implements FateMutator<T> {
 
   @Override
   public FateMutator<T> putStatus(TStatus status) {
+    requireReserved();
     TxAdminColumnFamily.STATUS_COLUMN.put(mutation, new Value(status.name()));
     return this;
   }
@@ -173,6 +174,7 @@ public class FateMutatorImpl<T> implements FateMutator<T> {
 
   @Override
   public FateMutator<T> putTxInfo(TxInfo txInfo, byte[] data) {
+    requireReserved();
     switch (txInfo) {
       case FATE_OP:
         putFateOp(data);
@@ -197,6 +199,7 @@ public class FateMutatorImpl<T> implements FateMutator<T> {
 
   @Override
   public FateMutator<T> putRepo(int position, Repo<T> repo) {
+    requireReserved();
     final Text cq = invertRepo(position);
     // ensure this repo is not already set
     mutation.addCondition(new Condition(RepoColumnFamily.NAME, cq));
@@ -206,11 +209,13 @@ public class FateMutatorImpl<T> implements FateMutator<T> {
 
   @Override
   public FateMutator<T> deleteRepo(int position) {
+    requireReserved();
     mutation.putDelete(RepoColumnFamily.NAME, invertRepo(position));
     return this;
   }
 
   public FateMutator<T> delete() {
+    requireReserved();
     try (Scanner scanner = context.createScanner(tableName, Authorizations.EMPTY)) {
       scanner.setRange(getRow(fateId));
       scanner.forEach(

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/FateMutatorImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/FateMutatorImpl.java
@@ -61,6 +61,7 @@ public class FateMutatorImpl<T> implements FateMutator<T> {
   private final ConditionalMutation mutation;
   private final Supplier<ConditionalWriter> writer;
   private boolean requiredUnreserved = false;
+  private boolean requiredReserved = false;
   public static final int INITIAL_ITERATOR_PRIO = 1000000;
 
   public FateMutatorImpl(ClientContext context, String tableName, FateId fateId,
@@ -109,6 +110,16 @@ public class FateMutatorImpl<T> implements FateMutator<T> {
   }
 
   @Override
+  public FateMutator<T> requireReserved() {
+    Preconditions.checkState(!requiredReserved);
+    Condition condition = new Condition(TxAdminColumnFamily.RESERVATION_COLUMN.getColumnFamily(),
+            TxAdminColumnFamily.RESERVATION_COLUMN.getColumnQualifier());
+    mutation.addCondition(condition);
+    requiredReserved = true;
+    return this;
+  }
+
+  @Override
   public FateMutator<T> requireAbsentKey() {
     Condition condition = new Condition(TxColumnFamily.TX_KEY_COLUMN.getColumnFamily(),
         TxColumnFamily.TX_KEY_COLUMN.getColumnQualifier());
@@ -125,10 +136,7 @@ public class FateMutatorImpl<T> implements FateMutator<T> {
 
   @Override
   public FateMutator<T> putUnreserveTx(FateStore.FateReservation reservation) {
-    Condition condition = new Condition(TxAdminColumnFamily.RESERVATION_COLUMN.getColumnFamily(),
-        TxAdminColumnFamily.RESERVATION_COLUMN.getColumnQualifier())
-        .setValue(reservation.getSerialized());
-    mutation.addCondition(condition);
+    requireReserved();
     TxAdminColumnFamily.RESERVATION_COLUMN.putDelete(mutation);
     return this;
   }

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/UserFateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/UserFateStore.java
@@ -546,6 +546,8 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
 
     @Override
     public Repo<T> top() {
+      verifyReservedAndNotDeleted(false);
+
       return scanTx(scanner -> {
         scanner.setRange(getRow(fateId));
         scanner.setBatchSize(1);
@@ -560,6 +562,8 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
 
     @Override
     public List<ReadOnlyRepo<T>> getStack() {
+      verifyReservedAndNotDeleted(false);
+
       return scanTx(scanner -> {
         scanner.setRange(getRow(fateId));
         scanner.fetchColumnFamily(RepoColumnFamily.NAME);
@@ -573,6 +577,8 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
 
     @Override
     public Serializable getTransactionInfo(TxInfo txInfo) {
+      verifyReservedAndNotDeleted(false);
+
       try (Scanner scanner = context.createScanner(tableName, Authorizations.EMPTY)) {
         scanner.setRange(getRow(fateId));
 
@@ -594,6 +600,8 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
 
     @Override
     public long timeCreated() {
+      verifyReservedAndNotDeleted(false);
+
       return scanTx(scanner -> {
         scanner.setRange(getRow(fateId));
         TxColumnFamily.CREATE_TIME_COLUMN.fetch(scanner);
@@ -610,8 +618,8 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
         throw new StackOverflowException("Repo stack size too large");
       }
 
-      FateMutator<T> fateMutator =
-          newMutator(fateId).requireStatus(REQ_PUSH_STATUS.toArray(TStatus[]::new));
+      FateMutator<T> fateMutator = newMutator(fateId)
+          .requireStatus(REQ_PUSH_STATUS.toArray(TStatus[]::new)).requireReserved(reservation);
       fateMutator.putRepo(top.map(t -> t + 1).orElse(1), repo).mutate();
     }
 
@@ -619,26 +627,25 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
     public void pop() {
       Optional<Integer> top = findTop();
       top.ifPresent(t -> newMutator(fateId).requireStatus(REQ_POP_STATUS.toArray(TStatus[]::new))
-          .deleteRepo(t).mutate());
+          .requireReserved(reservation).deleteRepo(t).mutate());
     }
 
     @Override
     public void setStatus(TStatus status) {
-      newMutator(fateId).putStatus(status).mutate();
+      newMutator(fateId).requireReserved(reservation).putStatus(status).mutate();
       observedStatus = status;
     }
 
     @Override
     public void setTransactionInfo(TxInfo txInfo, Serializable so) {
       final byte[] serialized = serializeTxInfo(so);
-
-      newMutator(fateId).putTxInfo(txInfo, serialized).mutate();
+      newMutator(fateId).requireReserved(reservation).putTxInfo(txInfo, serialized).mutate();
     }
 
     @Override
     public void delete() {
       var mutator = newMutator(fateId);
-      mutator.requireStatus(REQ_DELETE_STATUS.toArray(TStatus[]::new));
+      mutator.requireStatus(REQ_DELETE_STATUS.toArray(TStatus[]::new)).requireReserved(reservation);
       mutator.delete().mutate();
       this.deleted = true;
     }
@@ -646,7 +653,8 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
     @Override
     public void forceDelete() {
       var mutator = newMutator(fateId);
-      mutator.requireStatus(REQ_FORCE_DELETE_STATUS.toArray(TStatus[]::new));
+      mutator.requireStatus(REQ_FORCE_DELETE_STATUS.toArray(TStatus[]::new))
+          .requireReserved(reservation);
       mutator.delete().mutate();
       this.deleted = true;
     }

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/UserFateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/UserFateStore.java
@@ -546,7 +546,7 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
 
     @Override
     public Repo<T> top() {
-      verifyReservedAndNotDeleted(false);
+      newMutator(fateId).requireReserved(reservation);
 
       return scanTx(scanner -> {
         scanner.setRange(getRow(fateId));
@@ -562,7 +562,7 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
 
     @Override
     public List<ReadOnlyRepo<T>> getStack() {
-      verifyReservedAndNotDeleted(false);
+      newMutator(fateId).requireReserved(reservation);
 
       return scanTx(scanner -> {
         scanner.setRange(getRow(fateId));
@@ -577,7 +577,7 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
 
     @Override
     public Serializable getTransactionInfo(TxInfo txInfo) {
-      verifyReservedAndNotDeleted(false);
+      newMutator(fateId).requireReserved(reservation);
 
       try (Scanner scanner = context.createScanner(tableName, Authorizations.EMPTY)) {
         scanner.setRange(getRow(fateId));
@@ -600,7 +600,7 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
 
     @Override
     public long timeCreated() {
-      verifyReservedAndNotDeleted(false);
+      newMutator(fateId).requireReserved(reservation);
 
       return scanTx(scanner -> {
         scanner.setRange(getRow(fateId));

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/UserFateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/UserFateStore.java
@@ -414,6 +414,12 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
     return new FateMutatorImpl<>(context, tableName, fateId, writer);
   }
 
+  public FateMutatorImpl<T> newReservedMutator(FateId fateId, FateReservation reservation) {
+    Preconditions.checkState(fateId != null,
+        "Attempted write on deleted FATE transaction: " + fateId);
+    return (FateMutatorImpl<T>) newMutator(fateId).requireReserved(reservation);
+  }
+
   private <R> R scanTx(Function<Scanner,R> func) {
     try (Scanner scanner = context.createScanner(tableName, Authorizations.EMPTY)) {
       return func.apply(scanner);
@@ -546,8 +552,6 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
 
     @Override
     public Repo<T> top() {
-      newMutator(fateId).requireReserved(reservation);
-
       return scanTx(scanner -> {
         scanner.setRange(getRow(fateId));
         scanner.setBatchSize(1);
@@ -562,8 +566,6 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
 
     @Override
     public List<ReadOnlyRepo<T>> getStack() {
-      newMutator(fateId).requireReserved(reservation);
-
       return scanTx(scanner -> {
         scanner.setRange(getRow(fateId));
         scanner.fetchColumnFamily(RepoColumnFamily.NAME);
@@ -577,8 +579,6 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
 
     @Override
     public Serializable getTransactionInfo(TxInfo txInfo) {
-      newMutator(fateId).requireReserved(reservation);
-
       try (Scanner scanner = context.createScanner(tableName, Authorizations.EMPTY)) {
         scanner.setRange(getRow(fateId));
 
@@ -600,8 +600,6 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
 
     @Override
     public long timeCreated() {
-      newMutator(fateId).requireReserved(reservation);
-
       return scanTx(scanner -> {
         scanner.setRange(getRow(fateId));
         TxColumnFamily.CREATE_TIME_COLUMN.fetch(scanner);
@@ -618,43 +616,42 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
         throw new StackOverflowException("Repo stack size too large");
       }
 
-      FateMutator<T> fateMutator = newMutator(fateId)
-          .requireStatus(REQ_PUSH_STATUS.toArray(TStatus[]::new)).requireReserved(reservation);
+      FateMutator<T> fateMutator = newReservedMutator(fateId, reservation)
+          .requireStatus(REQ_PUSH_STATUS.toArray(TStatus[]::new));
       fateMutator.putRepo(top.map(t -> t + 1).orElse(1), repo).mutate();
     }
 
     @Override
     public void pop() {
       Optional<Integer> top = findTop();
-      top.ifPresent(t -> newMutator(fateId).requireStatus(REQ_POP_STATUS.toArray(TStatus[]::new))
-          .requireReserved(reservation).deleteRepo(t).mutate());
+      top.ifPresent(t -> newReservedMutator(fateId, reservation)
+          .requireStatus(REQ_POP_STATUS.toArray(TStatus[]::new)).deleteRepo(t).mutate());
     }
 
     @Override
     public void setStatus(TStatus status) {
-      newMutator(fateId).requireReserved(reservation).putStatus(status).mutate();
+      newReservedMutator(fateId, reservation).putStatus(status).mutate();
       observedStatus = status;
     }
 
     @Override
     public void setTransactionInfo(TxInfo txInfo, Serializable so) {
       final byte[] serialized = serializeTxInfo(so);
-      newMutator(fateId).requireReserved(reservation).putTxInfo(txInfo, serialized).mutate();
+      newReservedMutator(fateId, reservation).putTxInfo(txInfo, serialized).mutate();
     }
 
     @Override
     public void delete() {
-      var mutator = newMutator(fateId);
-      mutator.requireStatus(REQ_DELETE_STATUS.toArray(TStatus[]::new)).requireReserved(reservation);
+      var mutator = newReservedMutator(fateId, reservation);
+      mutator.requireStatus(REQ_DELETE_STATUS.toArray(TStatus[]::new));
       mutator.delete().mutate();
       this.deleted = true;
     }
 
     @Override
     public void forceDelete() {
-      var mutator = newMutator(fateId);
-      mutator.requireStatus(REQ_FORCE_DELETE_STATUS.toArray(TStatus[]::new))
-          .requireReserved(reservation);
+      var mutator = newReservedMutator(fateId, reservation);
+      mutator.requireStatus(REQ_FORCE_DELETE_STATUS.toArray(TStatus[]::new));
       mutator.delete().mutate();
       this.deleted = true;
     }

--- a/core/src/main/java/org/apache/accumulo/core/fate/user/UserFateStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/user/UserFateStore.java
@@ -546,8 +546,6 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
 
     @Override
     public Repo<T> top() {
-      verifyReservedAndNotDeleted(false);
-
       return scanTx(scanner -> {
         scanner.setRange(getRow(fateId));
         scanner.setBatchSize(1);
@@ -562,8 +560,6 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
 
     @Override
     public List<ReadOnlyRepo<T>> getStack() {
-      verifyReservedAndNotDeleted(false);
-
       return scanTx(scanner -> {
         scanner.setRange(getRow(fateId));
         scanner.fetchColumnFamily(RepoColumnFamily.NAME);
@@ -577,8 +573,6 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
 
     @Override
     public Serializable getTransactionInfo(TxInfo txInfo) {
-      verifyReservedAndNotDeleted(false);
-
       try (Scanner scanner = context.createScanner(tableName, Authorizations.EMPTY)) {
         scanner.setRange(getRow(fateId));
 
@@ -600,8 +594,6 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
 
     @Override
     public long timeCreated() {
-      verifyReservedAndNotDeleted(false);
-
       return scanTx(scanner -> {
         scanner.setRange(getRow(fateId));
         TxColumnFamily.CREATE_TIME_COLUMN.fetch(scanner);
@@ -612,8 +604,6 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
 
     @Override
     public void push(Repo<T> repo) throws StackOverflowException {
-      verifyReservedAndNotDeleted(true);
-
       Optional<Integer> top = findTop();
 
       if (top.filter(t -> t >= MAX_REPOS).isPresent()) {
@@ -627,8 +617,6 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
 
     @Override
     public void pop() {
-      verifyReservedAndNotDeleted(true);
-
       Optional<Integer> top = findTop();
       top.ifPresent(t -> newMutator(fateId).requireStatus(REQ_POP_STATUS.toArray(TStatus[]::new))
           .deleteRepo(t).mutate());
@@ -636,16 +624,12 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
 
     @Override
     public void setStatus(TStatus status) {
-      verifyReservedAndNotDeleted(true);
-
       newMutator(fateId).putStatus(status).mutate();
       observedStatus = status;
     }
 
     @Override
     public void setTransactionInfo(TxInfo txInfo, Serializable so) {
-      verifyReservedAndNotDeleted(true);
-
       final byte[] serialized = serializeTxInfo(so);
 
       newMutator(fateId).putTxInfo(txInfo, serialized).mutate();
@@ -653,8 +637,6 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
 
     @Override
     public void delete() {
-      verifyReservedAndNotDeleted(true);
-
       var mutator = newMutator(fateId);
       mutator.requireStatus(REQ_DELETE_STATUS.toArray(TStatus[]::new));
       mutator.delete().mutate();
@@ -663,8 +645,6 @@ public class UserFateStore<T> extends AbstractFateStore<T> {
 
     @Override
     public void forceDelete() {
-      verifyReservedAndNotDeleted(true);
-
       var mutator = newMutator(fateId);
       mutator.requireStatus(REQ_FORCE_DELETE_STATUS.toArray(TStatus[]::new));
       mutator.delete().mutate();


### PR DESCRIPTION
Add new method to `FateMutator.java` that requires a FateId to be reserved for certain transactions. This method will replace `AbstractFateStore.verifyReservedAndNotDeleted()` implementation in `UserFateStore.java`.
- Added `FateMutator.requireReserved()` and its implementation in `FateMutatorImpl.java`. `requireReserved()` requires a transaction to be reserved with a specific `FateStore.FateReservation`.
-  Removed usages of `verifyReservedandNotDeleted()` from `UserFateStore.java` methods. To replace its implementation, new method `requireReserved()` called through new helper method `newReservedMutator` in push(), pop(), setStatus(), setTransactionInfo(), delete(), and forceDelete(). For methods top(), getStack(), getTransactionInfo(), and timeCreated(), `verifyReservedandNotDeleted()` simply was removed since it is a no-op.

Closes #4908 