### PR TITLE
Add memory used to scan trace spans

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -1211,7 +1211,9 @@ public enum Property {
       "Options for the table scan dispatcher.", "2.0.0"),
   TABLE_SCAN_MAXMEM("table.scan.max.memory", "512k", PropertyType.BYTES,
       "The maximum amount of memory that will be used to cache results of a client query/scan. "
-          + "Once this limit is reached, the buffered data is sent to the client.",
+          + "Once this limit is reached, the buffered data is sent to the client. This is an "
+          + "estimate of heap usage and includes per entry object overhead, so it will always "
+          + "exceed the size of the key value data actually sent to the client.",
       "1.3.5"),
   TABLE_SHUFFLE_SOURCES("table.shuffle.sources", "false", PropertyType.BOOLEAN,
       "Shuffle the opening order for Rfiles to reduce thread contention on file open operations.",

--- a/core/src/main/java/org/apache/accumulo/core/trace/TraceAttributes.java
+++ b/core/src/main/java/org/apache/accumulo/core/trace/TraceAttributes.java
@@ -25,6 +25,8 @@ public class TraceAttributes {
       AttributeKey.longKey("accumulo.scan.entries.returned");
   public static final AttributeKey<Long> BYTES_RETURNED_KEY =
       AttributeKey.longKey("accumulo.scan.bytes.returned");
+  public static final AttributeKey<Long> MEMORY_USED_KEY =
+      AttributeKey.longKey("accumulo.scan.memory.used");
   public static final AttributeKey<Long> BYTES_READ_KEY =
       AttributeKey.longKey("accumulo.scan.bytes.read");
   public static final AttributeKey<Long> BYTES_READ_FILE_KEY =

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/KVEntry.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/KVEntry.java
@@ -25,6 +25,12 @@ import org.apache.accumulo.core.data.KeyValue;
 import org.apache.accumulo.core.data.Value;
 
 public class KVEntry extends KeyValue {
+
+  /**
+   * Estimated overhead for nine objects at 32 bytes each.
+   */
+  public static final int MEMORY_OVERHEAD = 9 * 32;
+
   private static final long serialVersionUID = 1L;
 
   public KVEntry(Key k, Value v) {
@@ -36,6 +42,6 @@ public class KVEntry extends KeyValue {
   }
 
   int estimateMemoryUsed() {
-    return getKey().getSize() + getValue().get().length + (9 * 32); // overhead is 32 per object
+    return getKey().getSize() + getValue().get().length + MEMORY_OVERHEAD;
   }
 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletBase.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletBase.java
@@ -253,10 +253,13 @@ public abstract class TabletBase {
     if (span.isRecording()) {
       span.setAttribute(TraceAttributes.ENTRIES_RETURNED_KEY, batch.size());
       long bytesReturned = 0;
+      long memoryUsed = 0;
       for (var e : batch) {
         bytesReturned += e.getKey().getLength() + e.getValue().get().length;
+        memoryUsed += e.estimateMemoryUsed();
       }
       span.setAttribute(TraceAttributes.BYTES_RETURNED_KEY, bytesReturned);
+      span.setAttribute(TraceAttributes.MEMORY_USED_KEY, memoryUsed);
       span.setAttribute(TraceAttributes.EXECUTOR_KEY,
           scanParameters.getScanDispatch().getExecutorName());
       span.setAttribute(TraceAttributes.TABLE_ID_KEY, getExtent().tableId().canonical());

--- a/test/src/main/java/org/apache/accumulo/test/tracing/ScanTracingIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/tracing/ScanTracingIT.java
@@ -57,6 +57,9 @@ class ScanTracingIT extends ConfigurableMacBase {
 
   private static final int OTLP_PORT = PortUtils.getRandomFreePort();
 
+  // must be kept in sync with KVEntry.estimateMemoryUsed(), which is not visible from here
+  private static final long KVENTRY_MEMORY_OVERHEAD = 9 * 32;
+
   private static List<String> getJvmArgs() {
     String javaAgent = null;
     for (var cpi : System.getProperty("java.class.path").split(":")) {
@@ -231,6 +234,8 @@ class ScanTracingIT extends ConfigurableMacBase {
       double colMultiplier = 10.0 / expectedColumns;
       assertClose((long) (results.scanSize * colMultiplier), stats.getBytesRead(), .05);
       assertClose(results.scanSize, stats.getBytesReturned(), .05);
+      assertEquals(stats.getBytesReturned() + KVENTRY_MEMORY_OVERHEAD * stats.getEntriesReturned(),
+          stats.getMemoryUsed(), stats::toString);
       if (secondScanFitsInCache && i == 1) {
         assertEquals(0, stats.getFileBytesRead(), stats::toString);
       } else {
@@ -333,6 +338,10 @@ class ScanTracingIT extends ConfigurableMacBase {
 
     long getBytesReturned() {
       return scanStats.getOrDefault(TraceAttributes.BYTES_RETURNED_KEY.getKey(), 0L);
+    }
+
+    long getMemoryUsed() {
+      return scanStats.getOrDefault(TraceAttributes.MEMORY_USED_KEY.getKey(), 0L);
     }
 
     long getDataCacheHits() {

--- a/test/src/main/java/org/apache/accumulo/test/tracing/ScanTracingIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/tracing/ScanTracingIT.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.test.tracing;
 
 import static org.apache.accumulo.core.trace.TraceAttributes.EXECUTOR_KEY;
 import static org.apache.accumulo.core.trace.TraceAttributes.EXTENT_KEY;
+import static org.apache.accumulo.tserver.tablet.KVEntry.MEMORY_OVERHEAD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -45,6 +46,7 @@ import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.server.util.PortUtils;
 import org.apache.accumulo.test.TestIngest;
 import org.apache.accumulo.test.functional.ConfigurableMacBase;
+import org.apache.accumulo.tserver.tablet.KVEntry;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,9 +58,6 @@ import com.google.gson.Gson;
 class ScanTracingIT extends ConfigurableMacBase {
 
   private static final int OTLP_PORT = PortUtils.getRandomFreePort();
-
-  // must be kept in sync with KVEntry.estimateMemoryUsed(), which is not visible from here
-  private static final long KVENTRY_MEMORY_OVERHEAD = 9 * 32;
 
   private static List<String> getJvmArgs() {
     String javaAgent = null;
@@ -234,7 +233,7 @@ class ScanTracingIT extends ConfigurableMacBase {
       double colMultiplier = 10.0 / expectedColumns;
       assertClose((long) (results.scanSize * colMultiplier), stats.getBytesRead(), .05);
       assertClose(results.scanSize, stats.getBytesReturned(), .05);
-      assertEquals(stats.getBytesReturned() + KVENTRY_MEMORY_OVERHEAD * stats.getEntriesReturned(),
+      assertEquals(stats.getBytesReturned() + KVEntry.MEMORY_OVERHEAD * stats.getEntriesReturned(),
           stats.getMemoryUsed(), stats::toString);
       if (secondScanFitsInCache && i == 1) {
         assertEquals(0, stats.getFileBytesRead(), stats::toString);


### PR DESCRIPTION
Closes #6022 

`table.scan.max.memory` is checked against `KVEntry.estimateMemoryUsed()` (which is the bytes + 288 bytes per entry overhead for the java object), but `accumulo.scan.bytes.returned` reports bytes only. Meaning a stopped batch will report lower than actual. For example a batch that stopped at 1M will report ~820k making it seem like the config was ignored.

This PR adds `accumulo.scan.memory.used` with the value the limit actually uses which clarifies the property description and helps outline the difference.