### PR TITLE
Remove inaccurate @NotThreadSafe from InMemoryMap.MemoryDataSource

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
@@ -37,8 +37,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.accumulo.core.client.SampleNotPresentException;
 import org.apache.accumulo.core.client.sample.Sampler;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
@@ -533,10 +531,9 @@ public class InMemoryMap {
 
   private final Set<MemoryIterator> activeIters = Collections.synchronizedSet(new HashSet<>());
 
-  @NotThreadSafe
   class MemoryDataSource implements DataSource {
 
-    private boolean switched = false;
+    private volatile boolean switched = false;
     private InterruptibleIterator iter;
     private FileSKVIterator reader;
     private final MemoryDataSource parent;


### PR DESCRIPTION
fixes #6093 

`InMemoryMap.MemoryDataSource` was marked with @NotThreadSafe but was actually accessed by multiple threads meaning that annotation is inaccurate.

Three threads can reach a single instance:
 - a scan thread via `SourceSwitchingIterator.seek()` and `next()`
 - the minor compaction thread via `InMemoryMap.delete()`
 - the closing thread in `MemoryIterator.close()`

All external callers are synchronized so its safe regardless. This means removing the annotation is the right move here.

