### PR TITLE
Bump protobuf-java due to recent OpenTelemetry bump

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -325,7 +325,7 @@ under the License.
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
-        <version>4.34.1</version>
+        <version>4.35.1</version>
       </dependency>
       <dependency>
         <groupId>com.lmax</groupId>


### PR DESCRIPTION
The recent OpenTelemetry version bump in #6515 requires a newer version of protobuf-java for ScanTracingIT.